### PR TITLE
draft for any check

### DIFF
--- a/npm/.flowconfig
+++ b/npm/.flowconfig
@@ -11,4 +11,4 @@ flow-typed
 experimental.const_params=true
 
 [version]
-0.22.1
+>=0.22.1

--- a/npm/src/cli.js
+++ b/npm/src/cli.js
@@ -7,6 +7,7 @@ import * as yargs from "yargs";
 import * as RunTests from "./commands/runTests.js";
 import * as ValidateDefs from "./commands/validateDefs.js";
 import * as Search from "./commands/search.js";
+import * as CheckForAny from "./commands/checkForAny.js";
 
 type CommandModule = {
   name: string,
@@ -17,25 +18,27 @@ type CommandModule = {
 const commands: Array<CommandModule> = [
   RunTests,
   ValidateDefs,
-  Search
+  Search,
+  CheckForAny,
 ];
 
 commands
   .reduce((cmdYargs, cmd) => cmdYargs.command(
-    cmd.name,
-    cmd.description,
-    typeof cmd.setup === 'function' ? cmd.setup : yargs => yargs,
-    args => cmd.run(args, yargs).catch(err => {
-      if (err.stack) {
-        console.log('UNCAUGHT ERROR: %s', err.stack);
-      } else if (typeof err === 'object' && err !== null) {
-        console.log("UNCAUGHT ERROR: %s", JSON.stringify(err, null, 2));
-      } else {
-        console.log("UNCAUGHT ERROR:", err);
-      }
-      process.exit(1);
-    }).then((code) => process.exit(code))
-  ), yargs)
+      cmd.name,
+      cmd.description,
+      typeof cmd.setup === 'function' ? cmd.setup : yargs => yargs,
+      args => cmd.run(args, yargs).catch(err => {
+        if (err.stack) {
+          console.log('UNCAUGHT ERROR: %s', err.stack);
+        } else if (typeof err === 'object' && err !== null) {
+          console.log("UNCAUGHT ERROR: %s", JSON.stringify(err, null, 2));
+        } else {
+          console.log("UNCAUGHT ERROR:", err);
+        }
+        process.exit(1);
+      }).then((code) => process.exit(code))
+    ), (yargs: any)
+  )
   .demand(1)
   .strict()
   .argv;

--- a/npm/src/commands/checkForAny.js
+++ b/npm/src/commands/checkForAny.js
@@ -1,0 +1,128 @@
+import {getLocalLibDefs, getLocalLibDefFlowVersions} from "../lib/libDef.js";
+import {recursiveRmdir, copyFile} from '../lib/fileUtils'
+import {getOrderedFlowBinVersions} from '../lib/flowVersions.js';
+import {child_process, path, fs} from "../lib/node.js";
+import {versionToString} from "../lib/semver.js";
+
+const PKG_ROOT_DIR = path.join(__dirname, "..", "..");
+const BIN_DIR = path.join(PKG_ROOT_DIR, "flow-bins");
+const TEST_DIR = path.join(PKG_ROOT_DIR, "test-dir");
+
+export const name = "checkForAny";
+export const description =
+"Checks if the libdef contains the any Type";
+
+export async function run() {
+  try {
+    // const flowVersions = await getOrderedFlowBinVersions();
+    // const newestFlowVersion = flowVersions[flowVersions.length - 1];
+    const newestFlowVersion = 'v0.24.0';
+    const localLibDefs = await getLocalLibDefs();
+    const localLibDefFlowVersions = await getLocalLibDefFlowVersions(localLibDefs);
+
+    while (localLibDefFlowVersions.length > 0) {
+      var testBatch = localLibDefFlowVersions.slice(0, Math.min(localLibDefFlowVersions.length, 5))
+      .map(t => localLibDefFlowVersions.pop());
+
+      try {
+        await fs.mkdir(TEST_DIR);
+      } catch (e) {
+
+      }
+
+      const allTypes = await Promise.all(testBatch.map(t => check(t, newestFlowVersion)));
+      const libDefsWithAny = [];
+      allTypes.forEach(typeResult => {
+        const types = JSON.parse(typeResult.stdOut);
+        types.forEach(type => {
+          if (type.type.includes('any') && (!type.reasons.length || type.reasons[0].desc !== `module \`${typeResult.name}\``)) {
+            libDefsWithAny.push({
+              type,
+              name: typeResult.name,
+            });
+          }
+        });
+      });
+      if (libDefsWithAny.length > 0) {
+        libDefsWithAny.forEach(error => {
+          console.error(`${error.name} contains any as type`);
+          console.error(`${error.type.line}:${error.type.start}-${error.type.endline}:${error.type.end}   ${error.type.type}`);
+        })
+      }
+    }
+  } finally {
+    if (await fs.exists(TEST_DIR)) {
+      await recursiveRmdir(TEST_DIR);
+    }
+  }
+}
+
+async function check(t, newestFlowVersion) {
+  const id = `${t.libDef.pkgName}_${t.libDef.pkgVersionStr}--flow_` +
+  `${versionToString(t.flowVersion)}`;
+  const testDirName = id
+  .replace(/>/g, "gt")
+  .replace(/</g, "lt")
+  .replace(/=/g, "eq");
+  const testDirPath = path.join(TEST_DIR, testDirName);
+  return new Promise(async res => {
+    try {
+      await fs.mkdir(testDirPath);
+
+      // Copy files into the test dir
+      const destLibDefPath = path.join(
+        testDirPath,
+        path.basename(t.libDefPath)
+      );
+      await Promise.all(
+        [
+          Promise.all(t.testFiles.map(async (filePath, idx) => {
+            const destBasename = idx + "-" + path.basename(filePath);
+            await copyFile(filePath, path.join(testDirPath, destBasename));
+          })),
+          copyFile(t.libDefPath, destLibDefPath),
+        ]
+      );
+
+      const destFlowConfigPath = path.join(testDirPath, ".flowconfig");
+      const flowConfigData = [
+        "[libs]",
+        path.basename(t.libDefPath),
+        "",
+        "[options]",
+        "suppress_comment=\\\\(.\\\\|\\n\\\\)*\\\\$ExpectError",
+        "",
+
+        // Be sure to ignore stuff in the node_modules directory of the flow-typed
+        // CLI repository!
+        "[ignore]",
+        path.join(testDirPath, "..", "..", "node_modules"),
+      ].join("\n");
+      await fs.writeFile(destFlowConfigPath, flowConfigData);
+
+      const child = child_process.exec([
+        path.join(BIN_DIR, `flow-${newestFlowVersion}`),
+        "dump-types",
+        "--json",
+        `"${destLibDefPath}"`
+      ].join(" "), {
+        cwd: PKG_ROOT_DIR,
+      });
+      let stdOut = '';
+      child.stdout.on("data", data => stdOut += data);
+      child.on("error", execError => {
+        res({errCode: null, execError});
+      });
+
+      child.on("close", errCode => {
+        res({
+          name: t.libDef.pkgName,
+          stdOut,
+        });
+      });
+    } catch (e) {
+      console.log(e);
+      res();
+    }
+  });
+}

