### PR TITLE
Add libdef for react-i18next

### DIFF
--- a/definitions/npm/react-i18next_v1.10.x/flow_v0.36.x-/react-i18next_v1.10.x.js
+++ b/definitions/npm/react-i18next_v1.10.x/flow_v0.36.x-/react-i18next_v1.10.x.js
@@ -1,0 +1,32 @@
+import type { TFunction } from 'i18next'
+
+declare module 'react-i18next' {
+  declare type TFunction = TFunction;
+  declare type Locales = string | Array<string>;
+
+  declare type StatelessComponent<P> = (props: P) => ?React$Element<any>;
+
+  declare type Comp<P> = StatelessComponent<P> | Class<React$Component<void, P, void>>;
+  declare type TranslatedComponent<OP> = Class<React$Component<void, $Diff<OP, { t: TFunction }>, void>>;
+  declare type Translator<OP, P> = (component: Comp<P>) => TranslatedComponent<OP>;
+
+  declare function translate<OP, P>(locales: Locales): Translator<OP, P>;
+
+  declare type NamespacesProps = {
+    components: Array<Comp<*>>,
+    i18n: { loadNamespaces: Function },
+  };
+
+  declare function loadNamespaces(props: NamespacesProps): Promise<void>;
+
+  declare type ProviderProps = { i18n: Object, children: React$Element<any> };
+
+  declare var I18nextProvider: Class<React$Component<void, ProviderProps, void>>;
+
+  declare type InterpolateProps = {
+    children?: React$Element<any>,
+    className?: string,
+  };
+
+  declare var Interpolate: Class<React$Component<void, InterpolateProps, void>>;
+}

