### PR TITLE
Add declaration for `pairs`

### DIFF
--- a/definitions/npm/underscore_v1.x.x/flow_v0.13.x-/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.13.x-/underscore_v1.x.x.js
@@ -22,6 +22,7 @@ declare module "underscore" {
   declare function map<K, T, U>(a: {[key:K]: T}, iteratee: (val: T, k?: K)=>U): U[];
 
   declare function object<T>(a: Array<[string, T]>): {[key:string]: T};
+  declare function pairs<T>(o: {[key:string]: T}): Array<[string, T]>;
 
   declare function every<T>(a: Array<T>, pred: (val: T)=>boolean): boolean;
 


### PR DESCRIPTION
Per the [documentation](http://underscorejs.org/#pairs), `pairs` converts an object into a list of `[key, value]` pairs. As such it is the inverse of the `object` function, as the signature alludes to.