### PR TITLE
support Enzyme 2.3 additions

### DIFF
--- a/definitions/npm/enzyme_v2.3.x/flow_>=v0.23.x/enzyme_v2.3.x.js
+++ b/definitions/npm/enzyme_v2.3.x/flow_>=v0.23.x/enzyme_v2.3.x.js
@@ -1,0 +1,33 @@
+declare module 'enzyme' {
+  declare type PredicateFunction = (wrapper: Wrapper) => boolean;
+  declare type NodeOrNodes = React$Element | Array<React$Element>;
+  declare class Wrapper<ReturnClass: Wrapper> {
+    find(selector: string): ReturnClass;
+    findWhere(predicate: PredicateFunction): ReturnClass;
+    filter(selector: string): ReturnClass;
+    filterWhere(predicate: PredicateFunction): ReturnClass;
+    contains(nodeOrNodes: NodeOrNodes): boolean;
+    equals(node: React$Element): boolean;
+    hasClass(className: string): boolean;
+    instance(): React$Component;
+    is(selector: string): boolean;
+    not(selector: string): boolean;
+    children(): ReturnClass;
+    childAt(index: number): ReturnClass;
+    props(): Object;
+    name(): string;
+    prop(key: string): any;
+    type(): string | Function;
+    text(): string;
+    html(): string;
+    update(): this;
+  }
+  declare class ReactWrapper<ReactWrapper> extends Wrapper {}
+  declare class ShallowWrapper<ShallowWrapper> extends Wrapper {
+    shallow(options?: { context?: Object }): ShallowWrapper;
+  }
+  declare class CheerioWrapper<CheerioWrapper> extends Wrapper {}
+  declare function shallow(node: React$Element, options?: { context?: Object }): ShallowWrapper;
+  declare function mount(node: React$Element, options?: { context?: Object, attachTo?: HTMLElement, childContextTypes?: Object }): ReactWrapper;
+  declare function render(node: React$Element, options?: { context?: Object }): CheerioWrapper;
+}

--- a/definitions/npm/enzyme_v2.3.x/test_enzyme-v2.3.js
+++ b/definitions/npm/enzyme_v2.3.x/test_enzyme-v2.3.js
@@ -1,0 +1,14 @@
+// @flow
+import enzyme from 'enzyme';
+
+// $ExpectError
+enzyme.render();
+shallowWrapper = enzyme.shallow(<div/>);
+(enzyme.render(<div/>, { context: { foo: true } }).text(): string)
+const A: bool = enzyme.render(<div/>, { context: { foo: true } }).find('foo').is('bla');
+const B: bool = enzyme.render(<div/>, { context: { foo: true } }).update().filter('bla').equals(<div/>);
+
+shallowWrapper.instance();
+shallowWrapper.find('someSelector');
+shallowWrapper.prop('foo');
+shallowWrapper.props().foo;


### PR DESCRIPTION
https://github.com/airbnb/enzyme/blob/master/CHANGELOG.md

Is this the right way to have a 2.x.x and 2.3.x matcher co-exist? (Actually, is that supported yet? The run-tests command seems to assume there will be only one because when added this dir it no longer picked up 2.x.x)