### PR TITLE
Add tape v4.5.x libdef

### DIFF
--- a/definitions/npm/tape_v4.5.x/flow_>=v0.25.x/tape_v4.5.x.js
+++ b/definitions/npm/tape_v4.5.x/flow_>=v0.25.x/tape_v4.5.x.js
@@ -10,83 +10,85 @@ declare type tape$TestOpts = {
   timeout: number,
 };
 
+
 declare type tape$TestCb = (t: tape$Context) => void;
-
 declare type tape$TestFn = (a: string | tape$TestOpts | tape$TestCb, b?: tape$TestOpts | tape$TestCb, c?: tape$TestCb) => void;
+
 declare interface tape$Context {
-  fail: (msg?: string) => void,
-  pass: (msg?: string) => void,
+  fail(msg?: string): void,
+  pass(msg?: string): void,
 
-  error: (err: mixed, msg?: string) => void,
-  ifError: (err: mixed, msg?: string) => void,
-  ifErr: (err: mixed, msg?: string) => void,
-  iferror: (err: mixed, msg?: string) => void,
+  error(err: mixed, msg?: string): void,
+  ifError(err: mixed, msg?: string): void,
+  ifErr(err: mixed, msg?: string): void,
+  iferror(err: mixed, msg?: string): void,
 
-  ok: (value: mixed, msg?: string) => void,
-  true: (value: mixed, msg?: string) => void,
-  assert: (value: mixed, msg?: string) => void,
+  ok(value: mixed, msg?: string): void,
+  true(value: mixed, msg?: string): void,
+  assert(value: mixed, msg?: string): void,
 
-  notOk: (value: mixed, msg?: string) => void,
-  false: (value: mixed, msg?: string) => void,
-  notok: (value: mixed, msg?: string) => void,
+  notOk(value: mixed, msg?: string): void,
+  false(value: mixed, msg?: string): void,
+  notok(value: mixed, msg?: string): void,
 
   // equal + aliases
-  equal: (actual: mixed, expected: mixed, msg?: string) => void,
-  equals: (actual: mixed, expected: mixed, msg?: string) => void,
-  isEqual: (actual: mixed, expected: mixed, msg?: string) => void,
-  is: (actual: mixed, expected: mixed, msg?: string) => void,
-  strictEqual: (actual: mixed, expected: mixed, msg?: string) => void,
-  strictEquals: (actual: mixed, expected: mixed, msg?: string) => void,
+  equal(actual: mixed, expected: mixed, msg?: string): void,
+  equals(actual: mixed, expected: mixed, msg?: string): void,
+  isEqual(actual: mixed, expected: mixed, msg?: string): void,
+  is(actual: mixed, expected: mixed, msg?: string): void,
+  strictEqual(actual: mixed, expected: mixed, msg?: string): void,
+  strictEquals(actual: mixed, expected: mixed, msg?: string): void,
 
   // notEqual + aliases
-  notEqual: (actual: mixed, expected: mixed, msg?: string) => void,
-  notEquals: (actual: mixed, expected: mixed, msg?: string) => void,
-  notStrictEqual: (actual: mixed, expected: mixed, msg?: string) => void,
-  notStrictEquals: (actual: mixed, expected: mixed, msg?: string) => void,
-  isNotEqual: (actual: mixed, expected: mixed, msg?: string) => void,
-  isNot: (actual: mixed, expected: mixed, msg?: string) => void,
-  not: (actual: mixed, expected: mixed, msg?: string) => void,
-  doesNotEqual: (actual: mixed, expected: mixed, msg?: string) => void,
-  isInequal: (actual: mixed, expected: mixed, msg?: string) => void,
+  notEqual(actual: mixed, expected: mixed, msg?: string): void,
+  notEquals(actual: mixed, expected: mixed, msg?: string): void,
+  notStrictEqual(actual: mixed, expected: mixed, msg?: string): void,
+  notStrictEquals(actual: mixed, expected: mixed, msg?: string): void,
+  isNotEqual(actual: mixed, expected: mixed, msg?: string): void,
+  isNot(actual: mixed, expected: mixed, msg?: string): void,
+  not(actual: mixed, expected: mixed, msg?: string): void,
+  doesNotEqual(actual: mixed, expected: mixed, msg?: string): void,
+  isInequal(actual: mixed, expected: mixed, msg?: string): void,
 
   // deepEqual + aliases
-  deepEqual: (actual: mixed, expected: mixed, msg?: string) => void,
-  deepEquals: (actual: mixed, expected: mixed, msg?: string) => void,
-  isEquivalent: (actual: mixed, expected: mixed, msg?: string) => void,
-  same: (actual: mixed, expected: mixed, msg?: string) => void,
+  deepEqual(actual: mixed, expected: mixed, msg?: string): void,
+  deepEquals(actual: mixed, expected: mixed, msg?: string): void,
+  isEquivalent(actual: mixed, expected: mixed, msg?: string): void,
+  same(actual: mixed, expected: mixed, msg?: string): void,
 
   // notDeepEqual
-  notDeepEqual: (actual: mixed, expected: mixed, msg?: string) => void,
-  notEquivalent: (actual: mixed, expected: mixed, msg?: string) => void,
-  notDeeply: (actual: mixed, expected: mixed, msg?: string) => void,
-  notSame: (actual: mixed, expected: mixed, msg?: string) => void,
-  isNotDeepEqual: (actual: mixed, expected: mixed, msg?: string) => void,
-  isNotDeeply: (actual: mixed, expected: mixed, msg?: string) => void,
-  isNotEquivalent: (actual: mixed, expected: mixed, msg?: string) => void,
-  isInequivalent: (actual: mixed, expected: mixed, msg?: string) => void,
+  notDeepEqual(actual: mixed, expected: mixed, msg?: string): void,
+  notEquivalent(actual: mixed, expected: mixed, msg?: string): void,
+  notDeeply(actual: mixed, expected: mixed, msg?: string): void,
+  notSame(actual: mixed, expected: mixed, msg?: string): void,
+  isNotDeepEqual(actual: mixed, expected: mixed, msg?: string): void,
+  isNotDeeply(actual: mixed, expected: mixed, msg?: string): void,
+  isNotEquivalent(actual: mixed, expected: mixed, msg?: string): void,
+  isInequivalent(actual: mixed, expected: mixed, msg?: string): void,
 
   // deepLooseEqual
-  deepLooseEqual: (actual: mixed, expected: mixed, msg?: string) => void,
-  looseEqual: (actual: mixed, expected: mixed, msg?: string) => void,
-  looseEquals: (actual: mixed, expected: mixed, msg?: string) => void,
+  deepLooseEqual(actual: mixed, expected: mixed, msg?: string): void,
+  looseEqual(actual: mixed, expected: mixed, msg?: string): void,
+  looseEquals(actual: mixed, expected: mixed, msg?: string): void,
 
   // notDeepLooseEqual
-  notDeepLooseEqual: (actual: mixed, expected: mixed, msg?: string) => void,
-  notLooseEqual: (actual: mixed, expected: mixed, msg?: string) => void,
-  notLooseEquals: (actual: mixed, expected: mixed, msg?: string) => void,
+  notDeepLooseEqual(actual: mixed, expected: mixed, msg?: string): void,
+  notLooseEqual(actual: mixed, expected: mixed, msg?: string): void,
+  notLooseEquals(actual: mixed, expected: mixed, msg?: string): void,
 
-  throws: (fn: Function, expected?: RegExp | Function, msg?: string) => void,
-  doesNotThrow: (fn: Function, expected?: RegExp | Function, msg?: string) => void,
+  throws(fn: Function, expected?: RegExp | Function, msg?: string): void,
+  doesNotThrow(fn: Function, expected?: RegExp | Function, msg?: string): void,
 
-  timeoutAfter: (ms: number) => void,
+  timeoutAfter(ms: number): void,
 
-  skip: (msg?: string) => void,
-  plan: (n: number) => void,
-  onFinish: (fn: Function) => void,
-  end: () => void,
-  comment: (msg: string) => void,
+  skip(msg?: string): void,
+  plan(n: number): void,
+  onFinish(fn: Function): void,
+  end(): void,
+  comment(msg: string): void,
   test: tape$TestFn,
 }
