### PR TITLE
Jest 16 definitions

### DIFF
--- a/definitions/npm/jest_v16.x.x/flow_v0.33.x-/jest_v16.x.x.js
+++ b/definitions/npm/jest_v16.x.x/flow_v0.33.x-/jest_v16.x.x.js
@@ -1,0 +1,116 @@
+// flow-typed signature: e2130120dcdc34bf09ff82449b0d508c
+// flow-typed version: 230d7577ce/jest_v12.0.x/flow_>=v0.23.x
+
+type JestMockFn = {
+  (...args: Array<any>): any;
+  mock: {
+    calls: Array<Array<any>>;
+    instances: mixed;
+  };
+  mockClear(): Function;
+  mockImplementation(fn: Function): JestMockFn;
+  mockImplementationOnce(fn: Function): JestMockFn;
+  mockReturnThis(): void;
+  mockReturnValue(value: any): JestMockFn;
+  mockReturnValueOnce(value: any): JestMockFn;
+}
+
+type JestAsymmetricEqualityType = {
+  asymmetricMatch(value: mixed): boolean;
+}
+
+type JestCallsType = {
+  allArgs(): mixed;
+  all(): mixed;
+  any(): boolean;
+  count(): number;
+  first(): mixed;
+  mostRecent(): mixed;
+  reset(): void;
+}
+
+type JestClockType = {
+  install(): void;
+  mockDate(date: Date): void;
+  tick(): void;
+  uninstall(): void;
+}
+
+type JestExpectType = {
+  not: JestExpectType;
+  lastCalledWith(...args: Array<any>): void;
+  toBe(value: any): void;
+  toBeCalled(): void;
+  toBeCalledWith(...args: Array<any>): void;
+  toBeCloseTo(num: number, delta: any): void;
+  toBeDefined(): void;
+  toBeFalsy(): void;
+  toBeGreaterThan(number: number): void;
+  toBeLessThan(number: number): void;
+  toBeNull(): void;
+  toBeTruthy(): void;
+  toBeUndefined(): void;
+  toContain(str: string): void;
+  toEqual(value: any): void;
+  toHaveBeenCalled(): void,
+  toHaveBeenCalledWith(...args: Array<any>): void;
+  toMatch(regexp: RegExp): void;
+  toMatchSnapshot(): void;
+  toThrow(message?: string | Error): void;
+  toThrowError(message?: string): void;
+}
+
+type JestSpyType = {
+  calls: JestCallsType;
+}
+
+declare function afterAll(fn: Function): void;
+declare function afterEach(fn: Function): void;
+declare function beforeAll(fn: Function): void;
+declare function beforeEach(fn: Function): void;
+declare function describe(name: string, fn: Function): void;
+declare function fdescribe(name: string, fn: Function): void;
+declare function fit(name: string, fn: Function): ?Promise<void>;
+declare function it(name: string, fn: Function): ?Promise<void>;
+declare function pit(name: string, fn: Function): Promise<void>;
+declare function test(name: string, fn: Function): ?Promise<void>;
+declare function xdescribe(name: string, fn: Function): void;
+declare function xit(name: string, fn: Function): ?Promise<void>;
+
+declare function expect(value: any): JestExpectType;
+
+// TODO handle return type
+// http://jasmine.github.io/2.4/introduction.html#section-Spies
+declare function spyOn(value: mixed, method: string): Object;
+
+declare var jest: {
+  autoMockOff(): void;
+  autoMockOn(): void;
+  clearAllTimers(): void;
+  currentTestPath(): void;
+  disableAutomock(): void;
+  doMock(moduleName: string, moduleFactory?: any): void;
+  dontMock(moduleName: string): void;
+  enableAutomock(): void;
+  fn(implementation?: Function): JestMockFn;
+  genMockFromModule(moduleName: string): any;
+  mock(moduleName: string, moduleFactory?: any): void;
+  runAllTicks(): void;
+  runAllTimers(): void;
+  runOnlyPendingTimers(): void;
+  setMock(moduleName: string, moduleExports: any): void;
+  unmock(moduleName: string): void;
+  useFakeTimers(): void;
+  useRealTimers(): void;
+}
+
+declare var jasmine: {
+  DEFAULT_TIMEOUT_INTERVAL: number;
+  any(value: mixed): JestAsymmetricEqualityType;
+  anything(): void;
+  arrayContaining(value: mixed[]): void;
+  clock(): JestClockType;
+  createSpy(name: string): JestSpyType;
+  objectContaining(value: Object): void;
+  stringMatching(value: string): void;
+}

