### PR TITLE
Definition for bser and node-int64

### DIFF
--- a/definitions/npm/bser_v1.x.x/flow_v0.28.x-/bser_v1.x.x.js
+++ b/definitions/npm/bser_v1.x.x/flow_v0.28.x-/bser_v1.x.x.js
@@ -1,0 +1,59 @@
+declare module 'bser' {
+  /*
+  TODO: Support importing of other libdefs
+  import typeof Int64 from 'node-int64'; 
+  */
+  declare type BserValidTypes =
+    | number
+    | string
+    | boolean
+    | null
+    /* |Int64 */
+    | Array<BserValidTypes>
+    | { [key: string]: BserValidTypes };
+
+
+  declare export class Accumulator {
+    buf: Buffer,
+    readOffset: number,
+    writeOffset: number,
+    constructor(initsize?: number): Accumulator,
+    writeAvail(): number,
+    readAvail(): number,
+    reserve(size: number): void,
+    append(buf: string|Buffer): void,
+    assertReadableSize(size: number): void,
+    peekString(size: number): string,
+    readString(size: number): string,
+    peekInt(size: number): number/* |Int64 */,
+    readInt(size: number): number/* |Int64 */,
+    peekDouble(): number,
+    readDouble(): number,
+    readAdvance(size: number): void,
+    writeByte(value: number): void,
+    writeInt(value: number, size: number): void,
+    writeDouble(value: number): void,
+    
+  }
+  declare export class BunserBuf extends events$EventEmitter {
+    buf: Accumulator,
+    state: number,
+    append(buf: string|Buffer, synchronous: true): BserValidTypes,
+    append(buf: string|Buffer, synchronous?: false): void,
+    processLater(): void,
+    process(synchronous: true): BserValidTypes,
+    process(synchronous?: false): void,
+    raise(reason: string): void,
+    expectCode(expected: number): void,
+    decodeAny(): BserValidTypes,
+    decodeArray(): Array<BserValidTypes>,
+    decodeObject(): { [key: string]: BserValidTypes },
+    decodeTemplate(): Array<BserValidTypes>,
+    decodeString(): string,
+    decodeInt(relaxSizeAsserts: true): number/* |Int64 */|false,
+    decodeInt(relaxSizeAsserts?: false): number/* |Int64 */,
+  }
+
+  declare export function loadFromBuffer(input: string|Buffer): BserValidTypes;
+  declare export function dumpToBuffer(val: BserValidTypes): Accumulator;
+}

--- a/definitions/npm/bser_v1.x.x/test_bser_v1.x.x.js
+++ b/definitions/npm/bser_v1.x.x/test_bser_v1.x.x.js
@@ -1,0 +1,18 @@
+import { Accumulator, BunserBuf, loadFromBuffer, dumpToBuffer } from 'bser';
+
+// $ExpectError
+loadFromBuffer();
+
+var result = loadFromBuffer('\x00\x01\x03\x28');
+
+// $ExpectError
+dumpToBuffer();
+
+var result2: Accumulator = dumpToBuffer(123456);
+
+var o = new BunserBuf();
+
+o.on('change', () => {});
+
+// $ExpectError
+o.doesnotexist('change');

--- a/definitions/npm/node-int64_v0.4.x/flow_v0.25.x-/node-int64_v0.4.x.js
+++ b/definitions/npm/node-int64_v0.4.x/flow_v0.25.x-/node-int64_v0.4.x.js
@@ -1,0 +1,20 @@
+declare module 'node-int64' {
+ declare class Int64 {
+ 	constructor(a1: Buffer|Uint8Array|number, a2?: number): Int64;
+ 	constructor(a1: string): Int64;
+ 	static MAX_INT: number;
+ 	static MIN_INT: number;
+ 	setValue(hi: string): void;
+ 	setValue(hi: number, lo?: number): void;
+ 	toNumber(allowImprecise?: bool): number;
+ 	valueOf(): number;
+ 	toString(radix?: number): string;
+ 	toOctetString(sep?: string): string;
+ 	toBuffer(rawBuffer?: bool): Buffer;
+ 	copy(targetBuffer: Buffer, targetOffset?: number): void;
+ 	compare(other: Int64): number;
+ 	equals(other: Int64): bool;
+ 	inspect(): string;
+  }
+  declare module.exports: typeof Int64;
+}

--- a/definitions/npm/node-int64_v0.4.x/test_node-int64_v0.4.x.js
+++ b/definitions/npm/node-int64_v0.4.x/test_node-int64_v0.4.x.js
@@ -1,0 +1,12 @@
+// $ExpectError
+import { Int64 as oha } from 'node-int64';
+
+import Int64 from 'node-int64';
+
+// $ExpectError
+new Int64();
+
+var x = new Int64(Int64.MAX_INT);
+var y = new Int64(1234567789);
+
+var f: bool = x.equals(y);


### PR DESCRIPTION
This is the definition for the package `bser` (https://github.com/facebook/watchman/tree/master/node/bser)

I have two questions:

* Is it valid that one of the objects extends `EventEmitter`, because flowtype.org/try says `"Could not resolve name EventEmitter"`?
* How would I use types from other definitions? Is that already possible? Because `bser` also accepts and returns instances of `Int64` (npm.im/node-int64), so assuming a type definition would exists for it how would I reference it?

Tests are still missing, but wanted to ask the questions first.