### PR TITLE
add fuzzy-install to filterLibDefs's types

### DIFF
--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -98,7 +98,7 @@ export async function run(args: Args): Promise<number> {
     };
   } else {
     filter = {
-      type: 'fuzzy',
+      type: 'fuzzy-install',
       term: defName,
       flowVersion,
     };

--- a/cli/src/lib/__tests__/libDefs-test.js
+++ b/cli/src/lib/__tests__/libDefs-test.js
@@ -147,6 +147,49 @@ describe('libDefs', () => {
       });
     });
 
+    describe('fuzzy-install filter', () => {
+      it('filters on exact name', () => {
+        const fixture = [
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
+        ];
+        const filtered = filterLibDefs(fixture, {type: 'fuzzy-install', term: 'mori'});
+        expect(filtered).toEqual([fixture[1], fixture[0]]);
+      });
+
+      it('filters on differently-cased name', () => {
+        const fixture = [
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
+        ];
+        const filtered = filterLibDefs(fixture, {type: 'fuzzy-install', term: 'Mori'});
+        expect(filtered).toEqual([fixture[1], fixture[0]]);
+      });
+
+      it('DOES NOT filter on partial name', () => {
+        const fixture = [
+          _generateFixturePkg('**mori', 'v0.3.x', '>=v0.22.x'),
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
+          _generateFixturePkg('mo**ri', 'v0.3.x', '>=v0.18.x'),
+        ];
+        const filtered = filterLibDefs(fixture, {type: 'fuzzy-install', term: 'mori'});
+        expect(filtered).toEqual([fixture[1]]);
+      });
+
+      it('filters on flow version', () => {
+        const fixture = [
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
+        ];
+        const filtered = filterLibDefs(fixture, {
+          type: 'fuzzy-install',
+          term: 'mori',
+          flowVersion: stringToVersion('v0.19.0')
+        });
+        expect(filtered).toEqual([fixture[1]]);
+      });
+    });
+
     describe('exact filter', () => {
       function _generateLibDef(pkgName, pkgVersionStr, flowVersionStr) {
         return {

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -517,6 +517,7 @@ export async function getCacheLibDefVersion(libDef: LibDef) {
  */
 type LibDefFilter =
   | {type: 'fuzzy', flowVersion?: Version, term: string}
+  | {type: 'fuzzy-install', flowVersion?: Version, term: string}
   //| {type: 'exact', flowVersion?: Version, pkgName: string, pkgVersion: Version}
   | {type: 'exact', flowVersion?: Version, libDef: LibDef}
 ;
@@ -531,6 +532,12 @@ export function filterLibDefs(
         filterMatch = (
           def.pkgName.toLowerCase() === filter.libDef.pkgName.toLowerCase()
           && semver.satisfies(filter.libDef.pkgVersionStr, def.pkgVersionStr)
+        );
+        break;
+
+      case 'fuzzy-install':
+        filterMatch = (
+          def.pkgName.toLowerCase() === filter.term.toLowerCase()
         );
         break;
 


### PR DESCRIPTION
fizzy filter should filter on partial name for search command.
But I think, in case of install command, it should filter using correct package name.

How do you think?

# before
```
$ flow-typed install -o -f 0.26.0 redux
 * found 3 matching libdefs.
'redux-actions_v0.9.x.js' installed at /Users/noguchimasato/.ghq/github.com/joe-re/pomodo-desuka/flow-typed/npm/redux-actions_v0.9.x.js.
```

oops...installed redux-action.

# after
```
$ flow-typed install -o -f 0.26.0 redux
 * found 1 matching libdefs.
'redux_v3.x.x.js' installed at /Users/noguchimasato/.ghq/github.com/joe-re/flow-typed/cli/flow-typed/npm/redux_v3.x.x.js.
```
