### PR TITLE
Add shelljs (v0.7.0) declarations

### DIFF
--- a/definitions/npm/shelljs_v0.7.x/flow_>=v0.28.x/shelljs_v0.7.x.js
+++ b/definitions/npm/shelljs_v0.7.x/flow_>=v0.28.x/shelljs_v0.7.x.js
@@ -1,0 +1,213 @@
+declare class $npm$shelljs$Array<T> extends Array<T> mixins $npm$shelljs$Result, String {}
+declare type  $npm$shelljs$Async = Class<child_process$ChildProcess>;
+declare type  $npm$shelljs$Pattern = RegExp | String | string;
+declare class $npm$shelljs$String mixins $npm$shelljs$Result, String {
+  constructor(stdout: string | string[], stderr?: string, code?: number): this;
+}
+
+declare interface $npm$shelljs$Config {
+  fatal: boolean;
+  globOpts: {
+    nodir: boolean;
+  };
+  silent: boolean;
+  verbose: boolean;
+}
+declare interface $npm$shelljs$Env {
+  [key: string]: string;
+};
+
+declare type $npm$shelljs$OptionsPoly<Flags: string> = {
+  [keys: Flags]: boolean;
+};
+declare interface $npm$shelljs$ExecThen {
+  (code: number, stdout: string, stderr: string): void;
+};
+declare type $npm$shelljs$ExecOptionsPoly<T: Object> = T & { async?: boolean; silent?: boolean };
+declare type $npm$shelljs$ExecOpts = $npm$shelljs$ExecOptionsPoly<child_process$execOpts>;
+declare type $npm$shelljs$ExecOptsSync = $npm$shelljs$ExecOptionsPoly<child_process$execSyncOpts>;
+declare type $npm$shelljs$GrepOpts = $npm$shelljs$OptionsPoly<'-l' | '-v'>;
+declare type $npm$shelljs$SedOpts = $npm$shelljs$OptionsPoly<'-i'>;
+declare type $npm$shelljs$SortOpts = $npm$shelljs$OptionsPoly<'-n' | '-r'>;
+declare type $npm$shelljs$TestOpts = '-b' | '-c' | '-d' | '-e' | '-f' | '-L' | '-p' | '-S';
+declare type $npm$shelljs$TouchOpts = {
+  [key: '-a' | '-c' | '-m']: boolean;
+  '-d'?: string;
+  '-r'?: string;
+};
+
+// dupe from flow lib until we can import
+declare interface $npm$shelljs$FileStats {
+  atime: Date;
+  blksize: number;
+  blocks: number;
+  ctime: Date;
+  dev: number;
+  gid: number;
+  ino: number;
+  mode: number;
+  mtime: Date;
+  nlink: number;
+  rdev: number;
+  size: number;
+  uid: number;
+  isBlockDevice(): boolean;
+  isCharacterDevice(): boolean;
+  isDirectory(): boolean;
+  isFIFO(): boolean;
+  isFile(): boolean;
+  isSocket(): boolean;
+  isSymbolicLink(): boolean;
+}
+
+declare class $npm$shelljs$Result {
+  code: number;
+  stdout: string;
+  stderr: string;
+  to(file: string): this;
+  toEnd(file: string): this;
+  cat:
+    ((rest: void) => $npm$shelljs$String);
+  exec:
+    ((cmd: string, opts: $npm$shelljs$ExecOpts & { async: true }, then: $npm$shelljs$ExecThen, rest: void) => $npm$shelljs$Async) &
+    ((cmd: string, opts: $npm$shelljs$ExecOpts & { async: true }, rest: void) => $npm$shelljs$Async) &
+    ((cmd: string, opts: $npm$shelljs$ExecOptsSync, rest: void) => $npm$shelljs$String) &
+    ((cmd: string, rest: void) => $npm$shelljs$String) &
+    ((cmd: string, then: $npm$shelljs$ExecThen, rest: void) => $npm$shelljs$Async);
+  grep:
+    ((opts: $npm$shelljs$GrepOpts, rx: $npm$shelljs$Pattern, rest: void) => $npm$shelljs$String) &
+    ((rx: $npm$shelljs$Pattern, rest: void) => $npm$shelljs$String);
+  head:
+    ((num: number, rest: void) => $npm$shelljs$String) &
+    ((rest: void) => $npm$shelljs$String);
+  sed:
+    ((rx: $npm$shelljs$Pattern, subst: string, rest: void) => $npm$shelljs$String);
+  sort:
+    ((opts: $npm$shelljs$SortOpts, rest: void) => $npm$shelljs$String) &
+    ((rest: void) => $npm$shelljs$String);
+  tail:
+    ((num: number, rest: void) => $npm$shelljs$String) &
+    ((rest: void) => $npm$shelljs$String);
+}
+
+declare module 'shelljs' {
+  declare export type ShellAsync = $npm$shelljs$Async;
+  declare export type ShellOptionsPoly<Flags: string> = $npm$shelljs$OptionsPoly<Flags>;
+  declare export type ShellConfig = $npm$shelljs$Config;
+  declare export type ShellEnv = $npm$shelljs$Env;
+  declare export type ShellFileStats = $npm$shelljs$FileStats;
+  declare export type ShellPattern = $npm$shelljs$Pattern;
+
+  declare export type ChmodOpts = $npm$shelljs$OptionsPoly<'-R' | '-c' | '-v'>;
+  declare export type CpOpts = $npm$shelljs$OptionsPoly<'-P' | '-L' | '-R' | '-f' | '-n'>;
+  declare export type DirsOpts = '-c';
+  declare export type DirsIdx = // FIXME
+    | '-0' | '-1' | '-2' | '-3' | '-4' | '-5' | '-6' | '-7' | '-8' | '-9' | '-10' | '-11' | '-12' | '-13' | '-14' | '-15' | '-16' | '-17' | '-18' | '-19' | '-20' | '-21' | '-22' | '-23' | '-24' | '-25' | '-26' | '-27' | '-28' | '-29' | '-30' | '-31'
+    | '+0' | '+1' | '+2' | '+3' | '+4' | '+5' | '+6' | '+7' | '+8' | '+9' | '+10' | '+11' | '+12' | '+13' | '+14' | '+15' | '+16' | '+17' | '+18' | '+19' | '+20' | '+21' | '+22' | '+23' | '+24' | '+25' | '+26' | '+27' | '+28' | '+29' | '+30' | '+31';
+  declare export type ExecOpts = $npm$shelljs$ExecOpts;
+  declare export type ExecOptsSync = $npm$shelljs$ExecOptsSync;
+  declare export type ExecThen = $npm$shelljs$ExecThen;
+  declare export type GrepOpts = $npm$shelljs$GrepOpts;
+  declare export type LnOpts = $npm$shelljs$OptionsPoly<'-f' | '-s'>;
+  declare export type LsOpts = $npm$shelljs$OptionsPoly<'-A' | '-R' | '-d' | '-l'>;
+  declare export type MkdirOpts = $npm$shelljs$OptionsPoly<'-p'>;
+  declare export type MvOpts = $npm$shelljs$OptionsPoly<'-f' | '-n'>;
+  declare export type PopdOpts = $npm$shelljs$OptionsPoly<'-n'>;
+  declare export type PushdOpts = $npm$shelljs$OptionsPoly<'-n'>;
+  declare export type RmOpts = $npm$shelljs$OptionsPoly<'-f' | '-r'>;
+  declare export type SedOpts = $npm$shelljs$SedOpts;
+  declare export type SortOpts = $npm$shelljs$SortOpts;
+
+  declare var ShellArray: Class<$npm$shelljs$Array<*>>;
+  declare var ShellString: Class<$npm$shelljs$String>;
+
+  declare module.exports: {
+    ShellArray: Class<ShellArray>;
+    ShellString: Class<ShellString>;
+    config: ShellConfig;
+    env: ShellEnv;
+    cat:
+      ((glob: string, ...rest: string[]) => ShellString);
+    cd:
+      ((dir: string, rest: void) => ShellString) &
+      ((rest: void) => ShellString);
+    chmod:
+      ((opts: ChmodOpts, mode: number | string, glob: string, ...rest: string[]) => ShellString) &
+      ((mode: number | string, glob: string, ...rest: string[]) => ShellString);
+    cp:
+      ((opts: CpOpts, src: string, next: string, ...rest: string[]) => ShellString) &
+      ((src: string, next: string, ...rest: string[]) => ShellString);
+    dirs:
+      ((idxOrOpts: DirsIdx | DirsOpts, rest: void) => string[]) &
+      ((rest: void) => string[]);
+    echo: // FIXME: consider allowing more input types
+      ((...rest: (number | string | String)[]) => ShellString);
+    error:
+      ((rest: void) => ?string);
+    exec:
+      ((cmd: string, opts: $npm$shelljs$ExecOpts & { async: true }, then: $npm$shelljs$ExecThen, rest: void) => ShellAsync) &
+      ((cmd: string, opts: $npm$shelljs$ExecOpts & { async: true }, rest: void) => ShellAsync) &
+      ((cmd: string, opts: $npm$shelljs$ExecOptsSync, rest: void) => ShellString) &
+      ((cmd: string, rest: void) => ShellString) &
+      ((cmd: string, then: $npm$shelljs$ExecThen, rest: void) => ShellAsync);
+    exit:
+      ((code: number, rest: void) => void) &
+      ((rest: void) => void);
+    find:
+      ((glob: string, ...rest: string[]) => ShellArray);
+    grep:
+      ((opts: $npm$shelljs$GrepOpts, rx: ShellPattern, glob: string, ...rest: string[]) => ShellString) &
+      ((rx: ShellPattern, glob: string, ...rest: string[]) => ShellString);
+    head:
+      ((num: number, glob: string, ...rest: string[]) => ShellString) &
+      ((glob: string, ...rest: string[]) => ShellString);
+    ln:
+      ((opts: LnOpts, src: string, tgt: string, rest: void) => ShellString) &
+      ((src: string, tgt: string, rest: void) => ShellString);
+    ls:
+      ((opts: LsOpts & { '-l': true }, glob: string, ...rest: string[]) => $npm$shelljs$FileStats) &
+      ((opts: LsOpts, glob: string, ...rest: string[]) => ShellArray) &
+      ((glob: string, ...rest: string[]) => ShellArray);
+    mkdir:
+      ((opts: MkdirOpts, dir: string, ...rest: string[]) => ShellString) &
+      ((dir: string, ...rest: string[]) => ShellString);
+    mv:
+      ((opts: MvOpts, src: string, next: string, ...rest: string[]) => ShellString) &
+      ((src: string, next: string, ...rest: string[]) => ShellString);
+    popd:
+      ((opts: PopdOpts, idx: string, rest: void) => string[]) &
+      ((opts: PopdOpts, rest: void) => string[]) &
+      ((idx: string, rest: void) => string[]) &
+      ((rest: void) => string[]);
+    pushd:
+      ((opts: PushdOpts, dirOrIdx: string, rest: void) => string[]) &
+      ((dirOrIdx: string, rest: void) => string[]);
+    pwd:
+      ((rest: void) => ShellString);
+    rm:
+      ((opts: RmOpts, glob: string, ...rest: string[]) => ShellString) &
+      ((glob: string, ...rest: string[]) => ShellString);
+    sed:
+      ((opts: $npm$shelljs$SedOpts, rx: ShellPattern, subst: string, glob: string, ...rest: string[]) => ShellString) &
+      ((rx: ShellPattern, subst: string, glob: string, ...rest: string[]) => ShellString);
+    set:
+      ((exitOnError: '-e' | '+e', rest: void) => void) &
+      ((verbose: '-v' | '+v', rest: void) => void) &
+      ((disableGlobbing: '-f' | '+f', rest: void) => void);
+    sort:
+      ((opts: $npm$shelljs$SortOpts, glob: string, ...rest: string[]) => ShellString) &
+      ((glob: string, ...rest: string[]) => ShellString);
+    tail:
+      ((num: number, glob: string, ...rest: string[]) => ShellString) &
+      ((glob: string, ...rest: string[]) => ShellString);
+    tempdir:
+      ((rest: void) => string);
+    test:
+      ((mode: $npm$shelljs$TestOpts, path: string, rest: void) => boolean);
+    touch:
+      ((opts: $npm$shelljs$TouchOpts, glob: string, ...rest: string[]) => ShellString) &
+      ((glob: string, ...rest: string[]) => ShellString);
+    which:
+      ((cmd: string, rest: void) => ShellString);
+  };
+}

