### PR TITLE
Remove common eslint warnings from jest.js

### DIFF
--- a/definitions/npm/jest_v17.x.x/flow_v0.33.x-/jest_v17.x.x.js
+++ b/definitions/npm/jest_v17.x.x/flow_v0.33.x-/jest_v17.x.x.js
@@ -30,7 +30,7 @@ type JestMockFn = {
   /**
    * Accepts a function that should be used as the implementation of the mock.
    * The mock itself will still record all calls that go into and instances
-   * that come from itself – the only difference is that the implementation
+   * that come from itself -- the only difference is that the implementation
    * will also be executed when the mock is called.
    */
   mockImplementation(fn: Function): JestMockFn,
@@ -270,7 +270,7 @@ type JestObjectType = {
    * The second argument can be used to specify an explicit module factory that
    * is being run instead of using Jest's automocking feature.
    *
-   * The third argument can be used to create virtual mocks – mocks of modules
+   * The third argument can be used to create virtual mocks -- mocks of modules
    * that don't exist anywhere in the system.
    */
   mock(moduleName: string, moduleFactory?: any): JestObjectType,

--- a/definitions/npm/jest_v17.x.x/flow_v0.33.x-/jest_v17.x.x.js
+++ b/definitions/npm/jest_v17.x.x/flow_v0.33.x-/jest_v17.x.x.js
@@ -1,178 +1,177 @@
 
 type JestMockFn = {
-  (...args: Array<any>): any;
+  (...args: Array<any>): any,
   /** An object for introspecting mock calls */
   mock: {
     /** An array that represents all calls that have been made into this mock function. Each call is represented by an array of arguments that were passed during the call. */
-    calls: Array<Array<any>>;
+    calls: Array<Array<any>>,
     /** An array that contains all the object instances that have been instantiated from this mock function. */
-    instances: mixed;
-  };
+    instances: mixed,
+  },
   /** Resets all information stored in the mockFn.mock.calls and mockFn.mock.instances arrays.
    * Often this is useful when you want to clean up a mock's usage data between two assertions.
   */
-  mockClear(): Function;
+  mockClear(): Function,
   /** Resets all information stored in the mock
    * This is useful when you want to completely restore a mock back to its initial state.
   */
-  mockReset(): Function;
+  mockReset(): Function,
   /** Accepts a function that should be used as the implementation of the mock. The mock itself will still record all calls that go into and instances that come from itself – the only difference is that the implementation will also be executed when the mock is called. */
-  mockImplementation(fn: Function): JestMockFn;
+  mockImplementation(fn: Function): JestMockFn,
   /** Accepts a function that will be used as an implementation of the mock for one call to the mocked function. Can be chained so that multiple function calls produce different results. */
-  mockImplementationOnce(fn: Function): JestMockFn;
+  mockImplementationOnce(fn: Function): JestMockFn,
   /** Just a simple sugar function for returning `this` */
-  mockReturnThis(): void;
+  mockReturnThis(): void,
   /** Deprecated: use jest.fn(() => value) instead */
-  mockReturnValue(value: any): JestMockFn;
+  mockReturnValue(value: any): JestMockFn,
   /** Sugar for only returning a value once inside your mock */
-  mockReturnValueOnce(value: any): JestMockFn;
+  mockReturnValueOnce(value: any): JestMockFn,
 }
 
 type JestAsymmetricEqualityType = {
   /** A custom Jasmine equality tester */
-  asymmetricMatch(value: mixed): boolean;
+  asymmetricMatch(value: mixed): boolean,
 }
 
 type JestCallsType = {
-  allArgs(): mixed;
-  all(): mixed;
-  any(): boolean;
-  count(): number;
-  first(): mixed;
-  mostRecent(): mixed;
-  reset(): void;
+  allArgs(): mixed,
+  all(): mixed,
+  any(): boolean,
+  count(): number,
+  first(): mixed,
+  mostRecent(): mixed,
+  reset(): void,
 }
 
 type JestClockType = {
-  install(): void;
-  mockDate(date: Date): void;
-  tick(): void;
-  uninstall(): void;
+  install(): void,
+  mockDate(date: Date): void,
+  tick(): void,
+  uninstall(): void,
 }
 
 type JestMatcherResult = {
-  message?: string | ()=>string;
-  pass: boolean;
-};
+  message?: string | ()=>string,
+  pass: boolean,
+}
 
 type JestMatcher = (actual: any, expected: any) => JestMatcherResult;
 
 type JestExpectType = {
-  not: JestExpectType;
+  not: JestExpectType,
   /** If you have a mock function, you can use .lastCalledWith to test what arguments it was last called with. */
-  lastCalledWith(...args: Array<any>): void;
+  lastCalledWith(...args: Array<any>): void,
   /** toBe just checks that a value is what you expect. It uses === to check strict equality. */
-  toBe(value: any): void;
+  toBe(value: any): void,
   /** Use .toHaveBeenCalled to ensure that a mock function got called. */
-  toBeCalled(): void;
+  toBeCalled(): void,
   /** Use .toBeCalledWith to ensure that a mock function was called with specific arguments. */
-  toBeCalledWith(...args: Array<any>): void;
+  toBeCalledWith(...args: Array<any>): void,
   /** Using exact equality with floating point numbers is a bad idea. Rounding means that intuitive things fail. */
-  toBeCloseTo(num: number, delta: any): void;
+  toBeCloseTo(num: number, delta: any): void,
   /** Use .toBeDefined to check that a variable is not undefined. */
-  toBeDefined(): void;
+  toBeDefined(): void,
   /** Use .toBeFalsy when you don't care what a value is, you just want to ensure a value is false in a boolean context. */
-  toBeFalsy(): void;
+  toBeFalsy(): void,
   /** To compare floating point numbers, you can use toBeGreaterThan. */
-  toBeGreaterThan(number: number): void;
+  toBeGreaterThan(number: number): void,
   /** To compare floating point numbers, you can use toBeGreaterThanOrEqual. */
-  toBeGreaterThanOrEqual(number: number): void;
+  toBeGreaterThanOrEqual(number: number): void,
   /** To compare floating point numbers, you can use toBeLessThan. */
-  toBeLessThan(number: number): void;
+  toBeLessThan(number: number): void,
   /** To compare floating point numbers, you can use toBeLessThanOrEqual. */
-  toBeLessThanOrEqual(number: number): void;
+  toBeLessThanOrEqual(number: number): void,
   /** Use .toBeInstanceOf(Class) to check that an object is an instance of a class.  */
-  toBeInstanceOf(cls: Class<*>): void;
+  toBeInstanceOf(cls: Class<*>): void,
   /** .toBeNull() is the same as .toBe(null) but the error messages are a bit nicer. */
-  toBeNull(): void;
+  toBeNull(): void,
   /** Use .toBeTruthy when you don't care what a value is, you just want to ensure a value is true in a boolean context. */
-  toBeTruthy(): void;
+  toBeTruthy(): void,
   /** Use .toBeUndefined to check that a variable is undefined. */
-  toBeUndefined(): void;
+  toBeUndefined(): void,
   /** Use .toContain when you want to check that an item is in a list. For testing the items in the list, this uses ===, a strict equality check. */
-  toContain(item: any): void;
-  /** Use .toContainEqual when you want to check that an item is in a list. For testing the items in the list, this matcher recursively checks the equality of all fields, rather than checking for object identity.
- */
-  toContainEqual(item: any): void;
+  toContain(item: any): void,
+  /** Use .toContainEqual when you want to check that an item is in a list. For testing the items in the list, this matcher recursively checks the equality of all fields, rather than checking for object identity. */
+  toContainEqual(item: any): void,
   /** Use .toEqual when you want to check that two objects have the same value. This matcher recursively checks the equality of all fields, rather than checking for object identity. */
-  toEqual(value: any): void;
+  toEqual(value: any): void,
   /** Use .toHaveBeenCalled to ensure that a mock function got called. */
-  toHaveBeenCalled(): void;
+  toHaveBeenCalled(): void,
   /** Use .toHaveBeenCalledTimes to ensure that a mock function got called exact number of times. */
-  toHaveBeenCalledTimes(number: number): void;
+  toHaveBeenCalledTimes(number: number): void,
   /** Use .toHaveBeenCalledWith to ensure that a mock function was called with specific arguments. */
-  toHaveBeenCalledWith(...args: Array<any>): void;
+  toHaveBeenCalledWith(...args: Array<any>): void,
   /** Use .toMatch to check that a string matches a regular expression. */
-  toMatch(regexp: RegExp): void;
+  toMatch(regexp: RegExp): void,
   /** This ensures that a React component matches the most recent snapshot. */
-  toMatchSnapshot(): void;
+  toMatchSnapshot(): void,
   /** Use .toThrow to test that a function throws when it is called. */
-  toThrow(message?: string | Error): void;
+  toThrow(message?: string | Error): void,
   /** Use .toThrowError to test that a function throws a specific error when it is called. The argument can be a string for the error message, a class for the error, or a regex that should match the error. */
-  toThrowError(message?: string | Error | RegExp): void;
+  toThrowError(message?: string | Error | RegExp): void,
   /** Use .toThrowErrorMatchingSnapshot to test that a function throws a error matching the most recent snapshot when it is called. */
-  toThrowErrorMatchingSnapshot(): void;
+  toThrowErrorMatchingSnapshot(): void,
 }
 
 type JestObjectType = {
   /**
    *  Disables automatic mocking in the module loader.
-   * 
+   *
    *  After this method is called, all `require()`s will return the real versions of each module (rather than a mocked version).
    */
-  disableAutomock(): JestObjectType;
+  disableAutomock(): JestObjectType,
   /** An un-hoisted version of disableAutomock */
-  autoMockOff(): JestObjectType;
+  autoMockOff(): JestObjectType,
   /** Enables automatic mocking in the module loader. */
-  enableAutomock(): JestObjectType;
+  enableAutomock(): JestObjectType,
     /** An un-hoisted version of enableAutomock */
-  autoMockOn(): JestObjectType;
+  autoMockOn(): JestObjectType,
   /** Resets the state of all mocks. Equivalent to calling .mockReset() on every mocked function. */
-  resetAllMocks(): JestObjectType;
+  resetAllMocks(): JestObjectType,
   /** Removes any pending timers from the timer system. */
-  clearAllTimers(): void;
+  clearAllTimers(): void,
   /** The same as `mock` but not moved to the top of the expectation by babel-jest. */
   doMock(moduleName: string, moduleFactory?: any): JestObjectType,
   /** The same as `unmock` but not moved to the top of the expectation by babel-jest. */
   dontMock(moduleName: string): JestObjectType,
   /** Returns a new, unused mock function. Optionally takes a mock implementation. */
-  fn(implementation?: Function): JestMockFn;
+  fn(implementation?: Function): JestMockFn,
   /** Determines if the given function is a mocked function. */
-  isMockFunction(fn: Function): boolean;
+  isMockFunction(fn: Function): boolean,
   /** Given the name of a module, use the automatic mocking system to generate a mocked version of the module for you. */
-  genMockFromModule(moduleName: string): any;
-  /** 
-   * Mocks a module with an auto-mocked version when it is being required. 
-   * 
+  genMockFromModule(moduleName: string): any,
+  /**
+   * Mocks a module with an auto-mocked version when it is being required.
+   *
    * The second argument can be used to specify an explicit module factory that is being run instead of using Jest's automocking feature.
-   *  
+   *
    * The third argument can be used to create virtual mocks – mocks of modules that don't exist anywhere in the system.
    */
-  mock(moduleName: string, moduleFactory?: any): JestObjectType;
+  mock(moduleName: string, moduleFactory?: any): JestObjectType,
   /** Resets the module registry - the cache of all required modules. This is useful to isolate modules where local state might conflict between tests. */
-  resetModules(): JestObjectType;
+  resetModules(): JestObjectType,
   /** Exhausts the micro-task queue (usually interfaced in node via process.nextTick). */
-  runAllTicks(): void;
+  runAllTicks(): void,
   /** Exhausts the macro-task queue (i.e., all tasks queued by setTimeout(), setInterval(), and setImmediate()). */
-  runAllTimers(): void;
+  runAllTimers(): void,
   /** Exhausts all tasks queued by setImmediate(). */
-  runAllImmediates(): void;
+  runAllImmediates(): void,
   /** Executes only the macro task queue (i.e. all tasks queued by setTimeout() or setInterval() and setImmediate()). */
-  runTimersToTime(msToRun: number): void;
+  runTimersToTime(msToRun: number): void,
   /** Executes only the macro-tasks that are currently pending (i.e., only the tasks that have been queued by setTimeout() or setInterval() up to this point) */
-  runOnlyPendingTimers(): void;
+  runOnlyPendingTimers(): void,
   /** Explicitly supplies the mock object that the module system should return for the specified module. Note: It is recommended to use jest.mock() instead. */
-  setMock(moduleName: string, moduleExports: any): JestObjectType;
+  setMock(moduleName: string, moduleExports: any): JestObjectType,
   /** Indicates that the module system should never return a mocked version of the specified module from require() (e.g. that it should always return the real module). */
-  unmock(moduleName: string): JestObjectType;
+  unmock(moduleName: string): JestObjectType,
   /** Instructs Jest to use fake versions of the standard timer functions (setTimeout, setInterval, clearTimeout, clearInterval, nextTick, setImmediate and clearImmediate). */
-  useFakeTimers(): JestObjectType;
+  useFakeTimers(): JestObjectType,
   /** Instructs Jest to use the real versions of the standard timer functions. */
-  useRealTimers(): JestObjectType;
-} 
+  useRealTimers(): JestObjectType,
+}
 
 type JestSpyType = {
-  calls: JestCallsType;
+  calls: JestCallsType,
 }
 
 /** Runs this function after every test inside this context */
