### PR TITLE
express: update res.redirect signature with overloading

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_>=v0.25.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_>=v0.25.x/express_v4.x.x.js
@@ -71,7 +71,8 @@ declare module 'express' {
     jsonp(body?: mixed): this;
     links(links: {[name: string]: string}): this;
     location(path: string): this;
-    redirect(status?: number, path: string): this;
+    redirect(url: string, ...args: Array<void>): this;
+    redirect(status: number, url: string, ...args: Array<void>): this;
     render(view: string, locals?: mixed, callback: (err?: ?Error) => mixed): this;
     send(body?: mixed): this;
     sendFile(path: string, options?: SendFileOptions, callback?: (err?: ?Error) => mixed): this;

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -103,3 +103,21 @@ app.render('view', { title: 'News Feed' }, (err: ?Error, html: string): void => 
     if (err) return console.log(err);
     console.log(html);
 });
+
+app.use('/somewhere', (req: $Request, res: $Response) => {
+  res.redirect('/somewhere-else');
+});
+
+app.use('/again', (req: $Request, res: $Response) => {
+  res.redirect(200, '/different');
+});
+
+app.use('/something', (req: $Request, res: $Response) => {
+  // $ExpectError
+  res.redirect('/different', 200);
+});
+
+app.use('/failure', (req: $Request, res: $Response) => {
+  // $ExpectError
+  res.redirect();
+});


### PR DESCRIPTION
[response.js#L839](https://github.com/expressjs/express/blob/master/lib/response.js#L839) shows that it can take either `string` or `number, string` as arguments, so the current definition is not correct. 