### PR TITLE
Add non-legacy method names to kefir.Emitter

### DIFF
--- a/definitions/npm/kefir_v3.x.x/flow_>=v0.20.x/kefir_v3.x.x.js
+++ b/definitions/npm/kefir_v3.x.x/flow_>=v0.20.x/kefir_v3.x.x.js
@@ -141,9 +141,11 @@ declare module kefir {
    * The `Emitter` class is private - but we can export the type.
    */
   declare type Emitter<T,E> = {
+    value(value: T): void,
     emit(value: T): void,
     error(err: E): void,
     end(): void,
+    event(event: Event<T,E>): void,
     emitEvent(event: Event<T,E>): void,
   }
 


### PR DESCRIPTION
After doing this I see that Kefir actually ships with [up-to-date types](https://github.com/rpominov/kefir/blob/master/kefir.js.flow), however, many people may not notice this and look to flow-typed for the definitions instead.

In [3.3.0](https://github.com/rpominov/kefir/blob/master/changelog.md#330-16072016), two methods were renamed. The old names work for now so I've just added new definitions and kept the old ones.

