### PR TITLE
fix static bluebird.reduce function definition

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-/bluebird_v3.x.x.js
@@ -66,7 +66,7 @@ declare class Bluebird$Promise<R> {
   ): Bluebird$Promise<Array<U>>;
   static reduce<T, U, Elem: Bluebird$Promisable<T>>(
     Promises: Array<Elem>,
-    reducer: (total: U, current: T, index: number, arrayLength: number) => U,
+    reducer: (total: U, current: T, index: number, arrayLength: number) => Bluebird$Promisable<U>,
     initialValue?: U
   ): Bluebird$Promise<U>;
   static filter<T, Elem: Bluebird$Promisable<T>>(


### PR DESCRIPTION
Note that according to Bluebird documentation (http://bluebirdjs.com/docs/api/promise.reduce.html) , the static `reduce` method can return a value or the Promise of a value (in which case the value is resolved before being passed to the reducer with the next element). However, the current type definition does not reflect that. Take the following example of a Promise chain using reduce that concatenates an array of chars which runs successfully.
```
const Bluebird = require('bluebird');
const values = ["h", "e", "l", "l", "o"];

Bluebird.reduce(values, (total, current) => Promise.resolve(total + current))
.then(result => console.log(result));
```
Here the reducer's `current` parameter has type `string` and the return value is of type `Promise<string>`. This causes flow to throw an error however, because the original type definition says that both the reducer's return value and `current` paramater must have the same type, `U`. However, by altering the return type of the reducer to be of type `Bluebird$Promisable<U>`, flow successfully verifies the code and it runs as expected