@@ -188,27 +187,27 @@ declare function describe(name: string, fn: Function): void;
 
 /** An individual test unit */
 declare var it: {
-  /**  
+  /**
    * An individual test unit
-   * 
+   *
    * @param {string} Name of Test
    * @param {Function} Test
    */
-  (name: string, fn?: Function): ?Promise<void>;
-  /**  
+  (name: string, fn?: Function): ?Promise<void>,
+  /**
    * Only run this test
-   * 
+   *
    * @param {string} Name of Test
    * @param {Function} Test
    */
-  only(name: string, fn?: Function): ?Promise<void>;
-  /**  
+  only(name: string, fn?: Function): ?Promise<void>,
+  /**
    * Skip running this test
-   * 
+   *
    * @param {string} Name of Test
    * @param {Function} Test
    */
-  skip(name: string, fn?: Function): ?Promise<void>;
+  skip(name: string, fn?: Function): ?Promise<void>,
 };
 declare function fit(name: string, fn: Function): ?Promise<void>;
 /** An individual test unit */
@@ -225,9 +224,9 @@ declare var xtest: typeof it;
 /** The expect function is used every time you want to test a value */
 declare var expect: {
   /** The object that you want to make assertions against */
-  (value: any): JestExpectType;
+  (value: any): JestExpectType,
   /** Add additional Jasmine matchers to Jest's roster */
-  extend(matchers: {[name:string]: JestMatcher}): void;
+  extend(matchers: {[name:string]: JestMatcher}): void,
 };
 
 // TODO handle return type
