### PR TITLE
Allow bunyan serializers to accept object literal (#400)

### DIFF
--- a/definitions/npm/bunyan_v1.x.x/flow_v0.21.x-/bunyan_v1.x.x.js
+++ b/definitions/npm/bunyan_v1.x.x/flow_v0.21.x-/bunyan_v1.x.x.js
@@ -97,8 +97,8 @@ declare module 'bunyan' {
         serializers?: Serializers;
         src?: boolean;
     }
-    declare interface Serializers {
-        [key: string]: (input: any) => string;
+    declare type Serializers = {
+        [key: string]: (input: any) => mixed;
     }
     declare type Stream = {
         type: string;

--- a/definitions/npm/bunyan_v1.x.x/test_bunyan_v1.x.x.js
+++ b/definitions/npm/bunyan_v1.x.x/test_bunyan_v1.x.x.js
@@ -57,3 +57,12 @@ logger.log()
 logger.addSTream();
 
 logger.trace({ err: new Error('foobar') }, 'error');
+
+Bunyan.createLogger({
+    name: 'foo',
+    serializers: {
+        foo(data) {
+            return {baz: data};
+        }
+    }
+}).info({foo: 'baz'});


### PR DESCRIPTION
See #400 for detailed description of the issue
