### PR TITLE
react-dnd definition improvements

### DIFF
--- a/definitions/npm/react-dnd_v2.x.x/flow_v0.23.x-/react-dnd_v2.x.x.js
+++ b/definitions/npm/react-dnd_v2.x.x/flow_v0.23.x-/react-dnd_v2.x.x.js
@@ -46,24 +46,24 @@ type DragSourceType<P> =
 type DragSourceSpec<D, P, S> = {
   beginDrag: (
     props: P,
-    monitor?: DragSourceMonitor,
-    component?: React$Component<D, P, S>
+    monitor: DragSourceMonitor,
+    component: React$Component<D, P, S>
   ) => Object,
 
   endDrag?: (
     props: P,
-    monitor?: DragSourceMonitor,
-    component?: ?React$Component<D, P, S>
+    monitor: DragSourceMonitor,
+    component: ?React$Component<D, P, S>
   ) => void,
 
   canDrag?: (
     props: P,
-    monitor?: DragSourceMonitor
+    monitor: DragSourceMonitor
   ) => boolean,
 
   isDragging?: (
     props: P,
-    monitor?: DragSourceMonitor
+    monitor: DragSourceMonitor
   ) => boolean
 };
 
@@ -128,19 +128,19 @@ type DropTargetTypes<P> =
 type DropTargetSpec<D, P, S> = {
   drop?: (
     props: P,
-    monitor?: DropTargetMonitor,
-    component?: React$Component<D, P, S>
+    monitor: DropTargetMonitor,
+    component: React$Component<D, P, S>
   ) => ?Object,
 
   hover?: (
     props: P,
-    monitor?: DropTargetMonitor,
-    component?: React$Component<D, P, S>
+    monitor: DropTargetMonitor,
+    component: React$Component<D, P, S>
   ) => void,
 
   canDrop?: (
     props: P,
-    monitor?: DropTargetMonitor
+    monitor: DropTargetMonitor
   ) => boolean
 };
 

--- a/definitions/npm/react-dnd_v2.x.x/flow_v0.23.x-/react-dnd_v2.x.x.js
+++ b/definitions/npm/react-dnd_v2.x.x/flow_v0.23.x-/react-dnd_v2.x.x.js
@@ -16,23 +16,23 @@ type ElementOrNode = React$Element<any> | HTMLElement;
 
 // Decorated Components
 // ----------------------------------------------------------------------
-declare class DndComponent<D, P, S> extends React$Component<D, P, S> {
+declare class DndComponent<C, D, P, S> extends React$Component<D, P, S> {
   static defaultProps: D;
   props: P;
   state: S;
 
-  static DecoratedComponent: Class<this>;
-  getDecoratedComponentInstance(): this;
+  static DecoratedComponent: Class<C>;
+  getDecoratedComponentInstance(): C;
   getHandlerId(): Identifier;
 }
 
-declare class ContextComponent<D, P, S> extends React$Component<D, P, S> {
+declare class ContextComponent<C, D, P, S> extends React$Component<D, P, S> {
   static defaultProps: D;
   props: P;
   state: S;
 
-  static DecoratedComponent: Class<this>;
-  getDecoratedComponentInstance(): this;
+  static DecoratedComponent: Class<C>;
+  getDecoratedComponentInstance(): C;
   // getManager is not yet documented in ReactDnd Docs
   getManager(): any;
 }
@@ -116,7 +116,7 @@ type DragSource = <D, P, S, C: React$Component<D, P, S>>(
   spec: DragSourceSpec<D, P, S>,
   collect: DragSourceCollector,
   options?: DndOptions<P>
-) => (component: Class<C>) => Class<DndComponent<D, P, S>>;
+) => (component: Class<C> | (props: P) => ?React$Element<*>) => Class<DndComponent<C, D, P, S>>;
 
 // Drop Target
 // ----------------------------------------------------------------------
@@ -174,7 +174,7 @@ type DropTarget = <D, P, S, C: React$Component<D, P, S>>(
     monitor: DropTargetMonitor
   ) => Object,
   options?: DndOptions<P>
-) => (component: Class<C>) => Class<DndComponent<D, P, S>>;
+) => (component: Class<C>) => Class<DndComponent<C, D, P, S>>;
 
 // Drag Layer
 // ----------------------------------------------------------------------
@@ -192,13 +192,13 @@ type DragLayerMonitor = {
 type DragLayer = <D, P, S, C: React$Component<D, P, S>>(
   collect: (monitor: DragLayerMonitor) => Object,
   options?: DndOptions<P>
-) => (component: Class<C>) => Class<DndComponent<D, P, S>>;
+) => (component: Class<C>) => Class<DndComponent<C, D, P, S>>;
 
 // Drag Drop Context
 // ----------------------------------------------------------------------
 type DragDropContext = <D, P, S, C: React$Component<D, P, S>>(
   backend: mixed
-) => (component: Class<C>) => Class<ContextComponent<D, P, S>>;
+) => (component: Class<C>) => Class<ContextComponent<C, D, P, S>>;
 
 // Top-level API
 // ----------------------------------------------------------------------

