### PR TITLE
RxJS: Add TimeoutError; remove error argument to timeout()

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-v0.33.x/rxjs_v5.0.x.js
@@ -245,7 +245,7 @@ declare class rxjs$Observable<+T> {
 
   throttleTime(duration: number): rxjs$Observable<T>;
 
-  timeout(due: number | Date, errorToSend?: any): rxjs$Observable<T>;
+  timeout(due: number | Date, _: void): rxjs$Observable<T>;
 
   toArray(): rxjs$Observable<T[]>;
 
@@ -659,6 +659,9 @@ declare class rxjs$SchedulerClass {
   schedule<T>(work: (state?: T) => void, delay?: number, state?: T): rxjs$Subscription;
 }
 
+declare class rxjs$TimeoutError extends Error {
+}
+
 declare module 'rxjs' {
   declare module.exports: {
     Observable: typeof rxjs$Observable,
@@ -673,6 +676,7 @@ declare module 'rxjs' {
       async: rxjs$SchedulerClass,
     },
     Subscription: typeof rxjs$Subscription,
+    TimeoutError: typeof rxjs$TimeoutError,
   }
 }
 

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -247,7 +247,7 @@ declare class rxjs$Observable<+T> {
 
   throttleTime(duration: number): rxjs$Observable<T>;
 
-  timeout(due: number | Date, errorToSend?: any): rxjs$Observable<T>;
+  timeout(due: number | Date, _: void): rxjs$Observable<T>;
 
   toArray(): rxjs$Observable<T[]>;
 
@@ -668,6 +668,9 @@ declare class rxjs$SchedulerClass {
   schedule<T>(work: (state?: T) => void, delay?: number, state?: T): rxjs$Subscription;
 }
 
+declare class rxjs$TimeoutError extends Error {
+}
+
 declare module 'rxjs' {
   declare module.exports: {
     Observable: typeof rxjs$Observable,
@@ -682,6 +685,7 @@ declare module 'rxjs' {
       async: rxjs$SchedulerClass,
     },
     Subscription: typeof rxjs$Subscription,
+    TimeoutError: typeof rxjs$TimeoutError,
   }
 }
 


### PR DESCRIPTION
The argument was removed prior to the 5.0.0 release. Users are now expected to compare against `Rx.TimeoutError`.