### PR TITLE
Add update-cache command

### DIFF
--- a/cli/src/cli.js
+++ b/cli/src/cli.js
@@ -13,6 +13,7 @@ import * as Install from "./commands/install.js";
 import * as RunTests from "./commands/runTests.js";
 import * as Search from "./commands/search.js";
 import * as ValidateDefs from "./commands/validateDefs.js";
+import * as UpdateCache from "./commands/update-cache";
 import * as Version from "./commands/version.js";
 
 export function runCLI() {
@@ -28,6 +29,7 @@ export function runCLI() {
     Search,
     ValidateDefs,
     Version,
+    UpdateCache,
   ];
 
   commands

--- a/cli/src/commands/update-cache.js
+++ b/cli/src/commands/update-cache.js
@@ -1,0 +1,48 @@
+// @flow
+
+import { _updateCacheRepo as updateCacheRepo } from '../lib/libDefs';
+
+export const name = 'update-cache';
+export const description = 'Updates the flow-typed definitions cache';
+
+export function setup(yargs: Object) {
+  return yargs
+    .usage(`$0 ${name} - ${description}`)
+    .options({
+      debug: {
+        describe: 'Enables verbose messages for the update procedure',
+        alias: 'd',
+        type: 'bool',
+        demand: false,
+      }
+    });
+};
+
+type Args = {
+  _: Array<string>,
+  debug?: boolean,
+}
+
+export async function run(args: Args): Promise<number> {
+  let verbose;
+
+  if (args.debug) {
+    verbose = process.stdout;
+  }
+
+  console.log('Updating flow-typed definitions...');
+  const success = await updateCacheRepo(verbose);
+
+  if (success) {
+    console.log('Definitions update successful!');
+    return 0;
+  }
+
+  console.log('Update failed...');
+
+  if (!args.debug) {
+    console.log('Rerun this command with the --debug for more information!');
+  }
+
+  return 1;
+}

--- a/cli/src/commands/update-cache.js
+++ b/cli/src/commands/update-cache.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { _updateCacheRepo as updateCacheRepo } from '../lib/libDefs';
+import {updateCacheRepo} from '../lib/libDefs';
 
 export const name = 'update-cache';
 export const description = 'Updates the flow-typed definitions cache';
@@ -24,25 +24,25 @@ type Args = {
 }
 
 export async function run(args: Args): Promise<number> {
-  let verbose;
+  try {
+    let verbose;
 
-  if (args.debug) {
-    verbose = process.stdout;
-  }
+    if (args.debug) {
+      verbose = process.stdout;
+    }
 
-  console.log('Updating flow-typed definitions...');
-  const success = await updateCacheRepo(verbose);
+    console.log('Updating flow-typed definitions...');
+    await updateCacheRepo(verbose);
 
-  if (success) {
     console.log('Definitions update successful!');
     return 0;
+  } catch (e) {
+    console.error(`Update failed: ${e.message}`);
+
+    if (args.debug) {
+      console.error(e);
+    }
+
+    return 1;
   }
-
-  console.log('Update failed...');
-
-  if (!args.debug) {
-    console.log('Rerun this command with the --debug for more information!');
-  }
-
-  return 1;
 }

--- a/cli/src/lib/__tests__/libDefs-test.js
+++ b/cli/src/lib/__tests__/libDefs-test.js
@@ -12,6 +12,7 @@ import {
   _CACHE_REPO_EXPIRY as CACHE_REPO_EXPIRY,
   _CACHE_REPO_GIT_DIR as CACHE_REPO_GIT_DIR,
   _ensureCacheRepo as ensureCacheRepo,
+  _updateCacheRepo as updateCacheRepo,
   _LAST_UPDATED_FILE as LAST_UPDATED_FILE,
   filterLibDefs,
 } from '../libDefs.js';
@@ -87,6 +88,37 @@ describe('libDefs', () => {
 
       await ensureCacheRepo();
       expect(_mock(Git.Repository.open).mock.calls.length).toBe(0);
+    });
+  });
+
+  describe('updateCacheRepo', () => {
+    beforeEach(() => {
+      _mock(Git.Clone).mockClear();
+      const repo = _mock(Git.Repository)._mockRepo;
+      repo.checkoutBranch.mockClear();
+      repo.rebaseBranches.mockClear();
+      _mock(Git.Repository.open).mockClear();
+    });
+
+    pit('rebases if present on disk + lastUpdated is old', async () => {
+      _mock(fs.exists).mockImplementation(dirPath => {
+        return dirPath === CACHE_REPO_DIR || dirPath === CACHE_REPO_GIT_DIR;
+      });
+      
+      _mock(fs.readFile).mockImplementation((filePath) => {
+        if (filePath === LAST_UPDATED_FILE) {
+          return String(Date.now() - CACHE_REPO_EXPIRY - 1);
+        }
+      });
+
+      await updateCacheRepo();
+      expect(_mock(Git.Repository.open).mock.calls).toEqual([
+        [CACHE_REPO_DIR],
+      ]);
+      const _mockRepo = _mock(Git.Repository)._mockRepo;
+      expect(_mockRepo.rebaseBranches.mock.calls).toEqual([
+        ['master', 'origin/master'],
+      ]);
     });
   });
 

--- a/cli/src/lib/__tests__/libDefs-test.js
+++ b/cli/src/lib/__tests__/libDefs-test.js
@@ -12,7 +12,7 @@ import {
   _CACHE_REPO_EXPIRY as CACHE_REPO_EXPIRY,
   _CACHE_REPO_GIT_DIR as CACHE_REPO_GIT_DIR,
   _ensureCacheRepo as ensureCacheRepo,
-  _updateCacheRepo as updateCacheRepo,
+  updateCacheRepo,
   _LAST_UPDATED_FILE as LAST_UPDATED_FILE,
   filterLibDefs,
 } from '../libDefs.js';

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -66,7 +66,7 @@ async function rebaseCacheRepo(verbose?: VerboseOutput) {
 /**
  * Utility wrapper for ensureCacheRepo with an update expiry of 0 hours.
  */
-async function updateCacheRepo(verbose?: VerboseOutput): Promise<boolean>{
+async function updateCacheRepo(verbose?: VerboseOutput) {
   return await ensureCacheRepo(verbose, 0);
 }
 

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -66,13 +66,8 @@ async function rebaseCacheRepo(verbose?: VerboseOutput) {
 /**
  * Utility wrapper for ensureCacheRepo with an update expiry of 0 hours.
  */
-async function updateCacheRepo(verbose?: VerboseOutput): Promise<boolean> {
-  try {
-    await ensureCacheRepo(verbose, 0);
-    return true;
-  } catch (e) {
-    return false;
-  }
+async function updateCacheRepo(verbose?: VerboseOutput): Promise<boolean>{
+  return await ensureCacheRepo(verbose, 0);
 }
 
 /**
@@ -123,7 +118,7 @@ export {
   CACHE_REPO_EXPIRY as _CACHE_REPO_EXPIRY,
   CACHE_REPO_GIT_DIR as _CACHE_REPO_GIT_DIR,
   ensureCacheRepo as _ensureCacheRepo,
-  updateCacheRepo as _updateCacheRepo,
+  updateCacheRepo,
   LAST_UPDATED_FILE as _LAST_UPDATED_FILE,
 };
 


### PR DESCRIPTION
This commit also adds another parameter to the ensureCacheRepo function,
so we can reuse the logic for updating the cache-repo without a 5-day
limit (which is still the limit by default).

Issue: #111 

@jeffmo 