### PR TITLE
Improve type information for react-dnd

### DIFF
--- a/definitions/npm/react-dnd_v2.x.x/flow_>=v0.23.x/react-dnd_v2.x.x.js
+++ b/definitions/npm/react-dnd_v2.x.x/flow_>=v0.23.x/react-dnd_v2.x.x.js
@@ -1,6 +1,202 @@
+// Shared
+// ----------------------------------------------------------------------
+// todo: add symbol once flow supports it
+type Identifier = string;
+
+type ClientOffset = {
+  x: number,
+  y: number
+}
+
+type DndOptions<P> = {
+  arePropsEqual?: (props: P, otherProps: P) => boolean
+};
+
+// Decorated Components
+// ----------------------------------------------------------------------
+declare class DndComponent<P> extends React$Component<any, P, any> {
+  static DecoratedComponent: Class<this>;
+  getDecoratedComponentInstance(): this;
+  getHandlerId(): Identifier;
+}
+
+declare class ContextComponent<P> extends React$Component<any, P, any> {
+  static DecoratedComponent: Class<this>;
+  getDecoratedComponentInstance(): this;
+  // getManager is not yet documented in ReactDnd Docs
+  getManager(): any;
+}
+
+// Drag Source
+// ----------------------------------------------------------------------
+type DragSourceType<P> =
+  Identifier |
+  (props: P) => Identifier;
+
+type DragSourceSpec<P> = {
+  beginDrag: (
+    props: P,
+    monitor?: DragSourceMonitor,
+    component?: React$Component<any, P, any>
+  ) => Object,
+
+  endDrag?: (
+    props: P,
+    monitor?: DragSourceMonitor,
+    component?: ?React$Component<any, P, any>
+  ) => void,
+
+  canDrag?: (
+    props: P,
+    monitor?: DragSourceMonitor
+  ) => boolean,
+
+  isDragging?: (
+    props: P,
+    monitor?: DragSourceMonitor
+  ) => boolean
+};
+
+type DragSourceMonitor = {
+  canDrag: () => boolean,
+  isDragging: () => boolean,
+  getItemType: () => Identifier,
+  getItem: () => Object,
+  getDropResult: () => Object,
+  didDrop: () => boolean,
+  getInitialClientOffset: () => ClientOffset,
+  getInitialSourceClientOffset: () => ClientOffset,
+  getClientOffset: () => ClientOffset,
+  getDifferenceFromInitialOffset: () => ClientOffset,
+  getSourceClientOffset: () => ClientOffset
+}
+
+type DragSourceConnector = {
+  dragSource: () => ConnectDragSource,
+  dragPreview: () => ConnectDragPreview
+}
+
+type DragSourceOptions = {
+  dropEffect?: string
+}
+
+type DragPreviewOptions = {
+  captureDraggingState?: boolean,
+  anchorX?: number,
+  anchorY?: number
+}
+
+type ConnectDragSource = (
+  elementOrNode: React$Element<any>
+  options?: DragSourceOptions
+) => React$Element<any>;
+
+type ConnectDragPreview = (
+  elementOrNode: React$Element<any>
+  options?: DragPreviewOptions
+) => React$Element<any>;
+
+type DragSourceCollector = (
+  connect: DragSourceConnector,
+  monitor: DragSourceMonitor
+) => Object;
+
+type DragSource = <P, C: React$Component<any, P, any>>(
+  type: DragSourceType<P>,
+  spec: DragSourceSpec<P>,
+  collect: DragSourceCollector,
+  options?: DndOptions<P>
+) => (component: Class<C>) => Class<DndComponent<P>>;
+
+// Drop Target
+// ----------------------------------------------------------------------
+type DropTargetTypes<P> =
+  Identifier |
+  Array<Identifier> |
+  (props: P) => Identifier | Array<Identifier>;
+
+type DropTargetSpec<P> = {
+  drop?: (
+    props: P,
+    monitor?: DropTargetMonitor,
+    component?: React$Component<any, P, any>
+  ) => ?Object,
+
+  hover?: (
+    props: P,
+    monitor?: DropTargetMonitor,
+    component?: React$Component<any, P, any>
+  ) => void,
+
+  canDrop?: (
+    props: P,
+    monitor?: DropTargetMonitor
+  ) => boolean
+};
+
+type DropTargetMonitor = {
+  canDrop: () => boolean,
+  isOver: (options?: { shallow: boolean }) => boolean,
+  getItemType: () => Identifier,
+  getItem: () => Object,
+  getDropResult: () => Object,
+  didDrop: () => boolean,
+  getInitialClientOffset: () => ClientOffset,
+  getInitialSourceClientOffset: () => ClientOffset,
+  getClientOffset: () => ClientOffset,
+  getDifferenceFromInitialOffset: () => ClientOffset,
+  getSourceClientOffset: () => ClientOffset
+}
+
+type DropTargetConnector = {
+  dropTarget: () => ConnectDropTarget
+}
+
+type ConnectDropTarget = (
+  elementOrNode: React$Element<any>
+) => React$Element<any>;
+
+type DropTarget = <P, C: React$Component<any, P, any>>(
+  types: DropTargetTypes<P>,
+  spec: DropTargetSpec<P>,
+  collect: (
+    connect: DropTargetConnector,
+    monitor: DropTargetMonitor
+  ) => Object,
+  options?: DndOptions<P>
+) => (component: Class<C>) => Class<DndComponent<P>>;
+
+// Drag Layer
+// ----------------------------------------------------------------------
+type DragLayerMonitor = {
+  isDragging: () => boolean;
+  getItemType: () => Identifier;
+  getItem: () => Object;
+  getInitialClientOffset: () => ClientOffset;
+  getInitialSourceClientOffset: () => ClientOffset;
+  getClientOffset: () => ClientOffset;
+  getDifferenceFromInitialOffset: () => ClientOffset;
+  getSourceClientOffset: () => ClientOffset;
+}
+
+type DragLayer = <P, C: React$Component<any, P, any>>(
+  collect: (monitor: DragLayerMonitor) => Object,
+  options?: DndOptions<P>
+) => (component: Class<C>) => Class<DndComponent<P>>;
+
+// Drag Drop Context
+// ----------------------------------------------------------------------
+type DragDropContext = <P, C: React$Component<any, P, any>>(
+  backend: mixed
+) => (component: Class<C>) => Class<ContextComponent<P>>;
+
+// Top-level API
+// ----------------------------------------------------------------------
 declare module 'react-dnd' {
-  declare function DropTarget<T: ReactClass<*>>(type: string|string[], spec?: Object, collect?: Object, options?: mixed): (component: T) => T;
-  declare function DragSource<T: ReactClass<*>>(type: string|string[], spec?: Object, collect?: Object, options?: mixed): (component: T) => T;
-  declare function DragLayer<T: ReactClass<*>>(type: string|string[], spec?: Object, collect?: Object, options?: mixed): (component: T) => T;
-  declare function DragDropContext(backend: mixed): ReactClass<*>;
+  declare var exports : {
+    DragSource: DragSource,
+    DropTarget: DropTarget,
+    DragLayer: DragLayer,
+    DragDropContext: DragDropContext
+  }
 }