@@ -237,17 +236,17 @@ declare function spyOn(value: mixed, method: string): Object;
 /** Holds all functions related to manipulating test runner */
 declare var jest: JestObjectType
 
-/** 
- * The global Jamine object, this is generally not exposed as the public API, 
+/**
+ * The global Jamine object, this is generally not exposed as the public API,
  * using features inside here could break in later versions of Jest.
  */
 declare var jasmine: {
-  DEFAULT_TIMEOUT_INTERVAL: number;
-  any(value: mixed): JestAsymmetricEqualityType;
-  anything(): void;
-  arrayContaining(value: mixed[]): void;
-  clock(): JestClockType;
-  createSpy(name: string): JestSpyType;
-  objectContaining(value: Object): void;
-  stringMatching(value: string): void;
+  DEFAULT_TIMEOUT_INTERVAL: number,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): void,
+  arrayContaining(value: mixed[]): void,
+  clock(): JestClockType,
+  createSpy(name: string): JestSpyType,
+  objectContaining(value: Object): void,
+  stringMatching(value: string): void,
 }

--- a/definitions/npm/jest_v17.x.x/flow_v0.33.x-/jest_v17.x.x.js
+++ b/definitions/npm/jest_v17.x.x/flow_v0.33.x-/jest_v17.x.x.js
@@ -1,35 +1,63 @@
-
 type JestMockFn = {
   (...args: Array<any>): any,
-  /** An object for introspecting mock calls */
+  /**
+   * An object for introspecting mock calls
+   */
   mock: {
-    /** An array that represents all calls that have been made into this mock function. Each call is represented by an array of arguments that were passed during the call. */
+    /**
+     * An array that represents all calls that have been made into this mock
+     * function. Each call is represented by an array of arguments that were
+     * passed during the call.
+     */
     calls: Array<Array<any>>,
-    /** An array that contains all the object instances that have been instantiated from this mock function. */
+    /**
+     * An array that contains all the object instances that have been
+     * instantiated from this mock function.
+     */
     instances: mixed,
   },
-  /** Resets all information stored in the mockFn.mock.calls and mockFn.mock.instances arrays.
-   * Often this is useful when you want to clean up a mock's usage data between two assertions.
-  */
+  /**
+   * Resets all information stored in the mockFn.mock.calls and
+   * mockFn.mock.instances arrays. Often this is useful when you want to clean
+   * up a mock's usage data between two assertions.
+   */
   mockClear(): Function,
-  /** Resets all information stored in the mock
-   * This is useful when you want to completely restore a mock back to its initial state.
-  */
+  /**
+   * Resets all information stored in the mock. This is useful when you want to
+   * completely restore a mock back to its initial state.
+   */
   mockReset(): Function,
-  /** Accepts a function that should be used as the implementation of the mock. The mock itself will still record all calls that go into and instances that come from itself – the only difference is that the implementation will also be executed when the mock is called. */
+  /**
+   * Accepts a function that should be used as the implementation of the mock.
+   * The mock itself will still record all calls that go into and instances
+   * that come from itself – the only difference is that the implementation
+   * will also be executed when the mock is called.
+   */
   mockImplementation(fn: Function): JestMockFn,
-  /** Accepts a function that will be used as an implementation of the mock for one call to the mocked function. Can be chained so that multiple function calls produce different results. */
+  /**
+   * Accepts a function that will be used as an implementation of the mock for
+   * one call to the mocked function. Can be chained so that multiple function
+   * calls produce different results.
+   */
   mockImplementationOnce(fn: Function): JestMockFn,
-  /** Just a simple sugar function for returning `this` */
+  /**
+   * Just a simple sugar function for returning `this`
+   */
   mockReturnThis(): void,
-  /** Deprecated: use jest.fn(() => value) instead */
+  /**
+   * Deprecated: use jest.fn(() => value) instead
+   */
   mockReturnValue(value: any): JestMockFn,
-  /** Sugar for only returning a value once inside your mock */
+  /**
+   * Sugar for only returning a value once inside your mock
+   */
   mockReturnValueOnce(value: any): JestMockFn,
 }
 
 type JestAsymmetricEqualityType = {
-  /** A custom Jasmine equality tester */
+  /**
+   * A custom Jasmine equality tester
+   */
   asymmetricMatch(value: mixed): boolean,
 }
 