--- a/definitions/npm/react-i18next_v1.10.x/flow_v0.36.x-/react-i18next_v1.10.x.js
+++ b/definitions/npm/react-i18next_v1.10.x/flow_v0.36.x-/react-i18next_v1.10.x.js
@@ -1,7 +1,5 @@
-import type { TFunction } from 'i18next'
-
 declare module 'react-i18next' {
-  declare type TFunction = TFunction;
+  declare type TFunction = (key?: ?string, data?: ?Object) => string;
   declare type Locales = string | Array<string>;
 
   declare type StatelessComponent<P> = (props: P) => ?React$Element<any>;

--- a/definitions/npm/react-i18next_v1.10.x/flow_v0.36.x-/react-i18next_v1.10.x.js
+++ b/definitions/npm/react-i18next_v1.10.x/flow_v0.36.x-/react-i18next_v1.10.x.js
@@ -6,9 +6,12 @@ declare module 'react-i18next' {
 
   declare type StatelessComponent<P> = (props: P) => ?React$Element<any>;
 
-  declare type Comp<P> = StatelessComponent<P> | Class<React$Component<void, P, void>>;
-  declare type TranslatedComponent<OP> = Class<React$Component<void, $Diff<OP, { t: TFunction }>, void>>;
-  declare type Translator<OP, P> = (component: Comp<P>) => TranslatedComponent<OP>;
+  declare type Comp<P> = StatelessComponent<P> | Class<React$Component<*, P, *>>;
+
+  declare type Translator<OP, P> = {
+    (component: StatelessComponent<P>): Class<React$Component<void, OP, void>>;
+    <Def, St>(component: Class<React$Component<Def, P, St>>): Class<React$Component<Def, OP, St>>;
+  }
 
   declare function translate<OP, P>(locales: Locales): Translator<OP, P>;
 

--- a/definitions/npm/react-i18next_v1.10.x/test_react-i18next_v1.10.x.js
+++ b/definitions/npm/react-i18next_v1.10.x/test_react-i18next_v1.10.x.js
@@ -49,19 +49,19 @@ class ClassComp extends React.Component {
 }
 
 // $ExpectError - wrong argument type
-const Comp = ({ s, t }: Props) => (
+const FlowErrorComp = ({ s, t }: Props) => (
   <div
-    prop1={ t('', '') }
+    prop1={ t('', '') } // misuse of t()
     prop2={ ' ' + s }
   />
 );
 
-class FlowErrorComp extends React.Component {
+class FlowErrorClassComp extends React.Component {
   props: Props;
   render() {
     // $ExpectError - wrong argument type
     const { s, t } = this.props;
-    return <div prop={ t({}) } />;
+    return <div prop={ t({}) } />; // misuse of t()
   }
 }
 

--- a/definitions/npm/react-i18next_v1.10.x/test_react-i18next_v1.10.x.js
+++ b/definitions/npm/react-i18next_v1.10.x/test_react-i18next_v1.10.x.js
@@ -30,7 +30,6 @@ loadNamespaces('');
 // $ExpectError - wrong component type
 loadNamespaces({ components: [{}], i18n });
 
-
 type OwnProps = { s: string };
 type Props = OwnProps & { t: TFunction };
 
@@ -46,6 +45,23 @@ class ClassComp extends React.Component {
   render() {
     const { s, t } = this.props;
     return <div prop={ t('') } />;
+  }
+}
+
+// $ExpectError - wrong argument type
+const Comp = ({ s, t }: Props) => (
+  <div
+    prop1={ t('', '') }
+    prop2={ ' ' + s }
+  />
+);
+
+class FlowErrorComp extends React.Component {
+  props: Props;
+  render() {
+    // $ExpectError - wrong argument type
+    const { s, t } = this.props;
+    return <div prop={ t({}) } />;
   }
 }
 

--- a/definitions/npm/react-i18next_v1.10.x/test_react-i18next_v1.10.x.js
+++ b/definitions/npm/react-i18next_v1.10.x/test_react-i18next_v1.10.x.js
@@ -1,0 +1,85 @@
+// @flow
+
+import React from 'react'
+import {
+  loadNamespaces,
+  translate,
+  I18nextProvider,
+  Interpolate,
+} from 'react-i18next'
+import type { TFunction, Translator } from 'react-i18next'
+
+const i18n = { loadNamespaces: () => {} };
+
+<I18nextProvider i18n={ i18n } children={ <div /> } />;
+
+// $ExpectError - missing children prop
+<I18nextProvider i18n={ i18n } />;
+// $ExpectError - missing i18n prop
+<I18nextProvider children={ <div /> } />;
+
+
+// passing
+loadNamespaces({ components: [], i18n });
+loadNamespaces({ components: [() => <div />], i18n });
+
+// $ExpectError - too few arguments
+loadNamespaces();
+// $ExpectError - wrong type
+loadNamespaces('');
+// $ExpectError - wrong component type
+loadNamespaces({ components: [{}], i18n });
+
+
+type OwnProps = { s: string };
+type Props = OwnProps & { t: TFunction };
+
+const Comp = ({ s, t }: Props) => (
+  <div
+    prop1={ t('') }
+    prop2={ ' ' + s }
+  />
+);
+
+class ClassComp extends React.Component {
+  props: Props;
+  render() {
+    const { s, t } = this.props;
+    return <div prop={ t('') } />;
+  }
+}
+
+// $ExpectError - too few arguments
+translate();
+// $ExpectError - wrong argument type
+translate({});
+
+const translator: Translator<OwnProps, Props> = translate('');
+const WrappedStatelessComp = translator(Comp);
+
+// passing
+<WrappedStatelessComp s="" />;
+
+// $ExpectError - missing prop "s"
+<WrappedStatelessComp />;
+// $ExpectError - wrong type
+<WrappedStatelessComp s={ 1 } />;
+
+const WrappedClassComp = translator(ClassComp);
+
+// passing
+<WrappedClassComp s="" />;
+
+// $ExpectError - missing prop "s"
+<WrappedClassComp />;
+// $ExpectError - wrong type
+<WrappedClassComp s={ 1 } />;
+
+// passing
+<Interpolate />;
+<Interpolate children={ <div /> } className="string" />;
+
+// $ExpectError - className prop wrong type
+<Interpolate className={ null } />;
+// $ExpectError - children prop wrong type
+<Interpolate children={ {} } />;


### PR DESCRIPTION
Adds libdef for react-i18next. Should be fairly robust, though there are some holes (not checking the i18n object). Special attention has been given to the `translate` HOC, which was modeled after `connect` from react-redux. I am new to flow, so please let me know if there is anything I can improve.

Usage:

```js
// @flow
import { translate } from 'react-i18next'
import type { Translator, TFunction } from 'react-i18next'

type OwnProps = { s: string }
type Props = OwnProps & { t: TFunction }

const Comp = ({ t }: Props) => <div s={}>{ t('whatever') }</div>

const translator: Translator<OwnProps, Props> = translate('whatever')

const WrappedComp = translator(Comp)

const OtherComp = () => <Comp s={ 2 } /> // TypeError
```