### PR TITLE
Add initial definitions for chai

### DIFF
--- a/definitions/npm/chai_v3.5.x/flow_>=v0.24.0/chai_v3.5.x.js
+++ b/definitions/npm/chai_v3.5.x/flow_>=v0.24.0/chai_v3.5.x.js
@@ -1,0 +1,105 @@
+/* @flow */
+declare module "chai" {
+
+    declare type ExpectChain<T> = {
+        and: ExpectChain<T>,
+        at: ExpectChain<T>,
+        be: ExpectChain<T>,
+        been: ExpectChain<T>,
+        have: ExpectChain<T>,
+        has: ExpectChain<T>,
+        is: ExpectChain<T>,
+        of: ExpectChain<T>,
+        same: ExpectChain<T>,
+        that: ExpectChain<T>,
+        to: ExpectChain<T>,
+        which: ExpectChain<T>,
+        with: ExpectChain<T>,
+
+        not: ExpectChain<T>,
+        deep: ExpectChain<T>,
+        any: ExpectChain<T>,
+        all: ExpectChain<T>,
+
+        a: ExpectChain<T> & (type: string) => ExpectChain<T>,
+        an: ExpectChain<T> & (type: string) => ExpectChain<T>,
+
+        include: ExpectChain<T> & (value: mixed) => ExpectChain<T>,
+        includes: ExpectChain<T> & (value: mixed) => ExpectChain<T>,
+        contain: ExpectChain<T> & (value: mixed) => ExpectChain<T>,
+        contains: ExpectChain<T> & (value: mixed) => ExpectChain<T>,
+
+        eql: (value: T) => ExpectChain<T>,
+        equal: (value: T) => ExpectChain<T>,
+        equals: (value: T) => ExpectChain<T>,
+
+        above: (value: T & number) => ExpectChain<T>,
+        least: (value: T & number) => ExpectChain<T>,
+        below: (value: T & number) => ExpectChain<T>,
+        most: (value: T & number) => ExpectChain<T>,
+        within: (start: T & number, finish: T & number) => ExpectChain<T>,
+
+        instanceof: (constructor: mixed) => ExpectChain<T>,
+        property: (
+          <P>(name: string, value?: P) => ExpectChain<P>
+          & (name: string) => ExpectChain<mixed>
+        ),
+
+        length: ExpectChain<number>,
+        lengthOf: (value: number) => ExpectChain<T>,
+
+        match: (regex: RegExp) => ExpectChain<T>,
+        string: (string: string) => ExpectChain<T>,
+
+        key: (key: string) => ExpectChain<T>,
+        keys: (key: string | Array<string>, ...keys: Array<string>) => ExpectChain<T>,
+
+        throw: <E>(err: Class<E> | Error | RegExp | string, msg?: RegExp | string) => ExpectChain<T>,
+
+        respondTo: (method: string) => ExpectChain<T>,
+        itself: ExpectChain<T>,
+
+        satisfy: (method: (value: T) => bool) => ExpectChain<T>,
+
+        closeTo: (expected: T & number, delta: number) => ExpectChain<T>,
+
+        members: (set: mixed) => ExpectChain<T>,
+        oneOf: (list: Array<T>) => ExpectChain<T>,
+
+        change: (obj: mixed, key: string) => ExpectChain<T>,
+        increase: (obj: mixed, key: string) => ExpectChain<T>,
+        decrease: (obj: mixed, key: string) => ExpectChain<T>,
+
+        // dirty-chai
+        ok: () => ExpectChain<T>,
+        true: () => ExpectChain<T>,
+        false: () => ExpectChain<T>,
+        null: () => ExpectChain<T>,
+        undefined: () => ExpectChain<T>,
+        exist: () => ExpectChain<T>,
+        empty: () => ExpectChain<T>,
+
+        // chai-immutable
+        size: (n: number) => ExpectChain<T>,
+
+        // sinon-chai
+        called: () => ExpectChain<T>,
+        callCount: (n: number) => ExpectChain<T>,
+        calledOnce: () => ExpectChain<T>,
+        calledBefore: (spy: mixed) => ExpectChain<T>,
+        calledAfter: (spy: mixed) => ExpectChain<T>,
+        calledWith: (...args: Array<mixed>) => ExpectChain<T>,
+        calledWithMatch: (...args: Array<mixed>) => ExpectChain<T>,
+        calledWithExactly: (...args: Array<mixed>) => ExpectChain<T>,
+    };
+
+    declare function expect<T>(actual: T): ExpectChain<T>;
+
+    declare function use(plugin: (chai: Object, utils: Object) => void): void;
+
+    declare var config: {
+        includeStack: boolean,
+        showDiff: boolean,
+        truncateThreshold: boolean
+    };
+}