+
 
 declare module 'tape' {
   declare type TestHarness = Tape;

--- a/definitions/npm/tape_v4.5.x/flow_>=v0.25.x/tape_v4.5.x.js
+++ b/definitions/npm/tape_v4.5.x/flow_>=v0.25.x/tape_v4.5.x.js
@@ -1,0 +1,106 @@
+/* @flow */
+
+/* eslint-disable  */
+
+declare type tape$TestOpts = {
+  skip: boolean,
+  timeout?: number,
+} | {
+  skip?: boolean,
+  timeout: number,
+};
+
+declare type tape$TestCb = (t: tape$Context) => void;
+
+declare type tape$TestFn = (a: string | tape$TestOpts | tape$TestCb, b?: tape$TestOpts | tape$TestCb, c?: tape$TestCb) => void;
+declare interface tape$Context {
+  fail: (msg?: string) => void,
+  pass: (msg?: string) => void,
+
+  error: (err: mixed, msg?: string) => void,
+  ifError: (err: mixed, msg?: string) => void,
+  ifErr: (err: mixed, msg?: string) => void,
+  iferror: (err: mixed, msg?: string) => void,
+
+  ok: (value: mixed, msg?: string) => void,
+  true: (value: mixed, msg?: string) => void,
+  assert: (value: mixed, msg?: string) => void,
+
+  notOk: (value: mixed, msg?: string) => void,
+  false: (value: mixed, msg?: string) => void,
+  notok: (value: mixed, msg?: string) => void,
+
+  // equal + aliases
+  equal: (actual: mixed, expected: mixed, msg?: string) => void,
+  equals: (actual: mixed, expected: mixed, msg?: string) => void,
+  isEqual: (actual: mixed, expected: mixed, msg?: string) => void,
+  is: (actual: mixed, expected: mixed, msg?: string) => void,
+  strictEqual: (actual: mixed, expected: mixed, msg?: string) => void,
+  strictEquals: (actual: mixed, expected: mixed, msg?: string) => void,
+
+  // notEqual + aliases
+  notEqual: (actual: mixed, expected: mixed, msg?: string) => void,
+  notEquals: (actual: mixed, expected: mixed, msg?: string) => void,
+  notStrictEqual: (actual: mixed, expected: mixed, msg?: string) => void,
+  notStrictEquals: (actual: mixed, expected: mixed, msg?: string) => void,
+  isNotEqual: (actual: mixed, expected: mixed, msg?: string) => void,
+  isNot: (actual: mixed, expected: mixed, msg?: string) => void,
+  not: (actual: mixed, expected: mixed, msg?: string) => void,
+  doesNotEqual: (actual: mixed, expected: mixed, msg?: string) => void,
+  isInequal: (actual: mixed, expected: mixed, msg?: string) => void,
+
+  // deepEqual + aliases
+  deepEqual: (actual: mixed, expected: mixed, msg?: string) => void,
+  deepEquals: (actual: mixed, expected: mixed, msg?: string) => void,
+  isEquivalent: (actual: mixed, expected: mixed, msg?: string) => void,
+  same: (actual: mixed, expected: mixed, msg?: string) => void,
+
+  // notDeepEqual
+  notDeepEqual: (actual: mixed, expected: mixed, msg?: string) => void,
+  notEquivalent: (actual: mixed, expected: mixed, msg?: string) => void,
+  notDeeply: (actual: mixed, expected: mixed, msg?: string) => void,
+  notSame: (actual: mixed, expected: mixed, msg?: string) => void,
+  isNotDeepEqual: (actual: mixed, expected: mixed, msg?: string) => void,
+  isNotDeeply: (actual: mixed, expected: mixed, msg?: string) => void,
+  isNotEquivalent: (actual: mixed, expected: mixed, msg?: string) => void,
+  isInequivalent: (actual: mixed, expected: mixed, msg?: string) => void,
+
+  // deepLooseEqual
+  deepLooseEqual: (actual: mixed, expected: mixed, msg?: string) => void,
+  looseEqual: (actual: mixed, expected: mixed, msg?: string) => void,
+  looseEquals: (actual: mixed, expected: mixed, msg?: string) => void,
+
+  // notDeepLooseEqual
+  notDeepLooseEqual: (actual: mixed, expected: mixed, msg?: string) => void,
+  notLooseEqual: (actual: mixed, expected: mixed, msg?: string) => void,
+  notLooseEquals: (actual: mixed, expected: mixed, msg?: string) => void,
+
+  throws: (fn: Function, expected?: RegExp | Function, msg?: string) => void,
+  doesNotThrow: (fn: Function, expected?: RegExp | Function, msg?: string) => void,
+
+  timeoutAfter: (ms: number) => void,
+
+  skip: (msg?: string) => void,
+  plan: (n: number) => void,
+  onFinish: (fn: Function) => void,
+  end: () => void,
+  comment: (msg: string) => void,
+  test: tape$TestFn,
+}
+
+declare module 'tape' {
+  declare type TestHarness = Tape;
+  declare type StreamOpts = {
+    objectMode?: boolean,
+  };
+
+  declare type Tape = {
+    (a: string | tape$TestOpts | tape$TestCb, b?: tape$TestCb | tape$TestOpts, c?: tape$TestCb, ...rest: Array<void>): void,
+    skip: (name: string, cb?: tape$TestCb) => void,
+    createHarness: () => TestHarness,
+    createStream: (opts?: StreamOpts) => stream$Readable, 
+    only: (a: string | tape$TestOpts | tape$TestCb, b?: tape$TestCb | tape$TestOpts, c?: tape$TestCb, ...rest: Array<void>) => void,
+  };
+
+  declare module.exports: Tape;
+}

--- a/definitions/npm/tape_v4.5.x/test_tape_v4.5.x.js
+++ b/definitions/npm/tape_v4.5.x/test_tape_v4.5.x.js
@@ -1,0 +1,156 @@
+/* @flow */
+
+/* eslint-disable no-console, no-unused-vars */
+
+import test from 'tape';
+
+test((t) => { t.end(); });
+test('flow', (t) => { t.end(); });
+
+test('flow', { skip: true }, (t) => {
+  t.end();
+});
+
+test('flow', { timeout: 100 }, (t) => {
+  t.end();
+});
+
+// $ExpectError
+test('flow', { skip: 1 }, (t) => {
+  t.end();
+});
+
+// $ExpectError
+test('flow', { timeout: '' }, (t) => {
+  t.end();
+});
+
+// Nested tests
+test('flow', { skip: true }, (t) => {
+  t.test({ skip: true }, (q) => {
+    q.end();
+  });
+
+  t.test((q) => {
+    q.end();
+  });
+
+  t.test('x', { skip: true }, (q) => {
+    q.end();
+  });
+
+  t.test('y', (q) => {
+    q.end();
+  });
+});
+
+test({ skip: true }, (t) => {
+  t.end();
+});
+
+
+// Context tests
+// TODO: If there is no specific tape$Context annotation,
+//       type errors inside this will not be directly marked,
+//       because flow thinks that there is a parameter problem,
+//       instead of telling the user that t.comment() was used wrong
+test('flow', (t: tape$Context) => {
+  const x = '1';
+  const y = '2';
+
+  t.onFinish(() => {});
+  t.plan(5);
+  t.fail('explode');
+  t.pass('pass');
+  t.timeoutAfter(1000);
+  t.skip('skipped');
+
+  t.ok(undefined, 'test');
+  t.ok('', 'test');
+  t.ok(true, 'test');
+  t.ok({}, 'test');
+  t.true(true, 'test');
+  t.assert(true, 'test');
+
+  t.notOk(false, 'test');
+  t.false('', 'test');
+  t.notok({}, 'test');
+
+  t.error(new Error('error'), 'some error');
+  t.error('', 'some error');
+  t.ifError('', 'some error');
+  t.ifErr('', 'some error');
+  t.iferror('', 'some error');
+
+  t.equal('1', '2', 'test');
+  t.equals(undefined, 1, 'test');
+  t.isEqual(undefined, undefined);
+  t.is({}, {}, 'test');
+  t.strictEqual(null, null, 'test');
+  t.strictEquals('', '', 'test');
+
+  t.notEqual('', 1, 'test');
+  t.notEquals('', 1, 'test');
+  t.notStrictEqual('', 1, 'test');
+  t.notStrictEquals('', 1, 'test');
+  t.isNotEqual('', 1, 'test');
+  t.isNot('', 1);
+  t.not(undefined, undefined, 'test');
+  t.doesNotEqual('', null, 'test');
+  t.isInequal('', 1, 'test');
+
+  t.deepEqual({}, {}, 'test');
+  t.deepEquals({}, {}, 'test');
+  t.isEquivalent({}, {}, 'test');
+  t.same({}, {}, 'test');
+
+  t.notDeepEqual({}, {}, 'test');
+  t.notEquivalent({}, {}, 'test');
+  t.notDeeply({}, {}, 'test');
+  t.notSame({}, {}, 'test');
+  t.isNotDeepEqual({}, {}, 'test');
+  t.isNotDeeply({}, {}, 'test');
+  t.isNotEquivalent({}, {}, 'test');
+  t.isInequivalent({}, {}, 'test');
+
+  t.deepLooseEqual({}, {}, 'test');
+  t.looseEqual({}, {}, 'test');
+  t.looseEquals({}, {}, 'test');
+
+  t.notDeepLooseEqual({}, {}, 'test');
+  t.notLooseEqual({}, {});
+  t.notLooseEquals({}, {}, '');
+
+  t.throws(() => {}, /expected error message/, 'test');
+  t.throws(() => {}, () => {}, 'test');
+  t.throws(() => {});
+
+  t.doesNotThrow(() => {}, /err message/, 'test');
+  t.doesNotThrow(() => {});
+
+  t.comment('test');
+
+  // $ExpectError: needs message
+  t.comment();
+
+  t.end();
+});
+
+const htest = test.createHarness();
+htest.createStream().pipe(process.stdout);
+htest.createStream({ objectMode: true }).pipe(process.stdout);
+
+// $ExpectError: objectMode should be a boolean
+htest.createStream({ objectMode: '' }).pipe(process.stdout);
+
+test.createStream({ objectMode: true }).on('data', (row) => {
+  console.log(JSON.stringify(row));
+});
+
+test.only('test', (t) => {
+  t.end();
+});
+
+test.only('test', { timeout: 1000 }, (t) => {
+  t.end();
+});


### PR DESCRIPTION
Finally got this working... I am not 100% happy with how flow infers the test-context function `(t) => { ... }`, when provided as first or second argument,.... but yeah, it's basically working with all of my (extensive) tape tests on our current projects.