### PR TITLE
Underscore updates

### DIFF
--- a/definitions/npm/underscore_v1.x.x/flow_v0.13.x-/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.13.x-/underscore_v1.x.x.js
@@ -70,7 +70,8 @@ declare module "underscore" {
 
   // TODO: size
 
-  // TODO: partition
+  declare function partition<T>(o: {[key:string]: T}, pred: (val: T, k: string)=>boolean): [T[], T[]];
+  declare function partition<T>(o: Array<T>, pred: (val: T)=>boolean): [T[], T[]];
 
   /**
    * Arrays

--- a/definitions/npm/underscore_v1.x.x/flow_v0.13.x-/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.13.x-/underscore_v1.x.x.js
@@ -68,7 +68,8 @@ declare module "underscore" {
 
   // TODO: toArray
 
-  // TODO: size
+  declare function size(o: Object): number;
+  declare function size(o: Array<any>): number;
 
   declare function partition<T>(o: {[key:string]: T}, pred: (val: T, k: string)=>boolean): [T[], T[]];
   declare function partition<T>(o: Array<T>, pred: (val: T)=>boolean): [T[], T[]];

--- a/definitions/npm/underscore_v1.x.x/flow_v0.13.x-/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.13.x-/underscore_v1.x.x.js
@@ -1,98 +1,250 @@
 // type definitions for (some of) underscore
 
 declare module "underscore" {
-  declare function find<T>(list: T[], predicate: (val: T)=>boolean): ?T;
-  declare function findWhere<T>(list: Array<T>, properties: {[key:string]: any}): ?T;
-  declare function clone<T>(obj: T): T;
-
-  declare function findIndex<T>(list: T[], predicate: (val: T)=>boolean): number;
-  declare function indexOf<T>(list: T[], val: T): number;
-  declare function contains<T>(list: T[], val: T, fromIndex?: number): boolean;
-
-  declare function isEqual(a: any, b: any): boolean;
-  declare function range(a: number, b: number): Array<number>;
-  declare function extend<S, T>(o1: S, o2: T): S & T;
-
-  declare function zip<S, T>(a1: S[], a2: T[]): Array<[S, T]>;
-
-  declare function flatten<S>(a: S[][]): S[];
-
+  /**
+   * Collections
+   */
   declare function each<T>(o: {[key:string]: T}, iteratee: (val: T, key: string)=>void): void;
   declare function each<T>(a: T[], iteratee: (val: T, key: string)=>void): void;
+  declare function forEach<T>(o: {[key:string]: T}, iteratee: (val: T, key: string)=>void): void;
+  declare function forEach<T>(a: T[], iteratee: (val: T, key: string)=>void): void;
 
   declare function map<T, U>(a: T[], iteratee: (val: T, n: number)=>U): U[];
   declare function map<K, T, U>(a: {[key:K]: T}, iteratee: (val: T, k: K)=>U): U[];
-  declare function pluck(a: Array<any>, propertyName: string): Array <any>;
+  declare function collect<T, U>(a: T[], iteratee: (val: T, n: number)=>U): U[];
+  declare function collect<K, T, U>(a: {[key:K]: T}, iteratee: (val: T, k: K)=>U): U[];
 
   declare function reduce<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
   declare function inject<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
   declare function foldl<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
-  declare function reduceRight<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
-  declare function foldRight<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
 
-  declare function object<T>(a: Array<[string, T]>): {[key:string]: T};
-  declare function pairs<T>(o: {[key:string]: T}): Array<[string, T]>;
+  declare function reduceRight<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+  declare function foldr<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+
+  declare function find<T>(list: T[], predicate: (val: T)=>boolean): ?T;
+  declare function detect<T>(list: T[], predicate: (val: T)=>boolean): ?T;
+
+  declare function filter<T>(o: {[key:string]: T}, pred: (val: T, k: string)=>boolean): T[];
+  declare function filter<T>(a: T[], pred: (val: T, k: string)=>boolean): T[];
+  declare function select<T>(o: {[key:string]: T}, pred: (val: T, k: string)=>boolean): T[];
+  declare function select<T>(a: T[], pred: (val: T, k: string)=>boolean): T[];
+
+  // TODO: where
+
+  declare function findWhere<T>(list: Array<T>, properties: {[key:string]: any}): ?T;
+
+  declare function reject<T>(o: {[key:string]: T}, pred: (val: T, k: string)=>boolean): T[];
+  declare function reject<T>(a: T[], pred: (val: T, k: string)=>boolean): T[];
 
   declare function every<T>(a: Array<T>, pred: (val: T)=>boolean): boolean;
   declare function all<T>(a: Array<T>, pred: (val: T)=>boolean): boolean;
+
   declare function some<T>(a: Array<T>, pred: (val: T)=>boolean): boolean;
   declare function any<T>(a: Array<T>, pred: (val: T)=>boolean): boolean;
 
-  declare function intersection<T>(...arrays: Array<Array<T>>): Array<T>;
-  declare function difference<T>(array: Array<T>, ...others: Array<Array<T>>): Array<T>;
+  declare function contains<T>(list: T[], val: T, fromIndex?: number): boolean;
+  declare function includes<T>(list: T[], val: T, fromIndex?: number): boolean;
 
-  declare function initial<T>(a: Array<T>, n?: number): Array<T>;
-  declare function rest<T>(a: Array<T>, index?: number): Array<T>;
+  // TODO: invoke
 
+  declare function pluck(a: Array<any>, propertyName: string): Array <any>;
+
+  declare function max<T>(a: Array<T>|{[key:any]: T}): T;
+
+  declare function min<T>(a: Array<T>|{[key:any]: T}): T;
+
+  declare function sortBy<T>(a: T[], property: any): T[];
+  declare function sortBy<T>(a: T[], iteratee: (val: T)=>any): T[];
+
+  declare function groupBy<T>(a: Array<T>, iteratee: (val: T, index: number)=>any): {[key:string]: T[]};
+
+  // TODO: indexBy
+
+  // TODO: countBy
+
+  // TODO: shuffle
+
+  declare function sample<T>(a: T[]): T;
+
+  // TODO: toArray
+
+  // TODO: size
+
+  // TODO: partition
+
+  /**
+   * Arrays
+   */
   declare function first<T>(a: Array<T>, n: number): Array<T>;
   declare function first<T>(a: Array<T>): T;
   declare function head<T>(a: Array<T>, n: number): Array<T>;
   declare function head<T>(a: Array<T>): T;
   declare function take<T>(a: Array<T>, n: number): Array<T>;
   declare function take<T>(a: Array<T>): T;
+
+  declare function initial<T>(a: Array<T>, n?: number): Array<T>;
+
   declare function last<T>(a: Array<T>, n: number): Array<T>;
   declare function last<T>(a: Array<T>): T;
-  declare function sample<T>(a: T[]): T;
 
-  declare function sortBy<T>(a: T[], property: any): T[];
-  declare function sortBy<T>(a: T[], iteratee: (val: T)=>any): T[];
+  declare function rest<T>(a: Array<T>, index?: number): Array<T>;
+  declare function tail<T>(a: Array<T>, index?: number): Array<T>;
+  declare function drop<T>(a: Array<T>, index?: number): Array<T>;
 
-  declare function uniq<T>(a: T[]): T[];
   declare function compact<T>(a: Array<?T>): T[];
-  declare function filter<T>(o: {[key:string]: T}, pred: (val: T, k: string)=>boolean): T[];
-  declare function filter<T>(a: T[], pred: (val: T, k: string)=>boolean): T[];
 
-  declare function select<T>(o: {[key:string]: T}, pred: (val: T, k: string)=>boolean): T[];
-  declare function select<T>(a: T[], pred: (val: T, k: string)=>boolean): T[];
-
-  declare function reject<T>(o: {[key:string]: T}, pred: (val: T, k: string)=>boolean): T[];
-  declare function reject<T>(a: T[], pred: (val: T, k: string)=>boolean): T[];
+  declare function flatten<S>(a: S[][]): S[];
 
   declare function without<T>(a: T[], ...values: T[]): T[];
 
-  declare function isEmpty(o: any): boolean;
+  // TODO: union
 
-  declare function groupBy<T>(a: Array<T>, iteratee: (val: T, index: number)=>any): {[key:string]: T[]};
+  declare function intersection<T>(...arrays: Array<Array<T>>): Array<T>;
 
-  declare function min<T>(a: Array<T>|{[key:any]: T}): T;
-  declare function max<T>(a: Array<T>|{[key:any]: T}): T;
+  declare function difference<T>(array: Array<T>, ...others: Array<Array<T>>): Array<T>;
 
-  declare function has(o: any, k: any): boolean;
-  declare function isArray(a: any): boolean;
+  declare function uniq<T>(a: T[]): T[];
+  declare function unique<T>(a: T[]): T[];
+
+  declare function zip<S, T>(a1: S[], a2: T[]): Array<[S, T]>;
+
+  // TODO: unzip
+
+  declare function object<T>(a: Array<[string, T]>): {[key:string]: T};
+
+  declare function indexOf<T>(list: T[], val: T): number;
+
+  // TODO: lastIndexOf
+
+  // TODO: sortedIndex
+
+  declare function findIndex<T>(list: T[], predicate: (val: T)=>boolean): number;
+
+  // TODO: findLastIndex
+
+  declare function range(a: number, b: number): Array<number>;
+
+  /**
+   * Functions
+   */
+  // TODO: bind
+
+  // TODO: bindAll
+
+  // TODO: partial
+
+  // TODO: memoize
+
+  // TODO: delay
+
+  declare function defer(fn: Function, ...arguments: Array<any>): void;
+
+  declare function throttle<T>(fn: T, wait: number, options?: {leading?: boolean, trailing?: boolean}): T;
+
+  declare function debounce<T>(fn: T, wait: number, immediate?: boolean): T;
+
+  // TODO: once
+
+  // TODO: after
+
+  // TODO: before
+
+  // TODO: wrap
+
+  // TODO: negate
+
+  // TODO: compose
+
+  /**
+   * Objects
+   */
   declare function keys<K, V>(o: {[key: K]: V}): K[];
+
+  // TODO: allKeys
+
   declare function values<K, V>(o: {[key: K]: V}): V[];
-  declare function flatten(a: Array<any>): Array<any>;
+
+  // TODO: mapObject
+
+  declare function pairs<T>(o: {[key:string]: T}): Array<[string, T]>;
+
+  // TODO: invert
+
+  // TODO: create
+
+  // TODO: functions, methods
+
+  // TODO: findKey
+
+  declare function extend<S, T>(o1: S, o2: T): S & T;
+
+  // TODO: extendOwn, assign
 
   declare function pick(o: any, ...keys: any): any;
   declare function pick<T>(o: T, fn: (v: any, k: any, o: T) => boolean): any;
+
   declare function omit(o: any, ...keys: Array < string > ): any;
   declare function omit<T>(o: any, fn: (v: any, k: any, o: T) => boolean): any;
 
-  // TODO: improve this
-  declare function chain<S>(obj: S): any;
+  // TODO: defaults
 
-  declare function throttle<T>(fn: T, wait: number, options?: {leading?: boolean, trailing?: boolean}): T;
-  declare function debounce<T>(fn: T, wait: number, immediate?: boolean): T;
-  declare function defer(fn: Function, ...arguments: Array<any>): void;
+  declare function clone<T>(obj: T): T;
+
+  // TODO: tap
+
+  declare function has(o: any, k: any): boolean;
+
+  // TODO: matcher, matches
+  // TODO: property
+  // TODO: propertyOf
+
+  declare function isEqual(a: any, b: any): boolean;
+
+  // TODO: isMatch
+
+  declare function isEmpty(o: any): boolean;
+
+  // TODO: isElement
+
+  declare function isArray(a: any): boolean;
+
+  // TODO: isObject
+  // TODO: isArguments
+  // TODO: isFunction
+  // TODO: isString
+  // TODO: isNumber
+  // TODO: isFinite
+  // TODO: isBoolean
+  // TODO: isDate
+  // TODO: isRegExp
+  // TODO: isError
+  // TODO: isNaN
+  // TODO: isNull
+  // TODO: isUndefined
+
+  /**
+   * Utility
+   */
+  // TODO: noConflict
+  // TODO: identity
+  // TODO: constant
+  // TODO: noop
+  // TODO: times
+  // TODO: random
+  // TODO: mixin
+  // TODO: iteratee
+  // TODO: uniqueId
+  // TODO: escape
+  // TODO: unescape
+  // TODO: result
+  // TODO: now
+  // TODO: template
+
+  /**
+   * Chaining
+   */
+  declare function chain<S>(obj: S): any;
+  // TODO: value
+
 }
 

