### PR TITLE
Fix `flow-typed install` for packages without a 'main'/index.js

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "prepublish": "mkdir -p dist; npm run test",
     "test": "npm run clean; npm run build; npm run test-quick",
-    "test-quick": "npm run lint && jest",
+    "test-quick": "jest && npm run lint",
     "watch": "mkdir -p dist; babel --source-maps --watch=./src --out-dir=./dist"
   },
   "repository": {

--- a/cli/src/lib/npmProjectUtils.js
+++ b/cli/src/lib/npmProjectUtils.js
@@ -2,6 +2,7 @@
 
 import {fs} from "./node.js";
 import {path} from "./node.js";
+import resolveAsync from "resolve";
 import {searchUpDirPath} from "./fileUtils.js";
 import semver from "semver";
 import {stringToVersion} from "./semver.js";
@@ -119,4 +120,12 @@ export async function determineFlowVersion(
   }
 
   return null;
+};
+
+export function resolve(name: string, options: Object): Promise<string> {
+  return new Promise((res, rej) =>
+    resolveAsync(name, options, (err, result) => {
+      if (err) { rej(err); } else { res(result); }
+    })
+  );
 };


### PR DESCRIPTION
Previously we'd use `resolve()` to find the path to an `npm install`ed
dependency. This usually works, but in some cases a package doesn't have
either an `index.js` file or a `main` entry in its package.json. `react-scripts`
is one such example.

This makes us resilient to this case when looking up the directory path for the installed package.

Fixes #338