### PR TITLE
Update moment_v2.x.x.js

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.28.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.28.x-/moment_v2.x.x.js
@@ -176,7 +176,7 @@ declare class moment$Moment {
   local(): this;
   utc(): this;
   utcOffset(offset: number|string): void;
-  utcOffset(): number|string;
+  utcOffset(): number;
   format(format?: string): string;
   fromNow(removeSuffix?: bool): string;
   from(value: moment$Moment|string|number|Date|Array<number>, removePrefix?: bool): string;

--- a/definitions/npm/moment_v2.x.x/flow_v0.28.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.28.x-/moment_v2.x.x.js
@@ -176,7 +176,7 @@ declare class moment$Moment {
   local(): this;
   utc(): this;
   utcOffset(offset: number|string): void;
-  utcOffset(): number;
+  utcOffset(): number|this;
   format(format?: string): string;
   fromNow(removeSuffix?: bool): string;
   from(value: moment$Moment|string|number|Date|Array<number>, removePrefix?: bool): string;


### PR DESCRIPTION
utcOffset() should only return number. allowing string as a possible return type breaks compatibility with the add() method, since add() doesn't accept string