### PR TITLE
Support Aphrodite conditional style API

### DIFF
--- a/definitions/npm/aphrodite_v0.5.x/flow_v0.28.x-/aphrodite_v0.5.x.js
+++ b/definitions/npm/aphrodite_v0.5.x/flow_v0.28.x-/aphrodite_v0.5.x.js
@@ -18,7 +18,7 @@ declare module 'aphrodite' {
     }
   };
 
-  declare export var css: (...definitions: StyleDefinition[]) => string;
+  declare export var css: (...definitions: Array<StyleDefinition | false>) => string;
 
   declare export var StyleSheetServer :{
     renderStatic(renderFunc: Function): DehydratedServerContent;

--- a/definitions/npm/aphrodite_v0.5.x/test_aphrodite-v0.5.x.js
+++ b/definitions/npm/aphrodite_v0.5.x/test_aphrodite-v0.5.x.js
@@ -46,3 +46,13 @@ console.log(content.html, content.css);
 
 StyleSheetTestUtils.suppressStyleInjection();
 StyleSheetTestUtils.clearBufferAndResumeStyleInjection();
+
+declare var x: number;
+
+css(false);
+// $ExpectError
+css(true);
+css(true && styles.big);
+// $ExpectError
+css(x && styles.big);
+css(Boolean(x) && styles.big);


### PR DESCRIPTION
The Aphrodite conditional styles API is not currently supported by the flow-typed definition:

https://github.com/Khan/aphrodite#conditionally-applying-styles

I do think trying to accept any false-y value hurts the value of our type checking a fair bit.

However, as a compromise, we can allow consumers to pass in the boolean `false` (or an expression that might resolve to false).  This permits us to use the full power of the API.  It's fairly trivial to cast a false-y value to a boolean if need be (some would argue this is more correct!).