### PR TITLE
Update node-slug options configuration

### DIFF
--- a/definitions/npm/slug_v0.9.x/flow_v0.28.x-/slug_v0.9.x.js
+++ b/definitions/npm/slug_v0.9.x/flow_v0.28.x-/slug_v0.9.x.js
@@ -2,13 +2,13 @@ type SlugMode = 'rfc3986' | 'pretty'
 
 declare module 'slug' {
   declare type SlugOptions = {
-    mode: SlugMode,
-    replacement: string,
-    multicharmap: { [key: string]: string },
-    charmap: { [key: string]: string },
-    remove: RegExp,
-    lower: boolean,
-    symbol: boolean,
+    mode?: SlugMode,
+    replacement?: string,
+    multicharmap?: { [key: string]: string },
+    charmap?: { [key: string]: string },
+    remove?: ?RegExp,
+    lower?: boolean,
+    symbols?: boolean,
   }
   declare module.exports: {
       (input: string, optionOrReplacement?: string | SlugOptions): string,

--- a/definitions/npm/slug_v0.9.x/test_slug_v0.9.x.js
+++ b/definitions/npm/slug_v0.9.x/test_slug_v0.9.x.js
@@ -16,6 +16,8 @@ slug('Hello world', { mode: 'invalid_mode' })
 // $ExpectError
 slug('Hello world', { remove: 'hello' })
 
+slug('Hello world', { remove: null })
+
 // $ExpectError
 slug('Hello world', { symbols: 'hello' })
 


### PR DESCRIPTION
All the keys of the option don't have to be set, we can for instance see in the package's tests such an example: `slug("foo bar baz", {charmap})`.