@@ -59,57 +87,127 @@ type JestMatcher = (actual: any, expected: any) => JestMatcherResult;
 
 type JestExpectType = {
   not: JestExpectType,
-  /** If you have a mock function, you can use .lastCalledWith to test what arguments it was last called with. */
+  /**
+   * If you have a mock function, you can use .lastCalledWith to test what
+   * arguments it was last called with.
+   */
   lastCalledWith(...args: Array<any>): void,
-  /** toBe just checks that a value is what you expect. It uses === to check strict equality. */
+  /**
+   * toBe just checks that a value is what you expect. It uses === to check
+   * strict equality.
+   */
   toBe(value: any): void,
-  /** Use .toHaveBeenCalled to ensure that a mock function got called. */
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
   toBeCalled(): void,
-  /** Use .toBeCalledWith to ensure that a mock function was called with specific arguments. */
+  /**
+   * Use .toBeCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
   toBeCalledWith(...args: Array<any>): void,
-  /** Using exact equality with floating point numbers is a bad idea. Rounding means that intuitive things fail. */
+  /**
+   * Using exact equality with floating point numbers is a bad idea. Rounding
+   * means that intuitive things fail.
+   */
   toBeCloseTo(num: number, delta: any): void,
-  /** Use .toBeDefined to check that a variable is not undefined. */
+  /**
+   * Use .toBeDefined to check that a variable is not undefined.
+   */
   toBeDefined(): void,
-  /** Use .toBeFalsy when you don't care what a value is, you just want to ensure a value is false in a boolean context. */
+  /**
+   * Use .toBeFalsy when you don't care what a value is, you just want to
+   * ensure a value is false in a boolean context.
+   */
   toBeFalsy(): void,
-  /** To compare floating point numbers, you can use toBeGreaterThan. */
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThan.
+   */
   toBeGreaterThan(number: number): void,
-  /** To compare floating point numbers, you can use toBeGreaterThanOrEqual. */
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThanOrEqual.
+   */
   toBeGreaterThanOrEqual(number: number): void,
-  /** To compare floating point numbers, you can use toBeLessThan. */
+  /**
+   * To compare floating point numbers, you can use toBeLessThan.
+   */
   toBeLessThan(number: number): void,
-  /** To compare floating point numbers, you can use toBeLessThanOrEqual. */
+  /**
+   * To compare floating point numbers, you can use toBeLessThanOrEqual.
+   */
   toBeLessThanOrEqual(number: number): void,
-  /** Use .toBeInstanceOf(Class) to check that an object is an instance of a class.  */
+  /**
+   * Use .toBeInstanceOf(Class) to check that an object is an instance of a
+   * class.
+   */
   toBeInstanceOf(cls: Class<*>): void,
-  /** .toBeNull() is the same as .toBe(null) but the error messages are a bit nicer. */
+  /**
+   * .toBeNull() is the same as .toBe(null) but the error messages are a bit
+   * nicer.
+   */
   toBeNull(): void,
-  /** Use .toBeTruthy when you don't care what a value is, you just want to ensure a value is true in a boolean context. */
+  /**
+   * Use .toBeTruthy when you don't care what a value is, you just want to
+   * ensure a value is true in a boolean context.
+   */
   toBeTruthy(): void,
-  /** Use .toBeUndefined to check that a variable is undefined. */
+  /**
+   * Use .toBeUndefined to check that a variable is undefined.
+   */
   toBeUndefined(): void,
-  /** Use .toContain when you want to check that an item is in a list. For testing the items in the list, this uses ===, a strict equality check. */
+  /**
+   * Use .toContain when you want to check that an item is in a list. For
+   * testing the items in the list, this uses ===, a strict equality check.
+   */
   toContain(item: any): void,
-  /** Use .toContainEqual when you want to check that an item is in a list. For testing the items in the list, this matcher recursively checks the equality of all fields, rather than checking for object identity. */
+  /**
+   * Use .toContainEqual when you want to check that an item is in a list. For
+   * testing the items in the list, this matcher recursively checks the
+   * equality of all fields, rather than checking for object identity.
+   */
   toContainEqual(item: any): void,
-  /** Use .toEqual when you want to check that two objects have the same value. This matcher recursively checks the equality of all fields, rather than checking for object identity. */
+  /**
+   * Use .toEqual when you want to check that two objects have the same value.
+   * This matcher recursively checks the equality of all fields, rather than
+   * checking for object identity.
+   */
   toEqual(value: any): void,
-  /** Use .toHaveBeenCalled to ensure that a mock function got called. */
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
   toHaveBeenCalled(): void,
-  /** Use .toHaveBeenCalledTimes to ensure that a mock function got called exact number of times. */
+  /**
+   * Use .toHaveBeenCalledTimes to ensure that a mock function got called exact
+   * number of times.
+   */
   toHaveBeenCalledTimes(number: number): void,
-  /** Use .toHaveBeenCalledWith to ensure that a mock function was called with specific arguments. */
+  /**
+   * Use .toHaveBeenCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
   toHaveBeenCalledWith(...args: Array<any>): void,
-  /** Use .toMatch to check that a string matches a regular expression. */
+  /**
+   * Use .toMatch to check that a string matches a regular expression.
+   */
   toMatch(regexp: RegExp): void,
-  /** This ensures that a React component matches the most recent snapshot. */
+  /**
+   * This ensures that a React component matches the most recent snapshot.
+   */
   toMatchSnapshot(): void,
-  /** Use .toThrow to test that a function throws when it is called. */
+  /**
+   * Use .toThrow to test that a function throws when it is called.
+   */
   toThrow(message?: string | Error): void,
-  /** Use .toThrowError to test that a function throws a specific error when it is called. The argument can be a string for the error message, a class for the error, or a regex that should match the error. */
+  /**
+   * Use .toThrowError to test that a function throws a specific error when it
+   * is called. The argument can be a string for the error message, a class for
+   * the error, or a regex that should match the error.
+   */
   toThrowError(message?: string | Error | RegExp): void,
-  /** Use .toThrowErrorMatchingSnapshot to test that a function throws a error matching the most recent snapshot when it is called. */
+  /**
+   * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
+   * matching the most recent snapshot when it is called.
+   */
   toThrowErrorMatchingSnapshot(): void,
 }
 
