### PR TITLE
Make `validate-defs` require that at least one test applies to every definition file

### DIFF
--- a/npm/src/commands/validateDefs.js
+++ b/npm/src/commands/validateDefs.js
@@ -17,6 +17,16 @@ export async function run(args: {}): Promise<number> {
     localLibDefs,
     validationErrors
   );
+
+  localLibDefFlowVersions.forEach(libDefFlowVer => {
+    const libDef = libDefFlowVer.libDef;
+    if (libDefFlowVer.testFiles.length === 0) {
+      const errors = validationErrors.get(libDef.pkgNameVersionStr) || [];
+      errors.push(`Every definition file must have at least one test file!`);
+      validationErrors.set(libDef.pkgNameVersionStr, errors);
+    }
+  });
+
   console.log(" ");
 
   validationErrors.forEach((errors, pkgNameVersion) => {


### PR DESCRIPTION
Per https://github.com/flowtype/flow-typed/issues/70, we want to be sure that all libdefs are tested.
By adding this requirement to `validate-defs`, we ensure that Travis checks this requirement for us