### PR TITLE
`install` comand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,5 @@ node_modules
 
 # CLI dist directory
 npm/dist/*
-npm/test-dir/*
-npm/flow-bins/*
+npm/.test-dir/*
+npm/.flow-bins-cache/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ addons:
 script: ./runtests.sh
 cache:
   directories:
-  - npm/flow-bins
+  - npm/.flow-bins-cache

--- a/definitions/yargs_v4.x.x/flow_>=v0.23.x/yargs_v4.x.x.js
+++ b/definitions/yargs_v4.x.x/flow_>=v0.23.x/yargs_v4.x.x.js
@@ -83,7 +83,7 @@ declare module 'yargs' {
 
     // Alias of require()!
     demand(key: string, msg: string | boolean): this;
-    demand(count: number, max?: number, msg: string | boolean): this;
+    demand(count: number, max?: number, msg?: string | boolean): this;
 
     describe(key: string, desc: string): this;
     describe(describeObject: { [key: string]: string }): this;
@@ -134,7 +134,7 @@ declare module 'yargs' {
 
     // Alias of demand()!
     require(key: string, msg: string | boolean): this;
-    require(count: number, max?: number, msg: string | boolean): this;
+    require(count: number, max?: number, msg?: string | boolean): this;
 
     requiresArg(key: string | Array<string>): this;
 

--- a/npm/.babelrc
+++ b/npm/.babelrc
@@ -3,7 +3,8 @@
     "transform-flow-strip-types",
     "transform-regenerator",
     "syntax-async-functions",
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "syntax-trailing-function-commas"
   ],
   "presets": [
     "es2015",

--- a/npm/.eslintignore
+++ b/npm/.eslintignore
@@ -1,0 +1,2 @@
+dist/
+flow-typed/

--- a/npm/.eslintrc
+++ b/npm/.eslintrc
@@ -1,0 +1,21 @@
+{
+  "parser": "babel-eslint",
+  "env": { 
+    "es6": true
+  },
+  "plugins": [
+    "flow-vars"
+  ],
+  "globals": {
+  },
+  "rules": {
+    "flow-vars/define-flow-type": 1,
+    "flow-vars/use-flow-type": 1,
+    "eqeqeq": [2, "smart"],
+    "semi": 2,
+    "no-unused-vars": [1, {
+      "varsIgnorePattern": "^_.?.?$",
+      "argsIgnorePattern": "^_.?.?$",
+    }],
+  }
+}

--- a/npm/.flowconfig
+++ b/npm/.flowconfig
@@ -4,11 +4,11 @@ flow-typed
 [ignore]
 .*/node_modules/json5/.*
 .*/node_modules/y18n/test/locales/bad-locale\.json
-.*/test-dir/.*
-.*/flow-bins/.*
+<PROJECT_ROOT>/.test-dir/.*
+<PROJECT_ROOT>/.flow-bins-cache/.*
 
 [options]
 experimental.const_params=true
 
 [version]
-0.22.1
+0.24.1

--- a/npm/.npmignore
+++ b/npm/.npmignore
@@ -1,4 +1,4 @@
 ./src
-./flow-bins
-./test-dir
+./.flow-bins-cache
+./.test-dir
 __tests__/.*

