### PR TITLE
Add highlight.js

### DIFF
--- a/definitions/highlight.js_v8.x.x/flow_>=v0.13.x/highlight.js_v8.x.x.js
+++ b/definitions/highlight.js_v8.x.x/flow_>=v0.13.x/highlight.js_v8.x.x.js
@@ -1,0 +1,51 @@
+declare class HighlightJs$Continuation {}
+
+type HighlightJs$HighlightResult = {
+  language: string,
+  relevance: number,
+  value: string,
+  top?: HighlightJs$Continuation,
+  second_best?: HighlightJs$HighlightResult
+};
+
+type HighlightJs$LanguageContains = {
+  begin?: string|RegExp,
+  beginKeywords?: string|RegExp,
+  className?: string,
+  contains?: Array<HighlightJs$LanguageContains>,
+  end?: string|RegExp,
+  keywords?: string,
+  relevance?: number
+};
+
+type HighlightJs$Language = {
+  aliases?: Array<string>,
+  keywords: {
+    keyword: string,
+    literal: string,
+    built_in: string,
+  },
+  contains: Array<HighlightJs$LanguageContains>
+};
+
+declare module 'highlight.js' {
+  declare class HighlightJs {
+    highlight(
+      name: string,
+      value: string,
+      ignore_illegals?: boolean,
+      continuation?: HighlightJs$Continuation
+    ): HighlightJs$HighlightResult;
+    highlightAuto(value: string, languageSubset?: Array<string>): HighlightJs$HighlightResult;
+    fixMarkup(value: string): string;
+    highlightBlock(block: Node): void;
+    configure(options: { tabReplace?: string, useBR?: boolean, classPrefix?: string, languages?: Array<string> }): void;
+    initHighlighting(): void;
+    initHighlightingOnLoad(): void;
+    registerLanguage(name: string, language: (hljs: HighlightJs) => HighlightJs$Language): void;
+    listLanguages(): Array<string>;
+    getLanguage(name: string): ? HighlightJs$Language;
+  }
+
+  declare var exports: HighlightJs
+}

--- a/definitions/highlight.js_v8.x.x/test_highlight.js-v8.js
+++ b/definitions/highlight.js_v8.x.x/test_highlight.js-v8.js
@@ -1,0 +1,35 @@
+/* @flow */
+
+import hljs from 'highlight.js'
+
+hljs.highlight('lang', 'code');
+var prop = hljs.highlight('lang', 'code', true);
+hljs.highlight('lang', 'code', false, prop.top);
+// $ExpectError string. This type is incompatible with Continuation
+hljs.highlight('lang', 'code', false, 'string');
+
+prop = hljs.highlightAuto('code', ['js']);
+hljs.highlightAuto('code');
+
+var result: string = hljs.fixMarkup('code');
+// $ExpectError number. This type is incompatible with string
+var result2: number = hljs.fixMarkup('code');
+
+// $ExpectError number. This type is incompatible with Object
+hljs.configure(1);
+
+hljs.initHighlighting();
+hljs.initHighlightingOnLoad();
+
+hljs.registerLanguage('name', (hljs) => {
+  // $ExpectError number. This type is incompatible with Object
+  hljs.calls();
+
+  return { aliases: [], keywords: { keyword: '', literal: '', built_in: '' }, contains: [] };
+});
+
+var langs: Array<string> = hljs.listLanguages();
+
+hljs.getLanguage('name');
+// $ExpectError number. This type is incompatible with string
+hljs.getLanguage(1);


### PR DESCRIPTION
This adds highlight.js with tests.

the only thing which I'm not sure is the `HighlightJs$Continuation`, what I wanted to achieve is that whatever is returned in `HighlightResult.top` is valid as `continuation` argument to `highlight()`, and nothing else. The object that is returned in `HighlightResult.top` is an internal token to be passed to highlight(), but is not described in their API docs.