### PR TITLE
react-modal: add setAppElement method

### DIFF
--- a/definitions/npm/react-modal_v1.x.x/flow_v0.26.x-/react-modal_v1.x.x.js
+++ b/definitions/npm/react-modal_v1.x.x/flow_v0.26.x-/react-modal_v1.x.x.js
@@ -19,6 +19,7 @@ declare module 'react-modal' {
     shouldCloseOnOverlayClick: bool,
   }
   declare class Modal extends React$Component {
+    static setAppElement(element: HTMLElement | string): void;
     static defaultProps: DefaultProps;
     props: Props;
   }

--- a/definitions/npm/react-modal_v1.x.x/test_react-modal-v1.js
+++ b/definitions/npm/react-modal_v1.x.x/test_react-modal-v1.js
@@ -5,3 +5,8 @@ const A = <Modal/>;
 const B = <Modal isOpen closeTimeoutMS={200} ariaHideApp={false}/>;
 // $ExpectError How should we type this?!
 const C: string = <Modal ariaHideApp={100}/>
+
+Modal.setAppElement('#foo');
+Modal.setAppElement(document.getElementById('foo'));
+// $ExpectError only string or Element
+Modal.setAppElement(2);


### PR DESCRIPTION
Added `Modal.setAppElement`, see [docs](https://github.com/reactjs/react-modal/tree/3d8e5a07466ed8ad367eed1f6a6c26a7516ab183#examples); defined [here](https://github.com/reactjs/react-modal/blob/3d8e5a07466ed8ad367eed1f6a6c26a7516ab183/lib/components/Modal.js#L17-L19) and [here](https://github.com/reactjs/react-modal/blob/3d8e5a07466ed8ad367eed1f6a6c26a7516ab183/lib/helpers/ariaAppHider.js#L3-L10).