### PR TITLE
add tests for libdefs that lack them

### DIFF
--- a/definitions/clamp-js_v0.7.x/test_clamp-js_v0.7.x.js
+++ b/definitions/clamp-js_v0.7.x/test_clamp-js_v0.7.x.js
@@ -1,0 +1,10 @@
+// @flow
+
+import clamp from "clamp-js";
+
+clamp(new HTMLInputElement());
+clamp(new HTMLInputElement(), {});
+clamp(new HTMLInputElement(), {useNativeClamp: true});
+
+// $ExpectError
+clamp(new HTMLInputElement(), {useNativeClamp: "nope!"});

--- a/definitions/classnames_v2.x.x/flow_>=v0.23.x/classnames_v2.x.x.js
+++ b/definitions/classnames_v2.x.x/flow_>=v0.23.x/classnames_v2.x.x.js
@@ -1,6 +1,5 @@
 declare module 'classnames' {
-  declare class Classnames {
-    (...classes: Array<string | { [class: string]: bool }>): string
-  }
-  declare var exports: Classnames;
+  declare function exports(
+    ...classes: Array<string | { [class: string]: bool }>
+  ): string;
 }

--- a/definitions/classnames_v2.x.x/test_classnames_v2.x.x.js
+++ b/definitions/classnames_v2.x.x/test_classnames_v2.x.x.js
@@ -1,0 +1,14 @@
+// @flow
+
+import classnames from "classnames";
+
+classnames();
+classnames('a');
+classnames('a', 'b');
+classnames({a: true});
+classnames({a: true}, {b: true});
+classnames('a', {b: true});
+classnames({a: true}, 'b');
+
+// $ExpectError
+classnames(42);

