### PR TITLE
[WIP] Added _.create test, improved _.clone test for lodash

### DIFF
--- a/definitions/npm/lodash_v4.x.x/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/test_lodash-v4.x.x.js
@@ -19,11 +19,15 @@ _.find({x: 1, y: 2}, { x: 3 });
 /**
  * _.clone
  */
-_.clone({a: 1}).a == 1;
+ var cloned: {a: 1} = _.clone({a: 1})
+
+cloned.a == 1;
+
+// $ExpectError number literal `1`. Cannot be compared to string
+cloned.a == 'c';
+
 // $ExpectError property `b`. Property not found in object literal
-_.clone({a: 1}).b == 1
-// $ExpectError number. This type is incompatible with function type.
-_.clone({a: 1}).a == 'c';
+cloned.b == 1;
 
 /**
  * _.create

--- a/definitions/npm/lodash_v4.x.x/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/test_lodash-v4.x.x.js
@@ -26,6 +26,12 @@ _.clone({a: 1}).b == 1
 _.clone({a: 1}).a == 'c';
 
 /**
+ * _.create
+ */
+var createProto = {a: 1};
+_.create(createProto, {b: 2}).a === 1;
+
+/**
  * _.isEqual
  */
 _.isEqual('a', 'b');

--- a/definitions/npm/lodash_v4.x.x/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/test_lodash-v4.x.x.js
@@ -32,8 +32,13 @@ cloned.b == 1;
 /**
  * _.create
  */
-var createProto = {a: 1};
-_.create(createProto, {b: 2}).a === 1;
+var createProto: {a: number} = {a: 1};
+var createdObj = _.create(createProto, {b: 2});
+
+createdObj.b == 2;
+
+// $ExpectError property `c`. Property not found in object type
+createdObj.c == 'c';
 
 /**
  * _.isEqual


### PR DESCRIPTION
Firstly, the `_.clone` test was not failing consistently, for two reasons: `$ExpectError` appears to cover the following block, not just the following line. If you have 2 lines that throw flow errors, and put `// $ExpectError` before the first line but not the second, both lines are allowed to pass the test. Secondly, the object passed to `_.clone()` was not typed strongly enough.

The main reason I have opened this PR is that `_.create` is not typed correctly. However, I can't find a way to do it correctly, so I'm opening this in the hope someone can help out.

``` javascript
var createdObj = _.create(createProto, {b: 2});
createdObj.b == 2;
```

This should pass, but flow errors out because the return type of `create<T>(prototype: T, properties?: Object)` is currently `$Supertype<T>`, making no mention of `properties` in the returned object.

Two points I can make with my limited understanding of OOP: Shouldn't the returned object be a _subtype_ of `T`, not a _supertype_? And how can we, in flow syntax, express the relationship of the returned object both to the prototype `T` and the properties `P`?
