### PR TITLE
Fix (non-static) Observable.concat type

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-v0.33.x/rxjs_v5.0.x.js
@@ -104,7 +104,7 @@ declare class rxjs$Observable<+T> {
 
   catch<U>(selector: (err: any, caught: rxjs$Observable<T>) => rxjs$Observable<U>): rxjs$Observable<U>;
 
-  concat(...sources: rxjs$Observable<T>[]): rxjs$Observable<T>;
+  concat<U>(...sources: rxjs$Observable<U>[]): rxjs$Observable<T | U>;
 
   concatAll<U>(): rxjs$Observable<U>;
 

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -104,7 +104,7 @@ declare class rxjs$Observable<+T> {
 
   catch<U>(selector: (err: any, caught: rxjs$Observable<T>) => rxjs$Observable<U>): rxjs$Observable<U>;
 
-  concat(...sources: rxjs$Observable<T>[]): rxjs$Observable<T>;
+  concat<U>(...sources: rxjs$Observable<U>[]): rxjs$Observable<T | U>;
 
   concatAll<U>(): rxjs$Observable<U>;
 
@@ -117,7 +117,7 @@ declare class rxjs$Observable<+T> {
   delay(dueTime: number): rxjs$Observable<T>;
 
   distinctUntilChanged(compare?: (x: T, y: T) => boolean): rxjs$Observable<T>;
-    
+
   distinct<U>(keySelector?: (value: T) => U, flushes?: rxjs$Observable<mixed>): rxjs$Observable<T>;
 
   distinctUntilKeyChanged(key: string, compare?: (x: mixed, y: mixed) => boolean): rxjs$Observable<T>;

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -86,6 +86,9 @@ const never: Observable<number> = Observable.empty()
   .concat(Observable.of('').ignoreElements())
   .concat(Observable.never());
 
+const numberOrString: Observable<number | string> = numbers
+  .concat(strings);
+
 (Observable.of(2).startWith(1, 2, 3): Observable<number>);
 // $ExpectError
 (Observable.of(2).startWith(1, '2', 3): Observable<number>);


### PR DESCRIPTION
Concatting an `Observable<T>` with an `Observable<U>` should result in an `Observable<T | U>`.
Currently this can expand the type of the first observable if it's not fixed, causing spurious errors down the line.