### PR TITLE
Express: Add ability to specify Request & Response type (w/ backwards compatibility)

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_v0.25.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.25.x-/express_v4.x.x.js
@@ -88,60 +88,65 @@ declare class express$Response extends http$ClientRequest mixins express$Request
 }
 
 declare type express$NextFunction = (err?: ?Error) => mixed;
-declare type express$Middleware =
-  ((req: express$Request, res: express$Response, next: express$NextFunction) => mixed) |
-  ((error: ?Error, req: express$Request, res: express$Response, next: express$NextFunction) => mixed);
-declare interface express$RouteMethodType<T> {
-  (middleware: express$Middleware): T;
-  (...middleware: Array<express$Middleware>): T;
-  (path: string|RegExp|string[], ...middleware: Array<express$Middleware>): T;
+declare type express$BaseMiddleware<Req, Res> =
+  ((req: Req, res: Res, next: express$NextFunction) => mixed) |
+  ((error: ?Error, req: Req, res: Res, next: express$NextFunction) => mixed);
+declare type express$Middleware = express$BaseMiddleware<express$Request, express$Response>
+declare interface express$BaseRouteMethodType<Req, Res, T> {
+  (middleware: express$BaseMiddleware<Req, Res>): T;
+  (...middleware: Array<express$BaseMiddleware<Req, Res>>): T;
+  (path: string|RegExp|string[], ...middleware: Array<express$BaseMiddleware<Req, Res>>): T;
 }
-declare interface express$RouterMethodType<T> {
-  (middleware: express$Middleware): T;
-  (...middleware: Array<express$Middleware>): T;
-  (path: string|RegExp|string[], ...middleware: Array<express$Middleware>): T;
-  (path: string, router: express$Router): T;
+declare type express$RouteMethodType<T> = express$BaseRouteMethodType<express$Request, express$Response, T>;
+declare interface express$BaseRouterMethodType<Req, Res, T> {
+  (middleware: express$BaseMiddleware<Req, Res>): T;
+  (...middleware: Array<express$BaseMiddleware<Req, Res>>): T;
+  (path: string|RegExp|string[], ...middleware: Array<express$BaseMiddleware<Req, Res>>): T;
+  (path: string, router: express$BaseRouter<Req, Res>): T;
 }
-declare class express$Route {
-  all: express$RouteMethodType<this>;
-  get: express$RouteMethodType<this>;
-  post: express$RouteMethodType<this>;
-  put: express$RouteMethodType<this>;
-  head: express$RouteMethodType<this>;
-  delete: express$RouteMethodType<this>;
-  options: express$RouteMethodType<this>;
-  trace: express$RouteMethodType<this>;
-  copy: express$RouteMethodType<this>;
-  lock: express$RouteMethodType<this>;
-  mkcol: express$RouteMethodType<this>;
-  move: express$RouteMethodType<this>;
-  purge: express$RouteMethodType<this>;
-  propfind: express$RouteMethodType<this>;
-  proppatch: express$RouteMethodType<this>;
-  unlock: express$RouteMethodType<this>;
-  report: express$RouteMethodType<this>;
-  mkactivity: express$RouteMethodType<this>;
-  checkout: express$RouteMethodType<this>;
-  merge: express$RouteMethodType<this>;
+declare type express$RouterMethodType<T> = express$BaseRouterMethodType<express$Request, express$Response, T>;
+declare class express$BaseRoute<Req, Res> {
+  all: express$BaseRouteMethodType<Req, Res, this>;
+  get: express$BaseRouteMethodType<Req, Res, this>;
+  post: express$BaseRouteMethodType<Req, Res, this>;
+  put: express$BaseRouteMethodType<Req, Res, this>;
+  head: express$BaseRouteMethodType<Req, Res, this>;
+  delete: express$BaseRouteMethodType<Req, Res, this>;
+  options: express$BaseRouteMethodType<Req, Res, this>;
+  trace: express$BaseRouteMethodType<Req, Res, this>;
+  copy: express$BaseRouteMethodType<Req, Res, this>;
+  lock: express$BaseRouteMethodType<Req, Res, this>;
+  mkcol: express$BaseRouteMethodType<Req, Res, this>;
+  move: express$BaseRouteMethodType<Req, Res, this>;
+  purge: express$BaseRouteMethodType<Req, Res, this>;
+  propfind: express$BaseRouteMethodType<Req, Res, this>;
+  proppatch: express$BaseRouteMethodType<Req, Res, this>;
+  unlock: express$BaseRouteMethodType<Req, Res, this>;
+  report: express$BaseRouteMethodType<Req, Res, this>;
+  mkactivity: express$BaseRouteMethodType<Req, Res, this>;
+  checkout: express$BaseRouteMethodType<Req, Res, this>;
+  merge: express$BaseRouteMethodType<Req, Res, this>;
 
   // @TODO Missing 'm-search' but get flow illegal name error.
 
-  notify: express$RouteMethodType<this>;
-  subscribe: express$RouteMethodType<this>;
-  unsubscribe: express$RouteMethodType<this>;
-  patch: express$RouteMethodType<this>;
-  search: express$RouteMethodType<this>;
-  connect: express$RouteMethodType<this>;
+  notify: express$BaseRouteMethodType<Req, Res, this>;
+  subscribe: express$BaseRouteMethodType<Req, Res, this>;
+  unsubscribe: express$BaseRouteMethodType<Req, Res, this>;
+  patch: express$BaseRouteMethodType<Req, Res, this>;
+  search: express$BaseRouteMethodType<Req, Res, this>;
+  connect: express$BaseRouteMethodType<Req, Res, this>;
 }
+declare type express$Route = express$BaseRoute<express$Request, express$Response>;
 
-declare class express$Router extends express$Route {
+declare class express$BaseRouter<Req, Res> extends express$BaseRoute<Req, Res> {
   constructor(options?: express$RouterOptions): void;
-  use: express$RouterMethodType<this>;
-  route(path: string): express$Route;
-  static (): express$Router;
+  use: express$BaseRouterMethodType<Req, Res, this>;
+  route(path: string): express$BaseRoute<Req, Res>;
+  static (): this;
 }
+declare type express$Router = express$BaseRouter<express$Request, express$Response>;
 
-declare class express$Application extends express$Router mixins events$EventEmitter {
+declare class express$BaseApplication<Req, Res> extends express$BaseRouter<Req, Res> mixins events$EventEmitter {
   constructor(): void;
   locals: {[name: string]: mixed};
   mountpath: string;
@@ -162,6 +167,7 @@ declare class express$Application extends express$Router mixins events$EventEmit
   set(name: string, value: mixed): mixed;
   render(name: string, optionsOrFunction: {[name: string]: mixed}, callback: express$RenderCallback): void;
 }
+declare type express$Application = express$BaseApplication<express$Request, express$Response>;
 
 declare module 'express' {
   declare function serveStatic(root: string, options?: Object): express$Middleware;
@@ -175,8 +181,8 @@ declare module 'express' {
   declare type $Application = express$Application;
 
   declare module.exports: {
-    (): express$Application, // If you try to call like a function, it will use this signature
+    (): express$BaseApplication<*, *>, // If you try to call like a function, it will use this signature
     static: serveStatic, // `static` property on the function
-    Router: typeof express$Router, // `Router` property on the function
+    Router: Class<express$Router>, // `Router` property on the function
   };
 }

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -1,12 +1,5 @@
 /* @flow */
 import express, { Router } from 'express';
-import type {
-    $Application,
-    $Request,
-    $Response,
-    Middleware,
-    NextFunction
-} from 'express';
 const app = express();
 
 // $ExpectError property `foo` Property not found in Application:
@@ -22,7 +15,7 @@ const num: number = app.mountpath;
 
 const myRouter = new express.Router();
 
-myRouter.use('/dang', (req, res: $Response, next: NextFunction) => {
+myRouter.use('/dang', (req, res: express$Response, next: express$NextFunction) => {
     res.set('My Header', 'Value');
     res.status(200);
     res.render('someTemplate', {}, (err, html: ?string) => null);
@@ -36,7 +29,7 @@ myRouter.use('/dang', (req, res: $Response, next: NextFunction) => {
 });
 
 
-function handleRequest<MiddleWare>(req: $Request, res: $Response, next: NextFunction): void {
+function handleRequest(req: express$Request, res: express$Response, next: express$NextFunction): void {
     (Math.random() >= 0.5 ? Promise.resolve({ books: ['Catcher and the Rye'] }) :
         Promise.reject(new Error('Something went wrong')))
         .then((data) => {
@@ -47,20 +40,20 @@ function handleRequest<MiddleWare>(req: $Request, res: $Response, next: NextFunc
         });
 }
 
-myRouter.use(handleRequest, (err: ?Error, req: $Request, res: $Response, next: NextFunction): void => {
+myRouter.use(handleRequest, (err: ?Error, req: express$Request, res: express$Response, next: express$NextFunction): void => {
     if (err) {
         console.error(err);
     }
     next(err);
 });
 
-app.on('mount', (parent: $Application) => {
+app.on('mount', (parent: express$Application) => {
     console.log('Parent Loaded', parent);
     // $ExpectError
     parent.fail();
 })
 
-app.use('/foo', (req: $Request, res: $Response, next) => {
+app.use('/foo', (req: express$Request, res: express$Response, next) => {
     // $ExpectError
     res.status('400');
     res.send('should work')
@@ -69,7 +62,7 @@ app.use('/foo', (req: $Request, res: $Response, next) => {
 
 const bar: Router = new Router();
 
-bar.get('/', (req: $Request, res: $Response): void => {
+bar.get('/', (req: express$Request, res: express$Response): void => {
   // $ExpectError should be of type object
   const locals: Array<any> = res.locals;
   res.locals.title = 'Home Page';
@@ -113,25 +106,25 @@ app.render('view', { title: 'News Feed' }, (err: ?Error, html: ?string): void =>
     console.log(html);
 });
 
-app.use('/somewhere', (req: $Request, res: $Response) => {
+app.use('/somewhere', (req: express$Request, res: express$Response) => {
   res.redirect('/somewhere-else');
 });
 
-app.use('/again', (req: $Request, res: $Response) => {
+app.use('/again', (req: express$Request, res: express$Response) => {
   res.redirect(200, '/different');
 });
 
-app.use('/something', (req: $Request, res: $Response) => {
+app.use('/something', (req: express$Request, res: express$Response) => {
   // $ExpectError
   res.redirect('/different', 200);
 });
 
-app.use('/failure', (req: $Request, res: $Response) => {
+app.use('/failure', (req: express$Request, res: express$Response) => {
   // $ExpectError
   res.redirect();
 });
 
-app.use((err: ?Error, req, res, next) => {
+app.use((err: ?Error, req: express$Request, res: express$Response, next: express$NextFunction) => {
     // test req
     req.accepts('accepted/type');
     // test response


### PR DESCRIPTION
**This diff does two things:**
- Keeps backward compatibility
- Adds base classes to accommodate this use case: https://github.com/flowtype/flow-typed/issues/442
- Updates the tests to use namespaced global types added here: https://github.com/flowtype/flow-typed/commit/aac2114da6b7a30ad01667980d623c60cc60f894

**New Usage:**
````javascript
class MyResponseType extends express$Response {}
class MyRequestType extends express$Request {
  session: { [key: string]: mixed };
}

const app: express$BaseApplication<MyRequestType, MyResponseType> = express()

app.use(session({
  //session config
}))

app.use((req: MyRequestType, res: MyResponseType, next: express$NextFunction) => {
  console.log(req.session)
  next()
})
````