### PR TITLE
Adding RxJS operators let, letBind, and switch

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-v0.32.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-v0.32.x/rxjs_v5.0.x.js
@@ -116,6 +116,13 @@ declare class rxjs$Observable<+T> {
 
   ignoreElements<U>(): rxjs$Observable<U>;
 
+  let<U>(project: (self: rxjs$Observable<T>) => rxjs$Observable<U>): rxjs$Observable<U>;
+
+  // Alias for `let`
+  letBind<U>(project: (self: rxjs$Observable<T>) => rxjs$Observable<U>): rxjs$Observable<U>;
+
+  switch(): T; // assumption: T is Observable
+
   // Alias for `mergeMap`
   flatMap<U>(
     project: (value: T) => rxjs$Observable<U> | Promise<U> | Iterable<U>

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -28,6 +28,17 @@ strings.elementAt(1, 5)
 // $ExpectError -- need the typecast or the error appears at the declaration site
 numbers.merge((strings: Observable<string>));
 
+numbers.let(_numbers => strings);
+numbers.letBind(_numbers => strings);
+// $ExpectError -- need to return an observable
+numbers.let(_numbers => 3);
+// $ExpectError -- need to return an observable
+numbers.letBind(_numbers => 3);
+
+(numbers.map(number => Observable.of(number)).switch(): Observable<number>);
+// $ExpectError -- .switch can't assert that it's operating on observables, but it can at least trace the type.
+(numbers.map(number => Observable.of(number)).switch(): Observable<string>);
+
 const combined: Observable<{n: number, s: string}> = Observable.combineLatest(
   numbers,
   strings,


### PR DESCRIPTION
Heyo, I've been using flow with RxJS for a few days, and noticed that a few method definitions are missing. This adds a couple that I've been wanting to use without ignoring in flow.

It's unfortunate that the typing for `.switch()` can't assert that `T` be an `Observable` (at least I assume this is the case, backed up by what I see with `.mergeAll()`), but I'd be happy to take suggestions to make that better.