--- a/definitions/npm/react-dnd_v2.x.x/flow_>=v0.23.x/react-dnd_v2.x.x.js
+++ b/definitions/npm/react-dnd_v2.x.x/flow_>=v0.23.x/react-dnd_v2.x.x.js
@@ -88,15 +88,15 @@ type DragPreviewOptions = {
   anchorY?: number
 }
 
-type ConnectDragSource = (
-  elementOrNode: ElementOrNode
+type ConnectDragSource = <T : ElementOrNode>(
+  elementOrNode: T,
   options?: DragSourceOptions
-) => ElementOrNode;
+) => ?T;
 
-type ConnectDragPreview = (
-  elementOrNode: ElementOrNode
+type ConnectDragPreview = <T : ElementOrNode>(
+  elementOrNode: T,
   options?: DragPreviewOptions
-) => ElementOrNode;
+) => ?T;
 
 type DragSourceCollector = (
   connect: DragSourceConnector,
@@ -154,9 +154,9 @@ type DropTargetConnector = {
   dropTarget: () => ConnectDropTarget
 }
 
-type ConnectDropTarget = (
-  elementOrNode: ElementOrNode
-) => ElementOrNode;
+type ConnectDropTarget = <T : ElementOrNode>(
+  elementOrNode: T
+) => ?T;
 
 type DropTarget = <P, C: React$Component<any, P, any>>(
   types: DropTargetTypes<P>,

--- a/definitions/npm/react-dnd_v2.x.x/flow_>=v0.23.x/react-dnd_v2.x.x.js
+++ b/definitions/npm/react-dnd_v2.x.x/flow_>=v0.23.x/react-dnd_v2.x.x.js
@@ -12,6 +12,8 @@ type DndOptions<P> = {
   arePropsEqual?: (props: P, otherProps: P) => boolean
 };
 
+type ElementOrNode = React$Element<any> | HTMLElement;
+
 // Decorated Components
 // ----------------------------------------------------------------------
 declare class DndComponent<P> extends React$Component<any, P, any> {
@@ -87,14 +89,14 @@ type DragPreviewOptions = {
 }
 
 type ConnectDragSource = (
-  elementOrNode: React$Element<any>
+  elementOrNode: ElementOrNode
   options?: DragSourceOptions
-) => React$Element<any>;
+) => ElementOrNode;
 
 type ConnectDragPreview = (
-  elementOrNode: React$Element<any>
+  elementOrNode: ElementOrNode
   options?: DragPreviewOptions
-) => React$Element<any>;
+) => ElementOrNode;
 
 type DragSourceCollector = (
   connect: DragSourceConnector,
@@ -153,8 +155,8 @@ type DropTargetConnector = {
 }
 
 type ConnectDropTarget = (
-  elementOrNode: React$Element<any>
-) => React$Element<any>;
+  elementOrNode: ElementOrNode
+) => ElementOrNode;
 
 type DropTarget = <P, C: React$Component<any, P, any>>(
   types: DropTargetTypes<P>,

--- a/definitions/npm/react-dnd_v2.x.x/flow_>=v0.23.x/react-dnd_v2.x.x.js
+++ b/definitions/npm/react-dnd_v2.x.x/flow_>=v0.23.x/react-dnd_v2.x.x.js
@@ -14,38 +14,23 @@ type DndOptions<P> = {
 
 type ElementOrNode = React$Element<any> | HTMLElement;
 
-// Decorated Components
-// ----------------------------------------------------------------------
-declare class DndComponent<P> extends React$Component<any, P, any> {
-  static DecoratedComponent: Class<this>;
-  getDecoratedComponentInstance(): this;
-  getHandlerId(): Identifier;
-}
-
-declare class ContextComponent<P> extends React$Component<any, P, any> {
-  static DecoratedComponent: Class<this>;
-  getDecoratedComponentInstance(): this;
-  // getManager is not yet documented in ReactDnd Docs
-  getManager(): any;
-}
-
 // Drag Source
 // ----------------------------------------------------------------------
 type DragSourceType<P> =
   Identifier |
   (props: P) => Identifier;
 
-type DragSourceSpec<P> = {
+type DragSourceSpec<D, P, S> = {
   beginDrag: (
     props: P,
     monitor?: DragSourceMonitor,
-    component?: React$Component<any, P, any>
+    component?: React$Component<D, P, S>
   ) => Object,
 
   endDrag?: (
     props: P,
     monitor?: DragSourceMonitor,
-    component?: ?React$Component<any, P, any>
+    component?: ?React$Component<D, P, S>
   ) => void,
 
   canDrag?: (
@@ -103,12 +88,12 @@ type DragSourceCollector = (
   monitor: DragSourceMonitor
 ) => Object;
 
-type DragSource = <P, C: React$Component<any, P, any>>(
+type DragSource = <D, P, S, C: React$Component<D, P, S>>(
   type: DragSourceType<P>,
-  spec: DragSourceSpec<P>,
+  spec: DragSourceSpec<D, P, S>,
   collect: DragSourceCollector,
   options?: DndOptions<P>
-) => (component: Class<C>) => Class<DndComponent<P>>;
+) => (component: Class<C>) => Class<React$Component<D, P, S>>;
 
 // Drop Target
 // ----------------------------------------------------------------------
@@ -117,17 +102,17 @@ type DropTargetTypes<P> =
   Array<Identifier> |
   (props: P) => Identifier | Array<Identifier>;
 
-type DropTargetSpec<P> = {
+type DropTargetSpec<D, P, S> = {
   drop?: (
     props: P,
     monitor?: DropTargetMonitor,
-    component?: React$Component<any, P, any>
+    component?: React$Component<D, P, S>
   ) => ?Object,
 
   hover?: (
     props: P,
     monitor?: DropTargetMonitor,
-    component?: React$Component<any, P, any>
+    component?: React$Component<D, P, S>
   ) => void,
 
   canDrop?: (
@@ -158,15 +143,15 @@ type ConnectDropTarget = <T : ElementOrNode>(
   elementOrNode: T
 ) => ?T;
 
-type DropTarget = <P, C: React$Component<any, P, any>>(
+type DropTarget = <D, P, S, C: React$Component<D, P, S>>(
   types: DropTargetTypes<P>,
-  spec: DropTargetSpec<P>,
+  spec: DropTargetSpec<D, P, S>,
   collect: (
     connect: DropTargetConnector,
     monitor: DropTargetMonitor
   ) => Object,
   options?: DndOptions<P>
-) => (component: Class<C>) => Class<DndComponent<P>>;
+) => (component: Class<C>) => Class<React$Component<D, P, S>>;
 
 // Drag Layer
 // ----------------------------------------------------------------------
@@ -181,16 +166,16 @@ type DragLayerMonitor = {
   getSourceClientOffset: () => ClientOffset;
 }
 
-type DragLayer = <P, C: React$Component<any, P, any>>(
+type DragLayer = <D, P, S, C: React$Component<D, P, S>>(
   collect: (monitor: DragLayerMonitor) => Object,
   options?: DndOptions<P>
-) => (component: Class<C>) => Class<DndComponent<P>>;
+) => (component: Class<C>) => Class<React$Component<D, P, S>>;
 
 // Drag Drop Context
 // ----------------------------------------------------------------------
-type DragDropContext = <P, C: React$Component<any, P, any>>(
+type DragDropContext = <D, P, S, C: React$Component<D, P, S>>(
   backend: mixed
-) => (component: Class<C>) => Class<ContextComponent<P>>;
+) => (component: Class<C>) => Class<React$Component<D, P, S>>;
 
 // Top-level API
 // ----------------------------------------------------------------------

--- a/definitions/npm/react-dnd_v2.x.x/flow_>=v0.23.x/react-dnd_v2.x.x.js
+++ b/definitions/npm/react-dnd_v2.x.x/flow_>=v0.23.x/react-dnd_v2.x.x.js
@@ -14,6 +14,29 @@ type DndOptions<P> = {
 
 type ElementOrNode = React$Element<any> | HTMLElement;
 
+// Decorated Components
+// ----------------------------------------------------------------------
+declare class DndComponent<D, P, S> extends React$Component<D, P, S> {
+  static defaultProps: D;
+  props: P;
+  state: S;
+
+  static DecoratedComponent: Class<this>;
+  getDecoratedComponentInstance(): this;
+  getHandlerId(): Identifier;
+}
+
+declare class ContextComponent<D, P, S> extends React$Component<D, P, S> {
+  static defaultProps: D;
+  props: P;
+  state: S;
+
+  static DecoratedComponent: Class<this>;
+  getDecoratedComponentInstance(): this;
+  // getManager is not yet documented in ReactDnd Docs
+  getManager(): any;
+}
+
 // Drag Source
 // ----------------------------------------------------------------------
 type DragSourceType<P> =
@@ -93,7 +116,7 @@ type DragSource = <D, P, S, C: React$Component<D, P, S>>(
   spec: DragSourceSpec<D, P, S>,
   collect: DragSourceCollector,
   options?: DndOptions<P>
-) => (component: Class<C>) => Class<React$Component<D, P, S>>;
+) => (component: Class<C>) => Class<DndComponent<D, P, S>>;
 
 // Drop Target
 // ----------------------------------------------------------------------
@@ -151,7 +174,7 @@ type DropTarget = <D, P, S, C: React$Component<D, P, S>>(
     monitor: DropTargetMonitor
   ) => Object,
   options?: DndOptions<P>
-) => (component: Class<C>) => Class<React$Component<D, P, S>>;
+) => (component: Class<C>) => Class<DndComponent<D, P, S>>;
 
 // Drag Layer
 // ----------------------------------------------------------------------
@@ -169,13 +192,13 @@ type DragLayerMonitor = {
 type DragLayer = <D, P, S, C: React$Component<D, P, S>>(
   collect: (monitor: DragLayerMonitor) => Object,
   options?: DndOptions<P>
-) => (component: Class<C>) => Class<React$Component<D, P, S>>;
+) => (component: Class<C>) => Class<DndComponent<D, P, S>>;
 
 // Drag Drop Context
 // ----------------------------------------------------------------------
 type DragDropContext = <D, P, S, C: React$Component<D, P, S>>(
   backend: mixed
-) => (component: Class<C>) => Class<React$Component<D, P, S>>;
+) => (component: Class<C>) => Class<ContextComponent<D, P, S>>;
 
 // Top-level API
 // ----------------------------------------------------------------------

--- a/definitions/npm/react-dnd_v2.x.x/test_react-dnd-v2.js
+++ b/definitions/npm/react-dnd_v2.x.x/test_react-dnd-v2.js
@@ -56,7 +56,7 @@ Knight.defaultProps = {
 };
 
 const DndKnight = DragSource('knight', knightSource, knightCollect)(Knight);
-(DndKnight: Class<React$Component<KnightProps, KnightProps, void>>);
+(DndKnight: Class<DndComponent<KnightProps, KnightProps, void>>);
 // $ExpectError
 (DndKnight: number);
 
@@ -162,7 +162,7 @@ BoardSquare.defaultProps = {
 };
 
 const DndBoardSquare = DropTarget('boardsquare', boardSquareTarget, boardSquareCollect)(BoardSquare);
-(DndBoardSquare: Class<React$Component<BoardSquareProps, BoardSquareProps, void>>);
+(DndBoardSquare: Class<DndComponent<BoardSquareProps, BoardSquareProps, void>>);
 // $ExpectError
 (DndBoardSquare: string);
 
@@ -202,7 +202,7 @@ CustomDragLayer.defaultProps = {
 };
 
 const DndCustomDragLayer = DragLayer(dragLayerCollect)(CustomDragLayer);
-(DndCustomDragLayer: Class<React$Component<CustomDragLayerProps, CustomDragLayerProps, void>>);
+(DndCustomDragLayer: Class<DndComponent<CustomDragLayerProps, CustomDragLayerProps, void>>);
 // $ExpectError
 (DndCustomDragLayer: number);
 
@@ -232,7 +232,7 @@ Board.defaultProps = {
 };
 
 const DndBoard = DragDropContext({})(Board);
-(DndBoard: Class<React$Component<BoardProps, BoardProps, void>>);
+(DndBoard: Class<ContextComponent<BoardProps, BoardProps, void>>);
 // $ExpectError
 (DndBoard: string);
 
@@ -266,4 +266,4 @@ const TestFuncComp = (props: TestProps) => {
 }
 
 const DndTestFuncComp = DragSource('test', testSource, testCollect)(TestFuncComp);
-(DndTestFuncComp: Class<React$Component<void, TestProps, void>>);
+(DndTestFuncComp: Class<DndComponent<void, TestProps, void>>);

--- a/definitions/npm/react-dnd_v2.x.x/test_react-dnd-v2.js
+++ b/definitions/npm/react-dnd_v2.x.x/test_react-dnd-v2.js
@@ -7,7 +7,7 @@ import { DragSource, DropTarget, DragLayer, DragDropContext } from 'react-dnd';
 // ----------------------------------------------------------------------
 type KnightProps = {
   connectDragSource: (e: React$Element<*>) => React$Element<*>,
-  connectDragPreview: (e: React$Element<*>) => React$Element<*>,
+  connectDragPreview: (e: Image) => Image,
   isDragging: boolean
 }
 
@@ -27,8 +27,8 @@ function knightCollect(connect, monitor) {
 
 class Knight extends React.Component<void, KnightProps, void> {
   componentDidMount() {
-    const img = React.DOM.img();
-    img.onload = () => this.props.connectDragPreview(img);
+    const img = new Image();
+    img.onload = () => { this.props.connectDragPreview(img) };
   }
 
   render() {
@@ -184,6 +184,38 @@ const DndBoard = DragDropContext({})(Board);
 (DndBoard: Class<ContextComponent<Board>>);
 // $ExpectError
 (DndBoard: string);
+
+// Test Functional React Components
+// ----------------------------------------------------------------------
+type TestProps = {
+  connectDragSource: (e: React$Element<*>) => React$Element<*>,
+  isDragging: boolean
+}
+
+const testSource = {
+  beginDrag() {
+    return {};
+  }
+};
+
+function testCollect(connect, monitor) {
+  return {
+    connectDragSource: connect.dragSource(),
+    isDragging: monitor.isDragging()
+  };
+}
+
+const TestFuncComp = (props: TestProps) => {
+  const { connectDragSource, isDragging } = props;
+  return connectDragSource(
+    <div style={{
+      opacity: isDragging ? 0.5 : 1
+    }} />
+  );
+}
+
+const DndTestFuncComp = DragSource('test', testSource, testCollect)(TestFuncComp);
+(DndTestFuncComp: Class<DndComponent<TestFuncComp>>);
 
 // Test Decorated Components
 // ----------------------------------------------------------------------

--- a/definitions/npm/react-dnd_v2.x.x/test_react-dnd-v2.js
+++ b/definitions/npm/react-dnd_v2.x.x/test_react-dnd-v2.js
@@ -6,8 +6,8 @@ import { DragSource, DropTarget, DragLayer, DragDropContext } from 'react-dnd';
 // Test Drag Source
 // ----------------------------------------------------------------------
 type KnightProps = {
-  connectDragSource: (e: React$Element<*>) => React$Element<*>,
-  connectDragPreview: (e: Image) => Image,
+  connectDragSource: (e: React$Element<*>) => ?React$Element<*>,
+  connectDragPreview: (e: Image) => ?Image,
   isDragging: boolean
 }
 
@@ -25,7 +25,11 @@ function knightCollect(connect, monitor) {
   };
 }
 
-class Knight extends React.Component<void, KnightProps, void> {
+class Knight extends React.Component {
+  props: KnightProps;
+
+  static defaultProps: KnightProps;
+
   componentDidMount() {
     const img = new Image();
     img.onload = () => { this.props.connectDragPreview(img) };
@@ -45,9 +49,14 @@ class Knight extends React.Component<void, KnightProps, void> {
     );
   }
 }
+Knight.defaultProps = {
+  connectDragSource: () => null,
+  connectDragPreview: () => null,
+  isDragging: false
+};
 
 const DndKnight = DragSource('knight', knightSource, knightCollect)(Knight);
-(DndKnight: Class<DndComponent<KnightProps>>);
+(DndKnight: Class<React$Component<KnightProps, KnightProps, void>>);
 // $ExpectError
 (DndKnight: number);
 
@@ -65,7 +74,7 @@ type BoardSquareProps = {
   y: number,
   isOver: boolean,
   canDrop: boolean,
-  connectDropTarget: (e: React$Element<*>) => React$Element<*>
+  connectDropTarget: (e: React$Element<*>) => ?React$Element<*>
 };
 
 const boardSquareTarget = {
@@ -86,7 +95,15 @@ function boardSquareCollect(connect, monitor) {
   };
 }
 
-class Square extends React.Component<void, { black: boolean }, void> {
+type SquareProps = {
+  black: boolean
+};
+
+class Square extends React.Component {
+  props: SquareProps;
+
+  static defaultProps: SquareProps;
+
   render() {
     const { black } = this.props;
     const fill = black ? 'black' : 'white';
@@ -94,8 +111,15 @@ class Square extends React.Component<void, { black: boolean }, void> {
     return <div style={{ backgroundColor: fill }} />;
   }
 }
+Square.defaultProps = {
+  black: true
+};
 
-class BoardSquare extends React.Component<void, BoardSquareProps, void> {
+class BoardSquare extends React.Component {
+  props: BoardSquareProps;
+
+  static defaultProps: BoardSquareProps;
+
   renderOverlay(color: string) {
     return (
       <div style={{
@@ -129,9 +153,16 @@ class BoardSquare extends React.Component<void, BoardSquareProps, void> {
     );
   }
 }
+BoardSquare.defaultProps = {
+  x: 0,
+  y: 0,
+  isOver: false,
+  canDrop: false,
+  connectDropTarget: () => null
+};
 
 const DndBoardSquare = DropTarget('boardsquare', boardSquareTarget, boardSquareCollect)(BoardSquare);
-(DndBoardSquare: Class<DndComponent<BoardSquareProps>>);
+(DndBoardSquare: Class<React$Component<BoardSquareProps, BoardSquareProps, void>>);
 // $ExpectError
 (DndBoardSquare: string);
 
@@ -149,19 +180,29 @@ function dragLayerCollect(monitor) {
   };
 }
 
-function CustomDragLayer(props: CustomDragLayerProps) {
-  const { title, isDragging } = props;
-  if (!isDragging) {
-    return null;
-  }
+class CustomDragLayer extends React.Component {
+  props: CustomDragLayerProps;
 
-  return (
-    <div>this.props.title</div>
-  );
+  static defaultProps: CustomDragLayerProps;
+
+  render() {
+    const { title, isDragging } = this.props;
+    if (!isDragging) {
+      return null;
+    }
+
+    return (
+      <div>this.props.title</div>
+    );
+  }
 }
+CustomDragLayer.defaultProps = {
+  isDragging: false,
+  title: ''
+};
 
 const DndCustomDragLayer = DragLayer(dragLayerCollect)(CustomDragLayer);
-(DndCustomDragLayer: Class<DndComponent<CustomDragLayer>>);
+(DndCustomDragLayer: Class<React$Component<CustomDragLayerProps, CustomDragLayerProps, void>>);
 // $ExpectError
 (DndCustomDragLayer: number);
 
@@ -172,16 +213,26 @@ type BoardProps = {
   height: number
 };
 
-function Board(props: BoardProps) {
-  const styles = {
-    width: props.width,
-    height: props.height
+class Board extends React.Component {
+  props: BoardProps;
+
+  static defaultProps: BoardProps;
+
+  render() {
+    const styles = {
+      width: this.props.width,
+      height: this.props.height
+    }
+    return <div style={ styles } />;
   }
-  return <div style={ styles } />;
 }
+Board.defaultProps = {
+  width: 400,
+  height: 400
+};
 
 const DndBoard = DragDropContext({})(Board);
-(DndBoard: Class<ContextComponent<Board>>);
+(DndBoard: Class<React$Component<BoardProps, BoardProps, void>>);
 // $ExpectError
 (DndBoard: string);
 
@@ -215,13 +266,4 @@ const TestFuncComp = (props: TestProps) => {
 }
 
 const DndTestFuncComp = DragSource('test', testSource, testCollect)(TestFuncComp);
-(DndTestFuncComp: Class<DndComponent<TestFuncComp>>);
-
-// Test Decorated Components
-// ----------------------------------------------------------------------
-(DndKnight.DecoratedComponent: Class<DndKnight>);
-const dk = <DndKnight />;
-
-// TODO: is it possible to type check the following? type of dk is React$Element<{}>
-// (dk.getDecoratedComponentInstance(): DndKnight);
-// (dk.getHandlerId(): string);
+(DndTestFuncComp: Class<React$Component<void, TestProps, void>>);

--- a/definitions/npm/react-dnd_v2.x.x/test_react-dnd-v2.js
+++ b/definitions/npm/react-dnd_v2.x.x/test_react-dnd-v2.js
@@ -1,21 +1,195 @@
-// @flow
+/* @flow */
 
-import ReactDND from 'react-dnd';
+import React from 'react';
+import { DragSource, DropTarget, DragLayer, DragDropContext } from 'react-dnd';
 
-const A = ReactDND.DropTarget('test');
-class AComponent extends React$Component<*, *, *> {};
-(A(AComponent): Class<AComponent>);
+// Test Drag Source
+// ----------------------------------------------------------------------
+type KnightProps = {
+  connectDragSource: (e: React$Element<*>) => React$Element<*>,
+  connectDragPreview: (e: React$Element<*>) => React$Element<*>,
+  isDragging: boolean
+}
+
+const knightSource = {
+  beginDrag() {
+    return {};
+  }
+};
+
+function knightCollect(connect, monitor) {
+  return {
+    connectDragSource: connect.dragSource(),
+    connectDragPreview: connect.dragPreview(),
+    isDragging: monitor.isDragging()
+  };
+}
+
+class Knight extends React.Component<void, KnightProps, void> {
+  componentDidMount() {
+    const img = React.DOM.img();
+    img.onload = () => this.props.connectDragPreview(img);
+  }
+
+  render() {
+    const { connectDragSource, isDragging } = this.props;
+    return connectDragSource(
+      <div style={{
+        fontSize: 40,
+        fontWeight: 'bold',
+        cursor: 'move',
+        opacity: isDragging ? 0.5 : 1
+      }}>
+        ♘
+      </div>
+    );
+  }
+}
+
+const DndKnight = DragSource('knight', knightSource, knightCollect)(Knight);
+(DndKnight: Class<DndComponent<KnightProps>>);
 // $ExpectError
-(A(AComponent): number);
+(DndKnight: number);
 
-const B = ReactDND.DragSource('test');
-class BComponent extends React$Component<*, *, *> {};
-(B(BComponent): Class<BComponent>);
-// $ExpectError
-(B(BComponent): number);
+// Test Drop Target
+// ----------------------------------------------------------------------
+function moveKnight(toX: number, toY: number) {
+}
 
-const C = ReactDND.DragLayer('test');
-class CComponent extends React$Component<*, *, *> {};
-(C(CComponent): Class<CComponent>);
+function canMoveKnight(toX: number, toY: number) {
+  return true;
+}
+
+type BoardSquareProps = {
+  x: number,
+  y: number,
+  isOver: boolean,
+  canDrop: boolean,
+  connectDropTarget: (e: React$Element<*>) => React$Element<*>
+};
+
+const boardSquareTarget = {
+  canDrop(props) {
+    return canMoveKnight(props.x, props.y);
+  },
+
+  drop(props) {
+    moveKnight(props.x, props.y);
+  }
+};
+
+function boardSquareCollect(connect, monitor) {
+  return {
+    connectDropTarget: connect.dropTarget(),
+    isOver: monitor.isOver(),
+    canDrop: monitor.canDrop()
+  };
+}
+
+class Square extends React.Component<void, { black: boolean }, void> {
+  render() {
+    const { black } = this.props;
+    const fill = black ? 'black' : 'white';
+
+    return <div style={{ backgroundColor: fill }} />;
+  }
+}
+
+class BoardSquare extends React.Component<void, BoardSquareProps, void> {
+  renderOverlay(color: string) {
+    return (
+      <div style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        height: '100%',
+        width: '100%',
+        zIndex: 1,
+        opacity: 0.5,
+        backgroundColor: color,
+      }} />
+    );
+  }
+
+  render() {
+    const { x, y, connectDropTarget, isOver, canDrop } = this.props;
+    const black = (x + y) % 2 === 1;
+
+    return connectDropTarget(
+      <div style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%'
+      }}>
+        <Square black={black} />
+        {isOver && !canDrop && this.renderOverlay('red')}
+        {!isOver && canDrop && this.renderOverlay('yellow')}
+        {isOver && canDrop && this.renderOverlay('green')}
+      </div>
+    );
+  }
+}
+
+const DndBoardSquare = DropTarget('boardsquare', boardSquareTarget, boardSquareCollect)(BoardSquare);
+(DndBoardSquare: Class<DndComponent<BoardSquareProps>>);
 // $ExpectError
-(C(CComponent): number);
+(DndBoardSquare: string);
+
+// Test Custom Drag Layer
+// ----------------------------------------------------------------------
+type CustomDragLayerProps = {
+  isDragging: boolean;
+  title: string;
+}
+
+function dragLayerCollect(monitor) {
+  return {
+    isDragging: monitor.isDragging(),
+    item: monitor.getItem(),
+  };
+}
+
+function CustomDragLayer(props: CustomDragLayerProps) {
+  const { title, isDragging } = props;
+  if (!isDragging) {
+    return null;
+  }
+
+  return (
+    <div>this.props.title</div>
+  );
+}
+
+const DndCustomDragLayer = DragLayer(dragLayerCollect)(CustomDragLayer);
+(DndCustomDragLayer: Class<DndComponent<CustomDragLayer>>);
+// $ExpectError
+(DndCustomDragLayer: number);
+
+// Test Drag Drop Context
+// ----------------------------------------------------------------------
+type BoardProps = {
+  width: number,
+  height: number
+};
+
+function Board(props: BoardProps) {
+  const styles = {
+    width: props.width,
+    height: props.height
+  }
+  return <div style={ styles } />;
+}
+
+const DndBoard = DragDropContext({})(Board);
+(DndBoard: Class<ContextComponent<Board>>);
+// $ExpectError
+(DndBoard: string);
+
+// Test Decorated Components
+// ----------------------------------------------------------------------
+(DndKnight.DecoratedComponent: Class<DndKnight>);
+const dk = <DndKnight />;
+
+// TODO: is it possible to type check the following? type of dk is React$Element<{}>
+// (dk.getDecoratedComponentInstance(): DndKnight);
+// (dk.getHandlerId(): string);


### PR DESCRIPTION
Updated the react-dnd definitions based on existing TypeScript
definitions from DefinitelyTyped. Type definitions are now complete
based on react-dnd documents.

Added unit tests exercising this functionality.

Also fixed incorrect signatures for DragLayer.