### PR TITLE
Improve libdef versioning in the cli

### DIFF
--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -6,7 +6,7 @@ import {getCacheLibDefVersion, getCacheLibDefs, filterLibDefs} from "../lib/libD
 import type {LibDef} from "../lib/libDefs.js";
 import {fs, path} from '../lib/node.js';
 import semver from 'semver';
-import {emptyVersion, stringToVersion, versionToString} from "../lib/semver.js";
+import {emptyVersion, stringToVersion, versionToString, getLowerBound} from "../lib/semver.js";
 import type {Version} from "../lib/semver.js";
 import {getPackageDependencies, getPackageFlowBinSemver} from "../lib/npmHelper.js";
 import type {DepsMap} from "../lib/npmHelper.js";
@@ -118,23 +118,24 @@ export async function run(args: Args): Promise<number> {
   // error caused by rebasing the libdedf cache concurrently.
   const defs: Array<LibDef> = [];
   for(let dep in depsMap) {
+    const depVersion = depsMap[dep]; 
     let def = await findLibDef(
       dep,
-      depsMap[dep],
+      depVersion,
       flowVersion);
     if(def) {
       defs.push(def);
+      if(libdefNeedsUpdate(def.pkgVersionStr, depVersion)) {
+        console.log(`${def.pkgName}_${def.pkgVersionStr} may need an update to fully support ${dep} at ${depVersion}.`);
+      }
     }
   }
 
   console.log(`Installing ${defs.length} defs`);
   await Promise.all(
-    defs.map((def) => installLibDef(
-        def,
-        projectRoot,
-        args.overwrite
-      )
-    )
+     defs.map((def) => {
+      return installLibDef(def, projectRoot, args.overwrite);
+    })
   );
 
   return 0;
@@ -258,6 +259,9 @@ async function findFlowProjectRoot(fromPath: string) {
 
 async function getFlowVersionString(startPath: string): Promise<string> {
   const versionString = await getPackageFlowBinSemver(startPath);
-  const verRange = new semver.Range(versionString);
-  return verRange.set[0][0].semver.version;
+  return getLowerBound(versionString);
+}
+
+function libdefNeedsUpdate(defVersion: string, pkgVersion: string): boolean {
+  return semver.lt(getLowerBound(defVersion), getLowerBound(pkgVersion));
 }

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -118,7 +118,7 @@ export async function run(args: Args): Promise<number> {
   // error caused by rebasing the libdedf cache concurrently.
   const defs: Array<LibDef> = [];
   for(let dep in depsMap) {
-    const depVersion = depsMap[dep]; 
+    const depVersion = depsMap[dep];
     let def = await findLibDef(
       dep,
       depVersion,
@@ -126,7 +126,9 @@ export async function run(args: Args): Promise<number> {
     if(def) {
       defs.push(def);
       if(libdefNeedsUpdate(def.pkgVersionStr, depVersion)) {
-        console.log(`${def.pkgName}_${def.pkgVersionStr} may need an update to fully support ${dep} at ${depVersion}.`);
+        console.log(
+`Found ${def.pkgName}_${def.pkgVersionStr}, but you may want to create
+  updated libdef in flow-typed for your version (${depVersion}).`);
       }
     }
   }

--- a/cli/src/lib/__tests__/libDefs-test.js
+++ b/cli/src/lib/__tests__/libDefs-test.js
@@ -122,10 +122,9 @@ describe('libDefs', () => {
   });
 
   describe('filterLibDefs', () => {
-    function _generateFixturePkg(name, verStr, flowVerStr) {
+    function _generateMockLibdef(name, verStr, flowVerStr) {
       return {
         pkgName: name,
-        pkgVersion: stringToVersion(verStr),
         pkgVersionStr: verStr,
         pkgNameVersionStr: `${name}_${verStr}`,
         flowVersion: stringToVersion(flowVerStr),
@@ -138,8 +137,8 @@ describe('libDefs', () => {
     describe('fuzzy filter', () => {
       it('filters on exact name', () => {
         const fixture = [
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.18.x'),
         ];
         const filtered = filterLibDefs(fixture, {type: 'fuzzy', term: 'mori'});
         expect(filtered).toEqual([fixture[1], fixture[0]]);
@@ -147,8 +146,8 @@ describe('libDefs', () => {
 
       it('filters on differently-cased name', () => {
         const fixture = [
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.18.x'),
         ];
         const filtered = filterLibDefs(fixture, {type: 'fuzzy', term: 'Mori'});
         expect(filtered).toEqual([fixture[1], fixture[0]]);
@@ -156,9 +155,9 @@ describe('libDefs', () => {
 
       it('filters on partial name', () => {
         const fixture = [
-          _generateFixturePkg('**mori', 'v0.3.x', '>=v0.22.x'),
-          _generateFixturePkg('mori**', 'v0.3.x', '>=v0.18.x'),
-          _generateFixturePkg('mo**ri', 'v0.3.x', '>=v0.18.x'),
+          _generateMockLibdef('**mori', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori**', 'v0.3.x', '>=v0.18.x'),
+          _generateMockLibdef('mo**ri', 'v0.3.x', '>=v0.18.x'),
         ];
         const filtered = filterLibDefs(fixture, {type: 'fuzzy', term: 'mori'});
         expect(filtered).toEqual([fixture[1], fixture[0]]);
@@ -166,8 +165,8 @@ describe('libDefs', () => {
 
       it('filters on flow version', () => {
         const fixture = [
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.18.x'),
         ];
         const filtered = filterLibDefs(fixture, {
           type: 'fuzzy',
@@ -181,8 +180,8 @@ describe('libDefs', () => {
     describe('exact-name filter', () => {
       it('filters on exact name', () => {
         const fixture = [
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.18.x'),
         ];
         const filtered = filterLibDefs(fixture, {type: 'exact-name', term: 'mori'});
         expect(filtered).toEqual([fixture[1], fixture[0]]);
@@ -190,8 +189,8 @@ describe('libDefs', () => {
 
       it('filters on differently-cased name', () => {
         const fixture = [
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.18.x'),
         ];
         const filtered = filterLibDefs(fixture, {type: 'exact-name', term: 'Mori'});
         expect(filtered).toEqual([fixture[1], fixture[0]]);
@@ -199,9 +198,9 @@ describe('libDefs', () => {
 
       it('DOES NOT filter on partial name', () => {
         const fixture = [
-          _generateFixturePkg('**mori', 'v0.3.x', '>=v0.22.x'),
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
-          _generateFixturePkg('mo**ri', 'v0.3.x', '>=v0.18.x'),
+          _generateMockLibdef('**mori', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.18.x'),
+          _generateMockLibdef('mo**ri', 'v0.3.x', '>=v0.18.x'),
         ];
         const filtered = filterLibDefs(fixture, {type: 'exact-name', term: 'mori'});
         expect(filtered).toEqual([fixture[1]]);
@@ -209,8 +208,8 @@ describe('libDefs', () => {
 
       it('filters on flow version', () => {
         const fixture = [
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.18.x'),
         ];
         const filtered = filterLibDefs(fixture, {
           type: 'exact-name',
@@ -222,7 +221,7 @@ describe('libDefs', () => {
     });
 
     describe('exact filter', () => {
-      function _generateLibDef(pkgName, pkgVersionStr, flowVersionStr) {
+      function _generatePackage(pkgName, pkgVersionStr, flowVersionStr) {
         return {
           pkgName,
           pkgVersionStr,
@@ -236,90 +235,118 @@ describe('libDefs', () => {
 
       it('filters on exact name', () => {
         const fixture = [
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
-          _generateFixturePkg('notmori', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('notmori', 'v0.3.x', '>=v0.22.x'),
         ];
         const filtered = filterLibDefs(
           fixture,
-          {type: 'exact', libDef: _generateLibDef('mori', 'v0.3.1', 'v0.x.x')},
+          {type: 'exact', libDef: _generatePackage('mori', 'v0.3.1', 'v0.x.x')},
         );
         expect(filtered).toEqual([fixture[0]]);
       });
 
       it('filters on differently-cased name', () => {
         const fixture = [
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
-          _generateFixturePkg('notmori', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('notmori', 'v0.3.x', '>=v0.22.x'),
         ];
         const filtered = filterLibDefs(
           fixture,
-          {type: 'exact', libDef: _generateLibDef('Mori', 'v0.3.1', 'v0.x.x')},
+          {type: 'exact', libDef: _generatePackage('Mori', 'v0.3.1', 'v0.x.x')},
         );
         expect(filtered).toEqual([fixture[0]]);
       });
 
       it('DOES NOT filter on partial name', () => {
         const fixture = [
-          _generateFixturePkg('**mori', 'v0.3.x', '>=v0.22.x'),
-          _generateFixturePkg('mori**', 'v0.3.x', '>=v0.22.x'),
-          _generateFixturePkg('mo**ri', 'v0.3.x', '>=v0.22.x'),
-          _generateFixturePkg('mori',   'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('**mori', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori**', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mo**ri', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori',   'v0.3.x', '>=v0.22.x'),
         ];
         const filtered = filterLibDefs(
           fixture,
-          {type: 'exact', libDef: _generateLibDef('mori', 'v0.3.1', 'v0.x.x')},
+          {type: 'exact', libDef: _generatePackage('mori', 'v0.3.1', 'v0.x.x')},
         );
         expect(filtered).toEqual([fixture[3]]);
       });
 
       it('filters on flow version', () => {
         const fixture = [
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
-          _generateFixturePkg('mori', 'v0.3.x', '>=v0.18.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori', 'v0.3.x', '>=v0.18.x'),
         ];
         const filtered = filterLibDefs(fixture,{
           type: 'exact',
-          libDef: _generateLibDef('mori', 'v0.3.1', 'v0.x.x'),
+          libDef: _generatePackage('mori', 'v0.3.1', 'v0.x.x'),
           flowVersion: stringToVersion('v0.19.0')
         });
         expect(filtered).toEqual([fixture[1]]);
       });
 
+      it('filters and orders from highest to lowest version', () => {
+        const fixture = [
+          _generateMockLibdef('mori', 'v2.x.x', '>=v0.22.x'),
+          _generateMockLibdef('mori', 'v3.x.x', '>=v0.22.x'),
+          _generateMockLibdef('mori', 'v2.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori', 'v2.1.x', '>=v0.22.x'),
+        ];
+        const filtered = filterLibDefs(
+          fixture,
+          {type: 'exact', libDef: _generatePackage('mori', 'v2.3.0', 'v0.x.x')},
+        );
+        expect(filtered).toEqual([fixture[2], fixture[3], fixture[0]]);
+      });
+
+      it('filters using default (implied ^) and equals libdef versions', () => {
+        const fixture = [
+          _generateMockLibdef('mori', 'v2.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori', '=v2.3.x', '>=v0.22.x'),
+          _generateMockLibdef('mori', 'v=2.3.x', '>=v0.22.x'),
+        ];
+        const filtered = filterLibDefs(
+          fixture,
+          {type: 'exact', libDef: _generatePackage('mori', 'v2.4.0', 'v0.x.x')},
+        );
+        expect(filtered).toEqual([fixture[0]]);
+      });
+
       describe('given a package range', () => {
         it("DOES NOT match when libdef range does not intersect package range", () => {
           const fixture = [
-            _generateFixturePkg('mori', 'v0.2.x', '>=v0.22.x'),
-            _generateFixturePkg('mori', 'v0.4.x', '>=v0.22.x'),
+            _generateMockLibdef('mori', 'v0.2.x', '>=v0.22.x'),
+            _generateMockLibdef('mori', 'v0.4.x', '>=v0.22.x'),
           ];
           const filtered = filterLibDefs(fixture,{
             type: 'exact',
-            libDef: _generateLibDef('mori', '^0.3.0', 'v0.x.x'),
+            libDef: _generatePackage('mori', 'v0.3.0', 'v0.x.x'),
           });
           expect(filtered).toEqual([]);
         });
         
         it("DOES NOT match when ranges intersect but package supports older versions than libdef", () => {
           const fixture = [
-            _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
+            _generateMockLibdef('mori', 'v0.3.x', '>=v0.22.x'),
           ];
           const filtered = filterLibDefs(fixture,{
             type: 'exact',
-            libDef: _generateLibDef('mori', '>=0.2.9 <0.3.0', 'v0.x.x'),
+            libDef: _generatePackage('mori', 'v0.2.9', 'v0.x.x'),
           });
           expect(filtered).toEqual([]);
         });
 
         it("matches when ranges intersect and libdef support older versions", () => {
           const fixture = [
-            _generateFixturePkg('mori', 'v0.3.x', '>=v0.22.x'),
-            _generateFixturePkg('mori', 'v0.3.8', '>=v0.22.x'),
+            _generateMockLibdef('mori', 'v0.3.x', '>=v0.22.x'),
+            _generateMockLibdef('mori', 'v0.3.8', '>=v0.22.x'),
           ];
           const filtered = filterLibDefs(fixture,{
             type: 'exact',
-            libDef: _generateLibDef('mori', '>=0.3.1 <0.4.0', 'v0.x.x'),
+            libDef: _generatePackage('mori', '>=0.3.2 <0.3.8', 'v0.x.x'),
           });
-          expect(filtered).toEqual([fixture[0], fixture[1]]);
+          expect(filtered).toEqual([fixture[0]]);
         });
+       
       });
     });
   });

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -569,8 +569,8 @@ function packageNameMatch(a: string, b: string): boolean {
   return a.toLowerCase() === b.toLowerCase();
 }
 
-function satisfiesSemver(pkgSemver: string, defVersion: string): boolean {
-  // the libdef version should treated as a semver prefixed
+function libdefMatchesPackageVersion(pkgSemver: string, defVersion: string): boolean {
+  // the libdef version should be treated as a semver prefixed
   // by a carat (ie. 2.2.x is the same range as ^2.2.x) unless
   // it is prefixed by the equals character (ie. =2.2.x)
   let defSemver = defVersion;
@@ -625,7 +625,7 @@ export function filterLibDefs(
       case 'exact':
         filterMatch = (
           packageNameMatch(def.pkgName, filter.libDef.pkgName)
-          && satisfiesSemver(filter.libDef.pkgVersionStr, def.pkgVersionStr)
+          && libdefMatchesPackageVersion(filter.libDef.pkgVersionStr, def.pkgVersionStr)
         );
         break;
 

--- a/cli/src/lib/semver.js
+++ b/cli/src/lib/semver.js
@@ -251,3 +251,8 @@ export function wildcardSatisfies(ver: Version, range: string): boolean {
     return semver.satisfies(versionToString(ver), range);
   }
 };
+
+export function getLowerBound(semverOrRange: string) {
+  const r = new semver.Range(semverOrRange);
+  return r.set[0][0].semver.version;
+}


### PR DESCRIPTION
This PR addresses #322 

Versioning now supports the use cases @jeffmo describes. 
libdef versions will be treated as ^x.x.x semver ranges by default.

If multiple versions match, they will now be returned in the descending order.