--- a/definitions/npm/shelljs_v0.7.x/test_shelljs_v0.7.x.js
+++ b/definitions/npm/shelljs_v0.7.x/test_shelljs_v0.7.x.js
@@ -1,0 +1,376 @@
+// @flow
+
+import type {
+  ShellArray,
+  ShellAsync,
+  ShellFileStats,
+  ShellString,
+} from 'shelljs';
+import sh from 'shelljs';
+
+// $ExpectError
+sh.cat();
+// $ExpectError
+sh.cat(0);
+// Success
+(sh.cat('/dev/null'): ShellString);
+
+// $ExpectError
+sh.cd(0);
+// Success
+(sh.cd(): ShellString);
+// Success
+(sh.cd('/tmp'): ShellString);
+
+// $ExpectError
+sh.chmod();
+// $ExpectError
+sh.chmod(755);
+// $ExpectError
+sh.chmod('nope', 755, '~');
+// $ExpectError
+sh.chmod({ '-x': true }, 755, '~');
+// Success
+(sh.chmod({ '-R': true }, 755, '~'): ShellString);
+// Success
+(sh.chmod(755, '~'): ShellString);
+// Success
+(sh.chmod('755', '~'): ShellString);
+// Success
+(sh.chmod('u+x', '~'): ShellString);
+
+// $ExpectError
+sh.cp();
+// $ExpectError
+sh.cp(0);
+// $ExpectError
+sh.cp('/dev/null');
+// $ExpectError
+sh.cp({ 'nope': true }, '/dev/null', '/tmp/');
+// Success
+(sh.cp({ '-R': true }, '/dev/null', '/tmp/'): ShellString);
+// Success
+(sh.cp('/dev/null', '/tmp/'): ShellString);
+// Success
+(sh.cp('/dev/null', '/dev/null', '/tmp/'): ShellString);
+
+// $ExpectError
+sh.dirs(0);
+// $ExpectError
+sh.dirs({ 'nope': true });
+// Success
+(sh.dirs('-c'): string[]);
+// Success
+(sh.dirs('-9'): string[]);
+
+// $ExpectError
+sh.echo(new Function());
+// Success 
+(sh.echo('foo', 'bar'): ShellString);
+
+// $ExpectError
+sh.env[0];
+// Success
+(sh.env['USER']: string);
+
+// Success
+(sh.error(): ?string);
+
+// $ExpectError
+sh.exec(0);
+// Success
+(sh.exec('pwd', { async: true, silent: true }, (code, stdout, stderr) => {}): ShellAsync);
+// Success
+(sh.exec('pwd', { async: true, silent: true }): ShellAsync);
+// Success
+(sh.exec('pwd', { silent: true }): ShellString);
+// Success
+(sh.exec('pwd'): ShellString);
+// Success
+(sh.exec('pwd', (code, stdout, stderr) => {}): ShellAsync);
+
+// $ExpectError
+sh.exit('');
+// Success
+(sh.exit(): void);
+// Success
+(sh.exit(0): void);
+
+// $ExpectError
+sh.find();
+// $ExpectError
+sh.find(0);
+// Success
+(sh.find('~', '/tmp'): ShellArray);
+
+// $ExpectError
+sh.grep();
+// $ExpectError
+sh.grep(0);
+// $ExpectError
+sh.grep({'-x': true }, 'type');
+// $ExpectError
+sh.grep({'-x': true }, 'type');
+// $ExpectError
+sh.grep({ '-x': true }, /type/, 'definitions/**/*.js');
+// Success
+(sh.grep({ '-l': true }, /type/, 'definitions/**/*.js'): ShellString);
+// Success
+(sh.grep({ '-l': true }, 'type', 'definitions/**/*.js'): ShellString);
+// Success
+(sh.grep('type', 'definitions/**/*.js'): ShellString);
+
+// $ExpectError
+sh.head();
+// $ExpectError
+sh.head({});
+// Success
+(sh.head(1, '/dev/random'): ShellString);
+// Success
+(sh.head('/dev/random'): ShellString);
+
+// $ExpectError
+sh.ln();
+// $ExpectError
+sh.ln(0);
+// $ExpectError
+sh.ln('~');
+// $ExpectError
+(sh.ln({ '-x': true }, '~', '/tmp/it-me'): ShellString);
+// Success
+(sh.ln({ '-s': true }, '~', '/tmp/it-me'): ShellString);
+
+// $ExpectError
+sh.ls();
+// $ExpectError
+sh.ls(0);
+// $ExpectError
+sh.ls({ '-x': true }, '~');
+// Success
+(sh.ls({ '-l': true }, '~'): ShellFileStats);
+// Success
+(sh.ls('~'): ShellArray);
+
+// $ExpectError
+sh.mkdir();
+// $ExpectError
+sh.mkdir(0);
+// $ExpectError
+sh.mkdir({ '-x': true }, '/tmp/tmp0/tmp1');
+// Success
+(sh.mkdir({ '-p': true }, '/tmp/tmp0/tmp1'): ShellString);
+// Success
+(sh.mkdir('/tmp/tmp0'): ShellString);
+
+// $ExpectError
+sh.mv();
+// $ExpectError
+sh.mv(0);
+// $ExpectError
+sh.mv('/tmp/tmp0');
+// $ExpectError
+sh.mv({ '-x': true }, '/tmp/tmp0');
+// $ExpectError
+sh.mv({ '-x': true }, '/tmp/tmp0', '/tmp/tmp1');
+// Success
+(sh.mv({ '-f': true }, '/tmp/tmp0', '/tmp/tmp1'): ShellString);
+
+// $ExpectError
+sh.pushd();
+// $ExpectError
+sh.pushd(0);
+// $ExpectError
+sh.pushd({ '-x': true }, '/tmp');
+// Success
+(sh.pushd({ '-n': true }, '/tmp'): string[]);
+// Success
+(sh.pushd('/tmp'): string[]);
+
+// $ExpectError
+sh.pwd(0);
+// Success
+(sh.pwd(): ShellString);
+
+// $ExpectError
+sh.rm();
+// $ExpectError
+sh.rm(0);
+// $ExpectError
+sh.rm('/tmp/tmp0', 0);
+// $ExpectError
+sh.rm({ '-x': true }, '/tmp/tmp0', '/tmp/tmp1');
+// Success
+(sh.rm({ '-r': true, '-f': true }, '/tmp/tmp0', '/tmp/tmp1'): ShellString);
+// Success
+(sh.rm('/tmp/tmp0', '/tmp/tmp1'): ShellString);
+
+// $ExpectError
+sh.sed();
+// $ExpectError
+sh.sed(0);
+// $ExpectError
+sh.sed('foo');
+// $ExpectError
+sh.sed('foo', 'bar');
+// $ExpectError
+sh.sed({ '-x': true }, 'foo', 'bar', '/tmp/tmp0');
+// Success
+(sh.sed({ '-i': true }, 'foo', 'bar', '/tmp/tmp0'): ShellString);
+// Success
+(sh.sed('foo', 'bar', '/tmp/tmp0'): ShellString);
+// Success
+(sh.sed(/foo/, 'bar', '/tmp/tmp0'): ShellString);
+
+// $ExpectError
+sh.set();
+// $ExpectError
+sh.set(0);
+// $ExpectError
+sh.set('-x');
+// Success
+(sh.set('-e'): void);
+// Success
+(sh.set('+e'): void);
+
+// $ExpectError
+sh.sort();
+// $ExpectError
+sh.sort(0);
+// $ExpectError
+sh.sort({ '-x': true }, '/tmp/tmp0');
+// Success
+(sh.sort({ '-r': true }, '/tmp/tmp0'): ShellString);
+// Success
+(sh.sort('/tmp/tmp0'): ShellString);
+
+// $ExpectError
+sh.tail();
+// $ExpectError
+sh.tail({});
+// Success
+(sh.tail(1, '/dev/random'): ShellString);
+// Success
+(sh.tail('/dev/random'): ShellString);
+
+// $ExpectError
+sh.tempdir(0);
+// Success
+(sh.tempdir(): string);
+
+// $ExpectError
+sh.test();
+// $ExpectError
+sh.test(0);
+// $ExpectError
+sh.test('-x');
+// $ExpectError
+sh.test('-x', '~');
+// Success
+(sh.test('-d', '~'): boolean);
+
+// $ExpectError
+sh.touch();
+// $ExpectError
+sh.touch(0);
+// $ExpectError
+sh.touch({ '-x': true }, '/tmp/tmp0');
+// Success
+(sh.touch({ '-c': true }, '/tmp/tmp0'): ShellString);
+// Success
+(sh.touch({ '-r': '/tmp/tmp0' }, '/tmp/tmp1'): ShellString);
+// Success
+(sh.touch('/tmp/tmp1'): ShellString);
+
+// $ExpectError
+sh.which();
+// $ExpectError
+sh.which(0);
+// $ExpectSucess
+(sh.which('sh'): ShellString);
+
+// $ExpectError
+sh.cat('/tmp/tmp0').cat(0);
+// Success
+(sh.cat('/tmp/tmp0').cat(): ShellString);
+
+// $ExpectError
+sh.cat('/tmp/tmp0').exec(0);
+// Success
+(sh.cat('/tmp/tmp0').exec('cat', { async: true, silent: true }, (code, stdout, stderr) => {}): ShellAsync);
+// Success
+(sh.cat('/tmp/tmp0').exec('cat', { async: true, silent: true }): ShellAsync);
+// Success
+(sh.cat('/tmp/tmp0').exec('cat', { silent: true }): ShellString);
+// Success
+(sh.cat('/tmp/tmp0').exec('cat'): ShellString);
+// Success
+(sh.cat('/tmp/tmp0').exec('cat', (code, stdout, stderr) => {}): ShellAsync);
+
+// $ExpectError
+sh.cat('/tmp/tmp0').grep();
+// $ExpectError
+sh.cat('/tmp/tmp0').grep(0);
+// $ExpectError
+sh.cat('/tmp/tmp0').grep({'-x': true }, 'type');
+// $ExpectError
+sh.cat('/tmp/tmp0').grep({'-x': true }, 'type');
+// $ExpectError
+sh.cat('/tmp/tmp0').grep({ '-x': true }, /type/, 'definitions/**/*.js');
+// Success
+(sh.cat('/tmp/tmp0').grep({ '-l': true }, /type/): ShellString);
+// Success
+(sh.cat('/tmp/tmp0').grep({ '-l': true }, 'type'): ShellString);
+// Success
+(sh.cat('/tmp/tmp0').grep('type'): ShellString);
+
+// $ExpectError
+sh.cat('/tmp/tmp0').head({});
+// Success
+(sh.cat('/tmp/tmp0').head(1): ShellString);
+// Success
+(sh.cat('/tmp/tmp0').head(): ShellString);
+
+// $ExpectError
+sh.cat('/tmp/tmp0').sed();
+// $ExpectError
+sh.cat('/tmp/tmp0').sed(0);
+// $ExpectError
+sh.cat('/tmp/tmp0').sed('foo');
+// $ExpectError
+sh.cat('/tmp/tmp0').sed({ '-x': true }, 'foo', 'bar');
+// Success
+(sh.cat('/tmp/tmp0').sed('foo', 'bar'): ShellString);
+// Success
+(sh.cat('/tmp/tmp0').sed(/foo/, 'bar'): ShellString);
+
+// $ExpectError
+sh.cat('/tmp/tmp0').sort({ '-x': true });
+// Success
+(sh.cat('/tmp/tmp0').sort({ '-r': true }): ShellString);
+// Success
+(sh.cat('/tmp/tmp0').sort(): ShellString);
+
+// $ExpectError
+sh.cat('/tmp/tmp0').tail({});
+// Success
+(sh.cat('/tmp/tmp0').tail(1): ShellString);
+// Success
+(sh.cat('/tmp/tmp0').tail(): ShellString);
+
+// $ExpectError
+sh.cat('/tmp/tmp0').to();
+// $ExpectError
+sh.cat('/tmp/tmp0').to(0);
+// Success
+(sh.cat('/tmp/tmp0').to('/tmp/tmp1'): ShellString);
+// Success
+(sh.cat('/tmp/tmp0').sed(/foo/, 'bar').to('/tmp/tmp1'): ShellString);
+
+// $ExpectError
+sh.cat('/tmp/tmp0').toEnd();
+// $ExpectError
+sh.cat('/tmp/tmp0').toEnd(0);
+// Success
+(sh.cat('/tmp/tmp0').toEnd('/tmp/tmp1'): ShellString);
+// Success
+(sh.cat('/tmp/tmp0').sed(/foo/, 'bar').toEnd('/tmp/tmp1'): ShellString);


### PR DESCRIPTION
This PR adds flow declarations for `shelljs`. It covers the complete API but in some cases I have restricted the interfaces for certain functions to the part that can be reasonably typed. However, this should not limit functionality.

I've added tests following some of the others as examples but I had some trouble getting the `flow-typed` CLI tool to run them.