### PR TITLE
Fix classnames_v2.x.x

### DIFF
--- a/definitions/npm/classnames_v2.x.x/flow_v0.23.x-v0.27.x/classnames_v2.x.x.js
+++ b/definitions/npm/classnames_v2.x.x/flow_v0.23.x-v0.27.x/classnames_v2.x.x.js
@@ -5,6 +5,7 @@ type $npm$classnames$Classes =
   {[className: string]: boolean } |
   {[className: string]: ?boolean } |
   Array<string> |
+  false |
   void |
   null
 

--- a/definitions/npm/classnames_v2.x.x/flow_v0.28.x-/classnames_v2.x.x.js
+++ b/definitions/npm/classnames_v2.x.x/flow_v0.28.x-/classnames_v2.x.x.js
@@ -2,6 +2,7 @@ type $npm$classnames$Classes =
   string |
   {[className: string]: ?boolean } |
   Array<string> |
+  false |
   void |
   null
 

--- a/definitions/npm/classnames_v2.x.x/test_classnames_v2.x.x.js
+++ b/definitions/npm/classnames_v2.x.x/test_classnames_v2.x.x.js
@@ -12,6 +12,7 @@ classnames({a: true}, 'b');
 classnames({a: null, b: undefined});
 classnames(undefined);
 classnames(null);
+classnames('a', false);
 
 // $ExpectError
 classnames(42);


### PR DESCRIPTION
`classnames(false)` should be handled too: https://github.com/JedWatson/classnames/blob/master/index.js#L18