### PR TITLE
Add types for more RxJS 5 methods

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-v0.32.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-v0.32.x/rxjs_v5.0.x.js
@@ -21,7 +21,13 @@ interface rxjs$ISubscription {
   unsubscribe(): void;
 }
 
-type TeardownLogic = rxjs$ISubscription | () => void;
+type rxjs$TeardownLogic = rxjs$ISubscription | () => void;
+
+type rxjs$EventListenerOptions = {
+  capture?: boolean;
+  passive?: boolean;
+  once?: boolean;
+} | boolean;
 
 declare class rxjs$Observable<+T> {
   static concat(...sources: rxjs$Observable<T>[]): rxjs$Observable<T>;
@@ -34,10 +40,24 @@ declare class rxjs$Observable<+T> {
 
   static from(iterable: Iterable<T>): rxjs$Observable<T>;
 
+  static fromEvent(element: any, eventName: string, ...none: Array<void>): rxjs$Observable<T>;
   static fromEvent(
     element: any,
     eventName: string,
-    selector?: () => T,
+    options: rxjs$EventListenerOptions,
+    ...none: Array<void>
+  ): rxjs$Observable<T>;
+  static fromEvent(
+    element: any,
+    eventName: string,
+    selector: () => T,
+    ...none: Array<void>
+  ): rxjs$Observable<T>;
+  static fromEvent(
+    element: any,
+    eventName: string,
+    options: rxjs$EventListenerOptions,
+    selector: () => T,
   ): rxjs$Observable<T>;
 
   static fromEventPattern(
@@ -69,6 +89,8 @@ declare class rxjs$Observable<+T> {
 
   static throw(error: any): rxjs$Observable<any>;
 
+  audit(durationSelector: (value: T) => rxjs$Observable<any> | Promise<any>): rxjs$Observable<T>;
+
   race(other: rxjs$Observable<T>): rxjs$Observable<T>;
 
   buffer(bufferBoundaries: rxjs$Observable<any>): rxjs$Observable<Array<T>>;
@@ -78,6 +100,8 @@ declare class rxjs$Observable<+T> {
   catch<U>(selector: (err: any, caught: rxjs$Observable<T>) => rxjs$Observable<U>): rxjs$Observable<U>;
 
   concat(...sources: rxjs$Observable<T>[]): rxjs$Observable<T>;
+
+  concatAll<U>(): rxjs$Observable<U>;
 
   concatMap<U>(
     f: (value: T) => rxjs$Observable<U> | Promise<U> | Iterable<U>
@@ -131,7 +155,7 @@ declare class rxjs$Observable<+T> {
 
   merge(other: rxjs$Observable<T>): rxjs$Observable<T>;
 
-  mergeAll(): T; // assumption: T is rxjs$Observable
+  mergeAll<U>(): rxjs$Observable<U>;
 
   mergeMap<U>(
     project: (value: T, index?: number) => rxjs$Observable<U> | Promise<U> | Iterable<U>,
@@ -140,6 +164,10 @@ declare class rxjs$Observable<+T> {
   multicast(
     subjectOrSubjectFactory: rxjs$Subject<T> | () => rxjs$Subject<T>,
   ): rxjs$ConnectableObservable<T>;
+
+  observeOn(scheduler: rxjs$SchedulerClass): rxjs$Observable<T>;
+
+  pairwise(): rxjs$Observable<[T, T]>;
 
   publish(): rxjs$ConnectableObservable<T>;
 
@@ -177,6 +205,8 @@ declare class rxjs$Observable<+T> {
   skipUntil(other: rxjs$Observable<any> | Promise<any>): rxjs$Observable<T>;
 
   startWith(...values: Array<T>): rxjs$Observable<T>;
+
+  subscribeOn(scheduler: rxjs$SchedulerClass): rxjs$Observable<T>;
 
   take(count: number): rxjs$Observable<T>;
 
@@ -382,6 +412,118 @@ declare class rxjs$Observable<+T> {
     resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H,
   ): rxjs$Observable<H>;
 
+  static forkJoin<A, B>(
+    a: rxjs$Observable<A>,
+    resultSelector: (a: A) => B,
+  ): rxjs$Observable<B>;
+
+  static forkJoin<A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    resultSelector: (a: A, b: B) => C,
+  ): rxjs$Observable<C>;
+
+  static forkJoin<A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    resultSelector: (a: A, b: B, c: C) => D,
+  ): rxjs$Observable<D>;
+
+  static forkJoin<A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    resultSelector: (a: A, b: B, c: C, d: D) => E,
+  ): rxjs$Observable<E>;
+
+  static forkJoin<A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    resultSelector: (a: A, b: B, c: C, d: D, e: E) => F,
+  ): rxjs$Observable<F>;
+
+  static forkJoin<A, B, C, D, E, F, G>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F) => G,
+  ): rxjs$Observable<G>;
+
+  static forkJoin<A, B, C, D, E, F, G, H>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    g: rxjs$Observable<G>,
+    resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H,
+  ): rxjs$Observable<H>;
+
+  static forkJoin<A, B>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+  ): rxjs$Observable<[A, B]>;
+
+  static forkJoin<A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+  ): rxjs$Observable<[A, B, C]>;
+
+  static forkJoin<A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+  ): rxjs$Observable<[A, B, C, D]>;
+
+  static forkJoin<A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+  ): rxjs$Observable<[A, B, C, D, E]>;
+
+  static forkJoin<A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+  ): rxjs$Observable<[A, B, C, D, E, F]>;
+
+  static forkJoin<A, B, C, D, E, F, G>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    g: rxjs$Observable<G>,
+  ): rxjs$Observable<[A, B, C, D, E, F, G]>;
+
+  static forkJoin<A, B, C, D, E, F, G, H>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    g: rxjs$Observable<G>,
+    h: rxjs$Observable<H>,
+  ): rxjs$Observable<[A, B, C, D, E, F, G, H]>;
+
   withLatestFrom<A>(
     a: rxjs$Observable<A>
   ): rxjs$Observable<[T, A]>;