--- a/npm/flow-typed/yargs_v4.x.x.js
+++ b/npm/flow-typed/yargs_v4.x.x.js
@@ -1,1 +1,168 @@
-../../definitions/yargs_v4.x.x/flow_>=v0.23.x/yargs_v4.x.x.js
+declare module 'yargs' {
+  declare type Argv = {_: Array<string>, [key: string]: mixed};
+
+  declare type Options = $Shape<{
+    alias: string,
+    array: boolean,
+    choices: Array<any>,
+    config: boolean,
+    configParser: (configPath: string) => {[key: string]: mixed},
+    count: boolean,
+    default: boolean,
+    defaultDescription: string,
+    demand: boolean,
+    desc: string,
+    describe: string,
+    description: string,
+    global: boolean,
+    group: string,
+    nargs: number,
+    normalize: boolean,
+    number: boolean,
+    require: boolean,
+    required: boolean,
+    requiresArg: boolean,
+    string: boolean,
+    type: 'array' | 'boolean' | 'count' | 'number' | 'string',
+  }>;
+
+  declare type DescParseFn = (configPath: string) => Object;
+
+  declare type ModuleObject = {
+    command: string,
+    describe: string,
+    builder: {[key: string]: Options} | (yargsInstance: Yargs) => void,
+    handler: (argv: Argv) => void,
+  };
+
+  declare class Yargs {
+    alias(toBeAliased: string, alias: string): this;
+    argv: Argv;
+    array(key: string|Array<string>): this;
+    boolean(paramter: string|Array<string>): this;
+    check(fn: (argv: Argv, options: Array<string>) => ?bool): this;
+    choices(key: string, allowed: Array<string>): this;
+
+    command(
+      cmd: string,
+      desc: string|false,
+      builder?: {[key: string]: Options} | (yargsInstance: Yargs) => void,
+      handler?: Function
+    ): this;
+
+    command(
+      cmd: string,
+      desc: string|false,
+      module: ModuleObject,
+    ): this;
+
+    command(
+      module: ModuleObject
+    ): this;
+
+    completion(
+      cmd: string,
+      description?: string,
+      fn?: (
+        current: string,
+        argv: Object,
+        done: (competion: Array<string>) => void
+      ) => ?(Array<string>|Promise<Array<string>>)
+    ): this;
+
+    config(
+      key: string,
+      description?: string|DescParseFn,
+      parseFn?: DescParseFn
+    ): this;
+
+    count(name: string): this;
+
+    default(defaultObject: { [paramter: string]: any }): this;
+    default(parameter: string, value: any): this;
+
+    // Alias of require()!
+    demand(key: string, msg: string | boolean): this;
+    demand(count: number, max?: number, msg?: string | boolean): this;
+
+    describe(key: string, desc: string): this;
+    describe(describeObject: { [key: string]: string }): this;
+
+    detectLocale(shouldI: bool): this;
+
+    env(prefix?: string): this;
+
+    epilog(epi: string): this;
+    epilogue(epi: string): this;
+
+    example(cmd: string, desc: string): this;
+
+    exitProcess(enable: bool): this;
+
+    fail(fn: (failureMessage: string) => mixed): this;
+
+    global(globals: string | Array<string>): this;
+
+    group(key: string | Array<string>, groupName: string): this;
+
+    help(option?: string, desc?: string): this;
+
+    implies(keyA: string, keyB: string): this;
+    implies(keys: { [key: string]: string }): this;
+
+    locale(
+      locale: 'de' | 'en' | 'es' | 'fr' | 'id' | 'it' | 'ja' | 'ko' | 'nb' |
+              'pirate' | 'pl' | 'pt' | 'pt_BR' | 'tr' | 'zh'
+    ): this;
+    locale(): string;
+
+    nargs(key: string, count: number): this;
+
+    normalize(key: string): this;
+
+    number(key: string | Array<string>): this;
+
+    option(key: string, options: Options): this;
+    option(optionMap: { [key: string]: Options}): this;
+
+    options(key: string, options: Options): this;
+    options(optionMap: { [key: string]: Options}): this;
+
+    parse(args: string | Array<string>): Argv;
+
+    pkgConf(key: string, cwd?: string): this;
+
+    // Alias of demand()!
+    require(key: string, msg: string | boolean): this;
+    require(count: number, max?: number, msg?: string | boolean): this;
+
+    requiresArg(key: string | Array<string>): this;
+
+    reset(): this;
+
+    showCompletionScript(): this;
+
+    showHelp(consoleLevel: 'error' | 'log' | 'warn'): this;
+
+    showHelpOnFail(enable: bool, message?: string): this;
+
+    strict(): this;
+
+    string(key: string | Array<string>): this;
+
+    updateLocale(obj: {[key: string]: string}): this;
+    updateStrings(obj: {[key: string]: string}): this;
+
+    usage(message: string, opts?: {[key: string]: Options}): this;
+
+    version(
+      option?: string | () => string,
+      description?: string | Function,
+      version?: string | Function
+    ): this;
+
+    wrap(columns: number | null): this;
+  }
+
+  declare var exports: Yargs;
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -7,10 +7,11 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "mkdir -p dist; babel ./src --out-dir=./dist",
-    "flow": "flow; [[ $?=0||$?=2 ]]",
+    "flow": "flow; test $? -eq 0 -o $? -eq 2",
+    "lint": "eslint .",
     "prepublish": "mkdir -p dist; babel ./src --out-dir=./dist",
-    "test": "npm run clean; npm run build; jest",
-    "test-quick": "jest",
+    "test": "npm run clean; npm run build; npm run test-quick",
+    "test-quick": "npm run lint && jest",
     "watch": "mkdir -p dist; babel --watch=./src --out-dir=./dist"
   },
   "repository": {
@@ -34,18 +35,23 @@
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",
+    "babel-eslint": "^6.0.4",
     "babel-jest": "11.0.0",
     "babel-plugin-syntax-async-functions": "^6.5.0",
+    "babel-plugin-syntax-trailing-function-commas": "^6.8.0",
     "babel-plugin-transform-flow-strip-types": "^6.7.0",
     "babel-plugin-transform-object-rest-spread": "6.6.5",
     "babel-plugin-transform-regenerator": "^6.6.5",
     "babel-polyfill": "^6.6.1",
     "babel-preset-es2015": "^6.6.0",
-    "flow-bin": "^0.22.1",
+    "eslint": "^2.9.0",
+    "eslint-plugin-flow-vars": "^0.4.0",
+    "flow-bin": "^0.24",
     "jest-cli": "11.0.0"
   },
   "dependencies": {
     "github": "^0.2.4",
+    "lodash": "^4.11.2",
     "request": "^2.69.0",
     "rx-lite": "4.0.8",
     "semver": "^5.1.0",

--- a/npm/src/cli.js
+++ b/npm/src/cli.js
@@ -4,9 +4,10 @@ import "babel-polyfill";
 
 import * as yargs from "yargs";
 
+import * as Install from "./commands/install.js";
 import * as RunTests from "./commands/runTests.js";
-import * as ValidateDefs from "./commands/validateDefs.js";
 import * as Search from "./commands/search.js";
+import * as ValidateDefs from "./commands/validateDefs.js";
 
 type CommandModule = {
   name: string,
@@ -15,9 +16,10 @@ type CommandModule = {
   run: (argv: Object) => Promise<number>,
 };
 const commands: Array<CommandModule> = [
+  Install,
   RunTests,
+  Search,
   ValidateDefs,
-  Search
 ];
 
 commands

--- a/npm/src/commands/__tests__/search-test.js
+++ b/npm/src/commands/__tests__/search-test.js
@@ -20,9 +20,9 @@ describe('search command', () => {
           flowVersionStr: '>=v0.18.x',
           flowVersion: { range: '>=', major: 0, minor: 18, patch: 'x' }
         }
-      ]
+      ];
 
-      const formatted = _formatDefTable(fixture)
+      const formatted = _formatDefTable(fixture);
       expect(formatted).toEqual(
         "\nFound definitions:" + "\n" +
         "╔══════╤═════════════════╤══════════════╗" + "\n" +
@@ -32,13 +32,13 @@ describe('search command', () => {
         "╟──────┼─────────────────┼──────────────╢" + "\n" +
         "║ mori │ v0.3.x          │ >=v0.18.x    ║" + "\n" +
         "╚══════╧═════════════════╧══════════════╝" + "\n"
-      )
-    })
+      );
+    });
 
     it('gracefully handles not finding any definitions', () => {
-      const fixture = []
-      const formatted = _formatDefTable(fixture)
-      expect(formatted).toEqual('No definitions found, sorry!')
-    })
-  })
+      const fixture = [];
+      const formatted = _formatDefTable(fixture);
+      expect(formatted).toEqual('No definitions found, sorry!');
+    });
+  });
 });

