### PR TITLE
Add definition for mocha's 'context' function

### DIFF
--- a/definitions/npm/mocha_v2.4.x/flow_>=v0.22.x/mocha_v2.4.x.js
+++ b/definitions/npm/mocha_v2.4.x/flow_>=v0.22.x/mocha_v2.4.x.js
@@ -7,6 +7,8 @@ declare var describe : {
     timeout(ms:number): void;
 };
 
+declare var context : typeof describe;
+
 declare var it : {
     (name:string, spec:TestFunction): void;
     only(description:string, spec:TestFunction): void;

--- a/definitions/npm/mocha_v2.4.x/test_mocha_v2.4.x_context.js
+++ b/definitions/npm/mocha_v2.4.x/test_mocha_v2.4.x_context.js
@@ -1,0 +1,50 @@
+/* @flow */
+
+/**
+ * context
+ */
+
+context('desc', () => {});
+
+// $ExpectError number. This type is incompatible with function type.
+context('desc', 12);
+// $ExpectError number. This type is incompatible with undefined.
+context('desc', () => 1);
+// $ExpectError number. This type is incompatible with string.
+context(12, () => {});
+
+
+/**
+ * context.skip
+ */
+
+context.skip('desc', () => {});
+
+// $ExpectError number. This type is incompatible with function type.
+context.skip('desc', 12);
+// $ExpectError number. This type is incompatible with undefined.
+context.skip('desc', () => 1);
+// $ExpectError number. This type is incompatible with string.
+context.skip(12, () => {});
+
+/**
+ * context.only
+ */
+
+context.only('desc', () => {});
+
+// $ExpectError number. This type is incompatible with function type.
+context.only('desc', 12);
+// $ExpectError number. This type is incompatible with undefined.
+context.only('desc', () => 1);
+// $ExpectError number. This type is incompatible with string.
+context.only(12, () => {});
+
+/**
+ * context.timeout
+ */
+
+context.timeout(1000);
+
+// $ExpectError string. This type is incompatible with number.
+context.timeout('1000');


### PR DESCRIPTION
`context` is an alias for `describe`