### PR TITLE
Fixes for redux-actions return types

### DIFF
--- a/definitions/npm/redux-actions_v0.9.x/flow_v0.23.x-/redux-actions_v0.9.x.js
+++ b/definitions/npm/redux-actions_v0.9.x/flow_v0.23.x-/redux-actions_v0.9.x.js
@@ -1,5 +1,5 @@
 declare module 'redux-actions' {
   declare function createAction(type: string, payloadCreator?: Function, metaCreator?: Function): Function;
-  declare function handleAction(type: string, reducer: Object|Function): void;
-  declare function handleActions(reducerMap: Object, defaultState?: Object): void;
+  declare function handleAction(type: string, reducer: Object|Function): Function;
+  declare function handleActions(reducerMap: Object, defaultState?: Object): Function;
 }

--- a/definitions/npm/redux-actions_v0.9.x/test_redux-actions-v0.9.js
+++ b/definitions/npm/redux-actions_v0.9.x/test_redux-actions-v0.9.js
@@ -3,11 +3,11 @@ import { createAction, handleAction, handleActions } from 'redux-actions';
 
 createAction('foo')();
 createAction('bar', () => {})()
-handleAction('foo', {});
+handleAction('foo', {})();
 handleActions({
   foo: {},
   bar() {},
-});
+})();
 // $ExpectError
 handleActions({
   foo: {},


### PR DESCRIPTION
`handleAction` and `handleActions` are defined as returning `void`. They actually [return](https://github.com/acdlite/redux-actions/blob/master/src/handleAction.js#L14-L20) [functions](https://github.com/acdlite/redux-actions/blob/master/src/handleActions.js#L9).