--- a/npm/src/commands/install.js
+++ b/npm/src/commands/install.js
@@ -1,0 +1,160 @@
+// @flow
+
+import mkdirp from 'mkdirp';
+import {
+  getGHLibsAndFlowVersions,
+  filterDefs,
+} from '../lib/libDef';
+import {stringToVersion} from "../lib/semver.js";
+import {path, https, fs} from '../lib/node.js';
+
+export const name = 'install';
+export const description = 'Installs a libdef to the ./flow-typed directory';
+
+export function setup(yargs: Object): Object {
+  return yargs
+    .usage(`$0 ${name} - ${description}`)
+    .options({
+      flowVersion: {
+        alias: 'v',
+        demand: true,
+        describe: 'The version of Flow fetched libdefs must be compatible with',
+        type: 'string',
+      },
+      overwrite: {
+        alias: 'o',
+        describe: 'Overwrite a libdef if it is already present in the ' +
+                  '`flow-typed` directory',
+        type: 'bool',
+        demand: false,
+      },
+    });
+};
+
+function failWithMessage(message: string) {
+  console.error(message);
+  return 1;
+}
+
+type Args = {
+  _: Array<string>;
+  flowVersion?: string;
+};
+
+export async function run(args: Args): Promise<number> {
+  if (args._ == null || !(args._.length > 1)) {
+    return failWithMessage(
+      'Please provide a libdef name (example: lodash, or lodash@4.2.1)'
+    );
+  }
+
+  const {flowVersion} = args;
+  if (flowVersion == null) {
+    return failWithMessage(
+      'Please provide a flow version (example: --flowVersion 0.24.0)'
+    );
+  }
+
+  const term = args._[1];
+
+  const matches = term.match(/([^@]*)@?(.*)?/);
+  const defName = (matches && matches[1]);
+  const defVersion = (matches && matches[2]) || 'auto';
+
+  if (!defName) {
+    return failWithMessage(
+      "Please specify a package name of the format `PackageFoo` or " +
+      "PackageFoo@0.2.2"
+    );
+  }
+
+  let filter;
+  if (defVersion !== 'auto') {
+    const verStr = `v${defVersion}`;
+    const ver = stringToVersion(verStr);
+    filter = {
+      type: 'exact',
+      libDef: {
+        pkgName: defName,
+        pkgVersion: ver,
+        pkgVersionStr: verStr,
+        pkgNameVersionStr: `${defName}_${verStr}`
+      }
+    };
+  } else {
+    filter = {
+      type: 'fuzzy',
+      term: defName,
+    };
+  }
+
+  process.stdout.write('Querying github for libdefs...');
+  const defs = await getGHLibsAndFlowVersions();
+
+  const filtered = filterDefs(
+    filter,
+    defs,
+    flowVersion
+  );
+  console.log('found %s matching libdefs.', filtered.length);
+
+  if (filtered.length === 0) {
+    return failWithMessage(
+      `Sorry, I was unable to find any libdefs for ${term} that work with ` +
+      `flow@${flowVersion}. Consider submitting one! :)\n\n` +
+      `https://github.com/flowtype/flow-typed/`
+    );
+  }
+
+  const def = filtered[0];
+  const flowTypedDir = path.join(process.cwd(), 'flow-typed');
+  const targetFile = path.join(
+    flowTypedDir,
+    `${def.pkgName}_${def.pkgVersionStr}.js`
+  );
+
+  const terseTargetFile = path.relative(process.cwd(), targetFile);
+  if ((await fs.exists(targetFile)) && !args.update) {
+    console.log(
+      `${terseTargetFile} already exists! Use --update/-u to overwrite the ` +
+      `existing libdef.`
+    );
+    return 0;
+  }
+
+  const url =
+    `https://raw.githubusercontent.com/flowtype/flow-typed/master/` +
+    `definitions/${def.pkgName}_${def.pkgVersionStr}/` +
+    `flow_${def.flowVersionStr}/${def.pkgName}_${def.pkgVersionStr}.js`;
+
+  process.stdout.write(
+    `Downloading flow_${def.flowVersionStr}/${def.pkgNameVersionStr}.js into ` +
+    `'${flowTypedDir}'...`
+  );
+  mkdirp.sync(flowTypedDir);
+
+  await new Promise((resolve, reject) => {
+    https.get(url, response => {
+      const file = fs.createWriteStream(targetFile);
+      file.on('close', () => resolve(0));
+      response.pipe(file);
+    }).on('error', e => reject(e));
+  });
+  console.log('done.');
+
+  // TODO: Sign the downloaded file with the latest commit number as a version
+  //       reference.
+  //
+  //       1) This will allow us to determine if their libdef is outdated and
+  //          has been improved since they last installed.
+  //
+  //       2) In the future this will help us quickly notice if the user has
+  //          made local changes (so that we might prompt them to contribute
+  //          their improvements upstream).
+  //
+  //       3) This will be handy for troubleshooting (i.e. determining which
+  //          version of the libdef the user has installed, and whether anything
+  //          changed locally since they installed)
+
+  return 0;
+};

