### PR TITLE
Add a descriptive error message for latest version

### DIFF
--- a/cli/src/cli.js
+++ b/cli/src/cli.js
@@ -8,6 +8,7 @@ if (!global.__flowTypedBabelPolyfill) {
 
 import yargs from "yargs";
 import {fs, path} from "./lib/node.js";
+import {printCliError} from "./lib/errors";
 
 import * as Install from "./commands/install.js";
 import * as CreateStub from "./commands/create-stub.js";
@@ -47,7 +48,9 @@ export function runCLI() {
       cmd.description,
       cmd.setup || identity,
       args => cmd.run(args, yargs).catch(err => {
-        if (err.stack) {
+        if (err.name === 'CliError') {
+          printCliError(err);
+        } else if (err.stack) {
           console.log('UNCAUGHT ERROR: %s', err.stack);
         } else if (typeof err === 'object' && err !== null) {
           console.log("UNCAUGHT ERROR: %s", JSON.stringify(err, null, 2));

--- a/cli/src/commands/create-stub.js
+++ b/cli/src/commands/create-stub.js
@@ -3,6 +3,7 @@
 export const name = 'create-stub';
 export const description = 'Creates a libdef stub for an untyped npm package';
 
+import {CliError} from '../lib/errors';
 import {createStub} from '../lib/stubUtils.js';
 import {findFlowRoot} from '../lib/flowProjectUtils.js';
 
@@ -30,25 +31,19 @@ type Args = {
   _: Array<string>,
 }
 
-function failWithMessage(message: string) {
-  console.error(message);
-  return 1;
-}
-
 export async function run(args: Args): Promise<number> {
   if (!Array.isArray(args._) || args._.length < 2) {
-    return failWithMessage(
-      'Please provide the names of one or more npm packages'
-    );
+    throw new CliError('Please provide the names of one or more npm packages');
   }
   const packages = args._.slice(1);
 
   // Find the project root
   const projectRoot = await findFlowRoot(process.cwd());
   if (projectRoot == null) {
-    return failWithMessage(
-      `\nERROR: Unable to find a flow project in the current dir or any of ` +
-      `it's parents!\nPlease run this command from within a Flow project.`
+    throw new CliError(
+      'Unable to find a flow project',
+      'The current working directory is not within a Flow project. ' +
+      'Please run this command from within a Flow project.'
     );
   }
 

--- a/cli/src/lib/__tests__/libDefs-test.js
+++ b/cli/src/lib/__tests__/libDefs-test.js
@@ -2,8 +2,9 @@
 jest.enableAutomock();
 jest.unmock('../libDefs.js');
 jest.unmock('../semver.js');
-jest.unmock('semver');
 jest.unmock('../flowVersion');
+jest.unmock('semver');
+jest.unmock('colors/safe');
 
 import {fs} from '../node.js';
 

--- a/cli/src/lib/errors.js
+++ b/cli/src/lib/errors.js
@@ -1,0 +1,26 @@
+// @flow
+import colors from "colors/safe";
+
+export class CliError extends Error {
+  description: ?string;
+
+  constructor(message: string, description?: string) {
+    super(message);
+    this.name = "CliError";
+    this.message = message;
+    this.description = description;
+
+    if (typeof Error.captureStackTrace === "function") {
+      Error.captureStackTrace(this, this.constructor);
+    } else {
+      this.stack = (new Error(message)).stack;
+    }
+  }
+}
+
+export function printCliError(error: CliError) {
+  console.log(
+    colors.bold(colors.red("✖ " + error.message)) +
+    (error.description ? "\n " + error.description : "")
+  );
+}

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -2,6 +2,7 @@
 
 import semver from "semver";
 
+import {CliError} from './errors';
 import {cloneInto, findLatestFileCommitHash, rebaseRepoMaster} from "./git.js";
 import {mkdirp} from "./fileUtils.js";
 import {fs, path, os} from "./node.js";
@@ -488,6 +489,15 @@ function libdefMatchesPackageVersion(pkgSemver: string, defVersionRaw: string): 
   // The libdef version should be treated as a semver prefixed by a carat
   // (i.e: "foo_v2.2.x" is the same range as "^2.2.x")
   // UNLESS it is prefixed by the equals character (i.e. "foo_=v2.2.x")
+
+  if (pkgSemver === 'latest') {
+    throw new CliError(
+      "Unsupported version 'latest'",
+      "flow-typed does not currently support installing library definitions based on packages set" +
+      "to 'latest'. Please set a version number."
+    );
+  }
+
   let defVersion = defVersionRaw;
   if (defVersionRaw[0] !== '=' && defVersionRaw[0] !== '^') {
     defVersion = '^' + defVersionRaw;


### PR DESCRIPTION
This adds a more descriptive error message for when there is a package
with 'latest' in the version field.

Related to #399