@@ -117,56 +215,116 @@ type JestObjectType = {
   /**
    *  Disables automatic mocking in the module loader.
    *
-   *  After this method is called, all `require()`s will return the real versions of each module (rather than a mocked version).
+   *  After this method is called, all `require()`s will return the real
+   *  versions of each module (rather than a mocked version).
    */
   disableAutomock(): JestObjectType,
-  /** An un-hoisted version of disableAutomock */
+  /**
+   * An un-hoisted version of disableAutomock
+   */
   autoMockOff(): JestObjectType,
-  /** Enables automatic mocking in the module loader. */
+  /**
+   * Enables automatic mocking in the module loader.
+   */
   enableAutomock(): JestObjectType,
-    /** An un-hoisted version of enableAutomock */
+  /**
+   * An un-hoisted version of enableAutomock
+   */
   autoMockOn(): JestObjectType,
-  /** Resets the state of all mocks. Equivalent to calling .mockReset() on every mocked function. */
+  /**
+   * Resets the state of all mocks. Equivalent to calling .mockReset() on every
+   * mocked function.
+   */
   resetAllMocks(): JestObjectType,
-  /** Removes any pending timers from the timer system. */
+  /**
+   * Removes any pending timers from the timer system.
+   */
   clearAllTimers(): void,
-  /** The same as `mock` but not moved to the top of the expectation by babel-jest. */
+  /**
+   * The same as `mock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
   doMock(moduleName: string, moduleFactory?: any): JestObjectType,
-  /** The same as `unmock` but not moved to the top of the expectation by babel-jest. */
+  /**
+   * The same as `unmock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
   dontMock(moduleName: string): JestObjectType,
-  /** Returns a new, unused mock function. Optionally takes a mock implementation. */
+  /**
+   * Returns a new, unused mock function. Optionally takes a mock
+   * implementation.
+   */
   fn(implementation?: Function): JestMockFn,
-  /** Determines if the given function is a mocked function. */
+  /**
+   * Determines if the given function is a mocked function.
+   */
   isMockFunction(fn: Function): boolean,
-  /** Given the name of a module, use the automatic mocking system to generate a mocked version of the module for you. */
+  /**
+   * Given the name of a module, use the automatic mocking system to generate a
+   * mocked version of the module for you.
+   */
   genMockFromModule(moduleName: string): any,
   /**
    * Mocks a module with an auto-mocked version when it is being required.
    *
-   * The second argument can be used to specify an explicit module factory that is being run instead of using Jest's automocking feature.
+   * The second argument can be used to specify an explicit module factory that
+   * is being run instead of using Jest's automocking feature.
    *
-   * The third argument can be used to create virtual mocks – mocks of modules that don't exist anywhere in the system.
+   * The third argument can be used to create virtual mocks – mocks of modules
+   * that don't exist anywhere in the system.
    */
   mock(moduleName: string, moduleFactory?: any): JestObjectType,
-  /** Resets the module registry - the cache of all required modules. This is useful to isolate modules where local state might conflict between tests. */
+  /**
+   * Resets the module registry - the cache of all required modules. This is
+   * useful to isolate modules where local state might conflict between tests.
+   */
   resetModules(): JestObjectType,
-  /** Exhausts the micro-task queue (usually interfaced in node via process.nextTick). */
+  /**
+   * Exhausts the micro-task queue (usually interfaced in node via
+   * process.nextTick).
+   */
   runAllTicks(): void,
-  /** Exhausts the macro-task queue (i.e., all tasks queued by setTimeout(), setInterval(), and setImmediate()). */
+  /**
+   * Exhausts the macro-task queue (i.e., all tasks queued by setTimeout(),
+   * setInterval(), and setImmediate()).
+   */
   runAllTimers(): void,
-  /** Exhausts all tasks queued by setImmediate(). */
+  /**
+   * Exhausts all tasks queued by setImmediate().
+   */
   runAllImmediates(): void,
-  /** Executes only the macro task queue (i.e. all tasks queued by setTimeout() or setInterval() and setImmediate()). */
+  /**
+   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+   * or setInterval() and setImmediate()).
+   */
   runTimersToTime(msToRun: number): void,
-  /** Executes only the macro-tasks that are currently pending (i.e., only the tasks that have been queued by setTimeout() or setInterval() up to this point) */
+  /**
+   * Executes only the macro-tasks that are currently pending (i.e., only the
+   * tasks that have been queued by setTimeout() or setInterval() up to this
+   * point)
+   */
   runOnlyPendingTimers(): void,
-  /** Explicitly supplies the mock object that the module system should return for the specified module. Note: It is recommended to use jest.mock() instead. */
+  /**
+   * Explicitly supplies the mock object that the module system should return
+   * for the specified module. Note: It is recommended to use jest.mock()
+   * instead.
+   */
   setMock(moduleName: string, moduleExports: any): JestObjectType,
-  /** Indicates that the module system should never return a mocked version of the specified module from require() (e.g. that it should always return the real module). */
+  /**
+   * Indicates that the module system should never return a mocked version of
+   * the specified module from require() (e.g. that it should always return the
+   * real module).
+   */
   unmock(moduleName: string): JestObjectType,
-  /** Instructs Jest to use fake versions of the standard timer functions (setTimeout, setInterval, clearTimeout, clearInterval, nextTick, setImmediate and clearImmediate). */
+  /**
+   * Instructs Jest to use fake versions of the standard timer functions
+   * (setTimeout, setInterval, clearTimeout, clearInterval, nextTick,
+   * setImmediate and clearImmediate).
+   */
   useFakeTimers(): JestObjectType,
-  /** Instructs Jest to use the real versions of the standard timer functions. */
+  /**
+   * Instructs Jest to use the real versions of the standard timer functions.
+   */
   useRealTimers(): JestObjectType,
 }
 

