### PR TITLE
pluralize

### DIFF
--- a/definitions/pluralize_v1.x.x/flow_>=v0.13.x/pluralize_v1.x.x.js
+++ b/definitions/pluralize_v1.x.x/flow_>=v0.13.x/pluralize_v1.x.x.js
@@ -1,0 +1,12 @@
+declare module 'pluralize' {
+  declare class Pluralize {
+    (word: string, count?: number, inclusive?: boolean): string;
+    plural(word: string): string;
+    singular(word: string): string;
+    addPluralRule(rule: string|RegExp, replacemant: string): void;
+    addSingularRule(rule: string|RegExp, replacemant: string): void;
+    addIrregularRule(single: string, plural: string): void;
+    addUncountableRule(ord: string|RegExp): void;
+  }
+  declare var exports: Pluralize;
+}


### PR DESCRIPTION
Should I use a class instead? Because I saw some definitions use classes. What is the difference when using a class?