### PR TITLE
fix: express$Response mixins with http$ServerResponse

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_v0.25.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.25.x-/express_v4.x.x.js
@@ -62,7 +62,7 @@ declare type express$SendFileOptions = {
   dotfiles?: 'allow' | 'deny' | 'ignore'
 };
 
-declare class express$Response extends http$ClientRequest mixins express$RequestResponseBase {
+declare class express$Response extends http$ClientRequest mixins express$RequestResponseBase, http$ServerResponse {
   headersSent: boolean;
   locals: {[name: string]: mixed};
   append(field: string, value?: string): this;


### PR DESCRIPTION
using the builtin http$ServerResponse class since the express.response class has these methods (in my case noticed `writeHead` missing)
https://github.com/facebook/flow/blob/master/lib/node.js#L879