--- a/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
+++ b/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
@@ -139,4 +139,9 @@ _.find([1, 2, 3], {val: 1});
 _.throttle(function(a) {a.length}, 10)('hello');
 _.debounce(function(a) {a.length}, 10)('hello');
 
-_.defer(function(){})
+_.defer(function(){});
+
+(_.partition([1,5,2,4], function(i: number) { return i<4 }): [Array<number>, Array<number>]);
+(_.partition({x: 'foo', y: 'bar'}, function(v: string, k: string) { return k === 'bar' }): [Array<string>, Array<string>]);
+
+

--- a/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
+++ b/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
@@ -144,4 +144,7 @@ _.defer(function(){});
 (_.partition([1,5,2,4], function(i: number) { return i<4 }): [Array<number>, Array<number>]);
 (_.partition({x: 'foo', y: 'bar'}, function(v: string, k: string) { return k === 'bar' }): [Array<string>, Array<string>]);
 
+(_.size([1,2]): number);
+(_.size({a: 1, b: 2}): number);
+
 


### PR DESCRIPTION
The overall diff for this probably looks a bit overwhelming, but it should have minimal 'actual' changes.

The first commit (https://github.com/flowtype/flow-typed/commit/94097e20545635022bbc2bf90394987dbfafd15c) reorders the underscore definitions to match the docs at http://underscorejs.org/, groups everything by its alias (eg _.each, _.forEach), and adds a couple of missing aliases.

The remaining two are just adding new definitions for _.partition & _.size