### PR TITLE
Make implementation optional in jest's it/test function

### DIFF
--- a/definitions/npm/jest_v17.x.x/flow_v0.33.x-/jest_v17.x.x.js
+++ b/definitions/npm/jest_v17.x.x/flow_v0.33.x-/jest_v17.x.x.js
@@ -194,21 +194,21 @@ declare var it: {
    * @param {string} Name of Test
    * @param {Function} Test
    */
-  (name: string, fn: Function): ?Promise<void>;
+  (name: string, fn?: Function): ?Promise<void>;
   /**  
    * Only run this test
    * 
    * @param {string} Name of Test
    * @param {Function} Test
    */
-  only(name: string, fn: Function): ?Promise<void>;
+  only(name: string, fn?: Function): ?Promise<void>;
   /**  
    * Skip running this test
    * 
    * @param {string} Name of Test
    * @param {Function} Test
    */
-  skip(name: string, fn: Function): ?Promise<void>;
+  skip(name: string, fn?: Function): ?Promise<void>;
 };
 declare function fit(name: string, fn: Function): ?Promise<void>;
 /** An individual test unit */

--- a/definitions/npm/react-scripts_v0.7.x/flow_v0.33.x-/react-scripts_v0.7.x.js
+++ b/definitions/npm/react-scripts_v0.7.x/flow_v0.33.x-/react-scripts_v0.7.x.js
@@ -73,9 +73,9 @@ declare function afterAll(fn: Function): void;
 declare function beforeAll(fn: Function): void;
 declare function describe(name: string, fn: Function): void;
 declare var it: {
-  (name: string, fn: Function): ?Promise<void>;
-  only(name: string, fn: Function): ?Promise<void>;
-  skip(name: string, fn: Function): ?Promise<void>;
+  (name: string, fn?: Function): ?Promise<void>;
+  only(name: string, fn?: Function): ?Promise<void>;
+  skip(name: string, fn?: Function): ?Promise<void>;
 };
 declare function fit(name: string, fn: Function): ?Promise<void>;
 declare var test: typeof it;


### PR DESCRIPTION
Make the test implementation optional in the it/test function. If the test implementation function is left off, jest just treats it like a skipped test.