### PR TITLE
Add a descriptive error message to repo commands

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -5,6 +5,7 @@ import {copyFile, recursiveRmdir} from "../lib/fileUtils.js";
 import {gitHubClient} from "../lib/github.js";
 import {getLibDefs} from "../lib/libDefs.js";
 import {versionToString} from "../lib/semver.js";
+import isInFlowTypedRepo from "../lib/isInFlowTypedRepo";
 
 import request from "request";
 import * as semver from "semver";
@@ -375,8 +376,15 @@ async function runTests(
 }
 
 export const name = "run-tests";
-export const description = "Run definition tests";
+export const description = "Run definition tests of library definitions in the flow-typed project.";
 export async function run(argv: Argv): Promise<number> {
+  if (!isInFlowTypedRepo()) {
+    console.log(
+      "This command only works in a clone of flowtype/flow-typed. " +
+      "It is a tool used to run tests of the library definitions in the flow-typed project."
+    );
+    return 1;
+  }
   const testPatterns = argv._.slice(1);
 
   const cwd = process.cwd();

--- a/cli/src/commands/validateDefs.js
+++ b/cli/src/commands/validateDefs.js
@@ -1,6 +1,7 @@
 // @flow
 
 import {getLocalLibDefs as getLocalDefs} from "../lib/libDefs.js";
+import isInFlowTypedRepo from "../lib/isInFlowTypedRepo";
 
 function validationError(errKey, errMsg, validationErrs) {
   const errors = validationErrs.get(errKey) || [];
@@ -9,9 +10,16 @@ function validationError(errKey, errMsg, validationErrs) {
 }
 
 export const name = "validate-defs";
-export const description =
-  "Validates the structure of the definitions in the local repo.";
+export const description = "Validates the structure of the definitions in the flow-typed project.";
+
 export async function run(): Promise<number> {
+  if (!isInFlowTypedRepo()) {
+    console.log(
+      "This command only works in a clone of flowtype/flow-typed. " +
+      "It is a tool used to validate the library definitions flow-typed project."
+    );
+    return 1;
+  }
   const validationErrors = new Map();
 
   const localDefs = await getLocalDefs(validationErrors);

--- a/cli/src/lib/isInFlowTypedRepo.js
+++ b/cli/src/lib/isInFlowTypedRepo.js
@@ -1,0 +1,5 @@
+// @flow
+
+export default function isInFlowTypedRepo() {
+  return /\/flow-typed/.test(process.cwd());
+}


### PR DESCRIPTION
If the commands run-tests and validate-libdefs commands is run outside
the flow-typed repo it will display an error message saying that the
command is meant for the flow-typed repo.

Related to #403 