--- a/definitions/npm/react-dnd_v2.x.x/flow_v0.23.x-/react-dnd_v2.x.x.js
+++ b/definitions/npm/react-dnd_v2.x.x/flow_v0.23.x-/react-dnd_v2.x.x.js
@@ -106,17 +106,17 @@ type ConnectDragPreview = <T : ElementOrNode>(
   options?: DragPreviewOptions
 ) => ?T;
 
-type DragSourceCollector = (
+type DragSourceCollector<T> = (
   connect: DragSourceConnector,
   monitor: DragSourceMonitor
-) => Object;
+) => T;
 
-type DragSource = <D, P, S, C: React$Component<D, P, S>>(
+type DragSource = <D, P, S, CP, C: React$Component<D, P, S>>(
   type: DragSourceType<P>,
   spec: DragSourceSpec<D, P, S>,
-  collect: DragSourceCollector,
+  collect: DragSourceCollector<CP>,
   options?: DndOptions<P>
-) => (component: Class<C> | (props: P) => ?React$Element<*>) => Class<DndComponent<C, D, P, S>>;
+) => (component: Class<C> | (props: P) => ?React$Element<*>) => Class<DndComponent<C, D, $Diff<P, CP>, S>>;
 
 // Drop Target
 // ----------------------------------------------------------------------
@@ -166,15 +166,15 @@ type ConnectDropTarget = <T : ElementOrNode>(
   elementOrNode: T
 ) => ?T;
 
-type DropTarget = <D, P, S, C: React$Component<D, P, S>>(
+type DropTarget = <D, P, S, CP, C: React$Component<D, P, S>>(
   types: DropTargetTypes<P>,
   spec: DropTargetSpec<D, P, S>,
   collect: (
     connect: DropTargetConnector,
     monitor: DropTargetMonitor
-  ) => Object,
+  ) => CP,
   options?: DndOptions<P>
-) => (component: Class<C>) => Class<DndComponent<C, D, P, S>>;
+) => (component: Class<C> | (props: P) => ?React$Element<*>) => Class<DndComponent<C, D, $Diff<P, CP>, S>>;
 
 // Drag Layer
 // ----------------------------------------------------------------------
@@ -189,10 +189,10 @@ type DragLayerMonitor = {
   getSourceClientOffset: () => ClientOffset;
 }
 
-type DragLayer = <D, P, S, C: React$Component<D, P, S>>(
-  collect: (monitor: DragLayerMonitor) => Object,
+type DragLayer = <D, P, S, CP, C: React$Component<D, P, S>>(
+  collect: (monitor: DragLayerMonitor) => CP,
   options?: DndOptions<P>
-) => (component: Class<C>) => Class<DndComponent<C, D, P, S>>;
+) => (component: Class<C> | (props: P) => ?React$Element<*>) => Class<DndComponent<C, D, $Diff<P, CP>, S>>;
 
 // Drag Drop Context
 // ----------------------------------------------------------------------

--- a/definitions/npm/react-dnd_v2.x.x/test_react-dnd-v2.js
+++ b/definitions/npm/react-dnd_v2.x.x/test_react-dnd-v2.js
@@ -1,15 +1,21 @@
 /* @flow */
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { DragSource, DropTarget, DragLayer, DragDropContext } from 'react-dnd';
 
 // Test Drag Source
 // ----------------------------------------------------------------------
