### PR TITLE
express: Fix the Request.locals typing

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_>=v0.25.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_>=v0.25.x/express_v4.x.x.js
@@ -60,7 +60,7 @@ declare module 'express' {
   };
   declare class Response extends http$ClientRequest mixins RequestResponseBase {
     headersSent: boolean;
-    locals: mixed;
+    locals: {[name: string]: mixed};
     append(field: string, value?: string): this;
     attachment(filename?: string): this;
     cookie(name: string, value: string, options?: CookieOptions): this;

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -66,6 +66,11 @@ app.use('/foo', (req: $Request, res: $Response, next) => {
 const bar: Router = new Router();
 
 bar.get('/', (req: $Request, res: $Response): void => {
+  // $ExpectError should be of type object
+  const locals: Array<any> = res.locals;
+  res.locals.title = 'Home Page';
+  // $ExpectError should not allow to set keys to non string value.
+  res.locals[0] = 'Fail';
   res.send('bar')
     .status(200);
 });


### PR DESCRIPTION
I wanted to fix an error that I accidentally added when I first submitted the PR. The `res.locals` is always an object, just the same as the `app.locals`. I added more to the test cases to catch this issue.