### PR TITLE
Add currency-formatter

### DIFF
--- a/definitions/npm/currency-formatter_v1.x.x/flow_v0.25.x-/currency-formatter_v1.x.x.js
+++ b/definitions/npm/currency-formatter_v1.x.x/flow_v0.25.x-/currency-formatter_v1.x.x.js
@@ -1,0 +1,36 @@
+/**
+ * Shared interfaces between the modules 'currency-formatter' and
+ * 'currency-formatter/currencies'
+ */
+declare type $npm$currencyFormatter$Currency = {
+  code: string,
+  decimalDigits: number,
+  decimalSeparator: string,
+  spaceBetweenAmountAndSymbol: boolean,
+  symbol: string,
+  symbolOnLeft: boolean,
+  thousandsSeparator: string,
+};
+
+declare module 'currency-formatter' {
+  declare type FormatOptions = {
+    code?: string,
+    decimal?: string,
+    format?: string | {
+      neg: string,
+      pos: string,
+      zero: string,
+    },
+    precision?: number,
+    symbol?: string,
+    thousand?: string,
+  };
+
+  declare var currencies: Array<$npm$currencyFormatter$Currency>;
+  declare function format(amount: number, currency: FormatOptions): string;
+  declare function findCurrency(code: string): ?$npm$currencyFormatter$Currency;
+}
+
+declare module 'currency-formatter/currencies' {
+  declare module.exports: Array<$npm$currencyFormatter$Currency>;
+}

--- a/definitions/npm/currency-formatter_v1.x.x/test_currency-formatter_v1.x.x.js
+++ b/definitions/npm/currency-formatter_v1.x.x/test_currency-formatter_v1.x.x.js
@@ -1,0 +1,40 @@
+// @flow
+
+import { format, findCurrency, currencies } from 'currency-formatter';
+import currencies2 from 'currency-formatter/currencies';
+
+(currencies[0].code: string);
+
+(currencies2[0].code: string);
+
+// $ExpectError is string, not number
+(currencies[0].symbol: number);
+
+// $ExpectError is string, not number
+(currencies2[0].symbol: number);
+
+
+format(22, {});
+
+// $ExpectError opts is missing
+format(22);
+
+// $ExpectError amount is number
+format('22', {});
+
+format(22, { format: { neg: '', pos: '', zero: '' } });
+
+// $ExpectError all formats must be covered
+format(22, { format: { neg: '' } });
+
+
+// $ExpectError is nullable
+findCurrency('GBP').code;
+
+let gbp = findCurrency('GBP');
+if (gbp) {
+  (gbp.code: string);
+
+  // $ExpectError is string
+  (gbp.symbol: boolean);
+}


### PR DESCRIPTION
[`currency-formatter`](https://www.npmjs.com/package/currency-formatter)

I was unsure how to share types between the two provided modules - `currency-formatter` and `currency-formatter/currencies`. I followed the style I saw in a few other files: `$npm$currencyFormatter$Currency`.