### PR TITLE
Only run tests in Travis for stuff that changed 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - '5.1'
+  - '5.11'
 compiler: clang-3.6
 env:
   - CXX=clang-3.6

--- a/cli/.flowconfig
+++ b/cli/.flowconfig
@@ -12,4 +12,4 @@ experimental.const_params=true
 suppress_comment=\\(.\\|\n\\)*\\$FlowIssue
 
 [version]
-^0.25.0
+^0.28.0

--- a/cli/flow-typed/npm/yargs_v4.x.x.js
+++ b/cli/flow-typed/npm/yargs_v4.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: b86972b47c44f9bf6772a814f317ca39
-// flow-typed version: ef85c464bf/yargs_v4.x.x/flow_>=v0.23.x
+// flow-typed signature: 44297a4413328857e4060d81e61e5cfc
+// flow-typed version: 5e1c1576ae/yargs_v4.x.x/flow_>=v0.23.x
 
 declare module 'yargs' {
   declare type Argv = {_: Array<string>, [key: string]: mixed};

--- a/cli/package.json
+++ b/cli/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "prepublish": "mkdir -p dist; npm run test",
     "test": "npm run clean; npm run build; npm run test-quick",
-    "test-quick": "npm run lint && jest",
+    "test-quick": "npm run lint && jest --colors",
     "watch": "mkdir -p dist; babel --watch=./src --out-dir=./dist"
   },
   "repository": {
@@ -45,7 +45,7 @@
     "babel-preset-es2015": "^6.6.0",
     "eslint": "^2.9.0",
     "eslint-plugin-flow-vars": "^0.4.0",
-    "flow-bin": "^0.25",
+    "flow-bin": "^0.28",
     "jest-cli": "^13.2.3"
   },
   "dependencies": {
@@ -55,6 +55,7 @@
     "md5": "^2.1.0",
     "mkdirp": "^0.5.1",
     "nodegit": "^0.15.1",
+    "nodegit-kit": "^0.11.1",
     "request": "^2.69.0",
     "rx-lite": "4.0.8",
     "semver": "^5.1.0",

--- a/cli/src/cli.js
+++ b/cli/src/cli.js
@@ -6,10 +6,11 @@ if (!global.__flowTypedBabelPolyfill) {
   global.__flowTypedBabelPolyfill = true;
 }
 
-import * as yargs from "yargs";
+import yargs from "yargs";
 import {fs, path} from "./lib/node.js";
 
 import * as Install from "./commands/install.js";
+import * as RunCITests from "./commands/runCITests.js";
 import * as RunTests from "./commands/runTests.js";
 import * as Search from "./commands/search.js";
 import * as ValidateDefs from "./commands/validateDefs.js";
@@ -20,11 +21,12 @@ export function runCLI() {
   type CommandModule = {
     name: string,
     description: string,
-    setup?: (yargs: Object) => Object,
+    setup?: (yargs: typeof yargs) => void,
     run: (argv: Object) => Promise<number>,
   };
   const commands: Array<CommandModule> = [
     Install,
+    RunCITests,
     RunTests,
     Search,
     ValidateDefs,

--- a/cli/src/commands/runCITests.js
+++ b/cli/src/commands/runCITests.js
@@ -1,0 +1,111 @@
+// @flow
+
+import Git from "nodegit";
+import GitKit from "nodegit-kit";
+import {path} from "../lib/node.js";
+import {parseRepoDirItem} from "../lib/libDefs.js";
+import {versionToString} from "../lib/semver.js";
+import type {Version} from "../lib/semver.js";
+
+import {run as runValidateDefs} from "./validateDefs.js";
+import {printRunTestsErrorResults, runTests} from "./runTests.js";
+
+export const name = "run-ci-tests";
+export const description = "Run continuous-integration validation tests";
+export async function run(argv: {_: Array<string>}) {
+  if (argv._.length !== 2) {
+    throw new Error(
+      'Please specify the path to the root of the git repo to run CI-tests on!'
+    );
+  }
+  const [_, gitPath] = argv._;
+
+  console.log(' * Validating definitions directories...');
+  const validateDefsResult = await runValidateDefs();
+  if (validateDefsResult !== 0) {
+    return validateDefsResult;
+  }
+
+  // Get a handle on the repo
+  const resolvedGitPath = await Git.Repository.discover(gitPath, 0, '');
+  const repoRoot = path.resolve(resolvedGitPath, '..');
+  console.log(' * Git dir resolved to %s', resolvedGitPath);
+  const repo  = await Git.Repository.open(resolvedGitPath);
+
+  // Find the files that've changed since master
+  const diffsFromMaster = await GitKit.diff(repo, 'HEAD', 'origin/master');
+  const changedFiles = diffsFromMaster.map(diff => diff.path);
+  console.log(' * Found %d changed files:', changedFiles.length);
+
+  // For each file that changed, determine the kinds of tests that need to run
+  const DEF_PATH_RE = /^(definitions\/npm\/([^\/]*))\/.*/;
+  const CLI_PATH_RE = /^cli\//;
+  const libDefsToTest: Map<string, [string, Version]> = new Map();
+  changedFiles.forEach(relFilePath => {
+    // Stuff that doesn't require any special CI tests.
+    // We keep a whitelist to ensure that Travis always fails for unexpected
+    // changes (since unexpected changes could be things we assumed would be
+    // tested by Travis). The fix, of course, is to simply add anything new to
+    // this list if it explicitly doesn't require any special Travis checks.
+    switch (relFilePath) {
+      case '.gitignore':
+      case '.travis.yml':
+      case 'CONTRIBUTING.md':
+      case 'LICENSE':
+      case 'README.md':
+      case 'flow-typed-logo.png':
+      case 'run_def_tests.sh':
+      case 'travis.sh':
+        return;
+    }
+
+    // libdef changes
+    const defPathMatches = relFilePath.match(DEF_PATH_RE);
+    if (defPathMatches) {
+      const [_, pkgDirPath, pkgDirName] = defPathMatches;
+      const {pkgName, pkgVersion} = parseRepoDirItem(pkgDirPath);
+      console.log(
+        `   - LibDef File Changed: ` +
+        `${pkgName}@${versionToString(pkgVersion)}: ${relFilePath}`
+      );
+      if (!libDefsToTest.has(pkgDirName)) {
+        libDefsToTest.set(pkgDirName, [pkgName, pkgVersion]);
+      }
+      return;
+    }
+
+    // CLI changes
+    if (CLI_PATH_RE.test(relFilePath)) {
+      console.log(`   - CLI File Changed: ${relFilePath}`);
+      return;
+    }
+
+    throw new Error(
+      `Unexpected file changed! Not sure how to run CI tests for ` +
+      `${relFilePath}! If this is a new file, decide if it needs to be ` +
+      `tested in Travis. If it does, update cli/src/commands/runCITests.js. ` +
+      `If it does not need to be tested in CI, add the new file to the ` +
+      `whitelist in runCITests.js`
+    );
+  });
+
+  if (libDefsToTest.size > 0) {
+    console.log(' * Running libdef tests...\n');
+    const libDefPkgNames = Array.from(libDefsToTest.values()).map(
+      ([pkgName]) => pkgName
+    );
+    const results = await runTests(
+      path.join(repoRoot, 'definitions', 'npm'),
+      libDefPkgNames,
+      /*stopOnFirstError=*/true,
+    );
+    printRunTestsErrorResults(results);
+    if (results.size > 0) {
+      return 1;
+    }
+  }
+
+  console.log(' * All CI tests passed!');
+
+  return 0;
+};

--- a/cli/src/commands/validateDefs.js
+++ b/cli/src/commands/validateDefs.js
@@ -25,18 +25,16 @@ export async function run(): Promise<number> {
     }
   });
 
-  console.log(" ");
-
   validationErrors.forEach((errors, pkgNameVersion) => {
-    console.log("Found some problems with %s:", pkgNameVersion);
+    console.log(`Found some problems with ${pkgNameVersion}:`);
     errors.forEach((err) => console.log("  * " + err));
     console.log("");
   });
 
   if (validationErrors.size === 0) {
     console.log(
-      `All library definitions are named and structured correctedly. ` +
-      `(Found ${localDefs.length})`
+      `All ${localDefs.length} library definitions are named and structured ` +
+      `correctly.`
     );
     return 0;
   }

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -336,7 +336,7 @@ async function parseLibDefsFromPkgDir(
  * directory's name into a package name and version.
  */
 const REPO_DIR_ITEM_NAME_RE = /^(.*)_v([0-9]+)\.([0-9]+|x)\.([0-9]+|x)$/;
-function parseRepoDirItem(dirItemPath, validationErrs) {
+export function parseRepoDirItem(dirItemPath: string, validationErrs?: VErrors) {
   const dirItem = path.basename(dirItemPath);
   const itemMatches = dirItem.match(REPO_DIR_ITEM_NAME_RE);
   if (itemMatches == null) {

--- a/travis.sh
+++ b/travis.sh
@@ -1,11 +1,28 @@
 #!/bin/bash
-#set -o errexit
+set -o errexit
+set -v
 
-cd definitions && \
-npm install && \
-npm test && \
-cd ../cli && \
-npm install && \
-./node_modules/.bin/flow && \
-node dist/cli.js validate-defs && \
-node dist/cli.js run-tests
+# We manage the git clone manually so that we have "origin/master" available to 
+# us for diffing
+if [ ! -z $TRAVIS ]; then
+  git fetch origin master
+  echo "TRAVIS_REPO_SLUG: $TRAVIS_REPO_SLUG"
+  git clone https://github.com/$TRAVIS_REPO_SLUG.git $TRAVIS_REPO_SLUG
+  cd $TRAVIS_REPO_SLUG
+  git fetch origin
+  echo "$TRAVIS_COMMIT_RANGE"
+  PR_COMMIT=`echo "$TRAVIS_COMMIT_RANGE"|cut -d. -f4`
+  echo "Checking out $PR_COMMIT..."
+  git checkout $PR_COMMIT
+  echo "PR_COMMIT checked out."
+  echo "git branches:"
+  git branch
+fi
+
+cd definitions
+npm install
+npm test
+cd ../cli
+npm install
+./node_modules/.bin/flow
+node dist/cli.js run-ci-tests ..


### PR DESCRIPTION
Adds a `flow-typed run-ci-tests` command that looks at the diff between the current working directory and `origin/master`, extracts a list of libdefs that were changed/added, and only runs applicable tests (rather than *all* tests).

Fixes https://github.com/flowtype/flow-typed/issues/76