### PR TITLE
mocha_v3.1.x

### DIFF
--- a/definitions/npm/mocha_v3.1.x/flow_v0.22.x-/mocha_v3.1.x.js
+++ b/definitions/npm/mocha_v3.1.x/flow_v0.22.x-/mocha_v3.1.x.js
@@ -1,0 +1,22 @@
+type TestFunction = ((done: () => void) => void | Promise<mixed>);
+
+declare var describe : {
+    (name:string, spec:() => void): void;
+    only(description:string, spec:() => void): void;
+    skip(description:string, spec:() => void): void;
+    timeout(ms:number): void;
+};
+
+declare var context : typeof describe;
+
+declare var it : {
+    (name:string, spec?:TestFunction): void;
+    only(description:string, spec:TestFunction): void;
+    skip(description:string, spec:TestFunction): void;
+    timeout(ms:number): void;
+};
+
+declare function before(method : TestFunction):void;
+declare function beforeEach(method : TestFunction):void;
+declare function after(method : TestFunction):void;
+declare function afterEach(method : TestFunction):void;

--- a/definitions/npm/mocha_v3.1.x/test_mocha_v3.1.x_context.js
+++ b/definitions/npm/mocha_v3.1.x/test_mocha_v3.1.x_context.js
@@ -1,0 +1,50 @@
+/* @flow */
+
+/**
+ * context
+ */
+
+context('desc', () => {});
+
+// $ExpectError number. This type is incompatible with function type.
+context('desc', 12);
+// $ExpectError number. This type is incompatible with undefined.
+context('desc', () => 1);
+// $ExpectError number. This type is incompatible with string.
+context(12, () => {});
+
+
+/**
+ * context.skip
+ */
+
+context.skip('desc', () => {});
+
+// $ExpectError number. This type is incompatible with function type.
+context.skip('desc', 12);
+// $ExpectError number. This type is incompatible with undefined.
+context.skip('desc', () => 1);
+// $ExpectError number. This type is incompatible with string.
+context.skip(12, () => {});
+
+/**
+ * context.only
+ */
+
+context.only('desc', () => {});
+
+// $ExpectError number. This type is incompatible with function type.
+context.only('desc', 12);
+// $ExpectError number. This type is incompatible with undefined.
+context.only('desc', () => 1);
+// $ExpectError number. This type is incompatible with string.
+context.only(12, () => {});
+
+/**
+ * context.timeout
+ */
+
+context.timeout(1000);
+
+// $ExpectError string. This type is incompatible with number.
+context.timeout('1000');

--- a/definitions/npm/mocha_v3.1.x/test_mocha_v3.1.x_describe.js
+++ b/definitions/npm/mocha_v3.1.x/test_mocha_v3.1.x_describe.js
@@ -1,0 +1,50 @@
+/* @flow */
+
+/**
+ * describe
+ */
+
+describe('desc', () => {});
+
+// $ExpectError number. This type is incompatible with function type.
+describe('desc', 12);
+// $ExpectError number. This type is incompatible with undefined.
+describe('desc', () => 1);
+// $ExpectError number. This type is incompatible with string.
+describe(12, () => {});
+
+
+/**
+ * describe.skip
+ */
+
+describe.skip('desc', () => {});
+
+// $ExpectError number. This type is incompatible with function type.
+describe.skip('desc', 12);
+// $ExpectError number. This type is incompatible with undefined.
+describe.skip('desc', () => 1);
+// $ExpectError number. This type is incompatible with string.
+describe.skip(12, () => {});
+
+/**
+ * describe.only
+ */
+
+describe.only('desc', () => {});
+
+// $ExpectError number. This type is incompatible with function type.
+describe.only('desc', 12);
+// $ExpectError number. This type is incompatible with undefined.
+describe.only('desc', () => 1);
+// $ExpectError number. This type is incompatible with string.
+describe.only(12, () => {});
+
+/**
+ * describe.timeout
+ */
+
+describe.timeout(1000);
+
+// $ExpectError string. This type is incompatible with number.
+describe.timeout('1000');

--- a/definitions/npm/mocha_v3.1.x/test_mocha_v3.1.x_hooks.js
+++ b/definitions/npm/mocha_v3.1.x/test_mocha_v3.1.x_hooks.js
@@ -1,0 +1,46 @@
+/* @flow */
+
+/**
+ * before
+ */
+
+before(() => {});
+before((done : Function) => {});
+before(() => new Promise((res, rej) => {}));
+
+// $ExpectError number. This type is incompatible with function type.
+before((done : number) => {});
+
+/**
+ * beforeEach
+ */
+
+beforeEach(() => {});
+beforeEach((done : Function) => {});
+beforeEach(() => new Promise((res, rej) => {}));
+
+// $ExpectError number. This type is incompatible with function type.
+beforeEach((done : number) => {});
+
+
+/**
+ * after
+ */
+
+after(() => {});
+after((done : Function) => {});
+after(() => new Promise((res, rej) => {}));
+
+// $ExpectError number. This type is incompatible with function type.
+after((done : number) => {});
+
+/**
+ * afterEach
+ */
+
+afterEach(() => {});
+afterEach((done : Function) => {});
+afterEach(() => new Promise((res, rej) => {}));
+
+// $ExpectError number. This type is incompatible with function type.
+afterEach((done : number) => {});

--- a/definitions/npm/mocha_v3.1.x/test_mocha_v3.1.x_it.js
+++ b/definitions/npm/mocha_v3.1.x/test_mocha_v3.1.x_it.js
@@ -1,0 +1,65 @@
+/* @flow */
+
+/**
+ * it
+ */
+
+it('desc', () => {});
+it('desc', (done : Function) => {});
+it('desc', () => new Promise((res, rej) => {}));
+
+// $ExpectError number. This type is incompatible with function type.
+it('desc', (done : number) => {});
+// $ExpectError number. This type is incompatible with function type.
+it('desc', 12);
+// $ExpectError number. This type is incompatible with undefined.
+it('desc', () => 1);
+// $ExpectError number. This type is incompatible with string.
+it(12, () => {});
+
+
+/**
+ * it.skip
+ */
+
+it.skip('desc', () => {});
+it.skip('desc', (done : Function) => {});
+it.skip('desc', () => new Promise((res, rej) => {}));
+
+// $ExpectError number. This type is incompatible with function type.
+it.skip('desc', (done : number) => {});
+// $ExpectError number. This type is incompatible with function type.
+it.skip('desc', 12);
+// $ExpectError number. This type is incompatible with undefined.
+it.skip('desc', () => 1);
+// $ExpectError number. This type is incompatible with string.
+it.skip(12, () => {});
+
+// Can also skip a test by not providing a body
+it('desc');
+
+/**
+ * it.only
+ */
+
+it.only('desc', () => {});
+it.only('desc', (done : Function) => {});
+it.only('desc', () => new Promise((res, rej) => {}));
+
+// $ExpectError number. This type is incompatible with function type.
+it.only('desc', (done : number) => {});
+// $ExpectError number. This type is incompatible with function type.
+it.only('desc', 12);
+// $ExpectError number. This type is incompatible with undefined.
+it.only('desc', () => 1);
+// $ExpectError number. This type is incompatible with string.
+it.only(12, () => {});
+
+/**
+ * it.timeout
+ */
+
+it.timeout(1000);
+
+// $ExpectError string. This type is incompatible with number.
+it.timeout('1000');


### PR DESCRIPTION
As far as I can tell, the defs already in `flow-typed` for mocha v2.4.x continue to work fine for mocha v3.1.x, so I've just copied them and `s/2.4/3.1/` where appropriate.