--- a/npm/src/commands/runTests.js
+++ b/npm/src/commands/runTests.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {child_process, fs, os, path} from "../lib/node.js";
+import {child_process, fs, path} from "../lib/node.js";
 import {copyFile, recursiveRmdir} from "../lib/fileUtils.js";
 import {gitHubClient} from "../lib/github.js";
 import {
@@ -8,6 +8,7 @@ import {
   getLocalLibDefFlowVersions,
 } from "../lib/libDef.js";
 import {versionToString} from "../lib/semver.js";
+import {getOrderedFlowBinVersions} from '../lib/flowVersions.js';
 
 import GitHub from "github";
 import request from "request";
@@ -15,17 +16,7 @@ import * as semver from "semver";
 
 import type {Version} from "../lib/semver.js";
 
-// Used to decide which binary to fetch for each version of Flow
-const BIN_PLATFORM = (_ => {
-  switch (os.type()) {
-    case "Linux": return "linux64";
-    case "Darwin": return "osx";
 
-    default: throw new Error(
-      "Unsupported os.type()! " + os.type()
-    );
-  }
-})();
 const PKG_ROOT_DIR = path.join(__dirname, "..", "..");
 const TEST_DIR = path.join(PKG_ROOT_DIR, "test-dir");
 const BIN_DIR = path.join(PKG_ROOT_DIR, "flow-bins");
@@ -65,126 +56,7 @@ async function getTestGroups(): Promise<Array<TestGroup>> {
  * zip for each version, extracts the zip, and moves the binary to
  * TEST_BIN/flow-vXXX for use later when running tests.
  */
-let _flowBinVersionPromise = null;
-async function getOrderedFlowBinVersions(): Promise<Array<string>> {
-  if (_flowBinVersionPromise === null) {
-    _flowBinVersionPromise = (async function() {
-      console.log("Fetching all Flow binaries...");
-      const FLOW_BIN_VERSION_ORDER = [];
-      const GH_CLIENT = gitHubClient();
-      const QUERY_PAGE_SIZE = 100;
-      const OS_ARCH_FILTER_RE = new RegExp(BIN_PLATFORM);
 
-      let binURLs = new Map();
-      let releases = new Map();
-      let apiPayload = null;
-      let page = 0;
-      while (apiPayload === null || apiPayload.length === QUERY_PAGE_SIZE) {
-        apiPayload = await new Promise((res, rej) => {
-          GH_CLIENT.releases.listReleases({
-            owner: "facebook",
-            repo: "flow",
-            page: page++,
-            per_page: QUERY_PAGE_SIZE,
-          }, (err, result) => { if (err) { rej(err); } else { res(result); } });
-        });
-
-        apiPayload.forEach(rel => {
-          // We only test against versions since 0.15.0 because it has proper
-          // [ignore] fixes (which are necessary to run tests)
-          if (semver.lt(rel.tag_name, "0.15.0")) {
-            return;
-          }
-
-          // Find the binary zip in the list of assets
-          const binZip = rel.assets.filter(({name}) => {
-            return OS_ARCH_FILTER_RE.test(name) && !/-latest.zip$/.test(name);
-          }).map(asset => asset.browser_download_url);
-
-          if (binZip.length !== 1) {
-            throw new Error(
-              "Unexpected number of " + BIN_PLATFORM + " assets for flow-" +
-              rel.tag_name + "! " + JSON.stringify(binZip)
-            );
-          } else {
-            const version =
-              rel.tag_name[0] === "v"
-              ? rel.tag_name
-              : "v" + rel.tag_name;
-
-            FLOW_BIN_VERSION_ORDER.push(version);
-            binURLs.set(version, binZip[0]);
-          }
-        });
-      }
-
-      FLOW_BIN_VERSION_ORDER.sort((a, b) => {
-        return semver.lt(a, b) ? -1 : 1;
-      });
-
-      if (!await fs.exists(BIN_DIR)) {
-        await fs.mkdir(BIN_DIR);
-      }
-
-      await P.all(Array.from(binURLs).map(async ([version, binURL]) => {
-        const zipPath = path.join(BIN_DIR, "flow-" + version + ".zip");
-
-        if (await fs.exists(path.join(BIN_DIR, "flow-" + version))) {
-          return;
-        }
-
-        // Download the zip file
-        await new Promise((res, rej) => {
-          console.log("  Fetching flow-%s...", version)
-          const fileRequest = request({
-            url: binURL,
-            headers: {
-              "User-Agent": "flow-typed Test Runner " +
-                            "(github.com/flowtype/flow-typed)"
-            }
-          }).on("error", err => rej(err));;
-
-          fileRequest.pipe(fs.createWriteStream(zipPath).on("close", _ => {
-            console.log("    flow-%s finished downloading.", version);
-            res();
-          }));
-        });
-
-        // Extract the flow binary
-        const flowBinDirPath = path.join(BIN_DIR, "TMP-flow-" + version);
-        await fs.mkdir(flowBinDirPath);
-        console.log("  Extracting flow-%s...", version);
-        await new Promise((res, rej) => {
-          const child = child_process.exec(
-            "unzip " + zipPath + " flow/flow -d " + flowBinDirPath
-          );
-          let stdErrOut = "";
-          child.stdout.on("data", data => stdErrOut += data);
-          child.stderr.on("data", data => stdErrOut += data);
-          child.on("error", err => rej(err));
-          child.on("close", code => {
-            if (code === 0) { res(); } else { rej(stdErrOut); }
-          });
-        });
-        await fs.rename(
-          path.join(flowBinDirPath, "flow", "flow"),
-          path.join(BIN_DIR, "flow-" + version)
-        );
-        console.log("  Removing flow-%s artifacts...", version);
-        await P.all([
-          recursiveRmdir(flowBinDirPath),
-          fs.unlink(zipPath)
-        ]);
-        console.log("    flow-%s complete!", version);
-      }));
-
-      console.log("Finished fetching Flow binaries.\n");
-
-      return FLOW_BIN_VERSION_ORDER;
-    })();
-  }
-  return _flowBinVersionPromise;
-}
 
 /**
  * Given a TestGroup structure determine all versions of Flow that match the

--- a/npm/src/lib/flowVersions.js
+++ b/npm/src/lib/flowVersions.js
@@ -1,0 +1,143 @@
+// @flow
+import {gitHubClient} from "./github.js";
+import {os, fs, path, child_process} from "./node.js";
+import {recursiveRmdir} from './fileUtils';
+import * as semver from "semver";
+import request from "request";
+
+const PKG_ROOT_DIR = path.join(__dirname, "..", "..");
+const BIN_DIR = path.join(PKG_ROOT_DIR, "flow-bins");
+const P = Promise;
+
+// Used to decide which binary to fetch for each version of Flow
+const BIN_PLATFORM = (_ => {
+  switch (os.type()) {
+    case "Linux": return "linux64";
+    case "Darwin": return "osx";
+
+    default: throw new Error(
+      "Unsupported os.type()! " + os.type()
+    );
+  }
+})();
+
+let _flowBinVersionPromise = null;
+export async function getOrderedFlowBinVersions(): Promise<Array<string>> {
+  if (_flowBinVersionPromise === null) {
+    _flowBinVersionPromise = (async function() {
+      console.log("Fetching all Flow binaries...");
+      const FLOW_BIN_VERSION_ORDER = [];
+      const GH_CLIENT = gitHubClient();
+      const QUERY_PAGE_SIZE = 100;
+      const OS_ARCH_FILTER_RE = new RegExp(BIN_PLATFORM);
+
+      let binURLs = new Map();
+      let releases = new Map();
+      let apiPayload = null;
+      let page = 0;
+      while (apiPayload === null || apiPayload.length === QUERY_PAGE_SIZE) {
+        apiPayload = await new Promise((res, rej) => {
+          GH_CLIENT.releases.listReleases({
+            owner: "facebook",
+            repo: "flow",
+            page: page++,
+            per_page: QUERY_PAGE_SIZE,
+          }, (err, result) => { if (err) { rej(err); } else { res(result); } });
+        });
+
+        apiPayload.forEach(rel => {
+          // We only test against versions since 0.15.0 because it has proper
+          // [ignore] fixes (which are necessary to run tests)
+          if (semver.lt(rel.tag_name, "0.15.0")) {
+            return;
+          }
+
+          // Find the binary zip in the list of assets
+          const binZip = rel.assets.filter(({name}) => {
+            return OS_ARCH_FILTER_RE.test(name) && !/-latest.zip$/.test(name);
+          }).map(asset => asset.browser_download_url);
+
+          if (binZip.length !== 1) {
+            throw new Error(
+              "Unexpected number of " + BIN_PLATFORM + " assets for flow-" +
+              rel.tag_name + "! " + JSON.stringify(binZip)
+            );
+          } else {
+            const version =
+              rel.tag_name[0] === "v"
+              ? rel.tag_name
+              : "v" + rel.tag_name;
+
+            FLOW_BIN_VERSION_ORDER.push(version);
+            binURLs.set(version, binZip[0]);
+          }
+        });
+      }
+
+      FLOW_BIN_VERSION_ORDER.sort((a, b) => {
+        return semver.lt(a, b) ? -1 : 1;
+      });
+
+      if (!await fs.exists(BIN_DIR)) {
+        await fs.mkdir(BIN_DIR);
+      }
+
+      await P.all(Array.from(binURLs).map(async ([version, binURL]) => {
+        const zipPath = path.join(BIN_DIR, "flow-" + version + ".zip");
+
+        if (await fs.exists(path.join(BIN_DIR, "flow-" + version))) {
+          return;
+        }
+
+        // Download the zip file
+        await new Promise((res, rej) => {
+          console.log("  Fetching flow-%s...", version)
+          const fileRequest = request({
+            url: binURL,
+            headers: {
+              "User-Agent": "flow-typed Test Runner " +
+                            "(github.com/flowtype/flow-typed)"
+            }
+          }).on("error", err => rej(err));;
+
+          fileRequest.pipe(fs.createWriteStream(zipPath).on("close", _ => {
+            console.log("    flow-%s finished downloading.", version);
+            res();
+          }));
+        });
+
+        // Extract the flow binary
+        const flowBinDirPath = path.join(BIN_DIR, "TMP-flow-" + version);
+        await fs.mkdir(flowBinDirPath);
+        console.log("  Extracting flow-%s...", version);
+        await new Promise((res, rej) => {
+          const child = child_process.exec(
+            "unzip " + zipPath + " flow/flow -d " + flowBinDirPath
+          );
+          let stdErrOut = "";
+          child.stdout.on("data", data => stdErrOut += data);
+          child.stderr.on("data", data => stdErrOut += data);
+          child.on("error", err => rej(err));
+          child.on("close", code => {
+            if (code === 0) { res(); } else { rej(stdErrOut); }
+          });
+        });
+        await fs.rename(
+          path.join(flowBinDirPath, "flow", "flow"),
+          path.join(BIN_DIR, "flow-" + version)
+        );
+        console.log("  Removing flow-%s artifacts...", version);
+        await P.all([
+          recursiveRmdir(flowBinDirPath),
+          fs.unlink(zipPath)
+        ]);
+        console.log("    flow-%s complete!", version);
+      }));
+
+      console.log("Finished fetching Flow binaries.\n");
+
+      return FLOW_BIN_VERSION_ORDER;
+    })();
+  }
+  return _flowBinVersionPromise;
+}


### PR DESCRIPTION
To address https://github.com/flowtype/flow-typed/issues/49
very basic check. It uses flow dump-types to check all types and searches for the "any" string.
Probably error prune. But the dump-type command does not dump each type. Arrow functions are one type, even with paramter.
So a arrow function with any type would not get catched if I do an exact match for any.
Anyone got an idea how to get better accuracy?