### PR TITLE
Fix support for `flow_all` as a flow-version directory

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-typed",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "A repository of high quality flowtype definitions",
   "main": "dist/cli.js",
   "bin": "dist/cli.js",

--- a/definitions/.cli-metadata.json
+++ b/definitions/.cli-metadata.json
@@ -1,3 +1,3 @@
 {
-  "compatibleCLIRange": ">=2.0.0-beta.3"
+  "compatibleCLIRange": ">=2.0.0-beta.4"
 }


### PR DESCRIPTION
`flow_all` as a flow-version directory name is just sugar for `flow_vx.x.x` and should work -- but it wasn't.
This fixes the version parser to deal with this.

https://github.com/flowtype/flow-typed/issues/105