-type KnightProps = {
-  connectDragSource: (e: React$Element<*>) => ?React$Element<*>,
-  connectDragPreview: (e: Image) => ?Image,
-  isDragging: boolean
-}
+type KnightDefaultProps = {
+  color: string;
+};
+type KnightProps = KnightDefaultProps & {
+  title: string;
+
+  connectDragSource: (e: React$Element<*>) => ?React$Element<*>;
+  connectDragPreview: (e: Image) => ?Image;
+  isDragging: boolean;
+};
 
 const knightSource = {
   beginDrag() {
@@ -28,7 +34,7 @@ function knightCollect(connect, monitor) {
 class Knight extends React.Component {
   props: KnightProps;
 
-  static defaultProps: KnightProps;
+  static defaultProps: KnightDefaultProps;
 
   componentDidMount() {
     const img = new Image();
@@ -40,9 +46,10 @@ class Knight extends React.Component {
   }
 
   render() {
-    const { connectDragSource, isDragging } = this.props;
+    const { color, title, connectDragSource, isDragging } = this.props;
     return connectDragSource(
-      <div style={{
+      <div title={title} style={{
+        color,
         fontSize: 40,
         fontWeight: 'bold',
         cursor: 'move',
@@ -54,13 +61,11 @@ class Knight extends React.Component {
   }
 }
 Knight.defaultProps = {
-  connectDragSource: () => null,
-  connectDragPreview: () => null,
-  isDragging: false
+  color: 'blue'
 };
 
 const DndKnight = DragSource('knight', knightSource, knightCollect)(Knight);
-(DndKnight: Class<DndComponent<Knight, KnightProps, KnightProps, void>>);
+(DndKnight: Class<DndComponent<Knight, *, *, void>>);
 // $ExpectError
 (DndKnight: number);
 
@@ -72,6 +77,8 @@ x.foo();
 // $ExpectError
 (x.getDecoratedComponentInstance().foo(): number);
 
+ReactDOM.render(<DndKnight title="foo" />, document.body);
+
 // Test Drop Target
 // ----------------------------------------------------------------------
 function moveKnight(toX: number, toY: number) {
@@ -79,32 +86,6 @@ function moveKnight(toX: number, toY: number) {
 
 function canMoveKnight(toX: number, toY: number) {
   return true;
-}
-
-type BoardSquareProps = {
-  x: number,
-  y: number,
-  isOver: boolean,
-  canDrop: boolean,
-  connectDropTarget: (e: React$Element<*>) => ?React$Element<*>
-};
-
-const boardSquareTarget = {
-  canDrop(props) {
-    return canMoveKnight(props.x, props.y);
-  },
-
-  drop(props) {
-    moveKnight(props.x, props.y);
-  }
-};
-
-function boardSquareCollect(connect, monitor) {
-  return {
-    connectDropTarget: connect.dropTarget(),
-    isOver: monitor.isOver(),
-    canDrop: monitor.canDrop()
-  };
 }
 
 type SquareProps = {
@@ -127,10 +108,37 @@ Square.defaultProps = {
   black: true
 };
 
+type BoardSquareDefaultProps = {
+  x: number;
+};
+type BoardSquareProps = BoardSquareDefaultProps & {
+  y: number;
+  connectDropTarget: (e: React$Element<*>) => ?React$Element<*>;
+  isOver: boolean;
+  canDrop: boolean;
+};
+
+const boardSquareTarget = {
+  canDrop(props) {
+    return canMoveKnight(props.x, props.y);
+  },
+
+  drop(props) {
+    moveKnight(props.x, props.y);
+  }
+};
+
+function boardSquareCollect(connect, monitor) {
+  return {
+    connectDropTarget: connect.dropTarget(),
+    isOver: monitor.isOver(),
+    canDrop: monitor.canDrop()
+  };
+}
 class BoardSquare extends React.Component {
   props: BoardSquareProps;
 
-  static defaultProps: BoardSquareProps;
+  static defaultProps: BoardSquareDefaultProps;
 
   renderOverlay(color: string) {
     return (
@@ -166,17 +174,15 @@ class BoardSquare extends React.Component {
   }
 }
 BoardSquare.defaultProps = {
-  x: 0,
-  y: 0,
-  isOver: false,
-  canDrop: false,
-  connectDropTarget: () => null
+  x: 0
 };
 
 const DndBoardSquare = DropTarget('boardsquare', boardSquareTarget, boardSquareCollect)(BoardSquare);
-(DndBoardSquare: Class<DndComponent<BoardSquare, BoardSquareProps, BoardSquareProps, void>>);
+(DndBoardSquare: Class<DndComponent<BoardSquare, *, *, void>>);
 // $ExpectError
 (DndBoardSquare: string);
+
+ReactDOM.render(<DndBoardSquare y={5} />, document.body);
 
 // Test Custom Drag Layer
 // ----------------------------------------------------------------------
@@ -214,7 +220,7 @@ CustomDragLayer.defaultProps = {
 };
 
 const DndCustomDragLayer = DragLayer(dragLayerCollect)(CustomDragLayer);
-(DndCustomDragLayer: Class<DndComponent<CustomDragLayer, CustomDragLayerProps, CustomDragLayerProps, void>>);
+(DndCustomDragLayer: Class<DndComponent<CustomDragLayer, *, *, void>>);
 // $ExpectError
 (DndCustomDragLayer: number);
 
@@ -278,4 +284,4 @@ const TestFuncComp = (props: TestProps) => {
 }
 
 const DndTestFuncComp = DragSource('test', testSource, testCollect)(TestFuncComp);
-(DndTestFuncComp: Class<DndComponent<*, void, TestProps, void>>);
+(DndTestFuncComp: Class<DndComponent<*, *, *, *>>);

--- a/definitions/npm/react-dnd_v2.x.x/test_react-dnd-v2.js
+++ b/definitions/npm/react-dnd_v2.x.x/test_react-dnd-v2.js
@@ -35,6 +35,10 @@ class Knight extends React.Component {
     img.onload = () => { this.props.connectDragPreview(img) };
   }
 
+  foo(): string {
+    return 'foo';
+  }
+
   render() {
     const { connectDragSource, isDragging } = this.props;
     return connectDragSource(
@@ -56,9 +60,17 @@ Knight.defaultProps = {
 };
 
 const DndKnight = DragSource('knight', knightSource, knightCollect)(Knight);
-(DndKnight: Class<DndComponent<KnightProps, KnightProps, void>>);
+(DndKnight: Class<DndComponent<Knight, KnightProps, KnightProps, void>>);
 // $ExpectError
 (DndKnight: number);
+
+const x: DndKnight = ({}:any);
+// $ExpectError
+x.foo();
+
+(x.getDecoratedComponentInstance().foo(): string);
+// $ExpectError
+(x.getDecoratedComponentInstance().foo(): number);
 
 // Test Drop Target
 // ----------------------------------------------------------------------
@@ -162,7 +174,7 @@ BoardSquare.defaultProps = {
 };
 
 const DndBoardSquare = DropTarget('boardsquare', boardSquareTarget, boardSquareCollect)(BoardSquare);
-(DndBoardSquare: Class<DndComponent<BoardSquareProps, BoardSquareProps, void>>);
+(DndBoardSquare: Class<DndComponent<BoardSquare, BoardSquareProps, BoardSquareProps, void>>);
 // $ExpectError
 (DndBoardSquare: string);
 
@@ -202,7 +214,7 @@ CustomDragLayer.defaultProps = {
 };
 
 const DndCustomDragLayer = DragLayer(dragLayerCollect)(CustomDragLayer);
-(DndCustomDragLayer: Class<DndComponent<CustomDragLayerProps, CustomDragLayerProps, void>>);
+(DndCustomDragLayer: Class<DndComponent<CustomDragLayer, CustomDragLayerProps, CustomDragLayerProps, void>>);
 // $ExpectError
 (DndCustomDragLayer: number);
 
@@ -232,7 +244,7 @@ Board.defaultProps = {
 };
 
 const DndBoard = DragDropContext({})(Board);
-(DndBoard: Class<ContextComponent<BoardProps, BoardProps, void>>);
+(DndBoard: Class<ContextComponent<Board, BoardProps, BoardProps, void>>);
 // $ExpectError
 (DndBoard: string);
 
@@ -266,4 +278,4 @@ const TestFuncComp = (props: TestProps) => {
 }
 
 const DndTestFuncComp = DragSource('test', testSource, testCollect)(TestFuncComp);
-(DndTestFuncComp: Class<DndComponent<void, TestProps, void>>);
+(DndTestFuncComp: Class<DndComponent<*, void, TestProps, void>>);


### PR DESCRIPTION
This pull request makes three main improvements to react-dnd's definitions. Each improvement is in its own commit.

The definitions of react-dnd prohibits legal code like this because `monitor` in the callback type is incorrectly typed as optional:

```js
import {DragSource} from 'react-dnd';

const ManageItemDragSource = {
  beginDrag(props: Props) {
    return {
      item: props.item,
      index: props.index
    };
  },

  endDrag(props, monitor){
    if(!monitor.didDrop()){
      props.onSetIndex(monitor.getItem().index, monitor.getItem().item);
    }
  },

  isDragging(props, monitor){
    return props.item.guid === monitor.getItem().item.guid;
  }
}


export default DragSource(..., ManageItemDragSource, ...);
```

The user of react-dnd has to pass some callback functions into the library. react-dnd calls these callbacks with a bunch of parameters and the user might not care about all of the parameters. The current react-dnd definitions incorrectly type some of the parameters as optional. The parameters are always passed. I believe they were typed as optional to allow the user's callbacks to not need to deal with them, but this is unnecessary (Flow allows a function to be called with extra parameters) and means that user callbacks that do want to deal with these extra parameters has to null-check values that will never be null. This pull request fixes it.

---

Another problem is that the `getDecoratedComponentInstance()` method had the wrong type. It was typed as returning the wrapper component, when it's supposed to return the type of the component being wrapped (so that methods could be called on it, etc). `DndComponent` has another type parameter referring to the wrapped class so that this just works now. Test included.

---

When you wrap a component with DragSource, DropTarget, or DragLayer, you pass a "collect" function which returns an object that provides more props to the component. The returned wrapper component does not need this props passed to it. However, the old definitions had the wrapper component have the same type (and therefore the same required props) as the wrapped component, so Flow still believed you needed to pass props that were provided by the collect function. This was fixed by setting the return value of the collect function into a type parameter, and then using `$Diff` on the wrapped component's prop type and the collect function's return type. This solution is consistent with the [documentation's recommendations on React higher order components](https://flowtype.org/docs/react.html).