--- a/npm/src/commands/runTests.js
+++ b/npm/src/commands/runTests.js
@@ -9,7 +9,6 @@ import {
 } from "../lib/libDef.js";
 import {versionToString} from "../lib/semver.js";
 
-import GitHub from "github";
 import request from "request";
 import * as semver from "semver";
 
@@ -27,8 +26,8 @@ const BIN_PLATFORM = (_ => {
   }
 })();
 const PKG_ROOT_DIR = path.join(__dirname, "..", "..");
-const TEST_DIR = path.join(PKG_ROOT_DIR, "test-dir");
-const BIN_DIR = path.join(PKG_ROOT_DIR, "flow-bins");
+const TEST_DIR = path.join(PKG_ROOT_DIR, ".test-dir");
+const BIN_DIR = path.join(PKG_ROOT_DIR, ".flow-bins-cache");
 const P = Promise;
 
 type TestGroup = {
@@ -76,7 +75,6 @@ async function getOrderedFlowBinVersions(): Promise<Array<string>> {
       const OS_ARCH_FILTER_RE = new RegExp(BIN_PLATFORM);
 
       let binURLs = new Map();
-      let releases = new Map();
       let apiPayload = null;
       let page = 0;
       while (apiPayload === null || apiPayload.length === QUERY_PAGE_SIZE) {
@@ -135,7 +133,7 @@ async function getOrderedFlowBinVersions(): Promise<Array<string>> {
 
         // Download the zip file
         await new Promise((res, rej) => {
-          console.log("  Fetching flow-%s...", version)
+          console.log("  Fetching flow-%s...", version);
           const fileRequest = request({
             url: binURL,
             headers: {
@@ -144,7 +142,7 @@ async function getOrderedFlowBinVersions(): Promise<Array<string>> {
             }
           }).on("error", err => rej(err));;
 
-          fileRequest.pipe(fs.createWriteStream(zipPath).on("close", _ => {
+          fileRequest.pipe(fs.createWriteStream(zipPath).on("close", () => {
             console.log("    flow-%s finished downloading.", version);
             res();
           }));

--- a/npm/src/commands/search.js
+++ b/npm/src/commands/search.js
@@ -1,13 +1,12 @@
 // @flow
 import {getGHLibsAndFlowVersions, filterDefs} from "../lib/libDef.js";
 import type {LibDefWithFlow} from "../lib/libDef.js";
-import {child_process, path} from '../lib/node'
 
 import table from 'table';
 
 export function _formatDefTable(defs: Array<LibDefWithFlow>): string {
   const formatted = [
-    ['Name', 'Package Version', 'Flow Version'/*, 'Install Command'*/]
+    ['Name', 'Package Version', 'Flow Version']
   ].concat(defs.map(def => {
     return [
       def.pkgName,
@@ -15,12 +14,12 @@ export function _formatDefTable(defs: Array<LibDefWithFlow>): string {
       def.flowVersionStr,
     ];
   }));
-  if (formatted.length == 1) {
+  if (formatted.length === 1) {
     return "No definitions found, sorry!";
   } else {
-    return "\nFound definitions:\n" + table(formatted)
+    return "\nFound definitions:\n" + table(formatted);
   }
-}
+};
 
 export const name = "search";
 export const description =
@@ -28,14 +27,14 @@ export const description =
 
 export async function run(args: {}): Promise<number> {
   if (!args._ || !(args._.length > 1)) {
-    console.error('Please provide a term for which to search!')
+    console.error('Please provide a term for which to search!');
     return 1;
   }
 
-  const flowVersion = args.flowVersion || undefined
+  const flowVersion = args.flowVersion || undefined;
   const term = args._[1];
   const defs = await getGHLibsAndFlowVersions();
-  const filtered = filterDefs(term, defs, flowVersion)
-  console.log(_formatDefTable(filtered))
+  const filtered = filterDefs(term, defs, flowVersion);
+  console.log(_formatDefTable(filtered));
   return 0;
 };

--- a/npm/src/commands/validateDefs.js
+++ b/npm/src/commands/validateDefs.js
@@ -1,16 +1,11 @@
 // @flow
 
-import {fs, path} from "../lib/node.js";
-
-import {versionToString} from "../lib/semver.js";
 import {getLocalLibDefs, getLocalLibDefFlowVersions} from "../lib/libDef.js";
-
-const P = Promise;
 
 export const name = "validate-defs";
 export const description =
   "Validates the structure of the definitions in the local repo.";
-export async function run(args: {}): Promise<number> {
+export async function run(): Promise<number> {
   const validationErrors = new Map();
   const localLibDefs = await getLocalLibDefs(validationErrors);
   const localLibDefFlowVersions = await getLocalLibDefFlowVersions(

--- a/npm/src/lib/__tests__/libDef-test.js
+++ b/npm/src/lib/__tests__/libDef-test.js
@@ -1,29 +1,30 @@
 // @flow
 jest.mock('../github.js', () => {
-  const fixtures = require('./libDef-test__fixtures.js')
+  const fixtures = require('./libDef-test__fixtures.js');
   return {
     gitHubClient: () => ({
       repos: {
         getContent: function(args, cb) {
-          if (args.path == '/definitions') {
-            cb(null, fixtures.definitionsFixture)
+          if (args.path === '/definitions') {
+            cb(null, fixtures.definitionsFixture);
           } else {
-            let name = args.path.match(/\/definitions\/(.*)/)[1]
-            cb(null, fixtures.flowVersionsFixture[name])
+            let name = args.path.match(/\/definitions\/(.*)/)[1];
+            cb(null, fixtures.flowVersionsFixture[name]);
           }
         }
       }
     })
-  }
-})
+  };
+});
 
 import {getGHLibsAndFlowVersions, filterDefs} from '../libDef.js';
+import {stringToVersion} from '../semver.js';
 
 describe('libDef helpers', () => {
   describe('getGHLibsAndFlowVersions', () => {
     pit('fetches a flat list of all libdefs for every flow version',
     async () => {
-      let versions = await getGHLibsAndFlowVersions()
+      let versions = await getGHLibsAndFlowVersions();
       expect(versions).toEqual([
         { pkgName: 'kefir',
           pkgVersion: { major: 3, minor: 'x', patch: 'x' },
@@ -46,32 +47,134 @@ describe('libDef helpers', () => {
           flowVersionStr: '>=v0.18.x',
           flowVersion: { range: '>=', major: 0, minor: 18, patch: 'x' }
         }
-      ])
-    })
-  })
+      ]);
+    });
+  });
 
   describe('filterDefs()', () => {
-    it('filters properly based on flow version', () => {
-      const fixture = [
-        { pkgName: 'mori',
-          pkgVersion: { major: 0, minor: 3, patch: 'x' },
-          pkgVersionStr: 'v0.3.x',
-          pkgNameVersionStr: 'mori_v0.3.x',
-          flowVersionStr: '>=v0.22.x',
-          flowVersion: { range: '>=', major: 0, minor: 22, patch: 'x' }
-        },
-        { pkgName: 'mori',
-          pkgVersion: { major: 0, minor: 3, patch: 'x' },
-          pkgVersionStr: 'v0.3.x',
-          pkgNameVersionStr: 'mori_v0.3.x',
-          flowVersionStr: '>=v0.18.x',
-          flowVersion: { range: '>=', major: 0, minor: 18, patch: 'x' }
-        }
-      ]
+    function _generateFixturePkg(name, verStr, flowVerStr) {
+      return {
+        pkgName: name,
+        pkgVersion: stringToVersion(verStr),
+        pkgVersionStr: verStr,
+        pkgNameVersionStr: `${name}_${verStr}`,
+        flowVersionStr: flowVerStr,
+        flowVersion: stringToVersion(verStr),
+      };
+    }
 
-      const filtered = filterDefs('mori', fixture, '0.19.0')
-      expect(filtered.length).toEqual(1)
-      expect(filtered[0].flowVersionStr).toEqual('>=v0.18.x')
-    })
-  })
-})
+    describe('fuzzy filter', () => {
+      it('filters on exact name', () => {
+        const fixture = [
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
+        ];
+        const filtered = filterDefs(
+          {type: 'fuzzy', term: 'mori'},
+          fixture,
+        );
+        expect(filtered).toEqual([fixture[1], fixture[0]]);
+      });
+
+      it('filters on differently-cased name', () => {
+        const fixture = [
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
+        ];
+        const filtered = filterDefs(
+          {type: 'fuzzy', term: 'Mori'},
+          fixture,
+        );
+        expect(filtered).toEqual([fixture[1], fixture[0]]);
+      });
+
+      it('filters on partial name', () => {
+        const fixture = [
+          _generateFixturePkg('**mori', 'v0.3.x', '>=v0.22.x'),
+          _generateFixturePkg('mori**', 'v0.3.x', '>=v0.18.x'),
+          _generateFixturePkg('mo**ri', 'v0.3.x', '>=v0.18.x'),
+        ];
+        const filtered = filterDefs(
+          {type: 'fuzzy', term: 'mori'},
+          fixture,
+        );
+        expect(filtered).toEqual([fixture[1], fixture[0]]);
+      });
+
+      it('filters on flow version', () => {
+        const fixture = [
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
+        ];
+        const filtered = filterDefs(
+          {type: 'fuzzy', term: 'mori'},
+          fixture,
+          'v0.19.0',
+        );
+        expect(filtered).toEqual([fixture[1]]);
+      });
+    });
+
+    describe('exact filter', () => {
+      function _generateLibDef(pkgName, pkgVersionStr) {
+        return {
+          pkgName,
+          pkgVersion: stringToVersion(pkgVersionStr),
+          pkgVersionStr,
+          pkgNameVersionStr: `${pkgName}_${pkgVersionStr}`,
+        };
+      }
+
+      it('filters on exact name', () => {
+        const fixture = [
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateFixturePkg('notmori', 'v0.3.x', '>=v0.22.x'),
+        ];
+        const filtered = filterDefs(
+          {type: 'exact', libDef: _generateLibDef('mori', 'v0.3.1')},
+          fixture,
+        );
+        expect(filtered).toEqual([fixture[0]]);
+      });
+
+      it('filters on differently-cased name', () => {
+        const fixture = [
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateFixturePkg('notmori', 'v0.3.x', '>=v0.22.x'),
+        ];
+        const filtered = filterDefs(
+          {type: 'exact', libDef: _generateLibDef('Mori', 'v0.3.1')},
+          fixture,
+        );
+        expect(filtered).toEqual([fixture[0]]);
+      });
+
+      it('DOES NOT filter on partial name', () => {
+        const fixture = [
+          _generateFixturePkg('**mori', 'v0.3.x', '>=v0.22.x'),
+          _generateFixturePkg('mori**', 'v0.3.x', '>=v0.22.x'),
+          _generateFixturePkg('mo**ri', 'v0.3.x', '>=v0.22.x'),
+          _generateFixturePkg('mori',   'v0.3.x', '>=v0.22.x'),
+        ];
+        const filtered = filterDefs(
+          {type: 'exact', libDef: _generateLibDef('mori', 'v0.3.1')},
+          fixture,
+        );
+        expect(filtered).toEqual([fixture[3]]);
+      });
+
+      it('filters on flow version', () => {
+        const fixture = [
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
+        ];
+        const filtered = filterDefs(
+          {type: 'exact', libDef: _generateLibDef('mori', 'v0.3.1')},
+          fixture,
+          'v0.19.0',
+        );
+        expect(filtered).toEqual([fixture[1]]);
+      });
+    });
+  });
+});

--- a/npm/src/lib/__tests__/libDef-test__fixtures.js
+++ b/npm/src/lib/__tests__/libDef-test__fixtures.js
@@ -8,7 +8,7 @@ export const flowVersionsFixture = {
       { "name": "flow_>=v0.18.x", },
       { "name": "test_mori-v0.3.x.js", }
   ]
-}
+};
 
 export const definitionsFixture = [
   {
@@ -26,4 +26,4 @@ export const definitionsFixture = [
     "path": "definitions/mori_v0.3.x",
     "sha": "99d6bd549a2777ab3e0813649d408126620df546"
   }
-]
+];

--- a/npm/src/lib/__tests__/semver-test.js
+++ b/npm/src/lib/__tests__/semver-test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {stringToVersion} from '../semver.js';
+import {stringToVersion, sortVersions} from '../semver.js';
 
 describe('semver', () => {
   describe('stringToVersion', () => {
@@ -33,6 +33,25 @@ describe('semver', () => {
         minor: 2,
         patch: 'x',
       });
+    });
+  });
+
+  describe('sortVersions', () => {
+    it('sorts versions correctly', () => {
+      let a = stringToVersion('v2.x.x');
+      let b = stringToVersion('v2.1.x');
+      let res = sortVersions(a, b);
+      expect(res).toEqual(-1);
+
+      a = stringToVersion('v1.x.x');
+      b = stringToVersion('v2.1.x');
+      res = sortVersions(a, b);
+      expect(res).toEqual(-1);
+
+      a = stringToVersion('v1.2.1');
+      b = stringToVersion('v0.2.0');
+      res = sortVersions(a, b);
+      expect(res).toEqual(1);
     });
   });
 });

