### PR TITLE
React test utils return Elements from get-by-class and get-by-tag and can return null

### DIFF
--- a/definitions/npm/react-addons-test-utils_v15.x.x/flow_>=v0.23.x/react-addons-test-utils_v15.x.x.js
+++ b/definitions/npm/react-addons-test-utils_v15.x.x/flow_>=v0.23.x/react-addons-test-utils_v15.x.x.js
@@ -11,12 +11,12 @@ declare module 'react-addons-test-utils' {
   declare function isCompositeComponent(instance: React$Component<any, any, any>): boolean;
   declare function isCompositeComponentWithType(instance: React$Component<any, any, any>, componentClass: ReactAddonTest$FunctionOrComponentClass): boolean;
   declare function findAllInRenderedTree(tree: React$Component<any, any, any>, test: (child: React$Component<any, any, any>) => boolean): Array<React$Component<any, any, any>>;
-  declare function scryRenderedDOMComponentsWithClass(tree: React$Component<any, any, any>, className: string): Array<React$Component<any, any, any>>;
-  declare function findRenderedDOMComponentWithClass(tree: React$Component<any, any, any>, className: string): React$Component<any, any, any>;
-  declare function scryRenderedDOMComponentsWithTag(tree: React$Component<any, any, any>, tagName: string): Array<React$Component<any, any, any>>;
-  declare function findRenderedDOMComponentWithTag(tree: React$Component<any, any, any>, tagName: string): React$Component<any, any, any>;
+  declare function scryRenderedDOMComponentsWithClass(tree: React$Component<any, any, any>, className: string): Array<Element>;
+  declare function findRenderedDOMComponentWithClass(tree: React$Component<any, any, any>, className: string): ?Element;
+  declare function scryRenderedDOMComponentsWithTag(tree: React$Component<any, any, any>, tagName: string): Array<Element>;
+  declare function findRenderedDOMComponentWithTag(tree: React$Component<any, any, any>, tagName: string): ?Element;
   declare function scryRenderedComponentsWithType(tree: React$Component<any, any, any>, componentClass: ReactAddonTest$FunctionOrComponentClass): Array<React$Component<any, any, any>>;
-  declare function findRenderedComponentWithType(tree: React$Component<any, any, any>, componentClass: ReactAddonTest$FunctionOrComponentClass): React$Component<any, any, any>;
+  declare function findRenderedComponentWithType(tree: React$Component<any, any, any>, componentClass: ReactAddonTest$FunctionOrComponentClass): ?React$Component<any, any, any>;
   declare class ReactShallowRender {
     render(element: React$Element<any>): void;
     getRenderOutput(): React$Element<any>;


### PR DESCRIPTION
Per PR title.

Looking up rendered nodes by tag name or className always return `Element`, not `React$Component`.