--- a/definitions/npm/jest_v16.x.x/flow_v0.33.x-/jest_v16.x.x.js
+++ b/definitions/npm/jest_v16.x.x/flow_v0.33.x-/jest_v16.x.x.js
@@ -1,6 +1,3 @@
-// flow-typed signature: e2130120dcdc34bf09ff82449b0d508c
-// flow-typed version: 230d7577ce/jest_v12.0.x/flow_>=v0.23.x
-
 type JestMockFn = {
   (...args: Array<any>): any;
   mock: {

--- a/definitions/npm/jest_v16.x.x/flow_v0.33.x-/jest_v16.x.x.js
+++ b/definitions/npm/jest_v16.x.x/flow_v0.33.x-/jest_v16.x.x.js
@@ -46,36 +46,46 @@ type JestExpectType = {
   toBeDefined(): void;
   toBeFalsy(): void;
   toBeGreaterThan(number: number): void;
+  toBeGreaterThanOrEqual(number: number): void;
   toBeLessThan(number: number): void;
+  toBeLessThanOrEqual(number: number): void;
+  toBeInstanceOf(cls: Class<*>): void;
   toBeNull(): void;
   toBeTruthy(): void;
   toBeUndefined(): void;
-  toContain(str: string): void;
+  toContain(item: any): void;
+  toContainEqual(item: any): void;
   toEqual(value: any): void;
-  toHaveBeenCalled(): void,
+  toHaveBeenCalled(): void;
+  toHaveBeenCalledTimes(number: number): void;
   toHaveBeenCalledWith(...args: Array<any>): void;
   toMatch(regexp: RegExp): void;
   toMatchSnapshot(): void;
   toThrow(message?: string | Error): void;
   toThrowError(message?: string): void;
+  toThrowErrorMatchingSnapshot(): void;
 }
 
 type JestSpyType = {
   calls: JestCallsType;
 }
 
-declare function afterAll(fn: Function): void;
 declare function afterEach(fn: Function): void;
-declare function beforeAll(fn: Function): void;
 declare function beforeEach(fn: Function): void;
+declare function afterAll(fn: Function): void;
+declare function beforeAll(fn: Function): void;
 declare function describe(name: string, fn: Function): void;
-declare function fdescribe(name: string, fn: Function): void;
+declare var it: {
+  (name: string, fn: Function): ?Promise<void>;
+  only(name: string, fn: Function): ?Promise<void>;
+  skip(name: string, fn: Function): ?Promise<void>;
+};
 declare function fit(name: string, fn: Function): ?Promise<void>;
-declare function it(name: string, fn: Function): ?Promise<void>;
-declare function pit(name: string, fn: Function): Promise<void>;
-declare function test(name: string, fn: Function): ?Promise<void>;
-declare function xdescribe(name: string, fn: Function): void;
-declare function xit(name: string, fn: Function): ?Promise<void>;
+declare var test: typeof it;
+declare var xdescribe: typeof describe;
+declare var fdescribe: typeof describe;
+declare var xit: typeof it;
+declare var xtest: typeof it;
 
 declare function expect(value: any): JestExpectType;
 
@@ -86,6 +96,7 @@ declare function spyOn(value: mixed, method: string): Object;
 declare var jest: {
   autoMockOff(): void;
   autoMockOn(): void;
+  clearAllMocks(): void;
   clearAllTimers(): void;
   currentTestPath(): void;
   disableAutomock(): void;
@@ -93,10 +104,13 @@ declare var jest: {
   dontMock(moduleName: string): void;
   enableAutomock(): void;
   fn(implementation?: Function): JestMockFn;
+  isMockFunction(fn: Function): boolean;
   genMockFromModule(moduleName: string): any;
   mock(moduleName: string, moduleFactory?: any): void;
+  resetModules(): void;
   runAllTicks(): void;
   runAllTimers(): void;
+  runTimersToTime(msToRun: number): void;
   runOnlyPendingTimers(): void;
   setMock(moduleName: string, moduleExports: any): void;
   unmock(moduleName: string): void;

--- a/definitions/npm/jest_v16.x.x/test_jest-v16.x.x.js
+++ b/definitions/npm/jest_v16.x.x/test_jest-v16.x.x.js
@@ -1,0 +1,27 @@
+/* @flow */
+/* eslint-disable */
+jest.autoMockOff()
+
+// $ExpectError property `atoMockOff` not found in object type
+jest.atoMockOff()
+
+const mockFn = jest.fn()
+mockFn.mock.calls.map(String).map(a => a + a)
+
+expect(1).toEqual(1)
+expect(true).toBe(true)
+expect(5).toBeGreaterThan(3)
+expect(5).toBeLessThan(8)
+expect('jester').toContain('jest')
+
+mockFn('a')
+expect('someVal').toBeCalled()
+expect('someVal').toBeCalledWith('a')
+
+// $ExpectError property `toHaveBeeenCalledWith` not found in object type
+expect('someVal').toHaveBeeenCalledWith('a')
+
+// $ExpectError property `fn` not found in Array
+mockFn.mock.calls.fn()
+
+test('test', () => expect('foo').toMatchSnapshot());

--- a/definitions/npm/jest_v16.x.x/test_jest-v16.x.x.js
+++ b/definitions/npm/jest_v16.x.x/test_jest-v16.x.x.js
@@ -25,3 +25,10 @@ expect('someVal').toHaveBeeenCalledWith('a')
 mockFn.mock.calls.fn()
 
 test('test', () => expect('foo').toMatchSnapshot());
+test.only('test', () => expect('foo').toMatchSnapshot());
+test.skip('test', () => expect('foo').toMatchSnapshot());
+
+// $ExpectError property `fonly` not found in object type
+test.fonly('test', () => expect('foo').toMatchSnapshot());
+
+xtest('test', () => {});


### PR DESCRIPTION
This adds definitions for Jest 16. I copied Jest 14's definitions and added in some missing things. (I think most of the definitions were based on Jasmine's, but Jest appears to have more functions than Jasmine did.) A bunch of missing expect() object methods were added, and I made some types more specific so that `{test,it}.{only,skip}` are typed now. (These APIs may or may not exist in older versions of Jest, dunno if anyone feels strongly about updating the older definitions too.) I re-ordered a few things not very far to match the order on [Jest's API page](https://facebook.github.io/jest/docs/api.html).

The first commit copies Jest 14's definitions as-is to new files for Jest 16, and then the second commit modifies them.