--- a/definitions/npm/chai_v3.5.x/test_chai_v3.5.x.js
+++ b/definitions/npm/chai_v3.5.x/test_chai_v3.5.x.js
@@ -1,0 +1,77 @@
+/* @flow */
+
+import {expect} from "chai";
+
+/**
+ * Word chains
+ */
+expect(true)
+  .and.at.be.been.have.has
+  .is.of.same.that.to.which
+  .with.not.deep.any.all.a.an.eql(false);
+
+/**
+ * Simple Assertions
+ */
+expect(1).to.be.a("number");
+expect([1]).to.be.an("array");
+// $ExpectError
+expect(1).to.be.a(["fail"]);
+
+expect([1]).to.include(1);
+expect([1]).which.includes(1);
+expect([1]).to.contain(1);
+expect([1]).which.contains(1);
+
+expect(1).to.eql(2);
+expect(1).to.equal(2);
+expect(1).which.equals(2);
+
+expect(1).to.be.above(7);
+expect(1).to.be.at.least(7);
+expect(1).to.be.below(7);
+expect(1).to.be.at.most(7);
+expect(1).to.be.within(5, 6);
+
+expect(new Date()).to.be.an.instanceof(Date);
+expect({a: 1}).to.have.property("a");
+expect({a: 1}).to.have.property("a").which.is.above(0);
+expect({a: 1}).to.have.property("a", 1);
+
+expect([1,2,3]).to.have.length.above(2);
+expect([1,2,3]).to.have.lengthOf(3);
+
+expect("abc").to.match(/[a-z]{3}/);
+expect("abc").to.have.string("b");
+
+expect({a: 1, b: 2}).to.have.key("a");
+expect({a: 1, b: 2}).to.have.keys("a", "b");
+expect({a: 1, b: 2}).to.have.keys(["a", "b"]);
+
+expect(() => {}).to.throw(Error);
+expect(() => {}).to.throw(new Error("stuff"));
+expect(() => {}).to.throw("stuff");
+expect(() => {}).to.throw(Error, "stuff");
+expect(() => {}).to.throw(/stuff/);
+expect(() => {}).to.throw(ReferenceError, /stuff/);
+
+expect({}).to.respondTo("bar");
+expect(Error).itself.to.respondTo("bar");
+
+expect(1).to.satisfy((x) => x > 0);
+// $ExpectError
+expect(1).to.satisfy((x, y) => x * y);
+
+expect(0.3 - 0.2).to.be.closeTo(0.1, 1e-3);
+
+expect([1, 2, 3]).to.include.members([3, 2]);
+
+expect('a').to.be.oneOf(['a', 'b', 'c']);
+
+expect((x) => x).to.change({val: 0}, 'val');
+expect((x) => x).to.increase({val: 0}, 'val');
+expect((x) => x).to.decrease({val: 0}, 'val');
+
+
+// $ExpectError
+expect(1).to.what("nope");


### PR DESCRIPTION
There's probably still some work to do for these to be widely usable, but I figured I'd share what I have so far.

Some annoyances:

```js
expect(1).to.eql("1");
```
This should really be a type error, but for some reason flow infers the type to be `ExpectChain<number | string>` rather than sticking with what `expect()` says. Unsure how to fix this.

*****

The plugin system

Chai's plugin system allows plugins to add extra methods and properties to the ExpectChain, the only way I can think of to manage this in flow is to add them all to the core def. This PR currently includes some methods from a couple of plugins that I'm using in the project this is sourced from.

To complicate matters more, chai has a slightly awkward API where getters have side effects that won't be changed for back-compat reasons. [dirty-chai](https://www.npmjs.com/package/dirty-chai) is the recommended way to fix the old API, which is a plugin that changes the definition of core methods.