### PR TITLE
Add xstream typings

### DIFF
--- a/definitions/npm/xstream_v6.x.x/flow_v0.33.0-/xstream_v6.x.x.js
+++ b/definitions/npm/xstream_v6.x.x/flow_v0.33.0-/xstream_v6.x.x.js
@@ -1,0 +1,72 @@
+declare class xstream$Stream<T> {
+  addListener(listener: xstream$Listener<T>): void;
+  removeListener(listener: xstream$Listener<T>): void;
+  subscribe(listener: xstream$Listener<T>): xstream$Subscription;
+  map<R>(project: (value: T) => R): xstream$Stream<R>;
+  mapTo<R>(projectedValue: R): xstream$Stream<R>;
+  filter(passes: (value: T) => boolean): xstream$Stream<T>;
+  take(amount: number): xstream$Stream<T>;
+  drop(amount: number): xstream$Stream<T>;
+  last(): xstream$Stream<T>;
+  startWith(initial: T): xstream$Stream<T>;
+  endWhen(other: xstream$Stream<*>): xstream$Stream<T>;
+  fold<R>(accumulate: (acc: R, x: T) => R, seed: R): xstream$Stream<R>;
+  replaceError(replace: xstream$Stream<T>): xstream$Stream<T>;
+  flatten(): T;
+  compose<R>(operator: (stream: xstream$Stream<T>) => xstream$Stream<R>): xstream$Stream<R>;
+  remember(): xstream$MemoryStream<T>;
+  debug(labelOrSpy: string | (x: T) => void): xstream$Stream<T>;
+  imitate(target: xstream$Stream<T>): void;
+  shamefullySendNext(value: T): void;
+  shamefullySendError(error: any): void;
+  shamefullySendComplete(): void;
+  setDebugListener(listener: xstream$Listener<T>): void;
+}
+
+declare class xstream$MemoryStream<T> extends xstream$Stream<T> {
+}
+
+declare type xstream$Listener<T> = {
+  next<T>(value: T): void;
+  error(error: Error): void;
+  complete(): void;
+}
+
+declare class xstream$Subscription {
+  unsubscribe(): void;
+}
+
+declare type xstream$Producer<T> = {
+  start: (listener: xstream$Listener<T>) => void;
+  stop: () => void;
+}
+
+declare function xstream$combineResult<T>(s: xstream$Stream<T>): T;
+
+declare type xstream$exports = {
+  default: xstream$exports;
+  create<T>(producer?: xstream$Producer<T>): xstream$Stream<T>;
+  createWithMemory<T>(producer: xstream$Producer<T>): xstream$MemoryStream<T>;
+  never<T>(): xstream$Stream<T>;
+  empty<T>(): xstream$Stream<T>;
+  throw<T>(error: any): xstream$Stream<T>;
+  from<T>(arrayOrPromise: T[] | Promise<T>): xstream$Stream<T>;
+  of<T>(...values: T[]): xstream$Stream<T>;
+  fromArray<T>(array: T[]): xstream$Stream<T>;
+  fromPromise<T>(promise: Promise<T>): xstream$Stream<T>;
+  periodic(period: number): xstream$Stream<number>;
+  merge<T>(stream1: xstream$Stream<T>, stream2: xstream$Stream<T>): xstream$Stream<T>;
+  merge<T>(...streams: Array<xstream$Stream<T>>): xstream$Stream<T>;
+  combine<T, R>(stream1: xstream$Stream<T>, stream2: xstream$Stream<R>): xstream$Stream<[T, R]>;
+  combine<T>(...streams: Array<xstream$Stream<T>>): xstream$Stream<T[]>;
+
+  Stream: typeof xstream$Stream;
+  MemoryStream: typeof xstream$MemoryStream;
+  Listener: xstream$Listener<*>;
+  Producer: xstream$Producer<*>;
+  Subscription: typeof xstream$Subscription;
+}
+
+declare module "xstream" {
+  declare module.exports: xstream$exports;
+}

--- a/definitions/npm/xstream_v6.x.x/test_xstream.js
+++ b/definitions/npm/xstream_v6.x.x/test_xstream.js
@@ -1,0 +1,77 @@
+/* @flow */
+import xs, {
+  Stream,
+  MemoryStream,
+  Subscription
+} from 'xstream';
+
+const producer = {
+  start: (listener) => {
+    listener.next(1);
+    listener.next(2);
+    listener.next(3);
+    listener.complete();
+  },
+  stop: console.log
+};
+
+const create: Stream<number> = xs.create(producer);
+const createWithMemory: MemoryStream<number> = xs.createWithMemory(producer);
+const never: Stream<*> = xs.never();
+const empty: Stream<*> = xs.empty();
+const _throw: Stream<*> = xs.throw(new Error(123));
+const from1: Stream<number> = xs.from([1]);
+const from2: Stream<number> = xs.from(Promise.resolve(1));
+const of: Stream<number> = xs.of(1);
+const fromArray: Stream<number> = xs.fromArray([1,2,3]);
+const fromPromise: Stream<number> = xs.from(Promise.resolve(1));
+const periodic: Stream<number> = xs.periodic(123);
+const merge: Stream<number> = xs.merge(of, of);
+const merge2: Stream<number> = xs.merge(of, of, of, of);
+const combine: Stream<[number, number]> = xs.combine(of, of);
+const combine2: Stream<[number, number, number, number]> = xs.combine(of, of, of, of);
+
+const listener = {
+  next: console.log,
+  error: console.error,
+  complete: console.log
+};
+
+of.addListener(listener);
+of.removeListener(listener);
+
+const subscription: Subscription = of.subscribe({
+  next: x => console.log(x),
+  error: console.error,
+  complete: console.log
+});
+
+subscription.unsubscribe();
+
+
+// $ExpectError
+const bogusStrings: Stream<string> = of.map(x => x);
+const map: Stream<string> = of.map(x => `${x}`);
+const mapTo: Stream<string> = of.mapTo('asdf');
+const filter: Stream<number> = of.filter(x => x < 2);
+const take: Stream<number> = of.take(2);
+const drop: Stream<number> = of.drop(2);
+const last: Stream<number> = of.last();
+const startWith: Stream<number> = of.startWith(1);
+const endWhen: Stream<number> = of.endWhen(fromArray);
+const fold: Stream<string> = of.fold((acc, x) => `${acc}${x}`, '');
+const replaceError: Stream<number> = of.replaceError(fromArray);
+const flatten: Stream<number> = of.map(x => xs.of(x)).flatten();
+const compose: Stream<number> = of.compose(stream => stream.map(x => x * 2));
+const remember: Stream<number> = of.remember();
+const debug: Stream<number> = of.debug('label');
+const debug2: Stream<number> = of.debug(x => void(0));
+xs.create().imitate(fromArray);
+xs.create().shamefullySendNext(1);
+xs.create().shamefullySendError(new Error('123'));
+xs.create().shamefullySendComplete();
+xs.create().setDebugListener({
+  next: console.log,
+  error: console.error,
+  complete: console.log
+});


### PR DESCRIPTION
Adds typings for [xstream](https://github.com/staltz/xstream)

Combine should probably use a $TupleMap, but I don't know how that feature even works. Would appreciate it if someone could show me how it should be done, i.e. given types A, B, and C, `combine(s1: Stream<A>, s2: Stream<B>, s3: Stream<C>): Stream<[A, B, C]>`