--- a/definitions/npm/jest_v17.x.x/flow_v0.33.x-/jest_v17.x.x.js
+++ b/definitions/npm/jest_v17.x.x/flow_v0.33.x-/jest_v17.x.x.js
@@ -402,7 +402,7 @@ declare var jasmine: {
   DEFAULT_TIMEOUT_INTERVAL: number,
   any(value: mixed): JestAsymmetricEqualityType,
   anything(): void,
-  arrayContaining(value: mixed[]): void,
+  arrayContaining(value: Array<mixed>): void,
   clock(): JestClockType,
   createSpy(name: string): JestSpyType,
   objectContaining(value: Object): void,

--- a/definitions/npm/jest_v17.x.x/flow_v0.33.x-/jest_v17.x.x.js
+++ b/definitions/npm/jest_v17.x.x/flow_v0.33.x-/jest_v17.x.x.js
@@ -132,9 +132,9 @@ type JestObjectType = {
   /** Removes any pending timers from the timer system. */
   clearAllTimers(): void;
   /** The same as `mock` but not moved to the top of the expectation by babel-jest. */
-  doMock(moduleName: string, moduleFactory?: any): void;
+  doMock(moduleName: string, moduleFactory?: any): JestObjectType,
   /** The same as `unmock` but not moved to the top of the expectation by babel-jest. */
-  dontMock(moduleName: string): void;
+  dontMock(moduleName: string): JestObjectType,
   /** Returns a new, unused mock function. Optionally takes a mock implementation. */
   fn(implementation?: Function): JestMockFn;
   /** Determines if the given function is a mocked function. */
@@ -148,9 +148,9 @@ type JestObjectType = {
    *  
    * The third argument can be used to create virtual mocks – mocks of modules that don't exist anywhere in the system.
    */
-  mock(moduleName: string, moduleFactory?: any): JestMockFn;
+  mock(moduleName: string, moduleFactory?: any): JestObjectType;
   /** Resets the module registry - the cache of all required modules. This is useful to isolate modules where local state might conflict between tests. */
-  resetModules(): void;
+  resetModules(): JestObjectType;
   /** Exhausts the micro-task queue (usually interfaced in node via process.nextTick). */
   runAllTicks(): void;
   /** Exhausts the macro-task queue (i.e., all tasks queued by setTimeout(), setInterval(), and setImmediate()). */

--- a/definitions/npm/jest_v17.x.x/test_jest-v17.x.x.js
+++ b/definitions/npm/jest_v17.x.x/test_jest-v17.x.x.js
@@ -66,3 +66,16 @@ expect(() => {
 expect(() => {
     throw err;
 }).toThrowError(err);
+
+// Test method chaining fixes
+jest
+  .doMock('testModule1', () => { })
+  .doMock('testModule2', () => { });
+
+jest
+  .dontMock('testModule1')
+  .dontMock('testModule2');
+
+jest
+  .resetModules()
+  .resetModules();


### PR DESCRIPTION
* There are many common eslint warnings that trigger on jest.js, this diff removes them.
* There are a few errors in which methods allow chaining of the jest object and this diff addresses those errors by changing the return type from void to JestObjectType.