### PR TITLE
Fix missing types in Lodash

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.28.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.28.x-/lodash_v4.x.x.js
@@ -25,28 +25,39 @@ declare module 'lodash' {
   };
 
   declare type NestedArray<T> = Array<Array<T>>;
+  
+  declare type matchesIterateeShorthand = Object;
+  declare type matchesPropertyIterateeShorthand = [string, any];
+  declare type propertyIterateeShorthand = string;
 
   declare type OPredicate<A, O> =
-                    | ((value: A, key: string, object: O) => any)
-                    | Object
-                    | string;
+    | ((value: A, key: string, object: O) => any)
+    | matchesIterateeShorthand
+    | matchesPropertyIterateeShorthand
+    | propertyIterateeShorthand;
+  
   declare type OIterateeWithResult<V, O, R> = Object|string|((value: V, key: string, object: O) => R);
   declare type OIteratee<O> = OIterateeWithResult<any, O, any>;
 
   declare type Predicate<T> =
-                    | ((value: T, index: number, array: Array<T>) => any)
-                    | Object
-                    | string;
+    | ((value: T, index: number, array: Array<T>) => any)
+    | matchesIterateeShorthand
+    | matchesPropertyIterateeShorthand
+    | propertyIterateeShorthand;
+  
   declare type _Iteratee<T> = (item: T, index: number, array: ?Array<T>) => mixed;
   declare type Iteratee<T> = _Iteratee<T>|Object|string;
   declare type Iteratee2<T, U> = ((item: T, index: number, array: ?Array<T>) => U)|Object|string;
   declare type FlatMapIteratee<T, U> = ((item: T, index: number, array: ?Array<T>) => Array<U>)|Object|string;
   declare type Comparator<T> = (item: T, item2: T) => bool;
 
-  declare type MapIterator1<T,U> = (item: T) => U;
-  declare type MapIterator2<T,U> = (item: T, index: number) => U;
-  declare type MapIterator3<T,U> = (item: T, index: number, array: Array<T>) => U;
-  declare type MapIterator<T,U> = MapIterator1<T,U>|MapIterator2<T,U>|MapIterator3<T,U>;
+  declare type MapIterator<T,U> =
+    | ((item: T, index: number, array: Array<T>) => U)
+    | propertyIterateeShorthand;
+
+  declare type OMapIterator<T,O,U> =
+    | ((item: T, key: string, object: O) => U)
+    | propertyIterateeShorthand;
 
   declare class Lodash {
     // Array
@@ -184,7 +195,7 @@ declare module 'lodash' {
     keyBy<T, V>(array: ?Array<T>, iteratee?: Iteratee2<T, V>): {[key: V]: T};
     keyBy<V, T: Object>(object: T, iteratee?: OIteratee<T>): Object;
     map<T, U>(array: ?Array<T>, iteratee?: MapIterator<T, U>): Array<U>;
-    map<V, T: Object, U>(object: ?T, iteratee?: OIterateeWithResult<V, T, U>): Array<U>;
+    map<V, T: Object, U>(object: ?T, iteratee?: OMapIterator<V, T, U>): Array<U>;
     map(str: ?string, iteratee?: (char: string, index: number, str: string) => any): string;
     orderBy<T>(array: ?Array<T>, iteratees?: Array<Iteratee<T>>|string, orders?: Array<'asc'|'desc'>|string): Array<T>;
     orderBy<V, T: Object>(object: T, iteratees?: Array<OIteratee<*>>|string, orders?: Array<'asc'|'desc'>|string): Array<V>;

--- a/definitions/npm/lodash_v4.x.x/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/test_lodash-v4.x.x.js
@@ -15,6 +15,44 @@ _.find([{x:1}, {x:2}, {x:3}], v => v.x == 3);
 _.find({x: 1, y: 2}, (a: number, b: string) => a);
 _.find({x: 1, y: 2}, { x: 3 });
 
+/**
+ * _.find examples from the official doc
+ */
+var users = [
+  { 'user': 'barney',  'age': 36, 'active': true },
+  { 'user': 'fred',    'age': 40, 'active': false },
+  { 'user': 'pebbles', 'age': 1,  'active': true }
+];
+
+_.find(users, function(o) { return o.age < 40; });
+
+// The `_.matches` iteratee shorthand.
+_.find(users, { 'age': 1, 'active': true });
+
+// The `_.matchesProperty` iteratee shorthand.
+_.find(users, ['active', false]);
+
+// The `_.property` iteratee shorthand.
+_.find(users, 'active');
+
+
+/**
+ * _.map examples from the official doc
+ */
+function square(n) {
+  return n * n;
+}
+
+_.map([4, 8], square);
+_.map({ 'a': 4, 'b': 8 }, square);
+
+var users = [
+  { 'user': 'barney' },
+  { 'user': 'fred' }
+];
+
+// The `_.property` iteratee shorthand.
+_.map(users, 'user');
 
 /**
  * _.clone


### PR DESCRIPTION
* Fix `_.matchesProperty` iteratee shorthand (e.g. `_.find(users, ['active', false])`)

* Fix `_.property` iteratee shorthand (e.g. `_.map(users, 'age')`)