### PR TITLE
express: support req.body

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_v0.25.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.25.x-/express_v4.x.x.js
@@ -14,7 +14,7 @@ declare class express$RequestResponseBase {
 
 declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
   baseUrl: string;
-  body?: {[key: string]: string};
+  body?: string | Buffer | {[key: string]: mixed};
   cookies: {[cookie: string]: string};
   fresh: boolean;
   hostname: boolean;

--- a/definitions/npm/express_v4.x.x/flow_v0.25.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.25.x-/express_v4.x.x.js
@@ -14,7 +14,7 @@ declare class express$RequestResponseBase {
 
 declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
   baseUrl: string;
-  body: mixed;
+  body?: {[key: string]: string};
   cookies: {[cookie: string]: string};
   fresh: boolean;
   hostname: boolean;

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -79,6 +79,16 @@ bar.get('/', (req: $Request, res: $Response): void => {
     .status(200);
 });
 
+//body parsed-property access
+bar.post('/', (req: $Request, res: $Response): void => {
+
+  var username: ?string = req.body ? req.body.Username : null;
+  // $ExpectError cannot access properties without a null check first
+  var password: string = req.body.Password;
+  // $ExpectError body key/values should be string
+  var userid: ?number = req.body ? req.body.UserId : null;
+});
+
 app.use('/bar', bar)
 
 app.listen(9000);

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -79,15 +79,59 @@ bar.get('/', (req: $Request, res: $Response): void => {
     .status(200);
 });
 
+
 //body parsed-property access
+//https://github.com/expressjs/body-parser/blob/master/README.md
 bar.post('/', (req: $Request, res: $Response): void => {
 
-  var username: ?string = req.body ? req.body.Username : null;
+  // json parsing
   // $ExpectError cannot access properties without a null check first
-  var password: string = req.body.Password;
-  // $ExpectError body key/values should be string
-  var userid: ?number = req.body ? req.body.UserId : null;
+  const password: ?mixed = req.body.Password;
+  if (req.body && typeof req.body === 'object') {
+    // simple property value, unknown type or existence
+    const usernameMixed: mixed = req.body.Username;
+    // $ExpectError cannot infer type
+    let usernameString: string = req.body.Username;
+    if (req.body.Username) {
+      const username: mixed = req.body.Username;
+      // $ExpectError still cannot infer type
+      usernameString = req.body.Username;
+      // test type of value
+      if (typeof req.body.Username === 'string') {
+        // now can infer type
+        usernameString = req.body.Username;
+      }
+    }
+    // property value as object
+    // $ExpectError cannot access properties without checking is object first
+    const unknown: mixed = req.body.TestChild.gds;
+    // type check property as object
+    if (req.body.TestChild && typeof req.body.TestChild === 'object') {
+      // allowed to refer to property as object now
+      const asd: Object = req.body.TestChild;
+      // allowed to directly access child property
+      const help: mixed = req.body.TestChild.agdge;
+    }
+  }
+
+  // text parsing
+  // $ExpectError must detect that body was a string
+  let bodyText: string = req.body;
+  // detect if body is string
+  if (typeof req.body === 'string') {
+    // can infer string now
+    bodyText = req.body;
+  }
+
+  // raw parsing
+  // $ExpectError must detect that body is a buffer
+  let bodyRaw: Buffer = req.body;
+  // detect if body is raw Buffer
+  if (req.body instanceof Buffer) {
+    bodyRaw = req.body;
+  }
 });
+
 
 app.use('/bar', bar)
 


### PR DESCRIPTION
`req.body` can be an object with attributes or undefined.

Previously, this was marked as `mixed`, resulting in flow throwing an error when attempting to access a property, e.g. `req.body.Username`.

According to [the express docs](http://expressjs.com/en/api.html#req.body), the `body` property can be undefined, or an object.

With passing tests.