### PR TITLE
Add RxJS `groupBy` operator

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_>=v0.25.0/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_>=v0.25.0/rxjs_v5.0.x.js
@@ -149,6 +149,12 @@ declare module 'rxjs' {
       defaultValue: U,
     ): Observable<U>;
 
+    groupBy(
+      keySelector: (value: T) => mixed,
+      elementSelector?: (value: T) => T,
+      compare?: (x: T, y: T) => boolean,
+    ): Observable<Observable<T>>;
+
     ignoreElements<U>(): Observable<U>;
 
     // Alias for `mergeMap`

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -76,3 +76,6 @@ const subObserver: rx$IObserver<SubFoo> = (null: any);
 // $ExpectError -- contravariant. Type parameter is only in input positions.
 (subObserver: rx$IObserver<SuperFoo>);
 (superObserver: rx$IObserver<SubFoo>);
+
+const groupedSubObservable: Observable<Observable<SubFoo>> =
+  subObservable.groupBy(subfoo => subfoo.y);


### PR DESCRIPTION
> The [GroupBy operator][1] divides an Observable that emits items into an
Observable that emits Observables, each one of which emits some subset
of the items from the original source Observable.

Fixes #153

[1]: http://reactivex.io/documentation/operators/groupby.html