### PR TITLE
rename upperBound to otherBound

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -249,17 +249,17 @@ async function runTestGroup(
         return true;
       }
 
-      const testGrpUpperBound = testGroup.flowVersion.upperBound;
-      testGroup.flowVersion.upperBound = undefined;
+      const testGrpOtherBound = testGroup.flowVersion.otherBound;
+      testGroup.flowVersion.otherBound = undefined;
       const testGrpLowerBoundStr = versionToString(testGroup.flowVersion);
-      const testGrpUpperBoundStr = testGrpUpperBound
-        ? versionToString(testGrpUpperBound)
+      const testGrpOtherBoundStr = testGrpOtherBound
+        ? versionToString(testGrpOtherBound)
         : undefined;
-      testGroup.flowVersion.upperBound = testGrpUpperBound;
+      testGroup.flowVersion.otherBound = testGrpOtherBound;
 
       if (semver.satisfies(flowVer, testGrpLowerBoundStr)) {
-        if (testGrpUpperBoundStr) {
-          return semver.satisfies(flowVer, testGrpUpperBoundStr);
+        if (testGrpOtherBoundStr) {
+          return semver.satisfies(flowVer, testGrpOtherBoundStr);
         } else{
           return true;
         }

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -179,10 +179,10 @@ function parsePkgFlowDirVersion(pkgFlowDirPath, validationErrs): Version {
     return emptyVersion();
   }
 
-  let upperBound;
+  let otherBound;
   let [
     _1, isAll, _2, range, major, minor, patch,
-    _3, upRange, upMajor, upMinor, upPatch
+    _3, otherRange, otherMajor, otherMinor, otherPatch
   ] = matches;
 
   if (isAll === 'all') {
@@ -199,24 +199,24 @@ function parsePkgFlowDirVersion(pkgFlowDirPath, validationErrs): Version {
     patch =
       validateVersionPart(patch, "patch", pkgFlowDirPath, validationErrs);
 
-    if (upMajor) {
-      upRange = validateVersionRange(upRange, pkgFlowDirPath, validationErrs);
-      upMajor =
-        validateVersionNumPart(upMajor, "major", pkgFlowDirPath, validationErrs);
-      upMinor =
-        validateVersionPart(upMinor, "minor", pkgFlowDirPath, validationErrs);
-      upPatch =
-        validateVersionPart(upPatch, "patch", pkgFlowDirPath, validationErrs);
-      upperBound = {
-        range: upRange,
-        major: upMajor,
-        minor: upMinor,
-        patch: upPatch,
+    if (otherMajor) {
+      otherRange = validateVersionRange(otherRange, pkgFlowDirPath, validationErrs);
+      otherMajor =
+        validateVersionNumPart(otherMajor, "major", pkgFlowDirPath, validationErrs);
+      otherMinor =
+        validateVersionPart(otherMinor, "minor", pkgFlowDirPath, validationErrs);
+      otherPatch =
+        validateVersionPart(otherPatch, "patch", pkgFlowDirPath, validationErrs);
+      otherBound = {
+        range: otherRange,
+        major: otherMajor,
+        minor: otherMinor,
+        patch: otherPatch,
       };
     }
   }
 
-  return {range, major, minor, patch, upperBound};
+  return {range, major, minor, patch, otherBound};
 }
 
 /**
@@ -573,13 +573,13 @@ export function filterLibDefs(
     const filterFlowVer = filter.flowVersion;
     if (filterFlowVer) {
       const filterFlowVerStr = versionToString(filterFlowVer);
-      const defUpperFlow = def.flowVersion.upperBound;
-      if (defUpperFlow) {
+      const defOtherFlow = def.flowVersion.otherBound;
+      if (defOtherFlow) {
         const defLowerFlow = copyVersion(def.flowVersion);
-        defLowerFlow.upperBound = undefined;
+        defLowerFlow.otherBound = undefined;
         return (
           semver.satisfies(filterFlowVerStr, versionToString(defLowerFlow))
-          && semver.satisfies(filterFlowVerStr, versionToString(defUpperFlow))
+          && semver.satisfies(filterFlowVerStr, versionToString(defOtherFlow))
         );
       } else {
         return semver.satisfies(filterFlowVerStr, def.flowVersionStr);

--- a/cli/src/lib/semver.js
+++ b/cli/src/lib/semver.js
@@ -8,7 +8,7 @@ export type Version = {
   major: number | "x",
   minor: number | "x",
   patch: number | "x",
-  upperBound?: Version, // TODO: rename to otherBound
+  otherBound?: Version,
 };
 
 export function emptyVersion(): Version {
@@ -53,8 +53,8 @@ export function sortVersions(a: Version, b: Version): number {
  */
 function maxSat(ver: Version): ?Version {
   if (ver.range === '>=') {
-    // TODO: ensure that if ver.upperBound exists, it is "greater than" ver
-    return ver.upperBound;
+    // TODO: ensure that if ver.otherBound exists, it is "greater than" ver
+    return ver.otherBound;
   };
   return ver;
 }
@@ -64,8 +64,8 @@ function maxSat(ver: Version): ?Version {
  */
 function minSat(ver: Version): ?Version {
   if (ver.range === '<=') {
-    // TODO: ensure that if ver.upperBound exists, it is "lesser than" ver
-    return ver.upperBound;
+    // TODO: ensure that if ver.otherBound exists, it is "lesser than" ver
+    return ver.otherBound;
   };
   return ver;
 }
@@ -132,14 +132,14 @@ export function stringToVersion(verStr: string): Version {
   }
   let [
     _1, range, major, minor, patch,
-    _2, upperRange, upperMajor, upperMinor, upperPatch,
+    _2, otherRange, otherMajor, otherMinor, otherPatch,
   ] = versionParts;
   if (range != null && range !== ">=" && range !== "<=") {
     throw new Error(`'${verStr}': Invalid version range: ${range}`);
   }
-  if (upperRange != null && upperRange !== ">=" && upperRange !== "<=") {
+  if (otherRange != null && otherRange !== ">=" && otherRange !== "<=") {
     throw new Error(
-      `'${verStr}': Invalid version upper-bound range: ${upperRange}`
+      `'${verStr}': Invalid version other-bound range: ${otherRange}`
     );
   }
 
@@ -151,20 +151,20 @@ export function stringToVersion(verStr: string): Version {
     patch = _validateVersionNumberPart(verStr, "patch", patch);
   }
 
-  let upperBound;
-  if (upperMajor) {
-    upperMajor = _validateVersionNumberPart(verStr, "upper-bound major", upperMajor);
-    if (upperMinor !== "x") {
-      upperMinor = _validateVersionNumberPart(verStr, "upper-bound minor", upperMinor);
+  let otherBound;
+  if (otherMajor) {
+    otherMajor = _validateVersionNumberPart(verStr, "other-bound major", otherMajor);
+    if (otherMinor !== "x") {
+      otherMinor = _validateVersionNumberPart(verStr, "other-bound minor", otherMinor);
     }
-    if (upperPatch !== "x") {
-      upperPatch = _validateVersionNumberPart(verStr, "upper-bound patch", upperPatch);
+    if (otherPatch !== "x") {
+      otherPatch = _validateVersionNumberPart(verStr, "other-bound patch", otherPatch);
     }
-    upperBound = {
-      range: upperRange,
-      major: upperMajor,
-      minor: upperMinor,
-      patch: upperPatch,
+    otherBound = {
+      range: otherRange,
+      major: otherMajor,
+      minor: otherMinor,
+      patch: otherPatch,
     };
   }
 
@@ -174,13 +174,13 @@ export function stringToVersion(verStr: string): Version {
     );
   }
 
-  return {range, major, minor, patch, upperBound};
+  return {range, major, minor, patch, otherBound};
 };
 
 export function versionToString(ver: Version): string {
   const rangeStr = ver.range ? ver.range : '';
-  const upperBoundStr = ver.upperBound ? `_${versionToString(ver.upperBound)}` : '';
-  return `${rangeStr}v${ver.major}.${ver.minor}.${ver.patch}${upperBoundStr}`;
+  const otherBoundStr = ver.otherBound ? `_${versionToString(ver.otherBound)}` : '';
+  return `${rangeStr}v${ver.major}.${ver.minor}.${ver.patch}${otherBoundStr}`;
 };
 
 function _validateVersionNumberPart(context, partName, part) {


### PR DESCRIPTION
version.upperBound is not necessarily an upper bound, because we don’t enforce that it begins with <=. (E.g., we might have <=v.1.1.x_>=v.1.0.x, where version.upperBound is actually a lower bound.) Thus renaming to otherBound.