### PR TITLE
Add `all` method to Express Application

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_v0.25.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.25.x-/express_v4.x.x.js
@@ -148,6 +148,7 @@ declare module 'express' {
     constructor(): void;
     locals: {[name: string]: mixed};
     mountpath: string;
+    all(path:string, callback?: (err?: ?Error) => mixed): void;
     listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): Server;
     listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): Server;
     listen(port: number, callback?: (err?: ?Error) => mixed): Server;


### PR DESCRIPTION
I'm not sure why, but this was needed to not throw an error in my code.