### PR TITLE
Fix EditorConfig for indent size / style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,8 +12,8 @@ insert_final_newline = true
 charset = utf-8
 
 # 2 space indentation
-tab_size = 2
-tab_style = space
+indent_size = 2
+indent_style = space
 
 [*.{js,json}]
 # trim any trailing whitespace


### PR DESCRIPTION
I noticed that I messed up the indent size and style for the editorconfig file. Oops, this should fix this.