### PR TITLE
fix(express): make`res.statusCode` accessible

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
@@ -83,6 +83,7 @@ declare class express$Response extends http$ClientRequest mixins express$Request
   sendStatus(statusCode: number): this;
   set(field: string, value?: string): this;
   status(statusCode: number): this;
+  statusCode: number;
   type(type: string): this;
   vary(field: string): this;
 }

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -134,3 +134,18 @@ app.use((err: ?Error, req, res, next) => {
     next();
     next(err);
 });
+
+app.use((req: $Request, res: $Response, next) => {
+  next()
+
+  res.on('finish', () => {
+    if (res.statusCode >= 200 && res.statusCode < 400) {
+      console.log('response success')
+    } else {
+      console.log('response error')
+    }
+
+    // $ExpectError
+    res.statusCode.toLowerCase()
+  })
+})


### PR DESCRIPTION
I have a middleware which send metrics to track if response statusCode is success see:

```jsx
res.on('finish', () => {
    // $FlowFixMe `res.statusCode` exists
    if (res.statusCode >= 200 && res.statusCode < 400) {
      const end = diff(start)
      const completeURL = req.baseUrl ? req.baseUrl + req.path : req.path
      const normalizedURL = completeURL.replace(/\/\d/g, '/:id')
      trace.recordMetric(`response time :: (${req.method}) -> ${normalizedURL}`, end)
    }
})
```

`res.statusCode` is correctly set and accessible at this time.