### PR TITLE
Add shields/badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
   width="400"
 />
 
+[![Travis](https://img.shields.io/travis/flowtype/flow-typed.svg)](https://travis-ci.org/flowtype/flow-typed) [![npm](https://img.shields.io/npm/dm/flow-typed.svg)](https://www.npmjs.com/package/flow-typed)
+
 `flow-typed` is a [repository](https://github.com/flowtype/flow-typed/tree/master/definitions) of third-party 
 [library interface definitions](http://flowtype.org/docs/third-party.html) 
 for use with [Flow](http://flowtype.org/).


### PR DESCRIPTION
This adds two badges to the readme. 1) to travis.ci and 2) npmjs.com.

![skarmavbild 2016-11-21 kl 00 01 37](https://cloud.githubusercontent.com/assets/220827/20467001/df818b12-af7d-11e6-9dcd-f4bd3634c7f3.png)
