### PR TITLE
Update moment queries (isAfter...) to be called without params

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.28.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.28.x-/moment_v2.x.x.js
@@ -192,11 +192,11 @@ declare class moment$Moment {
   toJSON(): string;
   toISOString(): string;
   toObject(): moment$MomentObject;
-  isBefore(date: moment$Moment|string|number|Date|Array<number>): bool;
-  isSame(date: moment$Moment|string|number|Date|Array<number>): bool;
-  isAfter(date: moment$Moment|string|number|Date|Array<number>): bool;
-  isSameOrBefore(date: moment$Moment|string|number|Date|Array<number>): bool;
-  isSameOrAfter(date: moment$Moment|string|number|Date|Array<number>): bool;
+  isBefore(date?: moment$Moment|string|number|Date|Array<number>): bool;
+  isSame(date?: moment$Moment|string|number|Date|Array<number>): bool;
+  isAfter(date?: moment$Moment|string|number|Date|Array<number>): bool;
+  isSameOrBefore(date?: moment$Moment|string|number|Date|Array<number>): bool;
+  isSameOrAfter(date?: moment$Moment|string|number|Date|Array<number>): bool;
   isBetween(date: moment$Moment|string|number|Date|Array<number>): bool;
   isDST(): bool;
   isDSTShifted(): bool;

--- a/definitions/npm/moment_v2.x.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.x.x/test_moment-v2.js
@@ -14,3 +14,9 @@ moment.unix('1234');
 moment().millisecond().seconds();
 
 moment().milliseconds(100).seconds();
+
+moment().isBefore();
+moment().isSame();
+moment().isAfter();
+moment().isSameOrBefore();
+moment().isSameOrAfter();


### PR DESCRIPTION
`isAfter|isBefore`etc. can also be called without any parameters. From the doc: 

> If nothing is passed to `moment#isBefore`, it will default to the current time.