### PR TITLE
Updated Readme + Contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,14 @@
 ## Library Definition Best Practices
 
+This is a set of best practices to keep in mind while writing a libdef. These 
+best practices should also be considered when reviewing new libdefs or changes
+to existing libdefs.
+
+### tldr
+
+* [Avoid `any` when possible](#avoid-any-when-possible)
+* [Always prefix global variables that aren't really meant to be global](prefix-global-variables-that-arent-really-meant-to-be-global)
+
 ##### Avoid `any` when possible
 
 Using the `any` type for a variable or interface results in the loss of type information as types pass through it. That means if a type passes through `any` before propogating on to other code, the `any` will potentially cause Flow to miss type errors!

--- a/README.md
+++ b/README.md
@@ -15,17 +15,33 @@ You can grab definitions directly from this GitHub repo, or you can use the CLI 
 $ npm install -g flow-typed
 
 $ cd /path/to/my/project
-$ flow-typed install -f 0.30 rxjs@5.0.0 # `-f 0.30` specifies the Flow version we're using for this project
+$ npm install
+$ flow-typed install
 'rxjs_v5.0.x.js' installed at /path/to/my/project/flow-typed/npm/rxjs_v5.0.xjs
 ```
 
+**We recommend checking installed libdefs in to your project's version control.**
+
+Libdefs in flow-typed are tagged at both Flow and library version when they are
+installed, but libdefs themselves can improve over time. For example, they may
+have a bug or there may be an improvement to their accuracy or completeness.
+
+When a libdef is improved or updated in flow-*typed*, there's some chance that
+the change could introduce new Flow errors into your project. As good as it is
+to find new issues, **we also want to make sure that Flow errors in your project
+are consistent and predictable over time**.
+
+So if/when you wish to upgrade a libdef that you've already checked in to your
+project's version control, you can do so explicitly with the 
+`flow-typed install --overwrite` command.
+
 ## Huh?
 
-When you start a project with Flow, **you might want to use some third-party 
-libraries that were *not* written with Flow**. Flow is usually able to work its 
-way around this, but at the unfortunate cost of typing those third-party modules 
-as `any`. As a result, Flow can't give errors if you accidentally mis-use the 
-library (nor will it be able to auto-complete the library).
+When you start a project with Flow, **you likely want to use some third-party 
+libraries that were *not* written with Flow**. By default, Flow will just ignore
+these libraries **leaving them untyped**. As a result, Flow can't give errors if 
+you accidentally mis-use the library (nor will it be able to auto-complete the 
+library).
 
 To address this, **Flow supports 
 [library definitions](http://flowtype.org/docs/third-party.html)** which allow 
@@ -33,57 +49,93 @@ you to describe the interface of a module or library separate from the
 implementation of that module/library. 
 
 **The `flow-typed` repo is a collection of high-quality library definitions**, 
-tests to ensure that they remain high quality, and tooling to make it as easy as 
-possible to import them into your project.
+tests to ensure that definitions remain high quality, and tooling to make it 
+as easy as possible to import them into your project. 
 
-## How Do I Contribute?
+All you have to do when you add a one or more new dependencies to your project 
+is run `flow-typed install`. This will search the libdef repo and download all
+the libdefs that are relevant for your project and install them for you. After
+that, **simply check them in** and be on your way!
+
+## How Do I Contribute Library Definitions?
 
 Just send a pull request!
 
 All definitions sit under the 
 [/definitions](https://github.com/flowtype/flow-typed/tree/master/definitions) 
-folder. They all must follow the following naming format:
+directory. They all must follow the following directory structure and naming 
+format:
 
-`<NPM_PACKAGE_NAME>_v<VERSION>`/`flow_v<VERSION>`/`<NPM_PACKAGE>_v<VERSION>.js`
+```
+└ definitions/npm/
+  ├ yargs_v4.x.x/           # <-- The name of the library, followed by _v<VERSION>
+  | |
+  | ├ flow_v0.23.x/         # <-- A folder containing libdefs tested against the 
+  | | |                     #     specified version(s) of Flow (v0.23.x in this
+  | | |                     #     case).
+  | | |
+  | | └ yargs_v4.x.x.js     # <-- The libdef file meant for the Flow version 
+  | |                       #     specified by the containing directory's name. 
+  | |                       #     Must be named `<LIB>_v<VERSION>.js`.
+  | |
+  | ├ flow_v0.19.x-v0.22.x/ # <-- A folder containing libdefs tested against a 
+  | | |                     #     different range of Flow versions: 
+  | | |                     #     Anything from v0.19.x to v0.22.x (inclusive)
+  | | |
+  | | ├ yargs_v4.x.x.js     # <-- The libdef file for versions of Flow from 
+  | | |                     #     v0.19.x to v0.22.x (inclusive)
+  | | |
+  | | └ test_yargs.js       # <-- Tests in this directory only apply to the 
+  | |                       #     adjacent libdef (and thus, are specific to
+  | |                       #     the libdefs for this specific Flow version) 
+  | |
+  | └ test_yargs.js         # <-- Tests in this directory apply to libdefs for
+  |                         #     all versions of Flow. 
+  ├ color_v0.7.x/
+  ├ ...
+```
 
-Where `<VERSION>` is a semver version number with all of MAJOR, MINOR, and PATCH
-version numbers included. `x` is an acceptable wildcard in place of any of the 
-three version numbers. 
+Versions are semver versions with some restrictions:
 
-For Flow versions it is also acceptable to put `-` in front of the `<VERSION>`
-to indicate "up to and including this version", or after the `<VERSION>` to 
-indicate "this version and anything after", or you can put two versions with a
-`-` in between to indicate "anything including or between these 2 versions".
-Note that `-` ranges are *not* supported for npm package versions, only `x` 
-wildcards. (Library interfaces are rarely identical across major versions)
+* All of MAJOR, MINOR, and PATCH versions must be specified. It's acceptable to
+  specify `x` in place of a number for MINOR and PATCH, but MAJOR cannot be `x`.
+* Library versions may not specify a semver range, but Flow versions can of the 
+  following forms: 
+  * **`flow_v0.22.x-`**: Flow v0.22.x and above
+  * **`flow_v0.22.x-v0.28.x`**: Flow versions v0.22.x up to v0.28.x (inclusive)
+  * **`flow_-v0.22.x`**: Every version under (and including) Flow v0.22.x
 
-Example filename:
-
-`underscore_v1.x.x/flow_v0.13.x-/underscore_v1.x.x.js`
-
-This is a library definition for all "1.x.x" versions of underscore that works
-with any version of Flow >= v0.13.
-
-**We structure files this way is to enable automated testing and tooling.**
+**We structure files this way to enable automated testing and tooling.**
 Tests ensure that library definitions continue to work as expected and the
 `flow-typed` tooling ensures that it's as easy as possible to find and install 
 library definitions.
 
-#### Writing Tests
+#### Writing LibDef Tests
 
 **When you contribute a new library definition (or make a change to an existing 
-one), you should include tests with your change.**
+one), you must include tests with your change.**
 
 Tests are simply `test_*.js` files that sit next to the library definition 
-file. Their purpose is to exercise the defined library and ultimately produce
-zero Flow errors for each version of Flow that the libdef is specified as 
-compatible with.
+file. They are normal @flow-ified .js files that import from and use the types
+declared in the libdef in a way they are expected to be used. Flow-typed CI will
+then run all applicable versions of Flow against the test file to be sure that
+only *expected* errors occur.
 
-**Often it is useful to test that a particular usage of a library definition 
-*does* produce an error.** For this you can write some code that produces a Flow 
-error and just put `// $ExpectError` on the line above where the error is 
-produced. This will tell the test runner that an error is intentional and 
-expected on the following line.
+In order to write code where you expect an error, you can put `// $ExpectError`
+on the line above one of the lines listed in the error. This tells the test 
+runner to ignore errors that mention that line. **We require at least 1
+// $ExpectError in each test**. This helps to ensure that the test is actually
+exercising types like the author expects it to be.
+
+## FAQs
+
+### I get an error that mentions `OpenSSL or Libgcrypt` while installing the `flow-typed` CLI
+
+You may need to install Libgcrypt. Try setting up 
+[homebrew](http://brew.sh/index.html) and running `brew install libgcrypt`.
+
+This issue was first reported here: 
+[#336](https://github.com/flowtype/flow-typed/issues/336)
 
 ## `flow-typed` CLI
 
@@ -92,32 +144,29 @@ working with this repository:
 
 ##### `flow-typed validate-defs`
 
-Verifies that all files under the `/definitions/` directory are structured 
-properly. **It does not run tests**, it only asserts that file and directory 
-names match the expected conventions.
+Verifies that all files under the `/definitions/` directory are structured and 
+named properly. **It does not run tests**, it only asserts that file and 
+directory names match the expected conventions.
+
+This command is run during CI.
 
 ##### `flow-typed run-tests [optional-pattern]`
 
-Runs *all* compatible versions of Flow over the each library definition with 
-it's tests to ensure that the tests pass as expected.
+For each libdef, find each test and run it with all compatible versions of Flow.
+If any errors arise that are not *`// $ExpectError`*, the test has failed.
 
 Note that this command assumes that the `/definitions/` directory is correctly 
-structured. You can always verify the structure with the 
-[`flow-typed validate-defs`](#flow-typed-validate-defs) command.
+structured. It should be run *after* running 
+[`flow-typed validate-defs`](#flow-typed-validate-defs).
 
 ##### `flow-typed update-cache [--debug]`
 
 By default flow-typed retrieves all available libdefs from its related upstream
-repository. To make this process more efficient, those libdefs will be cached to
-your local filesystem. Usually, the cache will automatically be updated after a
-certain grace period during a libdef installation, but sometimes it is useful to
+repository. To make this process more efficient, those libdefs are cached once 
+on your local filesystem. Usually, the cache will automatically be updated after
+a short grace period during a libdef installation, but sometimes it is useful to
 do this update manually. Use this command if you want to download the most
-recent definitions yourself.
+recent definitions into the cache for yourself.
 
 The debug flag will output additional (error) information, which can be useful for
 bug-reports.
-
-##### *(...coming soon...)* `flow-typed libdefs-for-pkg /path/to/package.json`
-
-Scans the specified `package.json`, looks for any compatible libdefs in the 
-`flow-typed` github repo, and prints a JSON list of URLs for each that is found.


### PR DESCRIPTION
This just tweaks the README.md and CONTRIBUTING.md docs a bit + updates them with post-launch details (This is part of https://github.com/flowtype/flow-typed/issues/254).

Note that assumes the [`flow-typed install` command (no flags)](https://github.com/flowtype/flow-typed/pull/289) feature has landed, so it shouldn't land until after that does.