### PR TITLE
Ramda: Evolve should create an object with the same type as its input

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.28.x-v0.30.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.28.x-v0.30.x/ramda_v0.x.x.js
@@ -552,8 +552,8 @@ declare module ramda {
 
   // TODO over
 
-  declare function path<V,A:NestedObject<V>>(p: Array<string>, ...rest: Array<void>): (o: A) => ?V;
-  declare function path<V,A:NestedObject<V>>(p: Array<string>, o: A): ?V;
+  declare function path<V,A:?NestedObject<V>>(p: Array<string>, ...rest: Array<void>): (o: A) => ?V;
+  declare function path<V,A:?NestedObject<V>>(p: Array<string>, o: A): ?V;
 
   declare function pathOr<T,V,A:NestedObject<V>>(or: T, ...rest: Array<void>):
   ((p: Array<string>, ...rest: Array<void>) => (o: ?A) => V|T)
@@ -720,7 +720,7 @@ declare module ramda {
     f2: (...args: Array<any>) => C
   ): (...args: Array<A>) => B|C;
 
-  declare function isEmpty(x:Array<any>|Object|string): boolean;
+  declare function isEmpty(x:?Array<any>|Object|string): boolean;
 
   declare function not(x:boolean): boolean;
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.28.x-v0.30.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.28.x-v0.30.x/ramda_v0.x.x.js
@@ -499,8 +499,8 @@ declare module ramda {
   declare function dissocPath<T>(key: Array<string>, val:T, ...args: Array<void>): (src: {[k:string]:T}) => {[k:string]:T};
   declare function dissocPath<T>(key: Array<string>, val:T, src: {[k:string]:T}): {[k:string]:T};
 
-  declare function evolve<V,R>(fn: NestedObject<(x:any) => R>, ...rest: Array<void>): (src: NestedObject<any>) => NestedObject<R>;
-  declare function evolve<V,R>(fn: NestedObject<(x:any) => R>, src: NestedObject<any>): NestedObject<R>;
+  declare function evolve<R: NestedObject<any>>(fn: NestedObject<UnarySameTypeFn<any>>, ...rest: Array<void>): (src: R) => R;
+  declare function evolve<R: NestedObject<any>>(fn: NestedObject<UnarySameTypeFn<any>>, src: R): R;
 
   declare function eqProps(key: string, ...args: Array<void>):
   ((o1: Object, ...rest: Array<void>) => (o2: Object) => boolean)
@@ -552,8 +552,8 @@ declare module ramda {
 
   // TODO over
 
-  declare function path<V,A:?NestedObject<V>>(p: Array<string>, ...rest: Array<void>): (o: A) => ?V;
-  declare function path<V,A:?NestedObject<V>>(p: Array<string>, o: A): ?V;
+  declare function path<V,A:NestedObject<V>>(p: Array<string>, ...rest: Array<void>): (o: A) => ?V;
+  declare function path<V,A:NestedObject<V>>(p: Array<string>, o: A): ?V;
 
   declare function pathOr<T,V,A:NestedObject<V>>(or: T, ...rest: Array<void>):
   ((p: Array<string>, ...rest: Array<void>) => (o: ?A) => V|T)
@@ -720,7 +720,7 @@ declare module ramda {
     f2: (...args: Array<any>) => C
   ): (...args: Array<A>) => B|C;
 
-  declare function isEmpty(x:?Array<any>|Object|string): boolean;
+  declare function isEmpty(x:Array<any>|Object|string): boolean;
 
   declare function not(x:boolean): boolean;
 


### PR DESCRIPTION
http://ramdajs.com/docs/#evolve

According to the Ramda documentation, evolve should accept an object of functions which return the same type as their input.  This means that we actually have stronger guarantees about the shape of the return value.