### PR TITLE
Add type definitions for bluebird-promisell

### DIFF
--- a/definitions/npm/bluebird-promisell_v0.5.x/flow_v0.29.x-/bluebird-promisell_v0.5.x.js
+++ b/definitions/npm/bluebird-promisell_v0.5.x/flow_v0.29.x-/bluebird-promisell_v0.5.x.js
@@ -1,0 +1,33 @@
+import type { Bluebird$Promise } from 'bluebird';
+
+type Promise<R> = Bluebird$Promise<R>
+
+declare module "bluebird-promisell" {
+  declare module.exports: {
+    purep <A>(a: A): Promise<A>;
+    fmapp <A,B>(fn: (a: A) => B): (pa: Promise<A>) => Promise<B>;
+    sequencep <A>(arr: Array<Promise<A>>): Promise<Array<A>>;
+    traversep <A,B>(fn: (a: A) => Promise<B>): (arr: Array<A>) => Promise<Array<B>>;
+
+    liftp1 <A,B>(fn: (a: A) => Promise<B> | B): (pa: Promise<A>) => Promise<B>;
+    liftp2 <A,B,C>(fn: (a: A, b: B, ...rest: Array<void>) => Promise<C> | C): (pa: Promise<A>, pb: Promise<B>, ...rest: Array<void>) => Promise<C>;
+    liftp3 <A,B,C,D>(fn: (a: A, b: B, c: C, ...rest: Array<void>) => Promise<D> | D): (pa: Promise<A>, pb: Promise<B>, pc: Promise<C>, ...rest: Array<void>) => Promise<D>;
+    liftp4 <A,B,C,D,E>(fn: (a: A, b: B, c: C, d: D, ...rest: Array<void>) => Promise<E> | E): (pa: Promise<A>, pb: Promise<B>, pc: Promise<C>, pd: Promise<D>, ...rest: Array<void>) => Promise<E>;
+    liftp5 <A,B,C,D,E,F>(fn: (a: A, b: B, c: C, d: D, e: E, ...rest: Array<void>) => Promise<F> | F): (pa: Promise<A>, pb: Promise<B>, pc: Promise<C>, pd: Promise<D>, pe: Promise<E>, ...rest: Array<void>) => Promise<F>;
+
+    liftp <A,B>(fn: (a: A, ...rest: Array<void>) => Promise<B> | B): (pa: Promise<A>, ...rest: Array<void>) => Promise<B>;
+    liftp <A,B,C>(fn: (a: A, b: B, ...rest: Array<void>) => Promise<C> | C): (pa: Promise<A>, pb: Promise<B>, ...rest: Array<void>) => Promise<C>;
+    liftp <A,B,C,D>(fn: (a: A, b: B, c: C, ...rest: Array<void>) => Promise<D> | D): (pa: Promise<A>, pb: Promise<B>, pc: Promise<C>, ...rest: Array<void>) => Promise<D>;
+    liftp <A,B,C,D,E>(fn: (a: A, b: B, c: C, d: D, ...rest: Array<void>) => Promise<E> | E): (pa: Promise<A>, pb: Promise<B>, pc: Promise<C>, pd: Promise<D>, ...rest: Array<void>) => Promise<E>;
+    liftp <A,B,C,D,E,F>(fn: (a: A, b: B, c: C, d: D, e: E, ...rest: Array<void>) => Promise<F> | F): (pa: Promise<A>, pb: Promise<B>, pc: Promise<C>, pd: Promise<D>, pe: Promise<E>, ...rest: Array<void>) => Promise<F>;
+
+    firstp <A,B>(pa: Promise<A>, pb: Promise<B>): Promise<A>;
+    secondp <A,B>(pa: Promise<A>, pb: Promise<B>): Promise<B>;
+    filterp <A>(fn: (a :A) => bool): (arr: Array<Promise<A>>) => Promise<Array<A>>;
+    foldp <A,B>(fn: (b: B, a: A) => Promise<B>): (b: B) => (arr: Array<A>) => Promise<B>;
+    mapError <ERROR,A>(fn: (e: ERROR) => ERROR): (a: Promise<A>) => Promise<A>;
+    resolveError <ERROR,B,A>(fn: (e: ERROR) => B): (pa: Promise<A>) => Promise<B>;
+    toPromise <A,ERROR>(predict: (a: A) => bool, toError: (a: A) => ERROR): (a: A) => Promise<A>;
+    pipep (fn: mixed): mixed;
+  }
+}

--- a/definitions/npm/bluebird-promisell_v0.5.x/flow_v0.29.x-/bluebird-promisell_v0.5.x.js
+++ b/definitions/npm/bluebird-promisell_v0.5.x/flow_v0.29.x-/bluebird-promisell_v0.5.x.js
@@ -1,8 +1,9 @@
 import type { Bluebird$Promise } from 'bluebird';
 
