### PR TITLE
Allow use of process.stdout as one of bunyan streams

### DIFF
--- a/definitions/npm/bunyan_v1.x.x/flow_>=v0.21.x/bunyan_v1.x.x.js
+++ b/definitions/npm/bunyan_v1.x.x/flow_>=v0.21.x/bunyan_v1.x.x.js
@@ -104,7 +104,7 @@ declare module 'bunyan' {
         type: string;
         level?: number | string;
         path?: string;
-        stream?: stream$Writable | Stream;
+        stream?: stream$Writable | tty$WriteStream | Stream;
         closeOnExit?: boolean;
         period?: string;
         count?: number;

--- a/definitions/npm/bunyan_v1.x.x/test_bunyan_v1.x.x.js
+++ b/definitions/npm/bunyan_v1.x.x/test_bunyan_v1.x.x.js
@@ -6,6 +6,9 @@ const logger = Bunyan.createLogger({
         type: 'rotating-file',
         level: 'error',
         path: './error.log'
+    }, {
+        type: 'stream',
+        stream: process.stdout
     }],
     serializers: {
         ...Bunyan.stdSerializers,


### PR DESCRIPTION
While `process.stdout` is not only a `stream$Writable`, but also a `tty$WriteStream` (https://github.com/facebook/flow/blob/master/lib/node.js#L1483), passing it as a `bunyan` stream causes errors.

Test was corrected to include originally failing case.