### PR TITLE
Let tape$TestCb return a promise

### DIFF
--- a/definitions/npm/tape_v4.5.x/flow_>=v0.25.x/tape_v4.5.x.js
+++ b/definitions/npm/tape_v4.5.x/flow_>=v0.25.x/tape_v4.5.x.js
@@ -11,7 +11,7 @@ declare type tape$TestOpts = {
 };
 
 
-declare type tape$TestCb = (t: tape$Context) => void;
+declare type tape$TestCb = (t: tape$Context) => void | Promise<any>;
 declare type tape$TestFn = (a: string | tape$TestOpts | tape$TestCb, b?: tape$TestOpts | tape$TestCb, c?: tape$TestCb) => void;
 
 declare interface tape$Context {

--- a/definitions/npm/tape_v4.5.x/flow_>=v0.25.x/tape_v4.5.x.js
+++ b/definitions/npm/tape_v4.5.x/flow_>=v0.25.x/tape_v4.5.x.js
@@ -11,7 +11,7 @@ declare type tape$TestOpts = {
 };
 
 
-declare type tape$TestCb = (t: tape$Context) => void | Promise<any>;
+declare type tape$TestCb = (t: tape$Context) => void | Promise<mixed>;
 declare type tape$TestFn = (a: string | tape$TestOpts | tape$TestCb, b?: tape$TestOpts | tape$TestCb, c?: tape$TestCb) => void;
 
 declare interface tape$Context {


### PR DESCRIPTION
Let tape$TestCb return a promise
    
If you want to use async/await with Tape you will need to prefix your test function with async, e.g.

```
test('Promise resolves true', async (assert: tape$Context) => {
  const result = await promiseFunction();
  assert.true(result);
  assert.end();
}
```
    
But this will cause type checking to fail as the callback no longer returns void.