### PR TITLE
Add definition for aphrodite.

### DIFF
--- a/definitions/npm/aphrodite_v0.5.x/flow_>=v0.28.x/aphrodite_v0.5.x.js
+++ b/definitions/npm/aphrodite_v0.5.x/flow_>=v0.28.x/aphrodite_v0.5.x.js
@@ -1,0 +1,37 @@
+declare module 'aphrodite' {
+  declare type DehydratedServerContent = {
+    html: string,
+    css: {
+      content: string,
+      renderedClassNames: Array<string>,
+    },
+  };
+
+  declare type SheetDefinition = {
+    [key: string]: Object,
+  };
+
+  declare type StyleDefinition = {
+    [key: string]: {
+      _name: string,
+      _definition: Object,
+    }
+  };
+
+  declare export var css: (...definitions: StyleDefinition[]) => string;
+
+  declare export var StyleSheetServer :{
+    renderStatic(renderFunc: Function): DehydratedServerContent;
+  };
+
+  declare export var StyleSheet: {
+    create(sheetDefinition: SheetDefinition): {
+      [key: string]: StyleDefinition
+    }
+  };
+
+  declare export var StyleSheetTestUtils: {
+    suppressStyleInjection: () => void;
+    clearBufferAndResumeStyleInjection: () => void;
+  };
+};

--- a/definitions/npm/aphrodite_v0.5.x/test_aphrodite-v0.5.x.js
+++ b/definitions/npm/aphrodite_v0.5.x/test_aphrodite-v0.5.x.js
@@ -1,0 +1,48 @@
+import {
+  css,
+  StyleSheet,
+  StyleSheetServer,
+  StyleSheetTestUtils
+} from 'aphrodite';
+
+const styles = StyleSheet.create({
+  foo: {
+    backgroundColor: 'red',
+  },
+  bar: {
+    backgroundColor: 'green',
+    fontSize: 12,
+  },
+  hover: {
+    ':hover': {
+      backgroundColor: 'green',
+    },
+  },
+  big: {
+    '@media (min-width: 800px)': {
+      fontSize: 14,
+    }
+  },
+});
+
+const fooClassName = css(styles.foo);
+const bigClassName = css(styles.big);
+
+// $ExpectError
+css(4);
+
+// $ExpectError
+StyleSheet.create('.foo { background-color: red }');
+
+const content = StyleSheetServer.renderStatic(() => `
+  <!doctype html>
+  <html>
+    <body>
+      My App as a string
+    </body>
+  </html>
+`);
+console.log(content.html, content.css);
+
+StyleSheetTestUtils.suppressStyleInjection();
+StyleSheetTestUtils.clearBufferAndResumeStyleInjection();


### PR DESCRIPTION
This adds a definition for [the aphrodite styles-in-js](https://github.com/Khan/aphrodite) library. It functions all the way back to flow 28 and I targeted v0.5 in my definition. 

A couple places annotate simply `Object` as I ran into some issues with more specific types conforming to the expected shape. Let me know if something more specific is preferred and I can try my best to make that happen :)