### PR TITLE
Express: Added all(...) method for Route

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_>=v0.25.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_>=v0.25.x/express_v4.x.x.js
@@ -102,6 +102,7 @@ declare module 'express' {
     (path: string, router: Router): T;
   }
   declare class Route {
+    all: RouteMethodType<this>;
     get: RouteMethodType<this>;
     post: RouteMethodType<this>;
     put: RouteMethodType<this>;


### PR DESCRIPTION
As I commented on #90, the express def file is missing the all() method for Route, so here it is.
I was also advised to update the test files accordingly, but upon inspection, said file does not test for any other method of Route with the exception of get() so I wasn't sure what else to add (also all said methods share the same signature so I'm guessing testing one should be enough).