### PR TITLE
rxjs: Add Observable.switchMapTo and Observable.using

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-/rxjs_v5.0.x.js
@@ -161,6 +161,10 @@ declare class rxjs$Observable<+T> {
     project: (value: T) => rxjs$Observable<U> | Promise<U> | Iterable<U>
   ): rxjs$Observable<U>;
 
+  switchMapTo<U>(
+    innerObservable: rxjs$Observable<U>,
+  ): rxjs$Observable<U>;
+
   map<U>(f: (value: T) => U): rxjs$Observable<U>;
 
   mapTo<U>(value: U): rxjs$Observable<U>;
@@ -595,6 +599,11 @@ declare class rxjs$Observable<+T> {
     g: rxjs$Observable<G>,
     resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H,
   ): rxjs$Observable<H>;
+
+  static using(
+    resourceFactory: () => ?rxjs$Subscription,
+    observableFactory: (resource: rxjs$Subscription) => rxjs$Observable<T> | Promise<T> | void,
+  ): rxjs$Observable<T>;
 }
 
 declare class rxjs$ConnectableObservable<T> extends rxjs$Observable<T> {

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -102,6 +102,24 @@ Observable.fromEvent(null, 'click', true);
 // $ExpectError
 Observable.fromEvent(null, 'click', {capture: 1});
 
+Observable.of(1).switchMapTo(Observable.of('test'));
+// $ExpectError
+Observable.of(1).switchMapTo(2);
+
+Observable.using(
+  () => {},
+  () => Observable.of(1),
+);
+Observable.using(
+  () => Observable.of(1).subscribe(() => {}),
+  subscription => new Promise(resolve => {}),
+);
+Observable.using(
+  // $ExpectError
+  () => Observable.of('bad'),
+  subscription => {},
+);
+
 // Testing covariance/contravariance/invariance of type parameters
 
 const subObservable: Observable<SubFoo> = new Observable();


### PR DESCRIPTION
Following the corresponding TypeScript definitions in

https://github.com/ReactiveX/rxjs/blob/master/src/operator/switchMapTo.ts
https://github.com/ReactiveX/rxjs/blob/master/src/observable/UsingObservable.ts