### PR TITLE
Add more underscore definitions

### DIFF
--- a/definitions/npm/underscore_v1.x.x/flow_v0.13.x-/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.13.x-/underscore_v1.x.x.js
@@ -5,6 +5,10 @@ declare module "underscore" {
   declare function findWhere<T>(list: Array<T>, properties: {[key:string]: any}): ?T;
   declare function clone<T>(obj: T): T;
 
+  declare function findIndex<T>(list: T[], predicate: (val: T)=>boolean): number;
+  declare function indexOf<T>(list: T[], val: T): number;
+  declare function contains<T>(list: T[], val: T, fromIndex?: number): boolean;
+
   declare function isEqual(a: any, b: any): boolean;
   declare function range(a: number, b: number): Array<number>;
   declare function extend<S, T>(o1: S, o2: T): S & T;
@@ -13,26 +17,58 @@ declare module "underscore" {
 
   declare function flatten<S>(a: S[][]): S[];
 
-  declare function any<T>(list: Array<T>, pred: (el: T)=>boolean): boolean;
-
   declare function each<T>(o: {[key:string]: T}, iteratee: (val: T, key: string)=>void): void;
   declare function each<T>(a: T[], iteratee: (val: T, key: string)=>void): void;
 
-  declare function map<T, U>(a: T[], iteratee: (val: T, n?: number)=>U): U[];
-  declare function map<K, T, U>(a: {[key:K]: T}, iteratee: (val: T, k?: K)=>U): U[];
+  declare function map<T, U>(a: T[], iteratee: (val: T, n: number)=>U): U[];
+  declare function map<K, T, U>(a: {[key:K]: T}, iteratee: (val: T, k: K)=>U): U[];
+  declare function pluck(a: Array<any>, propertyName: string): Array <any>;
+
+  declare function reduce<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+  declare function inject<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+  declare function foldl<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+  declare function reduceRight<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+  declare function foldRight<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
 
   declare function object<T>(a: Array<[string, T]>): {[key:string]: T};
   declare function pairs<T>(o: {[key:string]: T}): Array<[string, T]>;
 
   declare function every<T>(a: Array<T>, pred: (val: T)=>boolean): boolean;
+  declare function all<T>(a: Array<T>, pred: (val: T)=>boolean): boolean;
+  declare function some<T>(a: Array<T>, pred: (val: T)=>boolean): boolean;
+  declare function any<T>(a: Array<T>, pred: (val: T)=>boolean): boolean;
+
+  declare function intersection<T>(...arrays: Array<Array<T>>): Array<T>;
+  declare function difference<T>(array: Array<T>, ...others: Array<Array<T>>): Array<T>;
 
   declare function initial<T>(a: Array<T>, n?: number): Array<T>;
   declare function rest<T>(a: Array<T>, index?: number): Array<T>;
 
+  declare function first<T>(a: Array<T>, n: number): Array<T>;
+  declare function first<T>(a: Array<T>): T;
+  declare function head<T>(a: Array<T>, n: number): Array<T>;
+  declare function head<T>(a: Array<T>): T;
+  declare function take<T>(a: Array<T>, n: number): Array<T>;
+  declare function take<T>(a: Array<T>): T;
+  declare function last<T>(a: Array<T>, n: number): Array<T>;
+  declare function last<T>(a: Array<T>): T;
+  declare function sample<T>(a: T[]): T;
+
+  declare function sortBy<T>(a: T[], property: any): T[];
   declare function sortBy<T>(a: T[], iteratee: (val: T)=>any): T[];
 
+  declare function uniq<T>(a: T[]): T[];
+  declare function compact<T>(a: Array<?T>): T[];
   declare function filter<T>(o: {[key:string]: T}, pred: (val: T, k: string)=>boolean): T[];
   declare function filter<T>(a: T[], pred: (val: T, k: string)=>boolean): T[];
+
+  declare function select<T>(o: {[key:string]: T}, pred: (val: T, k: string)=>boolean): T[];
+  declare function select<T>(a: T[], pred: (val: T, k: string)=>boolean): T[];
+
+  declare function reject<T>(o: {[key:string]: T}, pred: (val: T, k: string)=>boolean): T[];
+  declare function reject<T>(a: T[], pred: (val: T, k: string)=>boolean): T[];
+
+  declare function without<T>(a: T[], ...values: T[]): T[];
 
   declare function isEmpty(o: any): boolean;
 
@@ -41,11 +77,22 @@ declare module "underscore" {
   declare function min<T>(a: Array<T>|{[key:any]: T}): T;
   declare function max<T>(a: Array<T>|{[key:any]: T}): T;
 
+  declare function has(o: any, k: any): boolean;
+  declare function isArray(a: any): boolean;
   declare function keys<K, V>(o: {[key: K]: V}): K[];
   declare function values<K, V>(o: {[key: K]: V}): V[];
   declare function flatten(a: Array<any>): Array<any>;
 
+  declare function pick(o: any, ...keys: any): any;
+  declare function pick<T>(o: T, fn: (v: any, k: any, o: T) => boolean): any;
+  declare function omit(o: any, ...keys: Array < string > ): any;
+  declare function omit<T>(o: any, fn: (v: any, k: any, o: T) => boolean): any;
+
   // TODO: improve this
   declare function chain<S>(obj: S): any;
+
+  declare function throttle<T>(fn: T, wait: number, options?: {leading?: boolean, trailing?: boolean}): T;
+  declare function debounce<T>(fn: T, wait: number, immediate?: boolean): T;
+  declare function defer(fn: Function, ...arguments: Array<any>): void;
 }
 

--- a/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
+++ b/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
@@ -98,3 +98,45 @@ _.find([1, 2, 3], x => x == 1);
 _.find([1, 2, 3], 1);
 // $ExpectError Callable signature not found in object literal
 _.find([1, 2, 3], {val: 1});
+
+(_.findIndex([1, 2, 3], function(i) { return i % 2 == 0} ): number);
+// $ExpectError number cannot be compared to string.
+(_.findIndex([1, 2, 3], function(i) { return i == '0'} ): number);
+
+(_.indexOf(['a', 'b', 'c'], function(e) { return e == 'b'}): number);
+
+(_.contains(['a', 'b', 'c'], 'b'): boolean);
+
+(_.map(['hello', 'world'], function(e) { return e.length }): Array<number>);
+(_.map({hello: 1, world: 2}, function(v, k) { return k.length }): Array<number>);
+// $ExpectError This type is incompatible with string
+(_.map({hello: 1, world: 2}, function(v, k) { return k * 2 }): Array<number>);
+(_.pluck([{name: 'bob'}, {name: 'jane'}], 'name'): Array<string>);
+(_.reduce([1, 2, 3], function(m, o) { return m + o }, 0): number);
+(_.all([2, 4, 5], function(i) { return i % 2 == 0 }): boolean);
+// $ExpectError Property not found in Number
+(_.all([2, 4, 5], function(i) { return i.length }): boolean);
+(_.some([2, 4, 5], function(i) { return i % 2 == 0 }): boolean);
+(_.intersection(['a', 'b'], ['b']): Array<string>);
+(_.difference(['a', 'b'], ['b']): Array<string>);
+(_.first([1,2,3]): number);
+(_.first([1,2,3], 2): Array<number>);
+(_.last([1,2,3]): number);
+(_.last([1,2,3], 2): Array<number>);
+(_.sample([1,2,3]): number);
+(_.sortBy(['hello', 'world'], function(e) { return e.length }): Array<string>);
+(_.uniq([1,2,2]): Array<number>);
+(_.compact([1, null]): Array<number>);
+(_.select([1,2,3], function(e) { return e % 2 == 0 }): Array<number>);
+(_.reject([1,2,3], function(e) { return e % 2 == 0 }): Array<number>);
+(_.without([1,2,3], 1, 2): Array<number>);
+(_.has({a: 1, b: 2}, 'b'): boolean);
+(_.isArray([1, 2]): boolean);
+(_.isArray(1): boolean);
+(_.pick({a: 1, b: 2}, 'a'): {[key: string]: number});
+(_.omit({a: 1, b: 2}, 'a'): {[key: string]: number});
+
+_.throttle(function(a) {a.length}, 10)('hello');
+_.debounce(function(a) {a.length}, 10)('hello');
+
+_.defer(function(){})


### PR DESCRIPTION
This adds a bunch of definitions which our app was relying on.  Also, I wasn't sure that the old definition for `map` was correct:

```diff
-  declare function map<T, U>(a: T[], iteratee: (val: T, n?: number)=>U): U[];
+  declare function map<T, U>(a: T[], iteratee: (val: T, n: number)=>U): U[];
```

The old version means you can't do `_.map(['a', 'b', 'c'], function(e, i) { return i < 2 })` because flow thinks `i` may be undefined.   I've changed it to allow that, which doesn't appear to any adverse effects on use of map where you don't include the index argument (eg `_.map(['a', 'b', 'c'], function(e) { return e != 'b' })`
