### PR TITLE
check version sat

### DIFF
--- a/cli/src/lib/__tests__/semver-test.js
+++ b/cli/src/lib/__tests__/semver-test.js
@@ -1,6 +1,12 @@
 // @flow
 
-import {stringToVersion, sortVersions, disjointVersions, disjointVersionsAll} from '../semver.js';
+import {
+  stringToVersion,
+  sortVersions,
+  disjointVersions,
+  disjointVersionsAll,
+  isSatVersion,
+} from '../semver.js';
 
 describe('semver', () => {
   describe('stringToVersion', () => {
@@ -120,6 +126,31 @@ describe('semver', () => {
       let b = stringToVersion('v0.1.x');
       let c = stringToVersion('v1.x.x');
       let res = disjointVersionsAll([a,b,c]);
+      expect(res).toEqual(false);
+    });
+  });
+
+  describe('isSatVersion', () => {
+    it('checks satisfiability of versions correctly', () => {
+      let res = isSatVersion(stringToVersion('v1.0.0'));
+      expect(res).toEqual(true);
+
+      res = isSatVersion(stringToVersion('<=v0.1.x'));
+      expect(res).toEqual(true);
+
+      res = isSatVersion(stringToVersion('>=v1.1.x'));
+      expect(res).toEqual(true);
+
+      res = isSatVersion(stringToVersion('>=v1.1.x_<=v0.1.x'));
+      expect(res).toEqual(false);
+
+      res = isSatVersion(stringToVersion('<=v0.1.x_>=v1.1.x'));
+      expect(res).toEqual(false);
+
+      res = isSatVersion(stringToVersion('v0.1.x_>=v1.1.x'));
+      expect(res).toEqual(false);
+
+      res = isSatVersion(stringToVersion('v1.1.x_<=v0.1.x'));
       expect(res).toEqual(false);
     });
   });

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -5,7 +5,13 @@ import semver from "semver";
 
 import {mkdirp} from "./fileUtils.js";
 import {fs, path, os} from "./node.js";
-import {emptyVersion, copyVersion, versionToString, disjointVersionsAll} from "./semver.js";
+import {
+  emptyVersion,
+  copyVersion,
+  versionToString,
+  disjointVersionsAll,
+  isSatVersion,
+} from "./semver.js";
 import type {Version} from "./semver.js";
 
 const P = Promise;
@@ -216,7 +222,11 @@ function parsePkgFlowDirVersion(pkgFlowDirPath, validationErrs): Version {
     }
   }
 
-  return {range, major, minor, patch, upperBound};
+  const ver = {range, major, minor, patch, upperBound};
+  if (!isSatVersion(ver)) {
+    validationError(pkgFlowDirPath, 'Flow version is unsatisfiable!', validationErrs);
+  }
+  return ver;
 }
 
 /**

--- a/cli/src/lib/semver.js
+++ b/cli/src/lib/semver.js
@@ -103,6 +103,23 @@ export function disjointVersions(a: Version, b: Version): boolean {
 }
 
 /**
+ * Given a version range, returns if the range is satisfiable.
+ */
+export function isSatVersion(ver: Version): boolean {
+  const upperBound = ver.upperBound;
+  if (upperBound) {
+    if (upperBound.range === '>=' && ver.range !== '>=') {
+      return !(before (ver, upperBound));
+    }
+    if (upperBound.range === '<=' && ver.range !== '<=') {
+      return !(before (upperBound, ver));
+    }
+    return true;
+  }
+  return true;
+}
+
+/**
  * Given an array of versions, returns whether they are mutually disjoint.
  */
 function _disjointVersionsAll(vers, len, i) {


### PR DESCRIPTION
flow versions of packages should be satisfiable, in the sense that we should not allow bogus ranges whose lower bound and upper bound point in the wrong directions