@@ -495,7 +637,11 @@ declare class rxjs$ReplaySubject<T> extends rxjs$Subject<T> {
 
 declare class rxjs$Subscription {
   unsubscribe(): void;
-  add(teardown: TeardownLogic): rxjs$Subscription;
+  add(teardown: rxjs$TeardownLogic): rxjs$Subscription;
+}
+
+declare class rxjs$SchedulerClass {
+  schedule<T>(work: (state?: T) => void, delay?: number, state?: T): rxjs$Subscription;
 }
 
 declare module 'rxjs' {
@@ -506,6 +652,12 @@ declare module 'rxjs' {
     Subject: typeof rxjs$Subject,
     BehaviorSubject: typeof rxjs$BehaviorSubject,
     ReplaySubject: typeof rxjs$ReplaySubject,
+    Scheduler: {
+      asap: rxjs$SchedulerClass,
+      queue: rxjs$SchedulerClass,
+      animationFrame: rxjs$SchedulerClass,
+      async: rxjs$SchedulerClass,
+    },
     Subscription: typeof rxjs$Subscription,
   }
 }

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import {Observable, Subject} from 'rxjs';
+import {Observable, Scheduler, Subject} from 'rxjs';
 import * as O from 'rxjs/Observable';
 import * as Obs from 'rxjs/Observer';
 import * as BS from 'rxjs/BehaviorSubject';
@@ -16,6 +16,8 @@ const strings: Observable<string> = numbers.map(x => x.toString());
 // $ExpectError
 const bogusStrings: Observable<string> = numbers.map(x => x);
 
+(numbers.audit(() => strings): Observable<number>);
+
 // $ExpectError
 numbers.subscribe((x: string) => {});
 strings.subscribe((x: string) => {});
@@ -23,7 +25,11 @@ strings.subscribe((x: string) => {});
 (strings.elementAt(1): Observable<string>);
 (strings.elementAt(1, ''): Observable<string>);
 // $ExpectError
-strings.elementAt(1, 5)
+strings.elementAt(1, 5);
+
+(Observable.of(numbers, numbers).concatAll(): Observable<number>);
+
+(numbers.pairwise(): Observable<Array<number>>);
 
 // $ExpectError -- need the typecast or the error appears at the declaration site
 numbers.merge((strings: Observable<string>));
@@ -38,6 +44,21 @@ const combined2: Observable<[number, string]> = Observable.combineLatest(numbers
 
 // $ExpectError
 const combinedBad: Observable<{n: number, s: string}> = Observable.combineLatest(
+  numbers,
+  numbers,
+  (n, s) => ({n, s})
+);
+
+const combined3: Observable<{n: number, s: string}> = Observable.forkJoin(
+  numbers,
+  strings,
+  (n, s) => ({n, s})
+);
+
+const combined4: Observable<[number, string]> = Observable.forkJoin(numbers, strings);
+
+// $ExpectError
+const combinedBad2: Observable<{n: number, s: string}> = Observable.forkJoin(
   numbers,
   numbers,
   (n, s) => ({n, s})
@@ -65,6 +86,13 @@ const never: Observable<number> = Observable.empty()
 // $ExpectError
 (numbers.withLatestFrom(numbers): Observable<[number, string]>);
 
+numbers.observeOn(Scheduler.async);
+// $ExpectError
+numbers.observeOn(null);
+
+Observable.fromEvent(null, 'click', true);
+// $ExpectError
+Observable.fromEvent(null, 'click', {capture: 1});
 
 // Testing covariance/contravariance/invariance of type parameters
 


### PR DESCRIPTION
Types for the following methods:

- `audit()`
- `concatAll()`
- `pairwise()`
- `forkJoin()`