### PR TITLE
Add definitions for pluralize 2.0 and 3.0

### DIFF
--- a/definitions/npm/pluralize_v2.x.x/flow_v0.13.x-/pluralize_v2.x.x.js
+++ b/definitions/npm/pluralize_v2.x.x/flow_v0.13.x-/pluralize_v2.x.x.js
@@ -1,0 +1,12 @@
+declare module 'pluralize' {
+  declare var exports: {
+    (word: string, count?: number, inclusive?: boolean): string;
+
+    addIrregularRule(single: string, plural: string): void;
+    addPluralRule(rule: string|RegExp, replacemant: string): void;
+    addSingularRule(rule: string|RegExp, replacemant: string): void;
+    addUncountableRule(ord: string|RegExp): void;
+    plural(word: string): string;
+    singular(word: string): string;
+  }
+}

--- a/definitions/npm/pluralize_v2.x.x/test_pluralize_v2.x.x.js
+++ b/definitions/npm/pluralize_v2.x.x/test_pluralize_v2.x.x.js
@@ -1,0 +1,13 @@
+// @flow
+
+import pluralize from "pluralize";
+
+(pluralize('word'): string);
+pluralize('word', 0);
+pluralize('word', 0, true);
+pluralize.addIrregularRule('word', 'wordz');
+
+// $ExpectError
+pluralize();
+// $ExpectError
+pluralize.nope;

--- a/definitions/npm/pluralize_v3.x.x/flow_v0.13.x-/pluralize_v3.x.x.js
+++ b/definitions/npm/pluralize_v3.x.x/flow_v0.13.x-/pluralize_v3.x.x.js
@@ -1,0 +1,12 @@
+declare module 'pluralize' {
+  declare var exports: {
+    (word: string, count?: number, inclusive?: boolean): string;
+
+    addIrregularRule(single: string, plural: string): void;
+    addPluralRule(rule: string|RegExp, replacemant: string): void;
+    addSingularRule(rule: string|RegExp, replacemant: string): void;
+    addUncountableRule(ord: string|RegExp): void;
+    plural(word: string): string;
+    singular(word: string): string;
+  }
+}

--- a/definitions/npm/pluralize_v3.x.x/test_pluralize_v3.x.x.js
+++ b/definitions/npm/pluralize_v3.x.x/test_pluralize_v3.x.x.js
@@ -1,0 +1,13 @@
+// @flow
+
+import pluralize from "pluralize";
+
+(pluralize('word'): string);
+pluralize('word', 0);
+pluralize('word', 0, true);
+pluralize.addIrregularRule('word', 'wordz');
+
+// $ExpectError
+pluralize();
+// $ExpectError
+pluralize.nope;


### PR DESCRIPTION
The definitions for 1.x, 2.0 and 3.0 are completely identical as the public API hasn't changed, but as far as I could see there is no way right now to inherit or have version ranges, right? 
Maybe this would be a nice addition, although not sure how often this case really happens.