### PR TITLE
type cookie maxAge as number

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_v0.25.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.25.x-/express_v4.x.x.js
@@ -46,7 +46,7 @@ declare type express$CookieOptions = {
   encode?: (value: string) => string,
   expires?: Date,
   httpOnly?: boolean,
-  maxAge?: string,
+  maxAge?: number,
   path?: string,
   secure?: boolean,
   signed?: boolean


### PR DESCRIPTION
http://expressjs.com/en/api.html#res.cookie

> maxAge	Number	Convenient option for setting the expiry time relative to the current time in milliseconds