### PR TITLE
Sign libdefs during `install` command

### DIFF
--- a/cli/.eslintrc
+++ b/cli/.eslintrc
@@ -15,7 +15,7 @@
     "semi": 2,
     "no-unused-vars": ["error", {
       "varsIgnorePattern": "^_.?.?$",
-      "argsIgnorePattern": "^_.?.?$",
+      "argsIgnorePattern": "^_.*$",
     }],
   }
 }

--- a/cli/flow-typed/yargs_v4.x.x.js
+++ b/cli/flow-typed/yargs_v4.x.x.js
@@ -1,3 +1,6 @@
+// flow-typed signature: a2ffb656454ea46e2249e12a13672b7a
+// flow-typed version: ef85c464bf6f060419003b2636d6380f4faa0f2e
+
 declare module 'yargs' {
   declare type Argv = {_: Array<string>, [key: string]: mixed};
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -52,11 +52,13 @@
   "dependencies": {
     "github": "^0.2.4",
     "lodash": "^4.11.2",
+    "md5": "^2.1.0",
     "nodegit": "^0.13.0",
     "request": "^2.69.0",
     "rx-lite": "4.0.8",
     "semver": "^5.1.0",
     "table": "3.7.8",
+    "through": "^2.3.8",
     "yargs": "^4.2.0"
   }
 }

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -1,8 +1,9 @@
 // @flow
 
+import {signCodeStream} from "../lib/codeSign.js";
 import {copyFile} from "../lib/fileUtils.js";
+import {filterLibDefs, getCacheLibDefs, getCacheLibDefVersion} from "../lib/libDefs.js";
 import {fs, path} from '../lib/node.js';
-import {filterLibDefs, getCacheLibDefs} from "../lib/libDefs.js";
 import {emptyVersion, stringToVersion, versionToString} from "../lib/semver.js";
 
 export const name = 'install';
@@ -127,22 +128,10 @@ export async function run(args: Args): Promise<number> {
     return 0;
   }
 
-  await copyFile(def.path, targetFilePath);
+  const libDefVersion = await getCacheLibDefVersion(def);
+  const codeSignPreprocessor = signCodeStream(libDefVersion);
+  await copyFile(def.path, targetFilePath, codeSignPreprocessor);
   console.log(`'${targetFileName}' installed at ${targetFilePath}.`);
-
-  // TODO: Sign the downloaded file with the latest commit number as a version
-  //       reference.
-  //
-  //       1) This will allow us to determine if their libdef is outdated and
-  //          has been improved since they last installed.
-  //
-  //       2) In the future this will help us quickly notice if the user has
-  //          made local changes (so that we might prompt them to contribute
-  //          their improvements upstream).
-  //
-  //       3) This will be handy for troubleshooting (i.e. determining which
-  //          version of the libdef the user has installed, and whether anything
-  //          changed locally since they installed)
 
   return 0;
 };

--- a/cli/src/lib/__tests__/codeSign-test.js
+++ b/cli/src/lib/__tests__/codeSign-test.js
@@ -1,0 +1,68 @@
+// @flow
+
+import {
+  getSignedCodeVersion,
+  signCode,
+  signCodeStream,
+  verifySignedCode
+} from "../codeSign.js";
+
+describe('codeSign', () => {
+  describe('verifySignedCode', () => {
+    it('verifies signed code', () => {
+      const code = 'line 1\nline 2\nline 3';
+      const version = 'VersionA';
+      const signedCode = signCode(code, version);
+      expect(verifySignedCode(signedCode)).toBe(true);
+    });
+
+    it('does not verify unsigned code', () => {
+      const code = 'line 1\nline2\nline3';
+      expect(verifySignedCode(code)).toBe(false);
+    });
+  });
+
+  describe('getSignedCodeVersion', () => {
+    it('gets version from well-signed code', () => {
+      const code = 'line 1\nline 2\nline 3';
+      const version = 'VersionA';
+      const signedCode = signCode(code, version);
+      expect(getSignedCodeVersion(signedCode)).toBe(version);
+    });
+
+    it('gets version from altered signed code', () => {
+      const code = 'line 1\nline 2\nline 3';
+      const version = 'VersionA';
+      const signedCode = signCode(code, version);
+      const alteredCode = `${signedCode}\nline 4`;
+      expect(getSignedCodeVersion(alteredCode)).toBe(version);
+    });
+
+    it('returns null for code without signature comments', () => {
+      const code = 'line 1\nline 2\nline 3';
+      expect(getSignedCodeVersion(code)).toBe(null);
+    });
+  });
+
+  describe('signCodeStream', () => {
+    pit('signs and versions the output code', () => {
+      const version = 'VersionA';
+      const stream = signCodeStream(version);
+      stream.write('line 1\n');
+      stream.write('line 2\n');
+      stream.write('line 3\n');
+
+      let signedCode = '';
+      stream.on('data', data => signedCode += data);
+
+      return new Promise((res, _rej) => {
+        stream.on('close', () => {
+          expect(verifySignedCode(signedCode)).toBe(true);
+          expect(getSignedCodeVersion(signedCode)).toBe(version);
+          res();
+        });
+        stream.end();
+      });
+    });
+  });
+});

