### PR TITLE
include flow version in signed code version string

### DIFF
--- a/cli/flow-typed/yargs_v4.x.x.js
+++ b/cli/flow-typed/yargs_v4.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: a2ffb656454ea46e2249e12a13672b7a
-// flow-typed version: ef85c464bf6f060419003b2636d6380f4faa0f2e
+// flow-typed signature: b86972b47c44f9bf6772a814f317ca39
+// flow-typed version: ef85c464bf/yargs_v4.x.x/flow_>=v0.23.x
 
 declare module 'yargs' {
   declare type Argv = {_: Array<string>, [key: string]: mixed};

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -486,7 +486,11 @@ export async function getCacheLibDefVersion(libDef: LibDef) {
       `flow_${libDef.flowVersionStr}'!`
     );
   }
-  return histEntries[0].commit.sha();
+  return (
+    `${histEntries[0].commit.sha().substr(0, 10)}/` +
+    `${libDef.pkgName}_${libDef.pkgVersionStr}/` +
+    `flow_${libDef.flowVersionStr}`
+  );
 };
 
 /**


### PR DESCRIPTION
* Change the code-signature logic to include the flow version (at the time of installation) for quick reference.
* Shorten the git sha version to 10chars ([more than enough to uniquely distinguish](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#Short-SHA-1))