### PR TITLE
Fix tests since the last commit

### DIFF
--- a/npm/src/commands/runTests.js
+++ b/npm/src/commands/runTests.js
@@ -109,9 +109,9 @@ async function getOrderedFlowBinVersions(): Promise<Array<string>> {
         });
 
         apiPayload.forEach(rel => {
-          // Suppression comments (which are needed in order to run tests) were
-          // added in 0.12 -- so we only test against versions since then.
-          if (semver.lt(rel.tag_name, "0.12.0")) {
+          // We only test against versions since 0.15.0 because it has proper
+          // [ignore] fixes (which are necessary to run tests)
+          if (semver.lt(rel.tag_name, "0.15.0")) {
             return;
           }
 
@@ -258,7 +258,13 @@ async function runTestGroup(
       path.basename(testGroup.libDefPath),
       "",
       "[options]",
-      "suppress_comment=\\\\(.\\\\|\\n\\\\)*\\\\$ExpectError"
+      "suppress_comment=\\\\(.\\\\|\\n\\\\)*\\\\$ExpectError",
+      "",
+
+      // Be sure to ignore stuff in the node_modules directory of the flow-typed
+      // CLI repository!
+      "[ignore]",
+      path.join(testDirPath, "..", "..", "node_modules"),
     ].join("\n");
     await fs.writeFile(destFlowConfigPath, flowConfigData);
 

--- a/npm/src/lib/definitions.js
+++ b/npm/src/lib/definitions.js
@@ -81,9 +81,9 @@ export async function getFlowVersionsForPackage(
 };
 
 export async function getPackages(): Promise<Array<VersionedName>> {
-  return (await fs.readdir(DEFINITIONS_DIR)).map(
-    dirName => dirNameToVersionedName(path.join(DEFINITIONS_DIR, dirName))
-  );
+  return (await fs.readdir(DEFINITIONS_DIR))
+    .filter(item => item != '.cli-metadata.json')
+    .map(item => dirNameToVersionedName(path.join(DEFINITIONS_DIR, item)));
 };
 
 export function versionToString(ver: Version): string {


### PR DESCRIPTION
[My previous (seemingly innocuous) commit](https://github.com/flowtype/flow-typed/commit/bb576bb2501514f6d3fce0386d6f125e8e448c46) added the `.cli-metadata.json` file in the /definitions directory
which broke `flow-typed validate-defs` and `flow-typed run-tests` (they didn't
expect to see a non-directory in there).

This fixes those commands (and their respective machinery) to just ignore this file
as a special-case.