--- a/npm/src/lib/fileUtils.js
+++ b/npm/src/lib/fileUtils.js
@@ -7,10 +7,10 @@ const P = Promise;
 export function copyFile(srcPath: string, destPath: string): Promise<void> {
   return new Promise((res, rej) => {
     const reader = fs.createReadStream(srcPath);
-    reader.on("error", err => rej(err));
+    reader.on("error", rej);
     const writer = fs.createWriteStream(destPath);
-    writer.on("error", err => rej(err));
-    writer.on("close", _ => res());
+    writer.on("error", rej);
+    writer.on("close", res);
     reader.pipe(writer);
   });
 }

--- a/npm/src/lib/github.js
+++ b/npm/src/lib/github.js
@@ -1,9 +1,6 @@
 // @flow
 
 import GitHub from "github";
-import {versionToString} from "./semver.js";
-
-import type {LibDef} from "./libDef.js";
 
 const CLIENT = new GitHub({version: "3.0.0"});
 if (process.env.GH_TOK) {

--- a/npm/src/lib/node.js
+++ b/npm/src/lib/node.js
@@ -19,7 +19,7 @@ export const fs = {
   mkdir: function(path: string, mode?: number): Promise<void> {
     return new Promise((res, rej) => {
       node_fs.mkdir(path, mode, (err) => {
-        if (err) { rej(err); } else { res() }
+        if (err) { rej(err); } else { res(); }
       });
     });
   },

--- a/npm/src/lib/semver.js
+++ b/npm/src/lib/semver.js
@@ -17,7 +17,7 @@ export function emptyVersion(): Version {
     major: 'x',
     minor: 'x',
     patch: 'x'
-  }
+  };
 }
 
 export function copyVersion(ver: Version): Version {
@@ -28,6 +28,25 @@ export function copyVersion(ver: Version): Version {
     patch: ver.patch,
   };
 }
