### PR TITLE
Update express_v4.x.x.js

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_v0.25.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.25.x-/express_v4.x.x.js
@@ -12,7 +12,7 @@ declare module 'express' {
   }
   declare class Request extends http$IncomingMessage mixins RequestResponseBase {
     baseUrl: string;
-    body: mixed;
+    body: any;
     cookies: {[cookie: string]: string};
     fresh: boolean;
     hostname: boolean;
@@ -138,7 +138,7 @@ declare module 'express' {
     use: RouterMethodType<this>;
 
     route(path: string): Route;
-    
+
     static (): Router;
   }
 


### PR DESCRIPTION
when working with express you usually do 

```
const foo = req.body.foo;
```

when `body` is `mixed` - this is impossible.
