### PR TITLE
Improved isomorphic-fetch definitions to be inline with the spec

### DIFF
--- a/definitions/npm/isomorphic-fetch_v2.x.x/flow_v0.27.x-/isomorphic-fetch_v2.x.x.js
+++ b/definitions/npm/isomorphic-fetch_v2.x.x/flow_v0.27.x-/isomorphic-fetch_v2.x.x.js
@@ -1,3 +1,0 @@
-declare module 'isomorphic-fetch' {
-  declare module.exports: (url: string, options?: Object) => Promise<mixed>;
-}

--- a/definitions/npm/isomorphic-fetch_v2.x.x/flow_v0.28.x-/isomorphic-fetch_v2.x.x.js
+++ b/definitions/npm/isomorphic-fetch_v2.x.x/flow_v0.28.x-/isomorphic-fetch_v2.x.x.js
@@ -1,0 +1,76 @@
+
+declare module 'isomorphic-fetch' {
+    declare export type RequestMode = 'cors' | 'no-cors' | 'cors-with-forced-preflight' | 'same-origin' | 'navigate';
+    declare export type RequestCredentials = 'omit' | 'same-origin' | 'include';
+    declare export type RequestRedirect = 'follow' | 'error' | 'manual';
+    declare export type RequestCache = 'default' | 'no-store' | 'reload' | 'no-cache' | 'force-cache';
+    declare export type ResponseType = 'basic' | 'cors' | 'error' | 'opaque';
+    declare export type ReferrerPolicy = 'no-referrer' | 'no-referrer-when-downgrade' | 'origin' |
+        'origin-when-cross-origin' | 'unsafe-url';
+
+    declare export class Headers {
+        Headers(): Headers;
+        append(name: string, value: mixed): void;
+        delete(name: string): void;
+        entries(): Iterator<*>;
+        get(name: string): string;
+        getAll(name: string): Array<string>;
+        has(name: string): Boolean;
+        keys(): Iterator<string>;
+        set(name: string, value: mixed): void;
+        values(): Iterator<*>;
+    }
+
+    declare export class Body {
+        bodyUsed: Boolean;
+        arrayBuffer(): Promise<ArrayBuffer>;
+        blob(): Promise<Blob>;
+        formData(): Promise<FormData>;
+        json(): Promise<JSON>;
+        text(): Promise<string>;
+    }
+
+    declare export class Request mixins Body {
+        Request(): Request;
+        clone(): Request;
+        method: string;
+        url: string;
+        headers: Headers;
+        referrer: string;
+        referrerPolicy: string;
+        mode: RequestMode;
+        credentials: RequestCredentials;
+        redirect: RequestRedirect;
+        integrity: string;
+        cache: RequestCache;
+    }
+
+    declare export type Options = {
+        method?: 'GET' | 'POST' | 'PUT' | 'HEAD' | 'OPTIONS' | 'DELETE',
+        headers?: Headers,
+        body?: Blob | ArrayBuffer | FormData | URLSearchParams | string,
+        mode?: RequestMode | Object,
+        credentials?: RequestCredentials,
+        cache?: RequestCache,
+        redirect?: RequestRedirect,
+        referrer?: string,
+        referrerPolicy?: ReferrerPolicy,
+        integrity?: string,
+    }
+
+    declare export class Response mixins Body {
+        Response(): Response;
+        clone(): Response;
+        error(): Response;
+        redirect(url: string, status?: number): Response;
+        headers: Headers;
+        ok: Boolean;
+        redirected: Boolean;
+        status: number;
+        statusText: string;
+        type: ResponseType;
+        url: string;
+    }
+
+    declare export default (url: string, options?: Options) => Promise<Response>;
+}

--- a/definitions/npm/isomorphic-fetch_v2.x.x/test_isomorphic-fetch_v2.js
+++ b/definitions/npm/isomorphic-fetch_v2.x.x/test_isomorphic-fetch_v2.js
@@ -1,6 +1,79 @@
-import isoFetch from 'isomorphic-fetch';
+import isoFetch, { Response, Headers } from 'isomorphic-fetch';
+import type { ResponseType } from 'isomorphic-fetch';
 
-(isoFetch('foo'): Promise<any>);
-(isoFetch('foo', {}): Promise<any>);
+(isoFetch('foo'): Promise<Response>);
+(isoFetch('foo', {}): Promise<Response>);
+
 // $ExpectError url has to be string
 (isoFetch(123): Promise<any>);
+
+isoFetch('foo', {
+    method: 'GET'
+});
+
+// $ExpectError foo is not a valid method
+isoFetch('foo', {
+    method: 'foo'
+});
+
+isoFetch('foo', {
+    body: 'bar'
+});
+
+// $ExpectError number is not a valid body type
+isoFetch('foo', {
+    body: 5
+});
+
+// Response tests
+isoFetch('foo').then(res => {
+    (res.Response(): Response);
+    (res.clone(): Response);
+    (res.error(): Response);
+    (res.redirect('foo', 500): Response);
+    // $ExpectError too few arguments
+    (res.redirect(): Response);
+    // $ExpectError url should be a string
+    (res.redirect(1, 200): Response);
+
+    // Response Headers
+    (res.headers: Headers);
+    (res.headers.Headers(): Headers);
+    (res.headers.append('foo', 'bar'): void);
+    // $ExpectError
+    (res.headers.append(5, 'bar'): void);
+    (res.headers.delete('foo'): void);
+    // $ExpectError
+    (res.headers.delete(5): void);
+    (res.headers.entries(): Iterator<*>);
+    (res.headers.get('test'): string);
+    // $ExpectError
+    (res.headers.get(5): string);
+    (res.headers.getAll('foo'): Array<string>);
+    // $ExpectError
+    (res.headers.getAll(5): Array<string>);
+    (res.headers.has('foo'): Boolean);
+    // $ExpectError
+    (res.headers.has(5): Boolean);
+    (res.headers.keys(): Iterator<string>);
+    (res.headers.set('foo', 5): void);
+    (res.headers.values(): Iterator<*>);
+
+
+    (res.ok: Boolean);
+    (res.redirected: Boolean);
+    (res.status: number);
+    (res.statusText: string);
+
+    // Response type
+    (res.type: ResponseType);
+    // $ExpectError foo is not a valid option
+    res.type = 'foo';
+
+    (res.url: string);
+});
+
+
+
+
+


### PR DESCRIPTION
A rewrite of the isomorphic-fetch definitions to match the FetchAPI spec:
https://developer.mozilla.org/en/docs/Web/API/Fetch_API

Had to bump up the minimum required version of flow from 0.27.x to 0.28.x as I didn't see a way to run a set of tests against a specific version but happy to re-visit this if someone is able to help me find a solution.