+
+/**
+ * Given two versions (can be ranges), returns < 0 if a's lower
+ * bound is less than b's lower bound. When used as a comparator,
+ * his should sort a list of ranges in ascending order by lower bound.
+ */
+function _replaceVersionPart(part) {
+  return typeof part === 'string' ? 0 : part;
+}
+export function sortVersions(a: Version, b: Version): number {
+  if (a.major !== b.major) {
+    return _replaceVersionPart(a.major) - _replaceVersionPart(b.major);
+  } else if (a.minor !== b.minor) {
+    return _replaceVersionPart(a.minor) - _replaceVersionPart(b.minor);
+  } else if (a.patch !== b.patch) {
+    return _replaceVersionPart(a.patch) - _replaceVersionPart(b.patch);
+  }
+  return 0;
+};
 
 // TODO: This has some egregious duplication with
 //       libDef.getLocalLibDefFlowVersions(). Need to better consolidate logic

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -o errexit
 
-cd npm && npm install && npm test && npm run build && node dist/cli.js validate-defs && node dist/cli.js run-tests
+cd npm && npm install && npm run flow && npm run test-quick && npm run build && node dist/cli.js validate-defs && node dist/cli.js run-tests


### PR DESCRIPTION
Thanks to both @splodingsocks and @ryyppy, this is a working version of `flow-typed install`!

