### PR TITLE
min/max also accept arrays of Moment

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_>=v0.28.x/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_>=v0.28.x/moment_v2.x.x.js
@@ -166,7 +166,9 @@ declare class moment$Moment {
   set(unit: string, value: number): this;
   set(options: { unit: string, value: number }): this;
   static max(...dates: Array<moment$Moment>): moment$Moment;
+  static max(dates: Array<moment$Moment>): moment$Moment;
   static min(...dates: Array<moment$Moment>): moment$Moment;
+  static min(dates: Array<moment$Moment>): moment$Moment;
   add(value: number|moment$MomentDuration|moment$Moment|Object, unit?: string): this;
   subtract(value: number|moment$MomentDuration|moment$Moment|string, unit?: string): this;
   startOf(unit: string): this;


### PR DESCRIPTION
see [max](http://momentjs.com/docs/#/get-set/max/) and [min](http://momentjs.com/docs/#/get-set/min/) documentation on the MomentJS website.