### PR TITLE
Add defs for redux-saga 0.13.x

### DIFF
--- a/definitions/npm/redux-saga_v0.11.x/flow_v0.28.x-/redux-saga_v0.11.x.js
+++ b/definitions/npm/redux-saga_v0.11.x/flow_v0.28.x-/redux-saga_v0.11.x.js
@@ -252,15 +252,15 @@ declare module 'redux-saga/effects' {
 
   declare type Pattern = string | Array<string> | (action: Object) => boolean;
 
-  declare type FnSpread<T, R> = (...args: Array<T>) => Promise<R>;
+  declare type FnSpread<T, R> = (...args: Array<T>) => R | Promise<R>;
 
-  declare type Fn0<R> = () => Promise<R> | Generator<*,R,*>;
-  declare type Fn1<T1, R> = (t1: T1) => Promise<R> | Generator<*,R,*>;
-  declare type Fn2<T1, T2, R> = (t1: T1, t2: T2) => Promise<R> | Generator<*,R,*>;
-  declare type Fn3<T1, T2, T3, R> = (t1: T1, t2: T2, t3: T3) => Promise<R> | Generator<*,R,*>;
-  declare type Fn4<T1, T2, T3, T4, R> = (t1: T1, t2: T2, t3: T3, t4: T4) => Promise<R> | Generator<*,R,*>;
-  declare type Fn5<T1, T2, T3, T4, T5, R> = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => Promise<R> | Generator<*,R,*>;
-  declare type Fn6<T1, T2, T3, T4, T5, T6, R> = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => Promise<R> | Generator<*,R,*>;
+  declare type Fn0<R> = () => R | Promise<R> | Generator<*,R,*>;
+  declare type Fn1<T1, R> = (t1: T1) => R | Promise<R> | Generator<*,R,*>;
+  declare type Fn2<T1, T2, R> = (t1: T1, t2: T2) => R | Promise<R> | Generator<*,R,*>;
+  declare type Fn3<T1, T2, T3, R> = (t1: T1, t2: T2, t3: T3) => R | Promise<R> | Generator<*,R,*>;
+  declare type Fn4<T1, T2, T3, T4, R> = (t1: T1, t2: T2, t3: T3, t4: T4) => R | Promise<R> | Generator<*,R,*>;
+  declare type Fn5<T1, T2, T3, T4, T5, R> = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => R | Promise<R> | Generator<*,R,*>;
+  declare type Fn6<T1, T2, T3, T4, T5, T6, R> = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => R | Promise<R> | Generator<*,R,*>;
 
   declare type SelectFnSpread<T> = (state: any, ...args: Array<T>) => any;
   declare type SelectFn0 = ((state: any) => any) & (() => any);

--- a/definitions/npm/redux-saga_v0.13.x/flow_v0.36.x-/redux-saga_v0.13.x.js
+++ b/definitions/npm/redux-saga_v0.13.x/flow_v0.36.x-/redux-saga_v0.13.x.js
@@ -66,9 +66,10 @@ declare module 'redux-saga' {
 
   declare export var buffers: {
     none: () => Buffer,
-    fixed: (limit: number) => Buffer,
-    dropping: (limit: number) => Buffer,
-    sliding: (limit: number) => Buffer,
+    fixed: (limit: ?number) => Buffer,
+    dropping: (limit: ?number) => Buffer,
+    sliding: (limit: ?number) => Buffer,
+    expanding: (initialSize: ?number) => Buffer,
   }
 
   declare export var channel: (buffer?: Buffer) => Channel;
@@ -88,23 +89,37 @@ declare module 'redux-saga' {
   declare type Saga5<Y: IOEffect, R, N, T1, T2, T3, T4, T5> = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => Generator<Y, R, N>;
   declare type Saga6<Y: IOEffect, R, N, T1, T2, T3, T4, T5, T6> = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => Generator<Y, R, N>;
 
-  declare interface TakeXRet extends Generator<*,*,*> {
+  declare interface FsmIterator extends Generator<*,*,*> {
     name: string,
   }
 
   declare type TakeXFn =
-     & (<Y, R, N, Fn: Saga0<Y, R, N>>(pattern: Pattern, saga: Fn) => TakeXRet)
-     & (<T1, Y, R, N, Fn: Saga1<Y, R, N, T1>>(pattern: Pattern, saga: Fn, t1: T1) => TakeXRet)
-     & (<T1, T2, Y, R, N, Fn: Saga2<Y, R, N, T1, T2>>(pattern: Pattern, saga: Fn, t1: T1, t2: T2) => TakeXRet)
-     & (<T1, T2, T3, Y, R, N, Fn: Saga3<Y, R, N, T1, T2, T3>>(pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3) => TakeXRet)
-     & (<T1, T2, T3, T4, Y, R, N, Fn: Saga4<Y, R, N, T1, T2, T3, T4>>(pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3, t4: T4) => TakeXRet)
-     & (<T1, T2, T3, T4, T5, Y, R, N, Fn: Saga5<Y, R, N, T1, T2, T3, T4, T5>>(pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => TakeXRet)
-     & (<T1, T2, T3, T4, T5, T6, Y, R, N, Fn: Saga6<Y, R, N, T1, T2, T3, T4, T5, T6>>(pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => TakeXRet)
-     & (<T, Y, R, N, Fn: SagaSpread<Y, R, N, T>>(pattern: Pattern, saga: Fn, ...rest: Array<T>) => TakeXRet)
+     & (<Y, R, N, Fn: Saga0<Y, R, N>>(pattern: Pattern, saga: Fn) => FsmIterator)
+     & (<T1, Y, R, N, Fn: Saga1<Y, R, N, T1>>(pattern: Pattern, saga: Fn, t1: T1) => FsmIterator)
+     & (<T1, T2, Y, R, N, Fn: Saga2<Y, R, N, T1, T2>>(pattern: Pattern, saga: Fn, t1: T1, t2: T2) => FsmIterator)
+     & (<T1, T2, T3, Y, R, N, Fn: Saga3<Y, R, N, T1, T2, T3>>(pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3) => FsmIterator)
+     & (<T1, T2, T3, T4, Y, R, N, Fn: Saga4<Y, R, N, T1, T2, T3, T4>>(pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3, t4: T4) => FsmIterator)
+     & (<T1, T2, T3, T4, T5, Y, R, N, Fn: Saga5<Y, R, N, T1, T2, T3, T4, T5>>(pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => FsmIterator)
+     & (<T1, T2, T3, T4, T5, T6, Y, R, N, Fn: Saga6<Y, R, N, T1, T2, T3, T4, T5, T6>>(pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => FsmIterator)
+     & (<T, Y, R, N, Fn: SagaSpread<Y, R, N, T>>(pattern: Pattern, saga: Fn, ...rest: Array<T>) => FsmIterator);
 
   declare export var takeEvery: TakeXFn;
   declare export var takeLatest: TakeXFn;
+
+  declare type ThrottleFn =
+     & (<Y, R, N, Fn: Saga0<Y, R, N>>(delayLength: number, pattern: Pattern, saga: Fn) => FsmIterator)
+     & (<T1, Y, R, N, Fn: Saga1<Y, R, N, T1>>(delayLength: number, pattern: Pattern, saga: Fn, t1: T1) => FsmIterator)
+     & (<T1, T2, Y, R, N, Fn: Saga2<Y, R, N, T1, T2>>(delayLength: number, pattern: Pattern, saga: Fn, t1: T1, t2: T2) => FsmIterator)
+     & (<T1, T2, T3, Y, R, N, Fn: Saga3<Y, R, N, T1, T2, T3>>(delayLength: number, pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3) => FsmIterator)
+     & (<T1, T2, T3, T4, Y, R, N, Fn: Saga4<Y, R, N, T1, T2, T3, T4>>(delayLength: number, pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3, t4: T4) => FsmIterator)
+     & (<T1, T2, T3, T4, T5, Y, R, N, Fn: Saga5<Y, R, N, T1, T2, T3, T4, T5>>(delayLength: number, pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => FsmIterator)
+     & (<T1, T2, T3, T4, T5, T6, Y, R, N, Fn: Saga6<Y, R, N, T1, T2, T3, T4, T5, T6>>(delayLength: number, pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => FsmIterator)
+     & (<T, Y, R, N, Fn: SagaSpread<Y, R, N, T>>(delayLength: number, pattern: Pattern, saga: Fn, ...rest: Array<T>) => FsmIterator);
+
+  declare export var throttle: ThrottleFn;
+
   declare export var delay: <T>(ms: number, val?: T) => Promise<T>;
+  declare export var CANCEL: Symbol;
 
   declare type RunSagaCb = (input: any) => any;
 
@@ -124,6 +139,8 @@ declare module 'redux-saga' {
   declare export var utils: {
     createMockTask: () => Task,
   };
+
+  declare export var effects: {};
 
   declare type MiddlewareRunFn =
     & (<Y, R, N, Fn: SagaList<Y, R, N>>(saga: Fn) => Task)
@@ -146,6 +163,7 @@ declare module 'redux-saga' {
     options?: {
       sagaMonitor?: SagaMonitor,
       logger?: Logger,
+      onError?: Function,
     }
   ) => SagaMiddleware;
 
@@ -248,6 +266,10 @@ declare module 'redux-saga/effects' {
 
   declare type CancelledEffect = $npm$ReduxSaga$IOEffect & {
     CANCELLED: Object,
+  }
+
+  declare type FlushEffect = $npm$ReduxSaga$IOEffect & {
+    FLUSH: Channel,
   }
 
   declare type Pattern = string | Array<string> | (action: Object) => boolean;
@@ -466,10 +488,15 @@ declare module 'redux-saga/effects' {
     <T: {[key: string]: IOEffect}>(effects: T): RaceEffect<T>;
   }
 
+  declare type FlushFn = {
+    (channel: Channel): FlushEffect;
+  }
+
   declare module.exports: {
     take: TakeFn,
     takem: TakeFn,
     put: PutFn,
+    race: RaceFn,
     call: CallFn,
     apply: ApplyFn,
     cps: CpsFn,
@@ -479,7 +506,7 @@ declare module 'redux-saga/effects' {
     cancel: CancelFn,
     select: SelectFn,
     actionChannel: ActionChannelFn,
-    race: RaceFn,
     cancelled: () => CancelledEffect,
+    flush: FlushFn,
   }
 }

--- a/definitions/npm/redux-saga_v0.13.x/flow_v0.36.x-/redux-saga_v0.13.x.js
+++ b/definitions/npm/redux-saga_v0.13.x/flow_v0.36.x-/redux-saga_v0.13.x.js
@@ -1,0 +1,485 @@
+/* @flow */
+
+/* eslint-disable */
+
+/**
+ * Shared interfaces between the modules 'redux-saga' and
+ * 'redux-saga/effects'
+ */
+declare interface $npm$ReduxSaga$Channel {
+  take: (cb: (msg: mixed) => void) => void,
+  put: (msg: mixed) => void,
+  close: Function,
+}
+
+declare type $npm$ReduxSaga$Task = {
+  '@@redux-saga/TASK': true,
+  isRunning: () => boolean;
+  isCancelled: () => boolean;
+  result: () => ?mixed;
+  error: () => ?Error;
+  cancel: () => void;
+  done?: Promise<*>;
+}
+
+declare interface $npm$ReduxSaga$Buffer {
+  isEmpty(): boolean;
+  put(msg: any): void;
+  take(): any;
+}
+
+declare type $npm$ReduxSaga$IOEffect = {
+  '@@redux-saga/IO': true,
+}
+
+declare module 'redux-saga' {
+  // Parts for the Channel interface
+  declare type EmitterFn = (msg: any) => void;
+  declare type UnsubscribeFn = () => void;
+  declare type SubscribeFn = (emitter: EmitterFn) => UnsubscribeFn;
+  declare type MatcherFn = (msg: any) => boolean;
+
+  declare type Pattern = string | Array<string> | (action: Object) => boolean;
+
+  declare type IOEffect = $npm$ReduxSaga$IOEffect;
+  declare export type Channel = $npm$ReduxSaga$Channel;
+  declare export type Buffer = $npm$ReduxSaga$Buffer;
+  declare export type Task = $npm$ReduxSaga$Task;
+
+  declare export interface SagaMonitor {
+    effectTriggered(options: {
+      effectId: number,
+      parentEffectId: number,
+      label: string,
+      effect: Object,
+    }): void;
+    effectResolved(effectId: number, result: any): void;
+    effectRejected(effectId: number, err: any): void;
+    effectCancelled(effectId: number): void;
+  }
+
+  declare export type Logger = (level: 'info'|'warning'|'error', ...args: Array<any>) => void;
+
+  declare export var eventChannel: {
+    (sub: SubscribeFn, buffer?: Buffer, matcher?: MatcherFn): Channel,
+  };
+
+  declare export var buffers: {
+    none: () => Buffer,
+    fixed: (limit: number) => Buffer,
+    dropping: (limit: number) => Buffer,
+    sliding: (limit: number) => Buffer,
+  }
+
+  declare export var channel: (buffer?: Buffer) => Channel;
+  declare export var END: { type: '@@redux-saga/CHANNEL_END' };
+
+  /**
+   * Saga stuff
+   */
+
+  declare type SagaSpread<Y: IOEffect, R, N, T> = (...args: Array<T>) => Generator<Y, R, N>;
+  declare type SagaList<Y: IOEffect[], R, N> = () => Generator<Y, R, N>;
+  declare type Saga0<Y: IOEffect, R, N> = () => Generator<Y, R, N>;
+  declare type Saga1<Y: IOEffect, R, N, T1> = (t1: T1) => Generator<Y, R, N>;
+  declare type Saga2<Y: IOEffect, R, N, T1, T2> = (t1: T1, t2: T2) => Generator<Y, R, N>;
+  declare type Saga3<Y: IOEffect, R, N, T1, T2, T3> = (t1: T1, t2: T2, t3: T3) => Generator<Y, R, N>;
+  declare type Saga4<Y: IOEffect, R, N, T1, T2, T3, T4> = (t1: T1, t2: T2, t3: T3, t4: T4) => Generator<Y, R, N>;
+  declare type Saga5<Y: IOEffect, R, N, T1, T2, T3, T4, T5> = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => Generator<Y, R, N>;
+  declare type Saga6<Y: IOEffect, R, N, T1, T2, T3, T4, T5, T6> = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => Generator<Y, R, N>;
+
+  declare interface TakeXRet extends Generator<*,*,*> {
+    name: string,
+  }
+
+  declare type TakeXFn =
+     & (<Y, R, N, Fn: Saga0<Y, R, N>>(pattern: Pattern, saga: Fn) => TakeXRet)
+     & (<T1, Y, R, N, Fn: Saga1<Y, R, N, T1>>(pattern: Pattern, saga: Fn, t1: T1) => TakeXRet)
+     & (<T1, T2, Y, R, N, Fn: Saga2<Y, R, N, T1, T2>>(pattern: Pattern, saga: Fn, t1: T1, t2: T2) => TakeXRet)
+     & (<T1, T2, T3, Y, R, N, Fn: Saga3<Y, R, N, T1, T2, T3>>(pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3) => TakeXRet)
+     & (<T1, T2, T3, T4, Y, R, N, Fn: Saga4<Y, R, N, T1, T2, T3, T4>>(pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3, t4: T4) => TakeXRet)
+     & (<T1, T2, T3, T4, T5, Y, R, N, Fn: Saga5<Y, R, N, T1, T2, T3, T4, T5>>(pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => TakeXRet)
+     & (<T1, T2, T3, T4, T5, T6, Y, R, N, Fn: Saga6<Y, R, N, T1, T2, T3, T4, T5, T6>>(pattern: Pattern, saga: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => TakeXRet)
+     & (<T, Y, R, N, Fn: SagaSpread<Y, R, N, T>>(pattern: Pattern, saga: Fn, ...rest: Array<T>) => TakeXRet)
+
+  declare export var takeEvery: TakeXFn;
+  declare export var takeLatest: TakeXFn;
+  declare export var delay: <T>(ms: number, val?: T) => Promise<T>;
+
+  declare type RunSagaCb = (input: any) => any;
+
+  // TODO: make this interface less generic,...
+  declare export var runSaga: (
+    iterator: Generator<*,*,*>,
+    options?: {
+      subscribe?: (cb: RunSagaCb) => UnsubscribeFn,
+      dispatch?: (output: any) => any,
+      getState?: () => any,
+      sagaMonitor?: SagaMonitor,
+      logger?: Logger,
+    }
+  ) => Task;
+
+  // Not fully typed because it's not really official API
+  declare export var utils: {
+    createMockTask: () => Task,
+  };
+
+  declare type MiddlewareRunFn =
+    & (<Y, R, N, Fn: SagaList<Y, R, N>>(saga: Fn) => Task)
+    & (<Y, R, N, Fn: Saga0<Y, R, N>>(saga: Fn, ...rest: Array<void>) => Task)
+    & (<T1, Y, R, N, Fn: Saga1<Y, R, N, T1>>(saga: Fn, t1: T1, ...rest: Array<void>) => Task)
+    & (<T1, T2, Y, R, N, Fn: Saga2<Y, R, N, T1, T2>>(saga: Fn, t1: T1, t2: T2, ...rest: Array<void>) => Task)
+    & (<T1, T2, T3, Y, R, N, Fn: Saga3<Y, R, N, T1, T2, T3>>(saga: Fn, t1: T1, t2: T2, t3: T3, ...rest: Array<void>) => Task)
+    & (<T1, T2, T3, T4, Y, R, N, Fn: Saga4<Y, R, N, T1, T2, T3, T4>>(saga: Fn, t1: T1, t2: T2, t3: T3, t4: T4, ...rest: Array<void>) => Task)
+    & (<T1, T2, T3, T4, T5, Y, R, N, Fn: Saga5<Y, R, N, T1, T2, T3, T4, T5>>(saga: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, ...rest: Array<void>) => Task)
+    & (<T1, T2, T3, T4, T5, T6, Y, R, N, Fn: Saga6<Y, R, N, T1, T2, T3, T4, T5, T6>>(saga: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, ...rest: Array<void>) => Task)
+    & (<T, Y, R, N, Fn: SagaSpread<Y, R, N, T>>(saga: Fn, t1: T, t2: T, t3: T, t4: T, t5: T, t6: T, ...rest: Array<void>) => Task)
+
+  declare interface SagaMiddleware {
+    // TODO: This should be aligned with the official redux typings sometime
+    (api: any): (next: any) => any;
+    run: MiddlewareRunFn;
+  }
+
+  declare type createSagaMiddleware = (
+    options?: {
+      sagaMonitor?: SagaMonitor,
+      logger?: Logger,
+    }
+  ) => SagaMiddleware;
+
+  declare export default createSagaMiddleware;
+}
+
+declare module 'redux-saga/effects' {
+  // Aliases from the global scope
+  declare type IOEffect = $npm$ReduxSaga$IOEffect;
+  declare type Channel = $npm$ReduxSaga$Channel;
+  declare type Buffer = $npm$ReduxSaga$Buffer;
+  declare type Task = $npm$ReduxSaga$Task;
+
+  declare type TakeEffect<P> = $npm$ReduxSaga$IOEffect & {
+    TAKE: {
+      channel: ?Channel,
+      pattern: P,
+    },
+  };
+
+  declare type PutEffect<T> = $npm$ReduxSaga$IOEffect & {
+    PUT: {
+      channel: ?Channel,
+      action: T,
+    },
+  };
+
+  declare type CallEffect<C, Fn, Args> = $npm$ReduxSaga$IOEffect & {
+    CALL: {
+      context: C,
+      fn: Fn,
+      args: Args,
+    },
+  };
+
+  declare type ForkEffect<C, Fn, Args> = $npm$ReduxSaga$IOEffect & {
+    FORK: {
+      context: C,
+      fn: Fn,
+      args: Args,
+    }
+  }
+
+  declare type CpsEffect<C, Fn, Args> = $npm$ReduxSaga$IOEffect & {
+    CPS: {
+      context: C,
+      fn: Fn,
+      args: Args,
+    }
+  }
+
+  declare type SelectEffect<Fn, Args> = $npm$ReduxSaga$IOEffect & {
+    SELECT: {
+      selector: Fn,
+      args: Args,
+    }
+  }
+
+  declare type SpawnEffect<C, Fn, Args> = $npm$ReduxSaga$IOEffect & {
+    FORK: {
+      context: C,
+      fn: Fn,
+      args: Args,
+      detached: true,
+    }
+  }
+
+  declare type ActionChannelEffect<P> = $npm$ReduxSaga$IOEffect & {
+    ACTION_CHANNEL: {
+      pattern: P,
+      buffer: ?$npm$ReduxSaga$Buffer,
+    }
+  }
+
+  // Apparently, the effects use a stripped
+  // version of a Task object
+  // Since there is some private API in there,
+  // we don't expose this in the Type interface
+  // to prevent misuse
+  declare type EffectTask = {
+    '@@redux-saga/TASK': true,
+    isRunning: () => boolean;
+    isCancelled: () => boolean;
+    result: () => ?mixed;
+    error: () => ?Error;
+    done?: Promise<*>;
+  }
+
+  declare type JoinEffect = $npm$ReduxSaga$IOEffect & {
+    JOIN: EffectTask,
+  }
+
+  declare type CancelEffect = $npm$ReduxSaga$IOEffect & {
+    CANCEL: EffectTask,
+  }
+
+  declare type RaceEffect<T> = $npm$ReduxSaga$IOEffect & {
+    RACE: $Shape<T>,
+  }
+
+  declare type CancelledEffect = $npm$ReduxSaga$IOEffect & {
+    CANCELLED: Object,
+  }
+
+  declare type Pattern = string | Array<string> | (action: Object) => boolean;
+
+  declare type FnSpread<T, R> = (...args: Array<T>) => R | Promise<R>;
+
+  declare type Fn0<R> = () => R | Promise<R> | Generator<*,R,*>;
+  declare type Fn1<T1, R> = (t1: T1) => R | Promise<R> | Generator<*,R,*>;
+  declare type Fn2<T1, T2, R> = (t1: T1, t2: T2) => R | Promise<R> | Generator<*,R,*>;
+  declare type Fn3<T1, T2, T3, R> = (t1: T1, t2: T2, t3: T3) => R | Promise<R> | Generator<*,R,*>;
+  declare type Fn4<T1, T2, T3, T4, R> = (t1: T1, t2: T2, t3: T3, t4: T4) => R | Promise<R> | Generator<*,R,*>;
+  declare type Fn5<T1, T2, T3, T4, T5, R> = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => R | Promise<R> | Generator<*,R,*>;
+  declare type Fn6<T1, T2, T3, T4, T5, T6, R> = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => R | Promise<R> | Generator<*,R,*>;
+
+  declare type SelectFnSpread<T> = (state: any, ...args: Array<T>) => any;
+  declare type SelectFn0 = ((state: any) => any) & (() => any);
+  declare type SelectFn1<T1> = (state: any, t1: T1) => any;
+  declare type SelectFn2<T1, T2> = (state: any, t1: T1, t2: T2) => any;
+  declare type SelectFn3<T1, T2, T3> = (state: any, t1: T1, t2: T2, t3: T3) => any;
+  declare type SelectFn4<T1, T2, T3, T4> = (state: any, t1: T1, t2: T2, t3: T3, t4: T4) => any;
+  declare type SelectFn5<T1, T2, T3, T4, T5> = (state: any, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => any;
+  declare type SelectFn6<T1, T2, T3, T4, T5, T6> = (state: any, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => any;
+
+  declare type CallEffectSpread<C, Fn, T> = CallEffect<C, Fn, Array<T>>;
+  declare type CallEffect0<C, Fn> = CallEffect<C, Fn, []>;
+  declare type CallEffect1<C, Fn, T1> = CallEffect<C, Fn, [T1]>;
+  declare type CallEffect2<C, Fn, T1, T2> = CallEffect<C, Fn, [T1, T2]>;
+  declare type CallEffect3<C, Fn, T1, T2, T3> = CallEffect<C, Fn, [T1, T2, T3]>;
+  declare type CallEffect4<C, Fn, T1, T2, T3, T4> = CallEffect<C, Fn, [T1, T2, T3, T4]>;
+  declare type CallEffect5<C, Fn, T1, T2, T3, T4, T5> = CallEffect<C, Fn, [T1, T2, T3, T4, T5]>;
+  declare type CallEffect6<C, Fn, T1, T2, T3, T4, T5, T6> = CallEffect<C, Fn, [T1, T2, T3, T4, T5, T6]>;
+
+  declare type ForkEffectSpread<C, Fn, T> = ForkEffect<C, Fn, Array<T>>;
+  declare type ForkEffect0<C, Fn> = ForkEffect<C, Fn, []>;
+  declare type ForkEffect1<C, Fn, T1> = ForkEffect<C, Fn, [T1]>;
+  declare type ForkEffect2<C, Fn, T1, T2> = ForkEffect<C, Fn, [T1, T2]>;
+  declare type ForkEffect3<C, Fn, T1, T2, T3> = ForkEffect<C, Fn, [T1, T2, T3]>;
+  declare type ForkEffect4<C, Fn, T1, T2, T3, T4> = ForkEffect<C, Fn, [T1, T2, T3, T4]>;
+  declare type ForkEffect5<C, Fn, T1, T2, T3, T4, T5> = ForkEffect<C, Fn, [T1, T2, T3, T4, T5]>;
+  declare type ForkEffect6<C, Fn, T1, T2, T3, T4, T5, T6> = ForkEffect<C, Fn, [T1, T2, T3, T4, T5, T6]>;
+
+  declare type CpsEffectSpread<C, Fn, T> = CpsEffect<C, Fn, Array<T>>;
+  declare type CpsEffect0<C, Fn> = CpsEffect<C, Fn, []>;
+  declare type CpsEffect1<C, Fn, T1> = CpsEffect<C, Fn, [T1]>;
+  declare type CpsEffect2<C, Fn, T1, T2> = CpsEffect<C, Fn, [T1, T2]>;
+  declare type CpsEffect3<C, Fn, T1, T2, T3> = CpsEffect<C, Fn, [T1, T2, T3]>;
+  declare type CpsEffect4<C, Fn, T1, T2, T3, T4> = CpsEffect<C, Fn, [T1, T2, T3, T4]>;
+  declare type CpsEffect5<C, Fn, T1, T2, T3, T4, T5> = CpsEffect<C, Fn, [T1, T2, T3, T4, T5]>;
+  declare type CpsEffect6<C, Fn, T1, T2, T3, T4, T5, T6> = CpsEffect<C, Fn, [T1, T2, T3, T4, T5, T6]>;
+
+  declare type SpawnEffectSpread<C, Fn, T> = SpawnEffect<C, Fn, Array<T>>;
+  declare type SpawnEffect0<C, Fn> = SpawnEffect<C, Fn, []>;
+  declare type SpawnEffect1<C, Fn, T1> = SpawnEffect<C, Fn, [T1]>;
+  declare type SpawnEffect2<C, Fn, T1, T2> = SpawnEffect<C, Fn, [T1, T2]>;
+  declare type SpawnEffect3<C, Fn, T1, T2, T3> = SpawnEffect<C, Fn, [T1, T2, T3]>;
+  declare type SpawnEffect4<C, Fn, T1, T2, T3, T4> = SpawnEffect<C, Fn, [T1, T2, T3, T4]>;
+  declare type SpawnEffect5<C, Fn, T1, T2, T3, T4, T5> = SpawnEffect<C, Fn, [T1, T2, T3, T4, T5]>;
+  declare type SpawnEffect6<C, Fn, T1, T2, T3, T4, T5, T6> = SpawnEffect<C, Fn, [T1, T2, T3, T4, T5, T6]>;
+
+  declare type SelectEffectSpread<Fn, T> = SelectEffect<Fn, Array<T>>;
+  declare type SelectEffect0<Fn> = SelectEffect<Fn, []>;
+  declare type SelectEffect1<Fn, T1> = SelectEffect<Fn, [T1]>;
+  declare type SelectEffect2<Fn, T1, T2> = SelectEffect<Fn, [T1, T2]>;
+  declare type SelectEffect3<Fn, T1, T2, T3> = SelectEffect<Fn, [T1, T2, T3]>;
+  declare type SelectEffect4<Fn, T1, T2, T3, T4> = SelectEffect<Fn, [T1, T2, T3, T4]>;
+  declare type SelectEffect5<Fn, T1, T2, T3, T4, T5> = SelectEffect<Fn, [T1, T2, T3, T4, T5]>;
+  declare type SelectEffect6<Fn, T1, T2, T3, T4, T5, T6> = SelectEffect<Fn, [T1, T2, T3, T4, T5, T6]>;
+
+  declare type Context = Object;
+
+  /**
+   * APPLY STUFF
+   */
+  declare type ApplyFn =
+    & (<R, C: Context, Fn: Fn0<R>>(c: C, fn: Fn, ...rest: Array<void>) => CallEffect0<C, Fn>)
+    & (<T1, R, C: Context, Fn: Fn1<T1, R>>(c: C, fn: Fn, t1: T1, ...rest: Array<void>) => CallEffect1<C, Fn, T1>)
+    & (<T1, T2, R, C: Context, Fn: Fn2<T1, T2, R>>(c: C, fn: Fn, t1: T1, t2: T2, ...rest: Array<void>) => CallEffect2<C, Fn, T1, T2>)
+    & (<T1, T2, T3, R, C: Context, Fn: Fn3<T1, T2, T3, R>>(c: C, fn: Fn, t1: T1, t2: T2, t3: T3, ...rest: Array<void>) => CallEffect3<C, Fn, T1, T2, T3>)
+    & (<T1, T2, T3, T4, R, C: Context, Fn: Fn4<T1, T2, T3, T4, R>>(c: C, fn: Fn, t1: T1, t2: T2, t3: T3, t4: T4, ...rest: Array<void>) => CallEffect4<C, Fn, T1, T2, T3, T4>)
+    & (<T1, T2, T3, T4, T5, R, C: Context, Fn: Fn5<T1, T2, T3, T4, T5, R>>(c: C, fn: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, ...rest: Array<void>) => CallEffect5<C, Fn, T1, T2, T3, T4, T5>)
+    & (<T1, T2, T3, T4, T5, T6, R, C: Context, Fn: Fn6<T1, T2, T3, T4, T5, T6, R>>(c: C, fn: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, ...rest: Array<void>) => CallEffect6<C, Fn, T1, T2, T3, T4, T5, T6>)
+    & (<T, R, C: Context, Fn: FnSpread<T, R>>(c: C, fn: Fn, t1: T, t2: T, t3: T, t4: T, t5: T, t6: T, ...args: Array<T>) => CallEffectSpread<null, Fn, T>);
+
+  /**
+   * CALL STUFF
+   */
+  declare type ContextCallFn =
+    & (<R, C: Context, Fn: Fn0<R>>(cfn: [C, Fn], ...rest: Array<void>) => CallEffect0<C, Fn>)
+    & (<T1, R, C: Context, Fn: Fn1<T1, R>>(cfn: [C, Fn], t1: T1, ...rest: Array<void>) => CallEffect1<C, Fn, T1>)
+    & (<T1, T2, R, C: Context, Fn: Fn2<T1, T2, R>>(cfn: [C, Fn], t1: T1, t2: T2, ...rest: Array<void>) => CallEffect2<C, Fn, T1, T2>)
+    & (<T1, T2, T3, R, C: Context, Fn: Fn3<T1, T2, T3, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, ...rest: Array<void>) => CallEffect3<C, Fn, T1, T2, T3>)
+    & (<T1, T2, T3, T4, R, C: Context, Fn: Fn4<T1, T2, T3, T4, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, t4: T4, ...rest: Array<void>) => CallEffect4<C, Fn, T1, T2, T3, T4>)
+    & (<T1, T2, T3, T4, T5, R, C: Context, Fn: Fn5<T1, T2, T3, T4, T5, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, ...rest: Array<void>) => CallEffect5<C, Fn, T1, T2, T3, T4, T5>)
+    & (<T1, T2, T3, T4, T5, T6, R, C: Context, Fn: Fn6<T1, T2, T3, T4, T5, T6, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, ...rest: Array<void>) => CallEffect6<C, Fn, T1, T2, T3, T4, T5, T6>)
+    & (<T, R, C: Context, Fn: FnSpread<T, R>>(cfn: [C, Fn], t1: T, t2: T, t3: T, t4: T, t5: T, t6: T, ...args: Array<T>) => CallEffectSpread<null, Fn, T>);
+
+  declare type CallFn =
+    & ContextCallFn
+    & (<R, Fn: Fn0<R>>(fn: Fn) => CallEffect0<null, Fn>)
+    & (<T1, R, Fn: Fn1<T1, R>>(fn: Fn, t1: T1) => CallEffect1<null, Fn, T1>)
+    & (<T1, T2, R, Fn: Fn2<T1, T2, R>>(fn: Fn, t1: T1, t2: T2) => CallEffect2<null, Fn, T1, T2>)
+    & (<T1, T2, T3, R, Fn: Fn3<T1, T2, T3, R>>(fn: Fn, t1: T1, t2: T2, t3: T3) => CallEffect3<null, Fn, T1, T2, T3>)
+    & (<T1, T2, T3, T4, R, Fn: Fn4<T1, T2, T3, T4, R>>(fn: Fn, t1: T1, t2: T2, t3: T3, t4: T4) => CallEffect4<null, Fn, T1, T2, T3, T4>)
+    & (<T1, T2, T3, T4, T5, R, Fn: Fn5<T1, T2, T3, T4, T5, R>>(fn: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => CallEffect5<null, Fn, T1, T2, T3, T4, T5>)
+    & (<T1, T2, T3, T4, T5, T6, R, Fn: Fn6<T1, T2, T3, T4, T5, T6, R>>(fn: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => CallEffect6<null, Fn, T1, T2, T3, T4, T5, T6>)
+    & (<T, R, Fn: FnSpread<T, R>>(fn: Fn, ...args: Array<T>) => CallEffectSpread<null, Fn, T>);
+
+  /**
+   * FORK STUFF
+   */
+  declare type ContextForkFn =
+    & (<R, C: Context, Fn: Fn0<R>>(cfn: [C, Fn], ...rest: Array<void>) => ForkEffect0<C, Fn>)
+    & (<T1, R, C: Context, Fn: Fn1<T1, R>>(cfn: [C, Fn], t1: T1, ...rest: Array<void>) => ForkEffect1<C, Fn, T1>)
+    & (<T1, T2, R, C: Context, Fn: Fn2<T1, T2, R>>(cfn: [C, Fn], t1: T1, t2: T2, ...rest: Array<void>) => ForkEffect2<C, Fn, T1, T2>)
+    & (<T1, T2, T3, R, C: Context, Fn: Fn3<T1, T2, T3, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, ...rest: Array<void>) => ForkEffect3<C, Fn, T1, T2, T3>)
+    & (<T1, T2, T3, T4, R, C: Context, Fn: Fn4<T1, T2, T3, T4, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, t4: T4, ...rest: Array<void>) => ForkEffect4<C, Fn, T1, T2, T3, T4>)
+    & (<T1, T2, T3, T4, T5, R, C: Context, Fn: Fn5<T1, T2, T3, T4, T5, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, ...rest: Array<void>) => ForkEffect5<C, Fn, T1, T2, T3, T4, T5>)
+    & (<T1, T2, T3, T4, T5, T6, R, C: Context, Fn: Fn6<T1, T2, T3, T4, T5, T6, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, ...rest: Array<void>) => ForkEffect6<C, Fn, T1, T2, T3, T4, T5, T6>)
+    & (<T, R, C: Context, Fn: FnSpread<T, R>>(cfn: [C, Fn], t1: T, t2: T, t3: T, t4: T, t5: T, t6: T, ...args: Array<T>) => ForkEffectSpread<null, Fn, T>);
+
+  declare type ForkFn =
+    & ContextForkFn
+    & (<R, Fn: Fn0<R>>(fn: Fn, ...rest: Array<void>) => ForkEffect0<null, Fn>)
+    & (<T1, R, Fn: Fn1<T1, R>>(fn: Fn, t1: T1, ...rest: Array<void>) => ForkEffect1<null, Fn, T1>)
+    & (<T1, T2, R, Fn: Fn2<T1, T2, R>>(fn: Fn, t1: T1, t2: T2, ...rest: Array<void>) => ForkEffect2<null, Fn, T1, T2>)
+    & (<T1, T2, T3, R, Fn: Fn3<T1, T2, T3, R>>(fn: Fn, t1: T1, t2: T2, t3: T3, ...rest: Array<void>) => ForkEffect3<null, Fn, T1, T2, T3>)
+    & (<T1, T2, T3, T4, R, Fn: Fn4<T1, T2, T3, T4, R>>(fn: Fn, t1: T1, t2: T2, t3: T3, t4: T4, ...rest: Array<void>) => ForkEffect4<null, Fn, T1, T2, T3, T4>)
+    & (<T1, T2, T3, T4, T5, R, Fn: Fn5<T1, T2, T3, T4, T5, R>>(fn: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, ...rest: Array<void>) => ForkEffect5<null, Fn, T1, T2, T3, T4, T5>)
+    & (<T1, T2, T3, T4, T5, T6, R, Fn: Fn6<T1, T2, T3, T4, T5, T6, R>>(fn: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, ...rest: Array<void>) => ForkEffect6<null, Fn, T1, T2, T3, T4, T5, T6>)
+    & (<T, R, Fn: FnSpread<T, R>>(fn: Fn, t1: T, t2: T, t3: T, t4: T, t5: T, t6: T, ...args: Array<T>) => ForkEffectSpread<null, Fn, T>);
+
+  /**
+   * CPS STUFF
+   */
+  declare type ContextCpsFn =
+    & (<R, C: Context, Fn: Fn0<R>>(cfn: [C, Fn], ...rest: Array<void>) => CpsEffect0<C, Fn>)
+    & (<T1, R, C: Context, Fn: Fn1<T1, R>>(cfn: [C, Fn], t1: T1, ...rest: Array<void>) => CpsEffect1<C, Fn, T1>)
+    & (<T1, T2, R, C: Context, Fn: Fn2<T1, T2, R>>(cfn: [C, Fn], t1: T1, t2: T2, ...rest: Array<void>) => CpsEffect2<C, Fn, T1, T2>)
+    & (<T1, T2, T3, R, C: Context, Fn: Fn3<T1, T2, T3, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, ...rest: Array<void>) => CpsEffect3<C, Fn, T1, T2, T3>)
+    & (<T1, T2, T3, T4, R, C: Context, Fn: Fn4<T1, T2, T3, T4, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, t4: T4, ...rest: Array<void>) => CpsEffect4<C, Fn, T1, T2, T3, T4>)
+    & (<T1, T2, T3, T4, T5, R, C: Context, Fn: Fn5<T1, T2, T3, T4, T5, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, ...rest: Array<void>) => CpsEffect5<C, Fn, T1, T2, T3, T4, T5>)
+    & (<T1, T2, T3, T4, T5, T6, R, C: Context, Fn: Fn6<T1, T2, T3, T4, T5, T6, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, ...rest: Array<void>) => CpsEffect6<C, Fn, T1, T2, T3, T4, T5, T6>)
+    & (<T, R, C: Context, Fn: FnSpread<T, R>>(cfn: [C, Fn], t1: T, t2: T, t3: T, t4: T, t5: T, t6: T, ...args: Array<T>) => CpsEffectSpread<null, Fn, T>);
+
+  declare type CpsFn =
+    & ContextCpsFn
+    & (<R, Fn: Fn0<R>>(fn: Fn, ...rest: Array<void>) => CpsEffect0<null, Fn>)
+    & (<T1, R, Fn: Fn1<T1, R>>(fn: Fn, t1: T1, ...rest: Array<void>) => CpsEffect1<null, Fn, T1>)
+    & (<T1, T2, R, Fn: Fn2<T1, T2, R>>(fn: Fn, t1: T1, t2: T2, ...rest: Array<void>) => CpsEffect2<null, Fn, T1, T2>)
+    & (<T1, T2, T3, R, Fn: Fn3<T1, T2, T3, R>>(fn: Fn, t1: T1, t2: T2, t3: T3, ...rest: Array<void>) => CpsEffect3<null, Fn, T1, T2, T3>)
+    & (<T1, T2, T3, T4, R, Fn: Fn4<T1, T2, T3, T4, R>>(fn: Fn, t1: T1, t2: T2, t3: T3, t4: T4, ...rest: Array<void>) => CpsEffect4<null, Fn, T1, T2, T3, T4>)
+    & (<T1, T2, T3, T4, T5, R, Fn: Fn5<T1, T2, T3, T4, T5, R>>(fn: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, ...rest: Array<void>) => CpsEffect5<null, Fn, T1, T2, T3, T4, T5>)
+    & (<T1, T2, T3, T4, T5, T6, R, Fn: Fn6<T1, T2, T3, T4, T5, T6, R>>(fn: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, ...rest: Array<void>) => CpsEffect6<null, Fn, T1, T2, T3, T4, T5, T6>)
+    & (<T, R, Fn: FnSpread<T, R>>(fn: Fn, t1: T, t2: T, t3: T, t4: T, t5: T, t6: T, ...args: Array<T>) => CpsEffectSpread<null, Fn, T>);
+
+  /**
+   * SPAWN STUFF
+   */
+  declare type ContextSpawnFn =
+    & (<R, C: Context, Fn: Fn0<R>>(cfn: [C, Fn], ...rest: Array<void>) => SpawnEffect0<C, Fn>)
+    & (<T1, R, C: Context, Fn: Fn1<T1, R>>(cfn: [C, Fn], t1: T1, ...rest: Array<void>) => SpawnEffect1<C, Fn, T1>)
+    & (<T1, T2, R, C: Context, Fn: Fn2<T1, T2, R>>(cfn: [C, Fn], t1: T1, t2: T2, ...rest: Array<void>) => SpawnEffect2<C, Fn, T1, T2>)
+    & (<T1, T2, T3, R, C: Context, Fn: Fn3<T1, T2, T3, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, ...rest: Array<void>) => SpawnEffect3<C, Fn, T1, T2, T3>)
+    & (<T1, T2, T3, T4, R, C: Context, Fn: Fn4<T1, T2, T3, T4, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, t4: T4, ...rest: Array<void>) => SpawnEffect4<C, Fn, T1, T2, T3, T4>)
+    & (<T1, T2, T3, T4, T5, R, C: Context, Fn: Fn5<T1, T2, T3, T4, T5, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, ...rest: Array<void>) => SpawnEffect5<C, Fn, T1, T2, T3, T4, T5>)
+    & (<T1, T2, T3, T4, T5, T6, R, C: Context, Fn: Fn6<T1, T2, T3, T4, T5, T6, R>>(cfn: [C, Fn], t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, ...rest: Array<void>) => SpawnEffect6<C, Fn, T1, T2, T3, T4, T5, T6>)
+    & (<T, R, C: Context, Fn: FnSpread<T, R>>(cfn: [C, Fn], t1: T, t2: T, t3: T, t4: T, t5: T, t6: T, ...args: Array<T>) => SpawnEffectSpread<null, Fn, T>);
+
+  declare type SpawnFn =
+    & ContextSpawnFn
+    & (<R, Fn: Fn0<R>>(fn: Fn, ...rest: Array<void>) => SpawnEffect0<null, Fn>)
+    & (<T1, R, Fn: Fn1<T1, R>>(fn: Fn, t1: T1, ...rest: Array<void>) => SpawnEffect1<null, Fn, T1>)
+    & (<T1, T2, R, Fn: Fn2<T1, T2, R>>(fn: Fn, t1: T1, t2: T2, ...rest: Array<void>) => SpawnEffect2<null, Fn, T1, T2>)
+    & (<T1, T2, T3, R, Fn: Fn3<T1, T2, T3, R>>(fn: Fn, t1: T1, t2: T2, t3: T3, ...rest: Array<void>) => SpawnEffect3<null, Fn, T1, T2, T3>)
+    & (<T1, T2, T3, T4, R, Fn: Fn4<T1, T2, T3, T4, R>>(fn: Fn, t1: T1, t2: T2, t3: T3, t4: T4, ...rest: Array<void>) => SpawnEffect4<null, Fn, T1, T2, T3, T4>)
+    & (<T1, T2, T3, T4, T5, R, Fn: Fn5<T1, T2, T3, T4, T5, R>>(fn: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, ...rest: Array<void>) => SpawnEffect5<null, Fn, T1, T2, T3, T4, T5>)
+    & (<T1, T2, T3, T4, T5, T6, R, Fn: Fn6<T1, T2, T3, T4, T5, T6, R>>(fn: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, ...rest: Array<void>) => SpawnEffect6<null, Fn, T1, T2, T3, T4, T5, T6>)
+    & (<T, R, Fn: FnSpread<T, R>>(fn: Fn, t1: T, t2: T, t3: T, t4: T, t5: T, t6: T, ...args: Array<T>) => SpawnEffectSpread<null, Fn, T>);
+
+  /**
+   * SELECT STUFF
+   */
+  declare type SelectFn =
+    & (<Fn: SelectFn>(selector: Fn, ...rest: Array<void>) => SelectEffect0<Fn>)
+    & (<T1, Fn: SelectFn1<T1>>(selector: Fn, t1: T1, ...rest: Array<void>) => SelectEffect1<Fn, T1>)
+    & (<T1, T2, Fn: SelectFn2<T1, T2>>(selector: Fn, t1: T1, t2: T2, ...rest: Array<void>) => SelectEffect2<Fn, T1, T2>)
+    & (<T1, T2, T3, Fn: SelectFn3<T1, T2, T3>>(selector: Fn, t1: T1, t2: T2, t3: T3, ...rest: Array<void>) => SelectEffect3<Fn, T1, T2, T3>)
+    & (<T1, T2, T3, T4, Fn: SelectFn4<T1, T2, T3, T4>>(selector: Fn, t1: T1, t2: T2, t3: T3, t4: T4, ...rest: Array<void>) => SelectEffect4<Fn, T1, T2, T3, T4>)
+    & (<T1, T2, T3, T4, T5, Fn: SelectFn5<T1, T2, T3, T4, T5>>(selector: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, ...rest: Array<void>) => SelectEffect5<Fn, T1, T2, T3, T4, T5>)
+    & (<T1, T2, T3, T4, T5, T6, Fn: SelectFn6<T1, T2, T3, T4, T5, T6>>(selector: Fn, t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, ...rest: Array<void>) => SelectEffect6<Fn, T1, T2, T3, T4, T5, T6>)
+    & (<T, Fn: SelectFnSpread<T>>(selector: Fn, t1: T, t2: T, t3: T, t4: T, t5: T, t6: T, ...rest: Array<T>) => SelectEffectSpread<Fn, T>)
+
+  declare type TakeFn = {
+    <P: Pattern>(                  pattern: P): TakeEffect<P>;
+    <P: Pattern>(channel: Channel, pattern: P): TakeEffect<P>;
+  }
+
+  declare type PutFn = {
+    <T: Object>(action: T): PutEffect<T>;
+    <T: Object>(channel: Channel, action: T): PutEffect<T>;
+  }
+
+  declare type ActionChannelFn = {
+    <P: Pattern>(pattern: P, buffer?: Buffer): ActionChannelEffect<P>;
+  }
+
+  declare type JoinFn = {
+    (task: Task): JoinEffect;
+  }
+
+  declare type CancelFn = {
+    (task: Task): CancelEffect;
+  }
+
+  declare type RaceFn = {
+    <T: {[key: string]: IOEffect}>(effects: T): RaceEffect<T>;
+  }
+
+  declare module.exports: {
+    take: TakeFn,
+    takem: TakeFn,
+    put: PutFn,
+    call: CallFn,
+    apply: ApplyFn,
+    cps: CpsFn,
+    fork: ForkFn,
+    spawn: SpawnFn,
+    join: JoinFn,
+    cancel: CancelFn,
+    select: SelectFn,
+    actionChannel: ActionChannelFn,
+    race: RaceFn,
+    cancelled: () => CancelledEffect,
+  }
+}

--- a/definitions/npm/redux-saga_v0.13.x/test_redux-saga_0.13.x.js
+++ b/definitions/npm/redux-saga_v0.13.x/test_redux-saga_0.13.x.js
@@ -1,0 +1,1001 @@
+/* @flow */
+
+/* eslint-disable no-unused-vars, no-undef, no-console */
+
+import createSagaMiddleware from 'redux-saga';
+
+import {
+  utils,
+  delay,
+  eventChannel,
+  buffers,
+  channel,
+  takeEvery,
+  takeLatest,
+  runSaga,
+  END,
+} from 'redux-saga';
+
+import {
+  take,
+  takem,
+  put,
+  call,
+  apply,
+  cps,
+  fork,
+  spawn,
+  join,
+  cancel,
+  select,
+  actionChannel,
+  race,
+  cancelled,
+} from 'redux-saga/effects';
+
+import type { Task, Channel, Buffer, SagaMonitor } from 'redux-saga';
+
+import type {
+  IOEffect,
+  TakeEffect,
+  PutEffect,
+  SelectEffect,
+} from 'redux-saga/effects';
+
+/**
+ * SOME COMMON TEST INFRASTRUCTURE
+ */
+const myChannel = channel();
+
+function SomeContext() { this.z = 'foo'; }
+
+const context = { a: 'foo' };
+const context2 = new SomeContext();
+
+const sagaMonitor: SagaMonitor = {
+  effectTriggered: () => {},
+  effectResolved: () => {},
+  effectRejected: () => {},
+  effectCancelled: () => {},
+};
+
+function* g0(): Generator<any, number, any> { return 1; }
+function* g1(a: string): Generator<any, number, any> { return 1; }
+function* g2(a: string, b: number): Generator<any, number, any> { return 1; }
+function* g3(a: string, b: number, c: string): Generator<any, number, any> { return 1; }
+function* g4(a: string, b: number, c: string, d: number): Generator<any, number, any> { return 1; }
+function* g5(a: string, b: number, c: string, d: number, e: string): Generator<any, number, any> { return 1; }
+function* g6(a: string, b: number, c: string, d: number, e: string, f: number): Generator<any, number, any> { return 1; }
+
+function* gSpread(...args: Array<boolean>): Generator<any, number, any> { return 1; }
+
+// Note: Without the return annotation, flow cannot determine the union case properly
+const fn0 = (): Promise<number> => Promise.resolve(1);
+const fn1 = (a: string): Promise<number> => Promise.resolve(1);
+const fn2 = (a: string, b: number): Promise<number> => Promise.resolve(1);
+const fn3 = (a: string, b: number, c: string): Promise<number> => Promise.resolve(1);
+const fn4 = (a: string, b: number, c: string, d: number): Promise<number> => Promise.resolve(1);
+const fn5 = (a: string, b: number, c: string, d: number, e: string): Promise<number> => Promise.resolve(1);
+const fn6 = (a: string, b: number, c: string, d: number, e: string, f: number): Promise<number> => Promise.resolve(1);
+
+const fnSpread = (...args: Array<number>): Promise<string> => Promise.resolve('');
+
+function nfn0(): number { return 1; }
+function nfn1(a: string): number { return 1; }
+function nfn2(a: string, b: number): number {  return 1; }
+function nfn3(a: string, b: number, c: boolean): number { return 1; }
+function nfn4(a: string, b: number, c: boolean, d: string, ): number { return 1; }
+function nfn5(a: string, b: number, c: boolean, d: string, e: number): number { return 1; }
+function nfn6(a: string, b: number, c: boolean, d: string, e: number, f: boolean): number { return 1; }
+
+function nfnSpread(...args: Array<string>): number { return 1; }
+
+/**
+ * ALL THE TESTS START FROM HERE
+ */
+
+function channelTest() {
+  (channel(buffers.fixed(1)): $npm$ReduxSaga$Channel);
+}
+
+function eventChannelTest() {
+  eventChannel((emitter) => () => {}, buffers.dropping(1));
+  eventChannel((emitter) => () => {}, buffers.dropping(1), () => true);
+
+  // $ExpectError: MatcherFn needs boolean as return type
+  eventChannel((emitter) => () => {}, buffers.dropping(1), () => '');
+
+  // $ExpectError: second parameter needs to be a Buffer
+  eventChannel((emitter) => () => {}, '');
+}
+
+function takeTest() {
+  take((action) => action.type === 'foo');
+  takem((action) => action.type === 'foo');
+
+  take(['FOO', 'BAR']);
+  takem(['FOO', 'BAR']);
+
+  // $ExpectError: PatternFn returns a boolean
+  take((action) => null);
+
+  // $ExpectError: PatternFn returns a boolean
+  takem((action) => null);
+
+  // $ExpectError: Only string patterns for arrays
+  take(['FOO', 'BAR', 1]);
+
+  // $ExpectError: Only string patterns for arrays
+  takem(['FOO', 'BAR', 1]);
+}
+
+function putTest() {
+  put({ type: 'test' });
+
+  const put1 = put({ type: 'FOO', bar: 'hi' });
+  (put1.PUT.action.bar: string);
+
+  const put2 = put(myChannel, { type: 'test' });
+  (put2.PUT.channel: ?$npm$ReduxSaga$Channel)
+
+  // $ExpectError: Only action objects allowed
+  put('test');
+
+  // $ExpectError: No null as channel accepted
+  put(null, { type: 'test' });
+
+  // $ExpectError: This property cannot be inferred
+  (put1.PUT.action.unknown: string);
+}
+
+function actionChannelTest() {
+  (actionChannel('ASDF').ACTION_CHANNEL.pattern: string);
+  (actionChannel(['FOO', 'BAR']).ACTION_CHANNEL.pattern[0]: string);
+}
+
+
+function callTest() {
+  const c0 = call(fn0);
+  const c1 = call(fn1, '1');
+  const c2 = call(fn2, '1', 2);
+  const c3 = call(fn3, '1', 2, '3');
+  const c4 = call(fn4, '1', 2, '3', 4);
+  const c5 = call(fn5, '1', 2, '3', 4, '5');
+  const c6 = call(fn6, '1', 2, '3', 4, '5', 6);
+
+  // $ExpectError: Too less arguments
+  call(fn6, '1', 2, '3', 4);
+
+  const cSpread = call(fnSpread, 1, 2, 3, 1);
+
+  // Args tests
+  (c0.CALL.args: []);
+  (c1.CALL.args: [string]);
+  (c2.CALL.args: [string, number]);
+  (c3.CALL.args: [string, number, string]);
+  (c4.CALL.args: [string, number, string, number]);
+  (c5.CALL.args: [string, number, string, number, string]);
+  (c6.CALL.args: [string, number, string, number, string, number]);
+
+  // $ExpectError: First parameter is a string, not a number
+  (c1.CALL.args: [number]);
+
+  // Fn tests
+  (c1.CALL.fn: typeof fn1);
+  (c2.CALL.fn: typeof fn2);
+  (c3.CALL.fn: typeof fn3);
+  (c4.CALL.fn: typeof fn4);
+  (c5.CALL.fn: typeof fn5);
+  (c6.CALL.fn: typeof fn6);
+
+  // NOTE: This should actually fail, but apparently more parameter are fine..
+  (c1.CALL.fn: typeof fn6);
+
+  // $ExpectError: fn returns a Promise<string> not Promise<number>
+  (c1.CALL.fn: (a: boolean) => Promise<number>);
+
+  // $ExpectError: 'a' is actually of type string
+  (c4.CALL.fn: (a: number, b: number) => Promise<string>);
+
+  // $ExpectError: Less parameter are noticed
+  (c6.CALL.fn: typeof fn1);
+
+  // Context tests
+  (c1.CALL.context: null);
+  (c2.CALL.context: null);
+  (c3.CALL.context: null);
+  (c4.CALL.context: null);
+  (c5.CALL.context: null);
+  (c6.CALL.context: null);
+
+  // $ExpectError
+  (c1.CALL.context: Object);
+}
+
+function callNormalFunctionTest() {
+  const c0 = call(nfn0);
+  const c1 = call(nfn1, '1');
+  const c2 = call(nfn2, '1', 2);
+  const c3 = call(nfn3, '1', 2, true);
+  const c4 = call(nfn4, '1', 2, true, '4');
+  const c5 = call(nfn5, '1', 2, true, '4', 5);
+  const c6 = call(nfn6, '1', 2, true, '4', 5, false);
+
+  // $ExpectError: Too less arguments
+  call(nfn6, '1', 2, true, '4');
+
+  const cSpread = call(nfnSpread, '1', '2', '3', '4');
+
+  // Args tests
+  (c0.CALL.args: []);
+  (c1.CALL.args: [string]);
+  (c2.CALL.args: [string, number]);
+  (c3.CALL.args: [string, number, boolean]);
+  (c4.CALL.args: [string, number, boolean, string]);
+  (c5.CALL.args: [string, number, boolean, string, number]);
+  (c6.CALL.args: [string, number, boolean, string, number, boolean]);
+
+  // $ExpectError: First parameter is a string, not a number
+  (c1.CALL.args: [number]);
+
+  // Fn tests
+  (c1.CALL.fn: typeof nfn1);
+  (c2.CALL.fn: typeof nfn2);
+  (c3.CALL.fn: typeof nfn3);
+  (c4.CALL.fn: typeof nfn4);
+  (c5.CALL.fn: typeof nfn5);
+  (c6.CALL.fn: typeof nfn6);
+
+  // $ExpectError: fn returns a number not string
+  (c1.CALL.fn: (a: boolean) => string);
+
+  // $ExpectError: 'a' is actually of type string
+  (c1.CALL.fn: (a: boolean) => number);
+
+  // $ExpectError: 'a' is actually of type string
+  (c4.CALL.fn: (a: number, b: number) => number);
+
+  // $ExpectError: Less parameter are noticed
+  (c6.CALL.fn: typeof nfn1);
+
+  // Context tests
+  (c1.CALL.context: null);
+  (c2.CALL.context: null);
+  (c3.CALL.context: null);
+  (c4.CALL.context: null);
+  (c5.CALL.context: null);
+  (c6.CALL.context: null);
+
+  // $ExpectError
+  (c1.CALL.context: Object);
+}
+
+function callGeneratorFunctionTest() {
+  const c0 = call(g0);
+  const c1 = call(g1, '1');
+  const c2 = call(g2, '1', 2);
+  const c3 = call(g3, '1', 2, '3');
+  const c4 = call(g4, '1', 2, '3', 4);
+  const c5 = call(g5, '1', 2, '3', 4, '5');
+  const c6 = call(g6, '1', 2, '3', 4, '5', 6);
+
+  // $ExpectError: Too less arguments
+  call(g6, '1', 2, '3', 4);
+
+  const cSpread = call(gSpread, true, false, true, false);
+
+  // Args tests
+  (c0.CALL.args: []);
+  (c1.CALL.args: [string]);
+  (c2.CALL.args: [string, number]);
+  (c3.CALL.args: [string, number, string]);
+  (c4.CALL.args: [string, number, string, number]);
+  (c5.CALL.args: [string, number, string, number, string]);
+  (c6.CALL.args: [string, number, string, number, string, number]);
+
+  // $ExpectError: First parameter is a string, not a number
+  (c1.CALL.args: [number]);
+
+  // Fn tests
+  (c1.CALL.fn: typeof g1);
+  (c2.CALL.fn: typeof g2);
+  (c3.CALL.fn: typeof g3);
+  (c4.CALL.fn: typeof g4);
+  (c5.CALL.fn: typeof g5);
+  (c6.CALL.fn: typeof g6);
+
+  // $ExpectError: fn returns a number not string
+  (c1.CALL.fn: (a: boolean) => string);
+
+  // $ExpectError: 'a' is actually of type string
+  (c1.CALL.fn: (a: boolean) => number);
+
+  // $ExpectError: 'a' is actually of type string
+  (c4.CALL.fn: (a: number, b: number) => number);
+
+  // $ExpectError: Less parameter are noticed
+  (c6.CALL.fn: typeof g1);
+
+  // Context tests
+  (c1.CALL.context: null);
+  (c2.CALL.context: null);
+  (c3.CALL.context: null);
+  (c4.CALL.context: null);
+  (c5.CALL.context: null);
+  (c6.CALL.context: null);
+
+  // $ExpectError
+  (c1.CALL.context: Object);
+}
+
+function contextCallTest() {
+  const c0 = call([context, fn0]);
+  const c1 = call([context, fn1], '1');
+  const c2 = call([context, fn2], '1', 2);
+  const c3 = call([context, fn3], '1', 2, '3');
+  const c4 = call([context, fn3], '1', 2, '3', 4);
+  const c5 = call([context, fn3], '1', 2, '3', 4, '5');
+  const c6 = call([context, fn3], '1', 2, '3', 4, '5', 6);
+  const cClass = call([context2, fn1], '1');
+
+  // Fn tests
+  (c1.CALL.fn: typeof fn1);
+  (c2.CALL.fn: typeof fn2);
+  (c3.CALL.fn: typeof fn3);
+  (c4.CALL.fn: typeof fn4);
+  (c5.CALL.fn: typeof fn5);
+  (c6.CALL.fn: typeof fn6);
+
+  // $ExpectError: Wrong number of parameters
+  (c6.CALL.fn: typeof fn1);
+
+  // Args tests
+  (c1.CALL.args: [string]);
+  (c2.CALL.args: [string, number]);
+  (c3.CALL.args: [string, number, string]);
+  (c4.CALL.args: [string, number, string, number]);
+  (c5.CALL.args: [string, number, string, number, string]);
+  (c6.CALL.args: [string, number, string, number, string, number]);
+
+  // $ExpectError: a is a number, not an Array
+  (c1.CALL.args: [Array<*>]);
+
+  // Context tests
+  (c1.CALL.context: typeof context);
+  (c2.CALL.context: typeof context);
+  (c3.CALL.context: typeof context);
+  (c4.CALL.context: typeof context);
+  (c5.CALL.context: typeof context);
+  (c6.CALL.context: typeof context);
+
+  (c1.CALL.context.a: string);
+
+  // $ExpectError: Different context
+  (c1.CALL.context: { b: 'nope' });
+
+  // $ExpectError: Parameter b requires a number
+  call([context, fn2], 'test', 'test');
+}
+
+function contextCallNormalFunctionTest() {
+  const c0 = call([context, nfn0]);
+  const c1 = call([context, nfn1], '1');
+  const c2 = call([context, nfn2], '1', 2);
+  const c3 = call([context, nfn3], '1', 2, true);
+  const c4 = call([context, nfn3], '1', 2, true, '4');
+  const c5 = call([context, nfn3], '1', 2, true, '4', 5);
+  const c6 = call([context, nfn3], '1', 2, true, '4', 5, false);
+  const cClass = call([context2, nfn1], '1');
+
+  // Fn tests
+  (c1.CALL.fn: typeof nfn1);
+  (c2.CALL.fn: typeof nfn2);
+  (c3.CALL.fn: typeof nfn3);
+  (c4.CALL.fn: typeof nfn4);
+  (c5.CALL.fn: typeof nfn5);
+  (c6.CALL.fn: typeof nfn6);
+
+  // $ExpectError: Wrong number of parameters
+  (c6.CALL.fn: typeof nfn1);
+
+  // Args tests
+  (c0.CALL.args: []);
+  (c1.CALL.args: [string]);
+  (c2.CALL.args: [string, number]);
+  (c3.CALL.args: [string, number, boolean]);
+  (c4.CALL.args: [string, number, boolean, string]);
+  (c5.CALL.args: [string, number, boolean, string, number]);
+  (c6.CALL.args: [string, number, boolean, string, number, boolean]);
+
+  // $ExpectError: a is a number, not an Array
+  (c1.CALL.args: [Array<*>]);
+
+  // Context tests
+  (c1.CALL.context: typeof context);
+  (c2.CALL.context: typeof context);
+  (c3.CALL.context: typeof context);
+  (c4.CALL.context: typeof context);
+  (c5.CALL.context: typeof context);
+  (c6.CALL.context: typeof context);
+  (cClass.CALL.context: typeof context2);
+
+  (c1.CALL.context.a: string);
+  (cClass.CALL.context.z: string);
+
+  // $ExpectError: Different context
+  (c1.CALL.context: { b: 'nope' });
+
+  // $ExpectError: Parameter b requires a number
+  call([context, nfn2], 'test', 'test');
+}
+
+function contextCallGeneratorFunctionTest() {
+  const c0 = call([context, g0]);
+  const c1 = call([context, g1], '1');
+  const c2 = call([context, g2], '1', 2);
+  const c3 = call([context, g3], '1', 2, '3');
+  const c4 = call([context, g3], '1', 2, '3', 4);
+  const c5 = call([context, g3], '1', 2, '3', 4, '5');
+  const c6 = call([context, g3], '1', 2, '3', 4, '5', 6);
+  const cClass = call([context2, g1], '1');
+
+  // Fn tests
+  (c1.CALL.fn: typeof g1);
+  (c2.CALL.fn: typeof g2);
+  (c3.CALL.fn: typeof g3);
+  (c4.CALL.fn: typeof g4);
+  (c5.CALL.fn: typeof g5);
+  (c6.CALL.fn: typeof g6);
+
+  // $ExpectError: Wrong number of parameters
+  (c6.CALL.fn: typeof g1);
+
+  // Args tests
+  (c1.CALL.args: [string]);
+  (c2.CALL.args: [string, number]);
+  (c3.CALL.args: [string, number, string]);
+  (c4.CALL.args: [string, number, string, number]);
+  (c5.CALL.args: [string, number, string, number, string]);
+  (c6.CALL.args: [string, number, string, number, string, number]);
+
+  // $ExpectError: a is a number, not an Array
+  (c1.CALL.args: [Array<*>]);
+
+  // Context tests
+  (c1.CALL.context: typeof context);
+  (c2.CALL.context: typeof context);
+  (c3.CALL.context: typeof context);
+  (c4.CALL.context: typeof context);
+  (c5.CALL.context: typeof context);
+  (c6.CALL.context: typeof context);
+  (cClass.CALL.context: typeof context2);
+
+  (c1.CALL.context.a: string);
+  (cClass.CALL.context.z: string);
+
+  // $ExpectError: Different context
+  (c1.CALL.context: { b: 'nope' });
+
+  // $ExpectError: Parameter b requires a number
+  call([context, g2], 'test', 'test');
+}
+
+function applyTest() {
+  const c0 = apply(context, fn0);
+  const c1 = apply(context, fn1, '1');
+  const c2 = apply(context, fn2, '1', 2);
+  const c3 = apply(context, fn3, '1', 2, '3');
+  const c4 = apply(context, fn4, '1', 2, '3', 4);
+  const c5 = apply(context, fn5, '1', 2, '3', 4, '5');
+  const c6 = apply(context, fn6, '1', 2, '3', 4, '5', 6);
+  const cClass = apply(context2, fn1, '1');
+
+  // Fn tests
+  (c1.CALL.fn: typeof fn1);
+  (c2.CALL.fn: typeof fn2);
+  (c3.CALL.fn: typeof fn3);
+  (c4.CALL.fn: typeof fn4);
+  (c5.CALL.fn: typeof fn5);
+  (c6.CALL.fn: typeof fn6);
+
+  // $ExpectError: Wrong number of parameters
+  (c6.CALL.fn: typeof fn1);
+
+  // Args tests
+  (c1.CALL.args: [string]);
+  (c2.CALL.args: [string, number]);
+  (c3.CALL.args: [string, number, string]);
+  (c4.CALL.args: [string, number, string, number]);
+  (c5.CALL.args: [string, number, string, number, string]);
+  (c6.CALL.args: [string, number, string, number, string, number]);
+
+  // $ExpectError: a is a number, not an Array
+  (c1.CALL.args: [boolean]);
+
+  // Context tests
+  (c1.CALL.context: typeof context);
+  (c2.CALL.context: typeof context);
+  (c3.CALL.context: typeof context);
+  (c4.CALL.context: typeof context);
+  (c5.CALL.context: typeof context);
+  (c6.CALL.context: typeof context);
+
+  (c1.CALL.context.a: string);
+  (c1.CALL.context.a: string);
+
+  // $ExpectError: Different context
+  (c1.CALL.context: { b: 'nope' });
+
+  // $ExpectError: Parameter b requires a number
+  call([context, fn2], 'test', 'test');
+}
+
+function contextForkTest() {
+  const e0 = fork([context, fn0]);
+  const e1 = fork([context, fn1], '1');
+  const e2 = fork([context, fn2], '1', 2);
+  const e3 = fork([context, fn3], '1', 2, '3');
+  const e4 = fork([context, fn4], '1', 2, '3', 4);
+  const e5 = fork([context, fn5], '1', 2, '3', 4, '5');
+  const e6 = fork([context, fn6], '1', 2, '3', 4, '5', 6);
+  const eClass = fork([context2, fn1], '1');
+  const eGen = fork([context, g1], '1');
+
+  // Args Test
+  (e0.FORK.args: []);
+  (e1.FORK.args: [string]);
+  (e2.FORK.args: [string, number]);
+  (e3.FORK.args: [string, number, string]);
+  (e4.FORK.args: [string, number, string, number]);
+  (e5.FORK.args: [string, number, string, number, string]);
+  (e6.FORK.args: [string, number, string, number, string, number]);
+
+  // Context Test
+  (e1.FORK.context: typeof context);
+  (e2.FORK.context: typeof context);
+  (e3.FORK.context: typeof context);
+  (e4.FORK.context: typeof context);
+  (e5.FORK.context: typeof context);
+  (e6.FORK.context: typeof context);
+  (eGen.FORK.context: typeof context);
+
+  // Fn Test
+  (e1.FORK.fn: typeof fn1);
+  (e2.FORK.fn: typeof fn2);
+  (e3.FORK.fn: typeof fn3);
+  (e4.FORK.fn: typeof fn4);
+  (e5.FORK.fn: typeof fn5);
+  (e6.FORK.fn: typeof fn6);
+  (eGen.FORK.fn: typeof g1);
+
+  // $ExpectError: wrong fn
+  (e6.FORK.fn: typeof fn1);
+}
+
+function forkTest() {
+  const e0 = fork(fn0);
+  const e1 = fork(fn1, '1');
+  const e2 = fork(fn2, '1', 2);
+  const e3 = fork(fn3, '1', 2, '3');
+  const e4 = fork(fn4, '1', 2, '3', 4);
+  const e5 = fork(fn5, '1', 2, '3', 4, '5');
+  const e6 = fork(fn6, '1', 2, '3', 4, '5', 6);
+  const eClass = fork(fn1, '1');
+  const eGen = fork(g1, '1');
+
+  // Args Test
+  (e0.FORK.args: []);
+  (e1.FORK.args: [string]);
+  (e2.FORK.args: [string, number]);
+  (e3.FORK.args: [string, number, string]);
+  (e4.FORK.args: [string, number, string, number]);
+  (e5.FORK.args: [string, number, string, number, string]);
+  (e6.FORK.args: [string, number, string, number, string, number]);
+
+  // Fn Test
+  (e1.FORK.fn: typeof fn1);
+  (e2.FORK.fn: typeof fn2);
+  (e3.FORK.fn: typeof fn3);
+  (e4.FORK.fn: typeof fn4);
+  (e5.FORK.fn: typeof fn5);
+  (e6.FORK.fn: typeof fn6);
+  (eGen.FORK.fn: typeof g1);
+
+  // $ExpectError: wrong fn
+  (e6.FORK.fn: typeof fn1);
+}
+
+function cpsTest() {
+  const e0 = cps(fn0);
+  const e1 = cps(fn1, '1');
+  const e2 = cps(fn2, '1', 2);
+  const e3 = cps(fn3, '1', 2, '3');
+  const e4 = cps(fn4, '1', 2, '3', 4);
+  const e5 = cps(fn5, '1', 2, '3', 4, '5');
+  const e6 = cps(fn6, '1', 2, '3', 4, '5', 6);
+  const eClass = cps(fn1, '1');
+  const eGen = cps(g1, '1');
+
+  // Args Test
+  (e0.CPS.args: []);
+  (e1.CPS.args: [string]);
+  (e2.CPS.args: [string, number]);
+  (e3.CPS.args: [string, number, string]);
+  (e4.CPS.args: [string, number, string, number]);
+  (e5.CPS.args: [string, number, string, number, string]);
+  (e6.CPS.args: [string, number, string, number, string, number]);
+
+  // Fn Test
+  (e1.CPS.fn: typeof fn1);
+  (e2.CPS.fn: typeof fn2);
+  (e3.CPS.fn: typeof fn3);
+  (e4.CPS.fn: typeof fn4);
+  (e5.CPS.fn: typeof fn5);
+  (e6.CPS.fn: typeof fn6);
+  (eGen.CPS.fn: typeof g1);
+
+  // $ExpectError: wrong fn
+  (e6.CPS.fn: typeof fn1);
+}
+
+function contextCpsTest() {
+  const e0 = cps([context, fn0]);
+  const e1 = cps([context, fn1], '1');
+  const e2 = cps([context, fn2], '1', 2);
+  const e3 = cps([context, fn3], '1', 2, '3');
+  const e4 = cps([context, fn4], '1', 2, '3', 4);
+  const e5 = cps([context, fn5], '1', 2, '3', 4, '5');
+  const e6 = cps([context, fn6], '1', 2, '3', 4, '5', 6);
+  const eClass = cps([context2, fn1], '1');
+  const eGen = cps([context, g1], '1');
+
+  // Args Test
+  (e0.CPS.args: []);
+  (e1.CPS.args: [string]);
+  (e2.CPS.args: [string, number]);
+  (e3.CPS.args: [string, number, string]);
+  (e4.CPS.args: [string, number, string, number]);
+  (e5.CPS.args: [string, number, string, number, string]);
+  (e6.CPS.args: [string, number, string, number, string, number]);
+
+  // Context Test
+  (e1.CPS.context: typeof context);
+  (e2.CPS.context: typeof context);
+  (e3.CPS.context: typeof context);
+  (e4.CPS.context: typeof context);
+  (e5.CPS.context: typeof context);
+  (e6.CPS.context: typeof context);
+  (eGen.CPS.context: typeof context);
+
+  // Fn Test
+  (e1.CPS.fn: typeof fn1);
+  (e2.CPS.fn: typeof fn2);
+  (e3.CPS.fn: typeof fn3);
+  (e4.CPS.fn: typeof fn4);
+  (e5.CPS.fn: typeof fn5);
+  (e6.CPS.fn: typeof fn6);
+  (eGen.CPS.fn: typeof g1);
+
+  // $ExpectError: wrong fn
+  (e6.CPS.fn: typeof fn1);
+}
+
+function spawnTest() {
+  const e0 = spawn(fn0);
+  const e1 = spawn(fn1, '1');
+  const e2 = spawn(fn2, '1', 2);
+  const e3 = spawn(fn3, '1', 2, '3');
+  const e4 = spawn(fn4, '1', 2, '3', 4);
+  const e5 = spawn(fn5, '1', 2, '3', 4, '5');
+  const e6 = spawn(fn6, '1', 2, '3', 4, '5', 6);
+  const eClass = spawn(fn1, '1');
+  const eGen = spawn(g1, '1');
+
+  // Args Test
+  (e0.FORK.args: []);
+  (e1.FORK.args: [string]);
+  (e2.FORK.args: [string, number]);
+  (e3.FORK.args: [string, number, string]);
+  (e4.FORK.args: [string, number, string, number]);
+  (e5.FORK.args: [string, number, string, number, string]);
+  (e6.FORK.args: [string, number, string, number, string, number]);
+
+  // Fn Test
+  (e1.FORK.fn: typeof fn1);
+  (e2.FORK.fn: typeof fn2);
+  (e3.FORK.fn: typeof fn3);
+  (e4.FORK.fn: typeof fn4);
+  (e5.FORK.fn: typeof fn5);
+  (e6.FORK.fn: typeof fn6);
+  (eGen.FORK.fn: typeof g1);
+
+  // $ExpectError: wrong fn
+  (e6.FORK.fn: typeof fn1);
+}
+
+function contextSpawnTest() {
+  const e0 = spawn([context, fn0]);
+  const e1 = spawn([context, fn1], '1');
+  const e2 = spawn([context, fn2], '1', 2);
+  const e3 = spawn([context, fn3], '1', 2, '3');
+  const e4 = spawn([context, fn4], '1', 2, '3', 4);
+  const e5 = spawn([context, fn5], '1', 2, '3', 4, '5');
+  const e6 = spawn([context, fn6], '1', 2, '3', 4, '5', 6);
+  const eClass = spawn([context2, fn1], '1');
+  const eGen = spawn([context, g1], '1');
+
+  // Args Test
+  (e0.FORK.args: []);
+  (e1.FORK.args: [string]);
+  (e2.FORK.args: [string, number]);
+  (e3.FORK.args: [string, number, string]);
+  (e4.FORK.args: [string, number, string, number]);
+  (e5.FORK.args: [string, number, string, number, string]);
+  (e6.FORK.args: [string, number, string, number, string, number]);
+
+  // Context Test
+  (e1.FORK.context: typeof context);
+  (e2.FORK.context: typeof context);
+  (e3.FORK.context: typeof context);
+  (e4.FORK.context: typeof context);
+  (e5.FORK.context: typeof context);
+  (e6.FORK.context: typeof context);
+  (eGen.FORK.context: typeof context);
+
+  // Fn Test
+  (e1.FORK.fn: typeof fn1);
+  (e2.FORK.fn: typeof fn2);
+  (e3.FORK.fn: typeof fn3);
+  (e4.FORK.fn: typeof fn4);
+  (e5.FORK.fn: typeof fn5);
+  (e6.FORK.fn: typeof fn6);
+  (eGen.FORK.fn: typeof g1);
+
+  // $ExpectError: wrong fn
+  (e6.FORK.fn: typeof fn1);
+}
+
+function joinTest() {
+  const task = utils.createMockTask();
+
+  const j = join(task);
+
+  // $ExpectError: This is not an actual Task object
+  (j.JOIN.call: Function);
+}
+
+function cancelTest() {
+  const task = utils.createMockTask();
+
+  const c = cancel(task);
+
+  // $ExpectError: This is not an actual Task object
+  (c.CANCEL.call: Function);
+}
+
+function raceTest() {
+  const e1 = take('FOO');
+  const e2 = put({ type: 'BAR' });
+
+  const r = race({
+    foo: e1,
+    bar: e2,
+  });
+
+  // Should recognize the RACE data structure
+  (r.RACE.foo: TakeEffect<string>);
+  (r.RACE.bar: PutEffect<{ type: string }>);
+
+  // $ExpectError: ReduxEffects have a hidden symbol
+  race({ fail: { PUT: 'hi' }});
+}
+
+function cancelledTest() {
+  const c = cancelled();
+
+  (c.CANCELLED: Object);
+}
+
+function selectTest() {
+  const s0 = (state: Object): Object => ({});
+  const s1 = (state: Object, a: string) => ({});
+  const s2 = (state: Object, a: string, b: number) => ({});
+  const s3 = (state: Object, a: string, b: number, c: string) => ({});
+  const s4 = (state: Object, a: string, b: number, c: string, d: number) => ({});
+  const s5 = (state: Object, a: string, b: number, c: string, d: number, e: string) => ({});
+  const s6 = (state: Object, a: string, b: number, c: string, d: number, e: string, f: number) => ({});
+  const sSpread = (state: Object, ...args: Array<string>): Object => ({});
+
+  const e0 = select(s0);
+  const e1 = select(s1, '1');
+  const e2 = select(s2, '1', 2);
+  const e3 = select(s3, '1', 2, '3');
+  const e4 = select(s4, '1', 2, '3', 4);
+  const e5 = select(s5, '1', 2, '3', 4, '5');
+  const e6 = select(s6, '1', 2, '3', 4, '5', 6);
+
+  // Args test
+  (e0.SELECT.args: []);
+  (e1.SELECT.args: [string]);
+  (e2.SELECT.args: [string, number]);
+  (e3.SELECT.args: [string, number, string]);
+  (e4.SELECT.args: [string, number, string, number]);
+  (e5.SELECT.args: [string, number, string, number, string]);
+  (e6.SELECT.args: [string, number, string, number, string, number]);
+
+  // $ExpectError: second args is not a boolean
+  (e3.SELECT.args: [string, boolean, string]);
+
+  // Fn check
+  (e0.SELECT.selector: typeof s0);
+  (e1.SELECT.selector: typeof s1);
+  (e2.SELECT.selector: typeof s2);
+  (e3.SELECT.selector: typeof s3);
+  (e4.SELECT.selector: typeof s4);
+  (e5.SELECT.selector: typeof s5);
+  (e6.SELECT.selector: typeof s6);
+
+  // $ExpectError: args.a should actually be a string
+  (e1.SELECT.selector: (state: Object, a: number) => Object);
+}
+
+function takeEveryTest() {
+  const getStuff = (state: Object): Object => ({a: ''})
+
+  function* saga0(): Generator<IOEffect, string, string> {
+    let foo = yield fork((): Promise<number> => Promise.resolve(1));
+    return '';
+  }
+
+  function* saga1(a: string): Generator<IOEffect,*,*>  {
+    // let foo = yield select(getStuff);
+    let foo = yield select(getStuff);
+    return '';
+  }
+
+  function* faultySaga(a: string): Generator<string,*,*> {
+    yield 'test';
+  }
+
+  // $ExpectError: yield should be a yield*
+  function* faulySagaOfSaga(): Generator<IOEffect,*,*> {
+    yield takeEvery('Foo', saga0);
+  }
+
+  // This saga should work, since it should yield effects as well
+  function* nestedSaga(a: string): Generator<IOEffect,*,*> {
+    yield* saga1(a);
+  }
+
+  function* sagaOfSaga(): Generator<IOEffect,*,*> {
+    yield* takeEvery('Foo', saga0);
+  }
+
+  const e0 = takeEvery('FOO', saga0);
+  const e1 = takeEvery('FOO', saga1, '1');
+
+  (e0.name: string);
+
+  // $ExpectError: faultySaga yields strings, which is not allowed
+  takeEvery('FOO', faultySaga, '1');
+
+  takeEvery('FOO', nestedSaga, '1');
+}
+
+function takeLatestTest() {
+  const getStuff = (state: Object): Object => ({a: ''})
+
+  function* saga0(): Generator<IOEffect, string, string> {
+    let foo = yield fork((): Promise<number> => Promise.resolve(1));
+    return '';
+  }
+
+  function* saga1(a: string): Generator<IOEffect,*,*>  {
+    // let foo = yield select(getStuff);
+    let foo = yield select(getStuff);
+    return '';
+  }
+
+  function* faultySaga(a: string): Generator<string,*,*> {
+    yield 'test';
+  }
+
+  // $ExpectError: yield should be a yield*
+  function* faulySagaOfSaga(): Generator<IOEffect,*,*> {
+    yield takeEvery('Foo', saga0);
+  }
+
+  // This saga should work, since it should yield effects as well
+  function* nestedSaga(a: string): Generator<IOEffect,*,*> {
+    yield* saga1(a);
+  }
+
+  function* sagaOfSaga(): Generator<IOEffect,*,*> {
+    yield* takeLatest('Foo', saga0);
+  }
+
+  function* yieldForkSaga(): Generator<IOEffect,*,*> {
+    yield fork(takeLatest, 'Foo', saga0);
+  }
+
+  const e0 = takeLatest('FOO', saga0);
+  const e1 = takeLatest('FOO', saga1, '1');
+
+  (e0.name: string);
+
+  // $ExpectError: faultySaga yields strings, which is not allowed
+  takeLatest('FOO', faultySaga, '1');
+
+  takeLatest('FOO', nestedSaga, '1');
+}
+
+function runSagaTest() {
+  const iter = function* f() {}();
+
+  (runSaga(iter): Task);
+  (runSaga(iter, {}): Task);
+
+  const cb = (input) => {};
+  const subscribe = (cb) => {
+    cb('');
+    return () => {}; // unsubscribe fn
+  };
+
+  const invalidSubscribe = (cb) => {
+    // $ExpectError: cb is a function
+    cb + 2;
+
+    // $ExpectError: return needs to be a subscribe fn
+    return '';
+  }
+
+  // $ExpectError: error level is a string enum
+  const invalidLogger = (level: number) => {};
+
+
+  const dispatch = (output) => {};
+  const getState = () => ({});
+  const logger = (level) => {};
+
+  // Should be fine
+  runSaga(iter, { subscribe });
+  runSaga(iter, { dispatch });
+  runSaga(iter, { getState });
+  runSaga(iter, { sagaMonitor });
+  runSaga(iter, { logger });
+
+  // Invalid instantiations
+  runSaga(iter, { logger: invalidLogger });
+  runSaga(iter, { subscribe: invalidSubscribe });
+}
+
+function createSagaMiddlewareTest() {
+  const middleware = createSagaMiddleware();
+
+  function* g0(): Generator<*, *, *> {};
+  function* g1(a: string): Generator<*, *, *> {};
+  function* g2(a: string, b: number): Generator<*, *, *> {};
+  function* g3(a: string, b: number, c: string): Generator<*, *, *> {};
+  function* g4(a: string, b: number, c: string, d: number): Generator<*, *, *> {};
+  function* g5(a: string, b: number, c: string, d: number, e: string): Generator<*, *, *> {};
+  function* g6(a: string, b: number, c: string, d: number, e: string, f: number): Generator<*, *, *> {};
+  function* gSpread(...args: Array<string>): Generator<*, *, *> {};
+  function* gList(): Generator<*, *, *> { yield []; };
+
+  middleware.run(g0);
+  middleware.run(g1, '1');
+  middleware.run(g2, '1', 2);
+  middleware.run(g3, '1', 2, '3');
+  middleware.run(g4, '1', 2, '3', 4);
+  middleware.run(g5, '1', 2, '3', 4, '5');
+  middleware.run(g6, '1', 2, '3', 4, '5', 6);
+  middleware.run(gList);
+
+  // $ExpectError: Too few arguments
+  middleware.run(g6, '1', 2, '3');
+
+  // $ExpectError: Boolean argument should be string
+  middleware.run(g3, true, 2, '3');
+
+  (middleware.run(g0): Task);
+}


### PR DESCRIPTION
Closes #469 .

For redux-saga 0.11.x, I applied quick fix for `Fn` definitions to support a call of normal function.
For redux-saga 0.13.x, I added new APIs and updated some definitions based on latest redux-saga's code. In addition to that, I added lots of test cases for `call` effect to check various types of function (normal function, Promise, Generator).