### PR TITLE
Added type definiations for few sindre is-* modules

### DIFF
--- a/definitions/npm/is-absolute-url_v2.x.x/flow_>=v0.25.x/is-absolute-url_v2.x.x.js
+++ b/definitions/npm/is-absolute-url_v2.x.x/flow_>=v0.25.x/is-absolute-url_v2.x.x.js
@@ -1,0 +1,3 @@
+declare module 'is-absolute-url' {
+  declare module.exports: (url: string) => boolean;
+}

--- a/definitions/npm/is-absolute-url_v2.x.x/test_is-absolute-url_v2.x.x.js
+++ b/definitions/npm/is-absolute-url_v2.x.x/test_is-absolute-url_v2.x.x.js
@@ -1,0 +1,19 @@
+import isAbsoluteUrl from 'is-absolute-url';
+
+isAbsoluteUrl('any-string');
+(isAbsoluteUrl('any-string'): boolean);
+
+// $ExpectError
+isAbsoluteUrl(4);
+
+// $ExpectError
+isAbsoluteUrl({});
+
+// $ExpectError
+isAbsoluteUrl();
+
+// $ExpectError
+isAbsoluteUrl(null);
+
+// $ExpectError
+(isAbsoluteUrl('any-string'): number);

--- a/definitions/npm/is-archive_v1.x.x/flow_>=v0.25.x/is-archive_v1.x.x.js
+++ b/definitions/npm/is-archive_v1.x.x/flow_>=v0.25.x/is-archive_v1.x.x.js
@@ -1,0 +1,3 @@
+declare module 'is-archive' {
+  declare module.exports: (url: string) => boolean;
+}

--- a/definitions/npm/is-archive_v1.x.x/test_is-archive_v1.x.x.js
+++ b/definitions/npm/is-archive_v1.x.x/test_is-archive_v1.x.x.js
@@ -1,0 +1,19 @@
+import isArchive from 'is-archive';
+
+isArchive('any-string');
+(isArchive('any-string'): boolean);
+
+// $ExpectError
+isArchive(4);
+
+// $ExpectError
+isArchive({});
+
+// $ExpectError
+isArchive();
+
+// $ExpectError
+isArchive(null);
+
+// $ExpectError
+(isArchive('any-string'): number);

--- a/definitions/npm/is-binary-path_v1.x.x/flow_>=v0.25.x/is-binary-path_v1.x.x.js
+++ b/definitions/npm/is-binary-path_v1.x.x/flow_>=v0.25.x/is-binary-path_v1.x.x.js
@@ -1,0 +1,3 @@
+declare module 'is-binary-path' {
+  declare module.exports: (url: string) => boolean;
+}

--- a/definitions/npm/is-binary-path_v1.x.x/test_is-binary-path_v1.x.x.js
+++ b/definitions/npm/is-binary-path_v1.x.x/test_is-binary-path_v1.x.x.js
@@ -1,0 +1,19 @@
+import isBinaryPath from 'is-binary-path';
+
+isBinaryPath('any-string');
+(isBinaryPath('any-string'): boolean);
+
+// $ExpectError
+isBinaryPath(4);
+
+// $ExpectError
+isBinaryPath({});
+
+// $ExpectError
+isBinaryPath();
+
+// $ExpectError
+isBinaryPath(null);
+
+// $ExpectError
+(isBinaryPath('any-string'): number);

--- a/definitions/npm/is-compressed_v1.x.x/flow_>=v0.25.x/is-compressed_v1.x.x.js
+++ b/definitions/npm/is-compressed_v1.x.x/flow_>=v0.25.x/is-compressed_v1.x.x.js
@@ -1,0 +1,3 @@
+declare module 'is-compressed' {
+  declare module.exports: (url: string) => boolean;
+}

--- a/definitions/npm/is-compressed_v1.x.x/test_is-compressed_v1.x.x.js
+++ b/definitions/npm/is-compressed_v1.x.x/test_is-compressed_v1.x.x.js
@@ -1,0 +1,19 @@
+import isCompressed from 'is-compressed';
+
+isCompressed('any-string');
+(isCompressed('any-string'): boolean);
+
+// $ExpectError
+isCompressed(4);
+
+// $ExpectError
+isCompressed({});
+
+// $ExpectError
+isCompressed();
+
+// $ExpectError
+isCompressed(null);
+
+// $ExpectError
+(isCompressed('any-string'): number);

--- a/definitions/npm/is-path-cwd_v1.x.x/flow_>=v0.25.x/is-path-cwd_v1.x.x.js
+++ b/definitions/npm/is-path-cwd_v1.x.x/flow_>=v0.25.x/is-path-cwd_v1.x.x.js
@@ -1,0 +1,3 @@
+declare module 'is-path-cwd' {
+  declare module.exports: (url: string) => boolean;
+}

--- a/definitions/npm/is-path-cwd_v1.x.x/test_is-path-cwd_v1.x.x.js
+++ b/definitions/npm/is-path-cwd_v1.x.x/test_is-path-cwd_v1.x.x.js
@@ -1,0 +1,19 @@
+import isPathCwd from 'is-path-cwd';
+
+isPathCwd('any-string');
+(isPathCwd('any-string'): boolean);
+
+// $ExpectError
+isPathCwd(4);
+
+// $ExpectError
+isPathCwd({});
+
+// $ExpectError
+isPathCwd();
+
+// $ExpectError
+isPathCwd(null);
+
+// $ExpectError
+(isPathCwd('any-string'): number);