It works using the same machinery as `flow-typed search`, except it will actually fetch and save the libdef to the `flow-typed/` directory. There's some extra noise in here from the addition of eslint, but hopefully not too hard to skim/scroll past...

Note: While the `install` command here works, it has certainly uncovered some more work for us. I'll make issues for each of these once this PR lands:

1. As @ryyppy pointed out somewhere already, this will hit the github API rate-limiter fairly quickly. We really need to solve this before we can "launch" the CLI. We can discuss options for this in the issue I'll create for it, but my current thoughts are that we should do something similar to homebrew and just store a cached checkout of the git repo somewhere on the user's machine (say, in `~/.flow-typed-cache/`). From there, all `search` and `install` operations can happen locally.

1. I think it's [going to be pretty important](https://github.com/flowtype/flow-typed/blob/install-command2/npm/src/commands/install.js#L147-L159) for us to track when/where an installed libdef came from (i.e. the last-change commit hash). Similarly I'll open an issue to track this, but I think we should probably come back to this as well before we "launch" (mostly to preserve option value post-launch).

1. This can only install a single libdef at a time -- but we should probably add support for specifying multiple arguments at once. Probably not launch-blocking.

1. We should build support for some kind of `--fromPkgJson` flag (that reads a `package.json` file and tries to install libdefs for as many dependencies as it can). I don't see this as needing to be launch-blocking.