### PR TITLE
fix ramda zipObj type

### DIFF
--- a/definitions/npm/ramda_v0.21.x/flow_v0.23.x-v0.27.x/ramda_v0.21.x.js
+++ b/definitions/npm/ramda_v0.21.x/flow_v0.23.x-v0.27.x/ramda_v0.21.x.js
@@ -315,8 +315,8 @@ declare module 'ramda' {
     xprod<T,S>(xs: Array<T>): (ys: Array<S>) => Array<[T,S]>;
     zip<T,S>(xs: Array<T>, ys: Array<S>): Array<[T,S]>;
     zip<T,S>(xs: Array<T>): (ys: Array<S>) => Array<[T,S]>;
-    zipObj<T:string,S>(xs: Array<T>, ys: Array<S>): Array<{[key: string]:S}>;
-    zipObj<T:string,S>(xs: Array<T>): (ys: Array<S>) => Array<{[key: string]:S}>;
+    zipObj<T:string,S>(xs: Array<T>, ys: Array<S>): {[key: string]:S};
+    zipObj<T:string,S>(xs: Array<T>): (ys: Array<S>) => {[key: string]:S};
     zipWith<T,S,R>(fn: (a: T, b: S) => R, xs: Array<T>, ys: Array<S>): Array<R>;
     zipWith<T,S,R>(fn: (a: T, b: S) => R, xs: Array<T>): (ys: Array<S>) => Array<R>;
     zipWith<T,S,R>(fn: (a: T, b: S) => R): (xs: Array<T>, ys: Array<S>) => Array<R>;

--- a/definitions/npm/ramda_v0.21.x/flow_v0.23.x-v0.27.x/test_ramda_v0.21.x.js
+++ b/definitions/npm/ramda_v0.21.x/flow_v0.23.x-v0.27.x/test_ramda_v0.21.x.js
@@ -171,6 +171,9 @@ describe('List', () => {
   it('should typecheck zipWith', () => {
     const res: Array<string> = _.zipWith((x, y) => x + y, [ 1, 2, 3 ], [ 'a', 'b', 'c' ])
   })
+  it('should typecheck zipObj', () => {
+    const res: {[key: string]: number} = _.zipObj([ 'a', 'b', 'c' ], [ 1, 2, 3 ])
+  })
   it('should typecheck nth', () => {
     const ys: ?number = _.nth(2, [ 1, 2, 3 ])
     const ys1: ?number = _.nth(2)([ 1, 2, 3 ])

--- a/definitions/npm/ramda_v0.21.x/flow_v0.28.x-v0.29.x/ramda_v0.21.x.js
+++ b/definitions/npm/ramda_v0.21.x/flow_v0.28.x-v0.29.x/ramda_v0.21.x.js
@@ -329,8 +329,8 @@ declare module ramda {
   declare function zip<T,S>(xs: Array<T>, ys: Array<S>): Array<[T,S]>
   declare function zip<T,S>(xs: Array<T>, ...rest: Array<void>): (ys: Array<S>) => Array<[T,S]>
 
-  declare function zipObj<T:string,S>(xs: Array<T>, ys: Array<S>): Array<{[key:T]:S}>
-  declare function zipObj<T:string,S>(xs: Array<T>, ...rest: Array<void>): (ys: Array<S>) => Array<{[key:T]:S}>
+  declare function zipObj<T:string,S>(xs: Array<T>, ys: Array<S>): {[key:T]:S}
+  declare function zipObj<T:string,S>(xs: Array<T>, ...rest: Array<void>): (ys: Array<S>) => {[key:T]:S}
 
   declare type NestedArray<T> = Array<T | NestedArray<T>>
   declare function flatten<T>(xs: NestedArray<T>): Array<T>;

--- a/definitions/npm/ramda_v0.21.x/flow_v0.28.x-v0.29.x/test_ramda_v0.21.x_list.js
+++ b/definitions/npm/ramda_v0.21.x/flow_v0.28.x-v0.29.x/test_ramda_v0.21.x_list.js
@@ -221,9 +221,9 @@ const str: string = 'hello world'
   //$ExpectError
   const zipxs1: Array<[ number, string ]> = _.zip([ true, false ])([ 'a', 'b' ])
 
-  const zipos: Array<{[k:string]:number}> = _.zipObj([ 'a', 'b', 'c' ], [ 1, 2, 3 ])
+  const zipos: {[k:string]:number} = _.zipObj([ 'a', 'b', 'c' ], [ 1, 2, 3 ])
 
-  const ys9: Array<{[k:string]: number}> = _.zipObj([ 'me', 'you' ], [ 1, 2 ])
+  const ys9: {[k:string]: number} = _.zipObj([ 'me', 'you' ], [ 1, 2 ])
   const zipped: Array<{s: number, y: string}> = zipWith((a, b) => ({ s: a, y: b }), [ 1, 2, 3 ], [ '1', '2', '3' ])
   const zipped2: Array<{s: number, y: string}> = _.zipWith((a, b) => ({ s: a, y: b }), [ 1, 2, 3 ])([ '1', '2', '3' ])
   const zipped3: Array<{s: number, y: string}> = _.zipWith((a, b) => ({ s: a, y: b }))([ 1, 2, 3 ])([ '1', '2', '3' ])


### PR DESCRIPTION
Currently, the R.zipObj type is incorrect. If you look at the docs,
http://ramdajs.com/docs/#zipObj, you'll see that zipObj returns an
object given two arrays (hence the name zipObj). I have confirmed this
error in my own projects and thought I'd make a PR to fix it here.