### PR TITLE
Add fetch-ponyfill definition

### DIFF
--- a/definitions/npm/fetch-ponyfill_v3.x.x/flow_v0.28.x-/fetch-ponyfill_v3.x.x.js
+++ b/definitions/npm/fetch-ponyfill_v3.x.x/flow_v0.28.x-/fetch-ponyfill_v3.x.x.js
@@ -1,0 +1,21 @@
+// @flow
+
+declare module 'fetch-ponyfill' {
+
+  declare type InitOptions = {
+    Promise?: $Subtype<Class<Promise<*>>>,
+    XMLHttpRequest?: $Subtype<Class<XMLHttpRequest>>,
+  };
+
+  // The below types are globals defined by Flow itself in bom.js, so we just have to tell it that the fetch export
+  // of this module is equivalent to window.fetch
+  declare type PonyfillExports = {
+    fetch: (input: string | Request, init?: RequestOptions) => Promise<Response>,
+    Request: Request,
+    Response: Response,
+    Headers: Headers
+  };
+
+  declare export default function PonyfillConstructor(options?: InitOptions): PonyfillExports;
+}
+

--- a/definitions/npm/fetch-ponyfill_v3.x.x/test_fetch-ponyfill_v3.x.x.js
+++ b/definitions/npm/fetch-ponyfill_v3.x.x/test_fetch-ponyfill_v3.x.x.js
@@ -1,0 +1,46 @@
+import _fetch from 'fetch-ponyfill';
+
+const url = 'https://www.github.com';
+//$ExpectError
+_fetch(url)
+
+import FetchConstructor from 'fetch-ponyfill';
+const {fetch, Request: _Request, Response: _Response, Headers: _Headers} = FetchConstructor();
+(_Request: Request);
+(_Response: Response);
+(_Headers: Headers);
+
+fetch(url);
+
+fetch(url, {
+  headers: {
+    foo: 'bar'
+  },
+  mode: 'cors',
+  method: 'PATCH',
+  cache: 'default',
+})
+.then(function(res: Response) {
+  //$ExpectError
+  res.xml();
+  res.arrayBuffer();
+  res.blob();
+  res.formData();
+  res.text();
+  return res.json();
+})
+.then(function(json: string) {
+  return json.split(',');
+})
+
+fetch(url, {
+  //$ExpectError
+  method: 'INVALID'
+})
+
+
+const _fetch1 = FetchConstructor({Promise, XMLHttpRequest}).fetch;
+//$ExpectError
+const _fetch1 = FetchConstructor({Promise: () => null}).fetch;
+
+


### PR DESCRIPTION
May find itself in more widespread use due to vendor bugs (most egregiously, Edge 14) which require that you overwrite or completely ignore `window.fetch`.