--- a/definitions/color_v0.7.x/flow_>=v0.23.x/color_v0.7.x.js
+++ b/definitions/color_v0.7.x/flow_>=v0.23.x/color_v0.7.x.js
@@ -1,28 +1,28 @@
-type npm$color$RGBObject = {
+type $npm$color$RGBObject = {
   r: number,
   g: number,
   b: number,
 };
 
-type npm$color$HSLObject = {
+type $npm$color$HSLObject = {
   h: number,
   s: number,
   l: number,
 };
 
-type npm$color$HSVObject = {
+type $npm$color$HSVObject = {
   h: number,
   s: number,
   v: number,
 };
 
-type npm$color$HWBObject = {
+type $npm$color$HWBObject = {
   h: number,
   w: number,
   b: number,
 };
 
-type npm$color$CMYKObject = {
+type $npm$color$CMYKObject = {
   c: number,
   m: number,
   y: number,
@@ -31,77 +31,102 @@ type npm$color$CMYKObject = {
 
 declare module 'color' {
   declare class Color {
-    static (value?: string|npm$color$RGBObject): Color;
-    rgb(): npm$color$RGBObject;
-    rgbArray(): Array<number>;
+    (value: $npm$color$RGBObject): Color;
+    (value: string): Color;
+    (): Color;
+
+    static (value: $npm$color$RGBObject): Color;
+    static (value: string): Color;
+    static (): Color;
+
     rgb(r: number, g: number, b: number): Color;
     rgb(rgb: Array<number>): Color;
-    hsl(): npm$color$HSLObject;
-    hslArray(): Array<number>;
+    rgb(): $npm$color$RGBObject;
+    rgbArray(): Array<number>;
+
     hsl(h: number, s: number, l: number): Color;
-    hsl(hsl: npm$color$HSLObject): Color;
-    hsv(): npm$color$HSVObject;
+    hsl(hsl: $npm$color$HSLObject): Color;
+    hsl(): $npm$color$HSLObject;
+    hslArray(): Array<number>;
+
     hsvArray(): Array<number>;
     hsv(h: number, s: number, v: number): Color;
-    hsv(hsv: npm$color$HSVObject): Color;
-    hwb(): npm$color$HWBObject;
-    hwbArray(): Array<number>;
+    hsv(hsv: $npm$color$HSVObject): Color;
+    hsv(): $npm$color$HSVObject;
+
     hwb(h: number, w: number, b: number): Color;
-    hwb(hwb: npm$color$HWBObject): Color;
-    cmyk(): npm$color$CMYKObject;
-    cmykArray(): Array<number>;
+    hwb(hwb: $npm$color$HWBObject): Color;
+    hwb(): $npm$color$HWBObject;
+    hwbArray(): Array<number>;
+
     cmyk(c: number, m: number, y: number, k: number): Color;
-    cmyk(cmyk: npm$color$CMYKObject): Color;
-    alpha(): number;
+    cmyk(cmyk: $npm$color$CMYKObject): Color;
+    cmyk(): $npm$color$CMYKObject;
+    cmykArray(): Array<number>;
+
     alpha(alpha: number): Color;
-    red(): number;
+    alpha(): number;
+
     red(red: number): Color;
-    green(): number;
+    red(): number;
+
     green(green: number): Color;
-    blue(): number;
+    green(): number;
+
     blue(blue: number): Color;
-    hue(): number;
+    blue(): number;
+
     hue(hue: number): Color;
-    saturation(): number;
+    hue(): number;
+
     saturation(saturation: number): Color;
-    saturationv(): number;
+    saturation(): number;
+
     saturationv(saturationv: number): Color;
-    lightness(): number;
+    saturationv(): number;
+
     lightness(lightness: number): Color;
-    whiteness(): number;
+    lightness(): number;
+
     whiteness(whiteness: number): Color;
-    blackness(): number;
+    whiteness(): number;
+
     blackness(blackness: number): Color;
-    cyan(): number;
+    blackness(): number;
+
     cyan(cyan: number): Color;
-    magenta(): number;
+    cyan(): number;
+
     magenta(magenta: number): Color;
-    yellow(): number;
+    magenta(): number;
+
     yellow(yellow: number): Color;
-    black(): number;
+    yellow(): number;
+
     black(black: number): Color;
-    hslString(): string;
+    black(): number;
+
+    clearer(value: number): Color;
+    clone(): Color;
+    contrast(color: Color): number;
+    dark(): bool;
+    darken(value: number): Color;
+    desaturate(value: number): Color;
+    grayscale(): Color;
     hexString(): string;
-    rgbString(): string;
-    percentString(): string;
     hslString(): string;
     hwbString(): string;
     keyword(): ?string;
-    luminosity(): number;
-    contrast(color: Color): number;
     light(): bool;
-    dark(): bool;
-    negate(): Color;
     lighten(value: number): Color;
-    darken(value: number): Color;
-    saturate(value: number): Color;
-    desaturate(value: number): Color;
-    grayscale(): Color;
-    clearer(value: number): Color;
-    opaquer(value: number): Color;
-    rotate(value: number): Color;
+    luminosity(): number;
     mix(color: Color, value?: number): Color;
-    clone(): Color;
+    negate(): Color;
+    opaquer(value: number): Color;
+    percentString(): string;
+    rgbString(): string;
+    rotate(value: number): Color;
+    saturate(value: number): Color;
   }
   declare var exports: typeof Color;
 }

--- a/definitions/color_v0.7.x/test_color_v0.7.x.js
+++ b/definitions/color_v0.7.x/test_color_v0.7.x.js
@@ -1,0 +1,21 @@
+// @flow
+
+import Color from "color";
+
+(new Color(): Color);
+new Color('rgb(0,0,0)');
+new Color({r: 0, g: 0, b: 0});
+new Color().rgb().r;
+(new Color().rgb(0, 0, 0): Color);
+
+// $ExpectError
+new Color().nope;
+
+(Color(): Color);
+Color('rgb(0,0,0)');
+Color({r: 0, g: 0, b: 0});
+Color().rgb().r;
+(Color().rgb(0, 0, 0): Color);
+
+// $ExpectError
+Color().nope;

--- a/definitions/dropzone_v4.x.x/flow_>=v0.23.x/dropzone_v4.x.x.js
+++ b/definitions/dropzone_v4.x.x/flow_>=v0.23.x/dropzone_v4.x.x.js
@@ -1,14 +1,14 @@
-type dropzone$FilesToString = (files: File|Array<File>) => string;
-type dropzone$DrawImageOptions = {
+type $npm$dropzone$FilesToString = (files: File|Array<File>) => string;
+type $npm$dropzone$DrawImageOptions = {
   srcX: number,
   srcY: number,
   srcWidth: number,
   srcHeight: number,
 }
 
-type dropzone$DropzoneOptions = {
-  url: string|dropzone$FilesToString,
-  method?: 'post'|'put'|dropzone$FilesToString,
+type $npm$dropzone$DropzoneOptions = {
+  url: string|$npm$dropzone$FilesToString,
+  method?: 'post'|'put'|$npm$dropzone$FilesToString,
   parallelUploads?: number,
   maxFilesize?: number,
   filesizeBase?: number,
@@ -23,7 +23,7 @@ type dropzone$DropzoneOptions = {
   thumbnailWidth?: number,
   thumbnailHeight?: number,
   maxFiles?: number,
-  resize?: (file: File) => dropzone$DrawImageOptions,
+  resize?: (file: File) => $npm$dropzone$DrawImageOptions,
   init?: () => mixed,
   acceptedFiles?: string,
   autoProcessQueue?: bool,
@@ -44,12 +44,14 @@ type dropzone$DropzoneOptions = {
 
 declare module 'dropzone' {
   declare class Dropzone {
-    static constructor(selector: string, options: dropzone$DropzoneOptions): Dropzone;
+    files: Array<File>;
+
+    static constructor(selector: string, options: $npm$dropzone$DropzoneOptions): Dropzone;
     static autoDiscover: bool;
     static confirm(question: string, accepted: () => mixed, rejected?: () => mixed): void;
+    destroy(): void;
     disable(): void;
     enable(): void;
-    files: Array<File>;
     getAcceptedFiles(): Array<File>;
     getQueuedFiles(): Array<File>;
     getRejectedFiles(): Array<File>;
@@ -59,7 +61,6 @@ declare module 'dropzone' {
     processQueue(): void;
     removeAllFiles(cancel?: bool): void;
     removeFile(file: File): void;
-    destroy(): void;
   }
   declare var exports: Class<Dropzone>;
 }

--- a/definitions/dropzone_v4.x.x/test_dropzone_v4.x.x.js
+++ b/definitions/dropzone_v4.x.x/test_dropzone_v4.x.x.js
@@ -1,0 +1,10 @@
+// @flow
+
+import Dropzone from "dropzone";
+
+(new Dropzone(): Dropzone);
+(new Dropzone().disable(): void);
+(new Dropzone().files: Array<File>);
+
+// $ExpectError
+(new Dropzone().files: number);

--- a/definitions/pluralize_v1.x.x/flow_>=v0.13.x/pluralize_v1.x.x.js
+++ b/definitions/pluralize_v1.x.x/flow_>=v0.13.x/pluralize_v1.x.x.js
@@ -1,12 +1,12 @@
 declare module 'pluralize' {
-  declare class Pluralize {
+  declare var exports: {
     (word: string, count?: number, inclusive?: boolean): string;
-    plural(word: string): string;
-    singular(word: string): string;
+
+    addIrregularRule(single: string, plural: string): void;
     addPluralRule(rule: string|RegExp, replacemant: string): void;
     addSingularRule(rule: string|RegExp, replacemant: string): void;
-    addIrregularRule(single: string, plural: string): void;
     addUncountableRule(ord: string|RegExp): void;
+    plural(word: string): string;
+    singular(word: string): string;
   }
-  declare var exports: Pluralize;
 }

--- a/definitions/pluralize_v1.x.x/test_pluralize_v1.x.x.js
+++ b/definitions/pluralize_v1.x.x/test_pluralize_v1.x.x.js
@@ -1,0 +1,13 @@
+// @flow
+
+import pluralize from "pluralize";
+
+(pluralize('word'): string);
+pluralize('word', 0);
+pluralize('word', 0, true);
+pluralize.addIrregularRule('word', 'wordz');
+
+// $ExpectError
+pluralize();
+// $ExpectError
+pluralize.nope;

--- a/npm/src/lib/libDef.js
+++ b/npm/src/lib/libDef.js
@@ -190,6 +190,10 @@ export async function getLocalLibDefFlowVersions(
       const itemPath = path.join(libDefPath, localDirItem);
       const itemContext = itemPath.substr(LOCAL_DEFINITIONS_DIR.length + 1);
       if (fs.statSync(itemPath).isFile()) {
+        if (path.extname(itemPath) === '.swp') {
+          return;
+        }
+
         if (_validateTestFile(itemPath, itemContext, validationErrors)) {
           libDefSharedTests.push(itemPath);
         }
@@ -256,6 +260,10 @@ export async function getLocalLibDefFlowVersions(
       const flowVersionDirItems = await fs.readdir(itemPath);
       await P.all(flowVersionDirItems.map(async (flowVerDirItem) => {
         if (flowVerDirItem === libDefFileName) {
+          return;
+        }
+
+        if (path.extname(flowVerDirItem) === '.swp') {
           return;
         }
 


### PR DESCRIPTION
Per https://github.com/flowtype/flow-typed/issues/70, we'll require at least 1 test file with all libdef contributions.

This PR adds tests for all libdefs we have currently that lack them, and up next (later today or tomorrow) I'm going to make `validate-defs` error if a libdef is missing tests to help ensure we stay clean in this sense going forward.

(cc @marudor @splodingsocks )