--- a/definitions/npm/is-path-in-cwd_v1.x.x/flow_>=v0.25.x/is-path-in-cwd_v1.x.x.js
+++ b/definitions/npm/is-path-in-cwd_v1.x.x/flow_>=v0.25.x/is-path-in-cwd_v1.x.x.js
@@ -1,0 +1,3 @@
+declare module 'is-path-in-cwd' {
+  declare module.exports: (url: string) => boolean;
+}

--- a/definitions/npm/is-path-in-cwd_v1.x.x/test_is-path-in-cwd_v1.x.x.js
+++ b/definitions/npm/is-path-in-cwd_v1.x.x/test_is-path-in-cwd_v1.x.x.js
@@ -1,0 +1,19 @@
+import isPathInCwd from 'is-path-in-cwd';
+
+isPathInCwd('any-string');
+(isPathInCwd('any-string'): boolean);
+
+// $ExpectError
+isPathInCwd(4);
+
+// $ExpectError
+isPathInCwd({});
+
+// $ExpectError
+isPathInCwd();
+
+// $ExpectError
+isPathInCwd(null);
+
+// $ExpectError
+(isPathInCwd('any-string'): number);

--- a/definitions/npm/is-relative-url_v2.x.x/flow_>=v0.25.x/is-relative-url_v2.x.x.js
+++ b/definitions/npm/is-relative-url_v2.x.x/flow_>=v0.25.x/is-relative-url_v2.x.x.js
@@ -1,0 +1,3 @@
+declare module 'is-relative-url' {
+  declare module.exports: (url: string) => boolean;
+}

--- a/definitions/npm/is-relative-url_v2.x.x/test_is-relative-url_v2.x.x.js
+++ b/definitions/npm/is-relative-url_v2.x.x/test_is-relative-url_v2.x.x.js
@@ -1,0 +1,19 @@
+import isRelativeUrl from 'is-relative-url';
+
+isRelativeUrl('any-string');
+(isRelativeUrl('any-string'): boolean);
+
+// $ExpectError
+isRelativeUrl(4);
+
+// $ExpectError
+isRelativeUrl({});
+
+// $ExpectError
+isRelativeUrl();
+
+// $ExpectError
+isRelativeUrl(null);
+
+// $ExpectError
+(isRelativeUrl('any-string'): number);

--- a/definitions/npm/is-root-path_v1.x.x/flow_>=v0.25.x/is-root-path_v1.x.x.js
+++ b/definitions/npm/is-root-path_v1.x.x/flow_>=v0.25.x/is-root-path_v1.x.x.js
@@ -1,0 +1,3 @@
+declare module 'is-root-path' {
+  declare module.exports: (url: string) => boolean;
+}

--- a/definitions/npm/is-root-path_v1.x.x/test_is-root-path_v1.x.x.js
+++ b/definitions/npm/is-root-path_v1.x.x/test_is-root-path_v1.x.x.js
@@ -1,0 +1,19 @@
+import isRootPath from 'is-root-path';
+
+isRootPath('any-string');
+(isRootPath('any-string'): boolean);
+
+// $ExpectError
+isRootPath(4);
+
+// $ExpectError
+isRootPath({});
+
+// $ExpectError
+isRootPath();
+
+// $ExpectError
+isRootPath(null);
+
+// $ExpectError
+(isRootPath('any-string'): number);

--- a/definitions/npm/is-root_v1.x.x/flow_>=v0.25.x/is-root_v1.x.x.js
+++ b/definitions/npm/is-root_v1.x.x/flow_>=v0.25.x/is-root_v1.x.x.js
@@ -1,0 +1,3 @@
+declare module 'is-root' {
+  declare module.exports: () => boolean;
+}

--- a/definitions/npm/is-root_v1.x.x/test_is-root_v1.x.x.js
+++ b/definitions/npm/is-root_v1.x.x/test_is-root_v1.x.x.js
@@ -1,0 +1,6 @@
+import isRoot from 'is-root';
+
+(isRoot(): boolean);
+
+// $ExpectError
+(isRoot(): number);

--- a/definitions/npm/is-text-path_v1.x.x/flow_>=v0.25.x/is-text-path_v1.x.x.js
+++ b/definitions/npm/is-text-path_v1.x.x/flow_>=v0.25.x/is-text-path_v1.x.x.js
@@ -1,0 +1,3 @@
+declare module 'is-text-path' {
+  declare module.exports: (url: string) => boolean;
+}

--- a/definitions/npm/is-text-path_v1.x.x/test_is-text-path_v1.x.x.js
+++ b/definitions/npm/is-text-path_v1.x.x/test_is-text-path_v1.x.x.js
@@ -1,0 +1,19 @@
+import isTextPath from 'is-text-path';
+
+isTextPath('any-string');
+(isTextPath('any-string'): boolean);
+
+// $ExpectError
+isTextPath(4);
+
+// $ExpectError
+isTextPath({});
+
+// $ExpectError
+isTextPath();
+
+// $ExpectError
+isTextPath(null);
+
+// $ExpectError
+(isTextPath('any-string'): number);


### PR DESCRIPTION
- [is-absolute-url](https://npmjs.com/package/is-absolute-url)
- [is-archive](https://npmjs.com/package/is-archive)
- [is-binary-path](https://npmjs.com/package/is-binary-path)
- [is-compressed](https://npmjs.com/package/is-compressed)
- [is-path-cwd](https://npmjs.com/package/is-path-cwd)
- [is-path-in-cwd](https://npmjs.com/package/is-path-in-cwd)
- [is-relative-url](https://npmjs.com/package/is-relative-url)
- [is-root](https://npmjs.com/package/is-root)
- [is-text-path](https://npmjs.com/package/is-text-path)
- [is-root-path](https://npmjs.com/package/is-root-path)