### PR TITLE
Switch from `https` to `http` for cache repo clones

### DIFF
--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -24,7 +24,7 @@ const CACHE_DIR = path.join(os.homedir(), '.flow-typed');
 const CACHE_REPO_DIR = path.join(CACHE_DIR, 'repo');
 const GIT_REPO_DIR = path.join(__dirname, '..', '..', '..');
 
-const REMOTE_REPO_URL = 'https://github.com/flowtype/flow-typed.git';
+const REMOTE_REPO_URL = 'http://github.com/flowtype/flow-typed.git';
 const LAST_UPDATED_FILE = path.join(CACHE_DIR, 'lastUpdated');
 
 async function cloneCacheRepo(verbose?: VerboseOutput) {


### PR DESCRIPTION
Per https://github.com/flowtype/flow-typed/issues/226, people seem to be having
issues when the CLI attempts to clone the flow-typed repo into local cache.

Specifically, the github seems to require authentication to do this clone.

[There are some reports](https://github.com/flowtype/flow-typed/issues/226#issuecomment-239968111) that suggest that cloning over http does not require said auth, so
this switches things to http to attempt to mitigate the problem.