### PR TITLE
Add libdef for mkdirp 0.5.x

### DIFF
--- a/definitions/npm/mkdirp_v0.5.x/flow_>=v0.25.x/mkdirp_v0.5.x.js
+++ b/definitions/npm/mkdirp_v0.5.x/flow_>=v0.25.x/mkdirp_v0.5.x.js
@@ -1,0 +1,36 @@
+declare module 'mkdirp' {
+
+  declare type FsImplementation = {
+    stat: (
+      path: string,
+      cb: (error: typeof Error, made: ?string) => void
+    ) => void,
+    mkdir: (
+      path: string,
+      mode: number,
+      cb: (error: typeof Error, made: ?string) => void
+    ) => void
+  }
+
+  declare type FsImplementationSync = {
+    statSync: (path: string) => mixed,
+    mkdirSync: (path: string, mode: number) => void
+  }
+
+  declare function sync(
+    path: string,
+    options?: {
+      mode?: string,
+      fs?: FsImplementationSync,
+    }
+  ): ?string;
+
+  declare module.exports: (
+    path: string,
+    options?: {
+      mode?: string,
+      fs?: FsImplementation,
+    } | (error: typeof Error, made: ?string) => void,
+    callback?: (error: typeof Error, made: ?string) => void
+  ) => void
+}

--- a/definitions/npm/mkdirp_v0.5.x/test_mkdirp_v0.5.x.js
+++ b/definitions/npm/mkdirp_v0.5.x/test_mkdirp_v0.5.x.js
@@ -1,0 +1,48 @@
+// @flow
+
+import mkdirp from 'mkdirp';
+
+function callback(err) {
+  console.log('Done!')
+}
+
+const fs = {
+  stat: (path, cb) => {},
+  mkdir: (path, mode) => {}
+}
+
+const fsSync = {
+  statSync: (path: string) => {},
+  mkdirSync: (path: string, mode: string) => {}
+}
+
+mkdirp('/tmp/foot/bar/baz', callback)
+mkdirp('/tmp/foo/bar/baz', {}, callback)
+mkdirp('/tmp/foo/bar/baz', {mode: "0777"}, callback)
+mkdirp('/tmp/foo/bar/baz', {fs: fs})
+
+mkdirp.sync('/tmp/foot/bar/baz')
+mkdirp.sync('/tmp/foo/bar/baz', {})
+mkdirp.sync('/tmp/foo/bar/baz', {mode: "0777"})
+mkdirp.sync('/tmp/foo/bar/baz', {fs: fsSync})
+
+// $ExpectError
+mkdirp(null)
+
+// $ExpectError
+mkdirp(2, callback)
+
+// $ExpectError
+mkdirp("2", 2, callback)
+
+// $ExpectError
+mkdirp("2", "2")
+
+// $ExpectError
+mkdirp('/tmp/foo/bar/baz', {fs: {}}, callback)
+
+// $ExpectError
+mkdirp.sync('/tmp/foo/bar/baz', callback)
+
+// $ExpectError
+mkdirp.sync('/tmp/foo/bar/baz', {fs: fs})


### PR DESCRIPTION
_This is not complete, but I got a bit stuck so I am opening a PR in case anyone has any pointers._  

These tests does not generate an error and I am unsure why.

``` js
// $ExpectError
mkdirp.sync('/tmp/foo/bar/baz', callback)

// $ExpectError
mkdirp.sync('/tmp/foo/bar/baz', {fs: fs})
```
