### PR TITLE
Correcting bitcoinjs definitions

### DIFF
--- a/definitions/npm/bitcoinjs-lib_v2.x.x/flow_>=v0.17.x/bitcoinjs-lib_v2.x.x.js
+++ b/definitions/npm/bitcoinjs-lib_v2.x.x/flow_>=v0.17.x/bitcoinjs-lib_v2.x.x.js
@@ -36,68 +36,70 @@ declare module 'bigi' {
   declare var exports: typeof $npm$bigi$BigInteger;
 }
 
-declare module 'ecurve' {
+declare class $npm$ecurve$Curve {
+  p: $npm$bigi$BigInteger;
+  a: $npm$bigi$BigInteger;
+  b: $npm$bigi$BigInteger;
+  G: $npm$ecurve$Point;
+  n: $npm$bigi$BigInteger;
+  h: $npm$bigi$BigInteger;
 
-  declare class Curve {
-    p: $npm$bigi$BigInteger;
-    a: $npm$bigi$BigInteger;
-    b: $npm$bigi$BigInteger;
-    G: Point;
-    n: $npm$bigi$BigInteger;
-    h: $npm$bigi$BigInteger;
+  constructor(
+    p: $npm$bigi$BigInteger,
+    a: $npm$bigi$BigInteger,
+    b: $npm$bigi$BigInteger,
+    Gx: $npm$bigi$BigInteger,
+    Gy: $npm$bigi$BigInteger,
+    n: $npm$bigi$BigInteger,
+    h: $npm$bigi$BigInteger
+  ): void;
 
-    constructor(
-      p: $npm$bigi$BigInteger,
-      a: $npm$bigi$BigInteger,
-      b: $npm$bigi$BigInteger,
-      Gx: $npm$bigi$BigInteger,
-      Gy: $npm$bigi$BigInteger,
-      n: $npm$bigi$BigInteger,
-      h: $npm$bigi$BigInteger
-    ): void;
+  infinity: $npm$ecurve$Point;
+  isInfinity(point: $npm$ecurve$Point): boolean;
+  validate(a: $npm$ecurve$Point): boolean;
+  isOnCurve(a: $npm$ecurve$Point): boolean;
+  pointFromX(odd: boolean, x: $npm$ecurve$Point): $npm$ecurve$Point;
+}
 
-    infinity: Point;
-    isInfinity(point: Point): boolean;
-    validate(a: Point): boolean;
-    isOnCurve(a: Point): boolean;
-    pointFromX(odd: boolean, x: Point): Point;
-  }
-
-  declare class Point {
-    constructor(
-      curve: Curve,
-      x: $npm$bigi$BigInteger,
-      y: $npm$bigi$BigInteger,
-      z: $npm$bigi$BigInteger
-    ): void;
-    
-    x: $npm$bigi$BigInteger;
-    y: $npm$bigi$BigInteger;
-    z: $npm$bigi$BigInteger;
-
-    zInv: $npm$bigi$BigInteger;
-    affineX: $npm$bigi$BigInteger;
-    affineY: $npm$bigi$BigInteger;
+declare class $npm$ecurve$Point {
+  constructor(
+    curve: $npm$ecurve$Curve,
+    x: $npm$bigi$BigInteger,
+    y: $npm$bigi$BigInteger,
+    z: $npm$bigi$BigInteger
+  ): void;
   
-    static fromAffine(curve: Curve, x: $npm$bigi$BigInteger, y: $npm$bigi$BigInteger): Point;
-    equals(other: Point): boolean;
-    negate(): Point;
-    add(other: Point): Point;
-    twice(): Point;
-    multiply(k: $npm$bigi$BigInteger): Point;
-    multiplyTwo(j: $npm$bigi$BigInteger, x: Point, k: $npm$bigi$BigInteger): Point;
+  x: $npm$bigi$BigInteger;
+  y: $npm$bigi$BigInteger;
+  z: $npm$bigi$BigInteger;
 
-    static decodeFrom(curve: Curve, buffer: Buffer): Point;
-    getEncoded(compressed: boolean): Buffer;
-   
-    toString(): string;
-  }
+  zInv: $npm$bigi$BigInteger;
+  affineX: $npm$bigi$BigInteger;
+  affineY: $npm$bigi$BigInteger;
 
+  static fromAffine(curve: $npm$ecurve$Curve, x: $npm$bigi$BigInteger, y: $npm$bigi$BigInteger): $npm$ecurve$Point;
+  equals(other: $npm$ecurve$Point): boolean;
+  negate(): $npm$ecurve$Point;
+  add(other: $npm$ecurve$Point): $npm$ecurve$Point;
+  twice(): $npm$ecurve$Point;
+  multiply(k: $npm$bigi$BigInteger): $npm$ecurve$Point;
+  multiplyTwo(j: $npm$bigi$BigInteger, x: $npm$ecurve$Point, k: $npm$bigi$BigInteger): $npm$ecurve$Point;
+
+  static decodeFrom(curve: $npm$ecurve$Curve, buffer: Buffer): $npm$ecurve$Point;
+  getEncoded(compressed: boolean): Buffer;
+  
+  toString(): string;
+}
+
+declare module 'ecurve' {
+  
+  declare var Point: typeof $npm$ecurve$Point;
+  
+  declare var Curve: typeof $npm$ecurve$Curve;
+  
   declare function getCurveByName(name: string): ?Curve;
 }
 // ---------- copypasta end ---- 
-
-import {Point as ECPoint} from 'ecurve';
 
 declare module 'bitcoinjs-lib' {
 
@@ -186,12 +188,12 @@ declare module 'bitcoinjs-lib' {
     
     declare class ECPair {
         d: ?$npm$bigi$BigInteger;
-        Q: ECPoint;
+        Q: $npm$ecurve$Point;
         compressed: boolean;
         network: Network;
         getNetwork(): Network;
 
-        constructor(d: ?$npm$bigi$BigInteger, Q: ?ECPoint): void;
+        constructor(d: ?$npm$bigi$BigInteger, Q: ?$npm$ecurve$Point): void;
         getAddress(): string;
         getPublicKeyBuffer(): Buffer;
         static fromPublicKeyBuffer(buffer: Buffer): ECPair;

--- a/definitions/npm/bitcoinjs-lib_v2.x.x/flow_>=v0.17.x/bitcoinjs-lib_v2.x.x.js
+++ b/definitions/npm/bitcoinjs-lib_v2.x.x/flow_>=v0.17.x/bitcoinjs-lib_v2.x.x.js
@@ -97,6 +97,8 @@ declare module 'ecurve' {
 }
 // ---------- copypasta end ---- 
 
+import {Point as ECPoint} from 'ecurve';
+
 declare module 'bitcoinjs-lib' {
 
     declare type Network = {
@@ -183,13 +185,13 @@ declare module 'bitcoinjs-lib' {
     }
     
     declare class ECPair {
-        d: ?Buffer;
-        Q: Buffer;
+        d: ?$npm$bigi$BigInteger;
+        Q: ECPoint;
         compressed: boolean;
         network: Network;
         getNetwork(): Network;
 
-        constructor(d: ?Buffer, Q: ?Buffer): void;
+        constructor(d: ?$npm$bigi$BigInteger, Q: ?ECPoint): void;
         getAddress(): string;
         getPublicKeyBuffer(): Buffer;
         static fromPublicKeyBuffer(buffer: Buffer): ECPair;

--- a/definitions/npm/bitcoinjs-lib_v2.x.x/test_bitcoinjs-lib_v2.x.x.js
+++ b/definitions/npm/bitcoinjs-lib_v2.x.x/test_bitcoinjs-lib_v2.x.x.js
@@ -14,8 +14,18 @@ var BigInteger = require('bigi');
 // $ExpectError
 (crypto.hash256("hex"): string);
 
-(new ECPair(new Buffer(1)): ECPair);
-(new ECPair(null, new Buffer(1)): ECPair);
+import {Curve, Point} from 'ecurve';
+var pi = new BigInteger('1');
+var a = new BigInteger('1');
+var b = new BigInteger('1');
+var Gx = new BigInteger('1');
+var Gy = new BigInteger('1');
+var n = new BigInteger('1');
+var h = new BigInteger('1');
+var p: Point = new Curve(pi, a, b, Gx, Gy, n, h).G;
+
+(new ECPair(b): ECPair);
+(new ECPair(null, p): ECPair);
 
 // $ExpectError
 (ECPair(new Buffer(1)): ECPair);

--- a/definitions/npm/bitcoinjs-lib_v2.x.x/test_bitcoinjs-lib_v2.x.x.js
+++ b/definitions/npm/bitcoinjs-lib_v2.x.x/test_bitcoinjs-lib_v2.x.x.js
@@ -28,6 +28,11 @@ var p: Point = new Curve(pi, a, b, Gx, Gy, n, h).G;
 (new ECPair(null, p): ECPair);
 
 // $ExpectError
+(new ECPair(new Buffer(1)): ECPair);
+// $ExpectError
+(new ECPair(null, new Buffer(1)): ECPair);
+
+// $ExpectError
 (ECPair(new Buffer(1)): ECPair);
 
 (ECPair.fromPublicKeyBuffer(new Buffer(1)): ECPair);

--- a/definitions/npm/ecurve_v1.x.x/flow_>=v0.17.x/ecurve_v1.x.x.js
+++ b/definitions/npm/ecurve_v1.x.x/flow_>=v0.17.x/ecurve_v1.x.x.js
@@ -36,62 +36,66 @@ declare module 'bigi' {
 }
 // ---------- copypasta end ---- 
 
-declare module 'ecurve' {
+declare class $npm$ecurve$Curve {
+  p: $npm$bigi$BigInteger;
+  a: $npm$bigi$BigInteger;
+  b: $npm$bigi$BigInteger;
+  G: $npm$ecurve$Point;
+  n: $npm$bigi$BigInteger;
+  h: $npm$bigi$BigInteger;
 
-  declare class Curve {
-    p: $npm$bigi$BigInteger;
-    a: $npm$bigi$BigInteger;
-    b: $npm$bigi$BigInteger;
-    G: Point;
-    n: $npm$bigi$BigInteger;
-    h: $npm$bigi$BigInteger;
+  constructor(
+    p: $npm$bigi$BigInteger,
+    a: $npm$bigi$BigInteger,
+    b: $npm$bigi$BigInteger,
+    Gx: $npm$bigi$BigInteger,
+    Gy: $npm$bigi$BigInteger,
+    n: $npm$bigi$BigInteger,
+    h: $npm$bigi$BigInteger
+  ): void;
 
-    constructor(
-      p: $npm$bigi$BigInteger,
-      a: $npm$bigi$BigInteger,
-      b: $npm$bigi$BigInteger,
-      Gx: $npm$bigi$BigInteger,
-      Gy: $npm$bigi$BigInteger,
-      n: $npm$bigi$BigInteger,
-      h: $npm$bigi$BigInteger
-    ): void;
+  infinity: $npm$ecurve$Point;
+  isInfinity(point: $npm$ecurve$Point): boolean;
+  validate(a: $npm$ecurve$Point): boolean;
+  isOnCurve(a: $npm$ecurve$Point): boolean;
+  pointFromX(odd: boolean, x: $npm$ecurve$Point): $npm$ecurve$Point;
+}
 
-    infinity: Point;
-    isInfinity(point: Point): boolean;
-    validate(a: Point): boolean;
-    isOnCurve(a: Point): boolean;
-    pointFromX(odd: boolean, x: Point): Point;
-  }
-
-  declare class Point {
-    constructor(
-      curve: Curve,
-      x: $npm$bigi$BigInteger,
-      y: $npm$bigi$BigInteger,
-      z: $npm$bigi$BigInteger
-    ): void;
-    
-    x: $npm$bigi$BigInteger;
-    y: $npm$bigi$BigInteger;
-    z: $npm$bigi$BigInteger;
-
-    zInv: $npm$bigi$BigInteger;
-    affineX: $npm$bigi$BigInteger;
-    affineY: $npm$bigi$BigInteger;
+declare class $npm$ecurve$Point {
+  constructor(
+    curve: $npm$ecurve$Curve,
+    x: $npm$bigi$BigInteger,
+    y: $npm$bigi$BigInteger,
+    z: $npm$bigi$BigInteger
+  ): void;
   
-    static fromAffine(curve: Curve, x: $npm$bigi$BigInteger, y: $npm$bigi$BigInteger): Point;
-    equals(other: Point): boolean;
-    negate(): Point;
-    add(other: Point): Point;
-    twice(): Point;
-    multiply(k: $npm$bigi$BigInteger): Point;
-    multiplyTwo(j: $npm$bigi$BigInteger, x: Point, k: $npm$bigi$BigInteger): Point;
+  x: $npm$bigi$BigInteger;
+  y: $npm$bigi$BigInteger;
+  z: $npm$bigi$BigInteger;
 
-    static decodeFrom(curve: Curve, buffer: Buffer): Point;
-    getEncoded(compressed: boolean): Buffer;
-   
-    toString(): string;
-  }
+  zInv: $npm$bigi$BigInteger;
+  affineX: $npm$bigi$BigInteger;
+  affineY: $npm$bigi$BigInteger;
 
+  static fromAffine(curve: $npm$ecurve$Curve, x: $npm$bigi$BigInteger, y: $npm$bigi$BigInteger): $npm$ecurve$Point;
+  equals(other: $npm$ecurve$Point): boolean;
+  negate(): $npm$ecurve$Point;
+  add(other: $npm$ecurve$Point): $npm$ecurve$Point;
+  twice(): $npm$ecurve$Point;
+  multiply(k: $npm$bigi$BigInteger): $npm$ecurve$Point;
+  multiplyTwo(j: $npm$bigi$BigInteger, x: $npm$ecurve$Point, k: $npm$bigi$BigInteger): $npm$ecurve$Point;
+
+  static decodeFrom(curve: $npm$ecurve$Curve, buffer: Buffer): $npm$ecurve$Point;
+  getEncoded(compressed: boolean): Buffer;
+  
+  toString(): string;
+}
+
+declare module 'ecurve' {
+  
+  declare var Point: typeof $npm$ecurve$Point;
+  
+  declare var Curve: typeof $npm$ecurve$Curve;
+  
   declare function getCurveByName(name: string): ?Curve;
 }


### PR DESCRIPTION
I found some errors in the bitcoinjs-lib definitions. 

The inputs to `ECPair` is not buffer, but either biginteger or ecpoint, both imported from different packages.