### PR TITLE
[Ramda] Fix ramda sortBy typedef, add test

### DIFF
--- a/definitions/npm/ramda_v0.21.x/flow_>=v0.23.x/ramda_v0.21.x.js
+++ b/definitions/npm/ramda_v0.21.x/flow_>=v0.23.x/ramda_v0.21.x.js
@@ -516,10 +516,8 @@ declare module 'ramda' {
     propEq(path: string, val: any): (o: Object) => boolean;
     propEq(path: string): (val: any, o: Object) => boolean;
     propEq(path: string): (val: any) => (o: Object) => boolean;
-    sortBy<T,V>(fn: (x:T) => V, x: Array<T>, y: Array<T>): Array<T>;
-    sortBy<T,V>(fn: (x:T) => V): (x: Array<T>, y: Array<T>) => Array<T>;
-    sortBy<T,V>(fn: (x:T) => V): (x: Array<T>) => (y: Array<T>) => Array<T>;
-    sortBy<T,V>(fn: (x:T) => V, x: Array<T>): (y: Array<T>) => Array<T>;
+    sortBy<T,V>(fn: (x:T) => V, x: Array<T>): Array<T>;
+    sortBy<T,V>(fn: (x:T) => V): (x: Array<T>) => Array<T>;
     symmetricDifference<T>(x: Array<T>, y: Array<T>): Array<T>;
     symmetricDifference<T>(x: Array<T>): (y: Array<T>) => Array<T>;
     symmetricDifferenceWith<T>(fn: BinaryPredicateFn<T>, x: Array<T>, y: Array<T>): Array<T>;

--- a/definitions/npm/ramda_v0.21.x/test_ramda_v0.21.x.js
+++ b/definitions/npm/ramda_v0.21.x/test_ramda_v0.21.x.js
@@ -209,6 +209,17 @@ describe('List', () => {
     ]
     const res: {[key: string]: Array<string>} = namesByGrade(students)
   })
+
+  it('should typecheck sortBy', () => {
+    const list = [ 3, 1, 2 ];
+
+    const negativeComparator = (x: number): number => -x;
+
+    const resA: Array<number> = _.sortBy(negativeComparator, list)
+
+    const curried = _.sortBy(negativeComparator)
+    const resB: Array<number> = curried(list)
+  })
 })
 
 describe('String', () => {


### PR DESCRIPTION
Ramda sortBy only accepts two arguments:

http://ramdajs.com/docs/#sortBy

This PR fixes that problem and adds a test for the curried/total cases.