--- a/cli/src/lib/codeSign.js
+++ b/cli/src/lib/codeSign.js
@@ -1,0 +1,46 @@
+// @flow
+
+import md5 from "md5";
+import through from "through";
+
+const VERSION_COMMENT_RE = /\/\/ flow-typed version: (.*)$/;
+export function getSignedCodeVersion(signedCode: string): string | null {
+  const [_, versionComment] = signedCode.split('\n');
+  const versionMatches = versionComment.trim().match(VERSION_COMMENT_RE);
+  if (versionMatches == null) {
+    return null;
+  }
+  return versionMatches[1];
+};
+
+export function signCode(code: string, version: string): string {
+  const versionedCode = `// flow-typed version: ${version}\n\n${code}`;
+  const hash = md5(versionedCode);
+  return `// flow-typed signature: ${hash}\n${versionedCode}`;
+};
+
+export function signCodeStream(version: string) {
+  let code = '';
+  return through(
+    function write(data) {
+      code += data;
+    },
+    function end() {
+      this.emit('data', signCode(code, version));
+      this.emit('close');
+    },
+  );
+};
+
+const HASH_COMMENT_RE = /\/\/ flow-typed signature: (.*)$/;
+export function verifySignedCode(signedCode: string): boolean {
+  const signedCodeLines = signedCode.split('\n');
+  const [hashComment] = signedCodeLines;
+  const hashMatches = hashComment.trim().match(HASH_COMMENT_RE);
+  if (hashMatches == null) {
+    return false;
+  }
+  const [_, hash] = hashMatches;
+  const versionedCode = signedCodeLines.slice(1).join('\n');
+  return md5(versionedCode) === hash;
+};

--- a/cli/src/lib/fileUtils.js
+++ b/cli/src/lib/fileUtils.js
@@ -6,14 +6,23 @@ import {fs, path} from "./node.js";
 
 const P = Promise;
 
-export function copyFile(srcPath: string, destPath: string): Promise<void> {
+export function copyFile(
+  srcPath: string,
+  destPath: string,
+  preProcessor?: stream$Duplex,
+): Promise<void> {
   return new Promise((res, rej) => {
     const reader = fs.createReadStream(srcPath);
     reader.on("error", rej);
     const writer = fs.createWriteStream(destPath);
     writer.on("error", rej);
     writer.on("close", res);
-    reader.pipe(writer);
+    if (preProcessor) {
+      reader.pipe(preProcessor);
+      preProcessor.pipe(writer);
+    } else {
+      reader.pipe(writer);
+    }
   });
 }
 

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -420,6 +420,26 @@ export async function getCacheLibDefs(
   return getLibDefs(CACHE_REPO_DEFS_DIR, validationErrs);
 };
 
+export async function getCacheLibDefVersion(libDef: LibDef) {
+  await ensureCacheRepo();
+  await verifyCLIVersion(CACHE_REPO_DEFS_DIR);
+  const repo = await Git.Repository.open(CACHE_REPO_DIR);
+  const revWalk = repo.createRevWalk();
+  revWalk.pushHead();
+  const histEntries = await revWalk.fileHistoryWalk(
+    path.relative(CACHE_REPO_DIR, libDef.path),
+    100000
+  );
+  if (histEntries.length === 0) {
+    throw new Error(
+      `Unable to find version information for `+
+      `'${libDef.pkgName}_${libDef.pkgVersionStr}/` +
+      `flow_${libDef.flowVersionStr}'!`
+    );
+  }
+  return histEntries[0].commit.sha();
+};
+
 /**
  * Filter a given list of LibDefs down using a specified filter.
  */

--- a/cli/src/lib/node.js
+++ b/cli/src/lib/node.js
@@ -3,8 +3,8 @@
 import * as node_child_process from 'child_process';
 import * as node_fs from 'fs';
 import * as node_https from "https";
-import * as node_path from 'path';
 import * as node_os from "os";
+import * as node_path from 'path';
 import * as node_url from "url";
 
 export const child_process = node_child_process;


### PR DESCRIPTION
This signs libdefs with a version (their "last updated" commit sha) so that we can detect if they've been locally modified or if there is a new version available.

We don't make use of the version or signature info just yet, but we'll likely want to in the near future:

* Tell the user if any of their installed libdefs have been updated since they last installed
* Detect local modifications and encourage users to contribute their libdef improvements upstream