### PR TITLE
feat[redux-saga] add support for yield array in middleware

### DIFF
--- a/definitions/npm/redux-saga_v0.11.x/flow_v0.28.x-/redux-saga_v0.11.x.js
+++ b/definitions/npm/redux-saga_v0.11.x/flow_v0.28.x-/redux-saga_v0.11.x.js
@@ -79,6 +79,7 @@ declare module 'redux-saga' {
    */
 
   declare type SagaSpread<Y: IOEffect, R, N, T> = (...args: Array<T>) => Generator<Y, R, N>;
+  declare type SagaList<Y: IOEffect[], R, N> = () => Generator<Y, R, N>;
   declare type Saga0<Y: IOEffect, R, N> = () => Generator<Y, R, N>;
   declare type Saga1<Y: IOEffect, R, N, T1> = (t1: T1) => Generator<Y, R, N>;
   declare type Saga2<Y: IOEffect, R, N, T1, T2> = (t1: T1, t2: T2) => Generator<Y, R, N>;
@@ -125,6 +126,7 @@ declare module 'redux-saga' {
   };
 
   declare type MiddlewareRunFn =
+    & (<Y, R, N, Fn: SagaList<Y, R, N>>(saga: Fn) => Task)
     & (<Y, R, N, Fn: Saga0<Y, R, N>>(saga: Fn, ...rest: Array<void>) => Task)
     & (<T1, Y, R, N, Fn: Saga1<Y, R, N, T1>>(saga: Fn, t1: T1, ...rest: Array<void>) => Task)
     & (<T1, T2, Y, R, N, Fn: Saga2<Y, R, N, T1, T2>>(saga: Fn, t1: T1, t2: T2, ...rest: Array<void>) => Task)

--- a/definitions/npm/redux-saga_v0.11.x/test_redux-saga_0.11.x.js
+++ b/definitions/npm/redux-saga_v0.11.x/test_redux-saga_0.11.x.js
@@ -748,6 +748,7 @@ function createSagaMiddlewareTest() {
   function* g5(a: string, b: number, c: string, d: number, e: string): Generator<*, *, *> {};
   function* g6(a: string, b: number, c: string, d: number, e: string, f: number): Generator<*, *, *> {};
   function* gSpread(...args: Array<string>): Generator<*, *, *> {};
+  function* gList(): Generator<*, *, *> { yield []; };
 
   middleware.run(g0);
   middleware.run(g1, '1');
@@ -756,6 +757,7 @@ function createSagaMiddlewareTest() {
   middleware.run(g4, '1', 2, '3', 4);
   middleware.run(g5, '1', 2, '3', 4, '5');
   middleware.run(g6, '1', 2, '3', 4, '5', 6);
+  middleware.run(gList);
 
   // $ExpectError: Too few arguments
   middleware.run(g6, '1', 2, '3');


### PR DESCRIPTION
Add middleware support to run a generator that returns an array of IOEffects, as in the [redux-saga real world example](https://github.com/yelouafi/redux-saga/blob/0dc376107d24537028bd1c66e4fce81c223f2c23/examples/real-world/sagas/index.js#L123)