### PR TITLE
tape v4.5.x: add missing named export 'test' to tape

### DIFF
--- a/definitions/npm/tape_v4.5.x/flow_v0.25.x-/tape_v4.5.x.js
+++ b/definitions/npm/tape_v4.5.x/flow_v0.25.x-/tape_v4.5.x.js
@@ -98,9 +98,10 @@ declare module 'tape' {
 
   declare type Tape = {
     (a: string | tape$TestOpts | tape$TestCb, b?: tape$TestCb | tape$TestOpts, c?: tape$TestCb, ...rest: Array<void>): void,
+    test: tape$TestFn,
     skip: (name: string, cb?: tape$TestCb) => void,
     createHarness: () => TestHarness,
-    createStream: (opts?: StreamOpts) => stream$Readable, 
+    createStream: (opts?: StreamOpts) => stream$Readable,
     only: (a: string | tape$TestOpts | tape$TestCb, b?: tape$TestCb | tape$TestOpts, c?: tape$TestCb, ...rest: Array<void>) => void,
   };
 


### PR DESCRIPTION
Fixes #477