-type Promise<R> = Bluebird$Promise<R>
 
 declare module "bluebird-promisell" {
+  declare export type Bluebird$Promise<R> = Bluebird$Promise<R>
+
   declare module.exports: {
     purep <A>(a: A): Promise<A>;
     fmapp <A,B>(fn: (a: A) => B): (pa: Promise<A>) => Promise<B>;

--- a/definitions/npm/bluebird-promisell_v0.5.x/test_bluebird-promisell_v0.5.x.js
+++ b/definitions/npm/bluebird-promisell_v0.5.x/test_bluebird-promisell_v0.5.x.js
@@ -1,0 +1,110 @@
+// @flow
+
+import type { Bluebird$Promise } from 'bluebird';
+type Promise<R> = Bluebird$Promise<R>
+
+import P from 'bluebird-promisell';
+
+// purep
+var purepOK: Promise<number> = P.purep(2);
+
+// $ExpectError
+var purepError: Promise<string> = P.purep(2);
+
+// liftp1
+var liftp1OK = P.liftp1(function(a: number): number {
+  return a + 1;
+})(P.purep(1));
+
+var liftp1OK2: (pa: Promise<number>) => Promise<number> = P.liftp(function(a: number): number {
+  return a + 1;
+});
+
+// $ExpectError
+var liftp1Error = P.liftp1(function(a: string) { return '2'; })(P.purep(1));
+
+// secondp
+var secondpOK: Promise<string> = P.secondp(P.purep(1), P.purep('1'));
+// $ExpectError
+var secondpError: Promise<number> = P.secondp(P.purep(1), P.purep('1'));
+
+// firstp
+var firstpOK: Promise<number> = P.firstp(P.purep(1), P.purep('1'));
+// $ExpectError
+var firstpError: Promise<string> = P.firstp(P.purep(1), P.purep('1'));
+
+// filterp
+var filterpOK: Promise<Array<number>> = P.filterp(function(a: number) {
+  return a > 2;
+})([P.purep(3), P.purep(1)]);
+
+var filterpOK2: (xs: Array<Promise<number>>) => Promise<Array<number>> = P.filterp(function(a: number) {
+  return a > 2;
+});
+// $ExpectError
+var filterpError: (xs: Array<Promise<number>>) => Promise<Array<string>> = P.filterp(function(a: number) {
+  return a > 2;
+});
+// $ExpectError
+var filterpError2: Promise<Array<number>> = P.filterp(function(a: number) {
+  return a > 2;
+})([P.purep(3), P.purep('1')]);
+
+// $ExpectError
+var filterpError3: Promise<Array<number>> = P.filterp(function(a: number) {
+  return '2';
+})([P.purep(3), P.purep(1)]);
+
+// traversep
+var traversed: Promise<Array<number>> = P.traversep(function(n: number) {
+  return P.purep(n + 1);
+})([1,2,3]);
+
+// $ExpectError
+var traversed: Promise<Array<string>> = P.traversep(function(n: number) {
+  return P.purep(n + 1);
+})([1,2,3]);
+
+// sequencep
+var sequenceOK: Promise<Array<number>> = P.sequencep([P.purep(1), P.purep(2)]);
+
+// $ExpectError
+var sequenceError1: Promise<Array<number>> = P.sequencep([P.purep(1), P.purep('2')]);
+// $ExpectError
+var sequenceError2: Promise<Array<string>> = P.sequencep([P.purep(1), P.purep(2)]);
+
+// foldp
+var foldpOK: Promise<number> = P.foldp(function(b: number, a: number) {
+  return P.purep(b + a);
+})(1)([2,3,4]);
+
+// $ExpectError
+var foldpError1: Promise<string> = P.foldp(function(b: number, a: number) {
+  return P.purep(b + a);
+})(1)([2,3,4]);
+
+// $ExpectError
+var foldpError2: Promise<number> = P.foldp(function(b: number, a: number): Promise<string> {
+  return P.purep(b + a);
+})(1)([2,3,4]);
+
+// toPromise
+var toPromiseOK: Promise<number> = P.toPromise(function(n: number) {
+  return n > 2;
+}, function(n: number) {
+  return new Error('number should greater than 2');
+})(10);
+
+// $ExpectError
+var toPromiseError: Promise<string> = P.toPromise(function(n: number) {
+  return n > 2;
+}, function(n: number) {
+  return new Error('number should greater than 2');
+})(10);
+
+// $ExpectError
+var toPromiseError: Promise<string> = P.toPromise(function(n: number) {
+  return n > 2;
+}, function(n: number) {
+  return 1;
+})(10);

--- a/definitions/npm/bluebird-promisell_v0.5.x/test_bluebird-promisell_v0.5.x.js
+++ b/definitions/npm/bluebird-promisell_v0.5.x/test_bluebird-promisell_v0.5.x.js
@@ -1,9 +1,7 @@
 // @flow
 
-import type { Bluebird$Promise } from 'bluebird';
-type Promise<R> = Bluebird$Promise<R>
-
 import P from 'bluebird-promisell';
+import type { Bluebird$Promise } from 'bluebird-promisell';
 
 // purep
 var purepOK: Promise<number> = P.purep(2);
@@ -16,7 +14,7 @@ var liftp1OK = P.liftp1(function(a: number): number {
   return a + 1;
 })(P.purep(1));
 
-var liftp1OK2: (pa: Promise<number>) => Promise<number> = P.liftp(function(a: number): number {
+var liftp1OK2: (pa: Promise<number>) => Promise<number> = P.liftp1(function(a: number): number {
   return a + 1;
 });
 


### PR DESCRIPTION
I'm adding type definitions to my library [bluebird-promisell](https://github.com/zhangchiqing/bluebird-promisell).

When I ran `./run_def_tests.sh bluebird-promisell`, I got the following error. How can I resolve the first error, which is saying `bluebird` not found? (My library depends on `bluebird`, so does the tests).

```
 * bluebird-promisell_v0.5.x/flow_>=v0.29.x (flow-v0.33.0): Unexpected Flow errors(2):
   0-test_bluebird-promisell_v0.5.x.js:3
     3: import type { Bluebird$Promise } from 'bluebird';
                                              ^^^^^^^^^^ bluebird. Required module not found

   0-test_bluebird-promisell_v0.5.x.js:11
    11: // $ExpectError
        ^^^^^^^^^^^^^^^ Error suppressing comment. Unused suppression
...

   Found 14 errors

   null
```

Thanks!
