### PR TITLE
RxJS 5: Remove cache operator

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-/rxjs_v5.0.x.js
@@ -102,8 +102,6 @@ declare class rxjs$Observable<+T> {
 
   buffer(bufferBoundaries: rxjs$Observable<any>): rxjs$Observable<Array<T>>;
 
-  cache(bufferSize?: number, windowTime?: number): rxjs$Observable<T>;
-
   catch<U>(selector: (err: any, caught: rxjs$Observable<T>) => rxjs$Observable<U>): rxjs$Observable<U>;
 
   concat(...sources: rxjs$Observable<T>[]): rxjs$Observable<T>;

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -90,9 +90,6 @@ const never: Observable<number> = Observable.empty()
 // $ExpectError
 (Observable.of(2).startWith(1, '2', 3): Observable<number>);
 
-(numbers.cache(): Observable<number>);
-(numbers.cache(1): Observable<number>);
-
 (numbers.withLatestFrom(strings): Observable<[number, string]>);
 // $ExpectError
 (numbers.withLatestFrom(numbers): Observable<[number, string]>);


### PR DESCRIPTION
The `cache()` operator was removed by ReactiveX/rxjs#2012. Since this
is still a prerelease (and Flow doesn't yet support prerelease
versions), we'll just remove it.