### PR TITLE
rxjs: Properly type Observables that never produce values

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_>=v0.25.0/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_>=v0.25.0/rxjs_v5.0.x.js
@@ -65,7 +65,7 @@ declare module 'rxjs' {
 
     static fromPromise(promise: Promise<T>): Observable<T>;
 
-    static empty(): Observable<any>;
+    static empty<U>(): Observable<U>;
 
     static interval(period: number): Observable<number>;
 
@@ -80,7 +80,7 @@ declare module 'rxjs' {
     ): Observable<T | U | V>;
     static merge(...sources: Observable<T>[]): Observable<T>;
 
-    static never(): Observable<void>;
+    static never<U>(): Observable<U>;
 
     static of(...values: T[]): Observable<T>;
 
@@ -145,7 +145,7 @@ declare module 'rxjs' {
       defaultValue: U,
     ): Observable<U>;
 
-    ignoreElements(): Observable<any>;
+    ignoreElements<U>(): Observable<U>;
 
     // Alias for `mergeMap`
     flatMap<U>(

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -28,3 +28,12 @@ const combinedBad: Observable<{n: number, s: string}> = Observable.combineLatest
 );
 
 (Observable.defer(() => numbers): Observable<number>);
+
+// $ExpectError
+const bogusEmpty: Observable<string> = Observable.empty()
+  .concat(numbers.map(x => x));
+
+// Equivalent to Observable.never()
+const never: Observable<number> = Observable.empty()
+  .concat(Observable.of('').ignoreElements())
+  .concat(Observable.never());


### PR DESCRIPTION
`empty`, `never`, and `ignoreElements` should be typed as "an observable of some type" rather than Observables of any. This prevents possible type degradation when they're combined with Observables of well-defined types.