### PR TITLE
Update: Fix typos and add optional error field to InputProps

### DIFF
--- a/definitions/npm/redux-form_v5.x.x/flow_>=v0.22.1/redux-form_v5.x.x.js
+++ b/definitions/npm/redux-form_v5.x.x/flow_>=v0.22.1/redux-form_v5.x.x.js
@@ -11,8 +11,9 @@ declare module 'redux-form' {
     pristine: boolean,
     active: boolean,
     touched: boolean,
-    viisted: boolean,
-    autofiller: boolean
+    visited: boolean,
+    autofilled: boolean,
+    error?: string
   };
   declare type FormProps = {
     active: string,


### PR DESCRIPTION
Ran into this flow error when implementing a form using `redux-form`...

<img width="641" alt="screen shot 2016-05-17 at 2 17 30 pm" src="https://cloud.githubusercontent.com/assets/830026/15339614/27a7f34a-1c3a-11e6-82f1-88897df61261.png">

Adding `error` as an optional field to `InputProps` fixes the issue and is consistent with the Redux Form API (http://redux-form.com/5.2.3/#/api/props?_k=dqnjtt). Also fixed a couple typos :) 