### PR TITLE
Debug v2.x.x: relax first param of Debugger declaration

### DIFF
--- a/definitions/npm/debug_v2.x.x/flow_>=v0.28.x/debug_v2.x.x.js
+++ b/definitions/npm/debug_v2.x.x/flow_>=v0.28.x/debug_v2.x.x.js
@@ -1,6 +1,7 @@
 declare module 'debug' {
   declare type Debugger = {
     (formatter: string, ...args: Array<any>): void,
+    (err: Error, ...args: Array<any>): void,
     enabled: boolean,
     log: () => {},
     namespace: string;

--- a/definitions/npm/debug_v2.x.x/flow_>=v0.28.x/debug_v2.x.x.js
+++ b/definitions/npm/debug_v2.x.x/flow_>=v0.28.x/debug_v2.x.x.js
@@ -1,5 +1,6 @@
 declare module 'debug' {
   declare type Debugger = {
+    (...args: Array<any>): void,
     (formatter: string, ...args: Array<any>): void,
     (err: Error, ...args: Array<any>): void,
     enabled: boolean,

--- a/definitions/npm/debug_v2.x.x/test_debug_v2.x.x.js
+++ b/definitions/npm/debug_v2.x.x/test_debug_v2.x.x.js
@@ -5,6 +5,8 @@ import debug from 'debug';
 const test = debug('test');
 
 test('Hello %s', 'World');
+test({a: 1, b: 2});
+test(new Error('error'));
 
 // $ExpectError
 debug();


### PR DESCRIPTION
As currently declared, Debugger functions can only accept a string as their first argument.
However, Debugger functions are specifically implemented to also accept an Error as their first argument (instead of a formatter)--or no formatter/error at all.

See:
https://github.com/visionmedia/debug/blob/master/debug.js#L88-L93
and 'coerce' at: https://github.com/visionmedia/debug/blob/master/debug.js#L194-L197

Note that these changes allow a debugger function to be called with any pattern of arguments--there may be value in restricting that, but I couldn't find any definitive guidance on the intended API of those functions in the project's docs/code.