### PR TITLE
Avoid `import type` in declaration files

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
@@ -1,4 +1,4 @@
-import type { Server } from 'http';
+import http from 'http';
 
 declare type express$RouterOptions = {
   caseSensitive?: boolean,
@@ -141,11 +141,11 @@ declare class express$Application extends express$Router mixins events$EventEmit
   constructor(): void;
   locals: {[name: string]: mixed};
   mountpath: string;
-  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): Server;
-  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): Server;
-  listen(port: number, callback?: (err?: ?Error) => mixed): Server;
-  listen(path: string, callback?: (err?: ?Error) => mixed): Server;
-  listen(handle: Object, callback?: (err?: ?Error) => mixed): Server;
+  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): http.Server;
+  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): http.Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): http.Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): http.Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): http.Server;
   disable(name: string): void;
   disabled(name: string): boolean;
   enable(name: string): void;

--- a/definitions/npm/express_v4.x.x/flow_v0.28.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.28.x-/express_v4.x.x.js
@@ -1,4 +1,4 @@
-import type { Server } from 'http';
+import http from 'http';
 
 declare type express$RouterOptions = {
   caseSensitive?: boolean,
@@ -141,11 +141,11 @@ declare class express$Application extends express$Router mixins events$EventEmit
   constructor(): void;
   locals: {[name: string]: mixed};
   mountpath: string;
-  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): Server;
-  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): Server;
-  listen(port: number, callback?: (err?: ?Error) => mixed): Server;
-  listen(path: string, callback?: (err?: ?Error) => mixed): Server;
-  listen(handle: Object, callback?: (err?: ?Error) => mixed): Server;
+  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): http.Server;
+  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): http.Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): http.Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): http.Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): http.Server;
   disable(name: string): void;
   disabled(name: string): boolean;
   enable(name: string): void;

--- a/definitions/npm/react-redux_v4.x.x/flow_v0.30.x-/react-redux_v4.x.x.js
+++ b/definitions/npm/react-redux_v4.x.x/flow_v0.30.x-/react-redux_v4.x.x.js
@@ -1,4 +1,4 @@
-import type { Dispatch, Store } from 'redux'
+import redux from 'redux'
 
 declare module 'react-redux' {
 
@@ -14,7 +14,7 @@ declare module 'react-redux' {
 
   declare type MapStateToProps<S, OP: Object, SP: Object> = (state: S, ownProps: OP) => SP | MapStateToProps<S, OP, SP>;
 
-  declare type MapDispatchToProps<A, OP: Object, DP: Object> = ((dispatch: Dispatch<A>, ownProps: OP) => DP) | DP;
+  declare type MapDispatchToProps<A, OP: Object, DP: Object> = ((dispatch: redux.Dispatch<A>, ownProps: OP) => DP) | DP;
 
   declare type MergeProps<SP, DP: Object, OP: Object, P: Object> = (stateProps: SP, dispatchProps: DP, ownProps: OP) => P;
 
@@ -35,7 +35,7 @@ declare module 'react-redux' {
     <Def, St>(component: Class<React$Component<Def, P, St>>): ConnectedComponentClass<OP, P, Def, St>;
   };
 
-  declare class Provider<S, A> extends React$Component<void, { store: Store<S, A>, children?: any }, void> { }
+  declare class Provider<S, A> extends React$Component<void, { store: redux.Store<S, A>, children?: any }, void> { }
 
   declare type ConnectOptions = {
     pure?: boolean,
@@ -46,21 +46,21 @@ declare module 'react-redux' {
 
   declare function connect<A, OP>(
     ...rest: Array<void> // <= workaround for https://github.com/facebook/flow/issues/2360
-  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
+  ): Connector<OP, $Supertype<{ dispatch: redux.Dispatch<A> } & OP>>;
 
   declare function connect<A, OP>(
     mapStateToProps: Null,
     mapDispatchToProps: Null,
     mergeProps: Null,
     options: ConnectOptions
-  ): Connector<OP, $Supertype<{ dispatch: Dispatch<A> } & OP>>;
+  ): Connector<OP, $Supertype<{ dispatch: redux.Dispatch<A> } & OP>>;
 
   declare function connect<S, A, OP, SP>(
     mapStateToProps: MapStateToProps<S, OP, SP>,
     mapDispatchToProps: Null,
     mergeProps: Null,
     options?: ConnectOptions
-  ): Connector<OP, $Supertype<SP & { dispatch: Dispatch<A> } & OP>>;
+  ): Connector<OP, $Supertype<SP & { dispatch: redux.Dispatch<A> } & OP>>;
 
   declare function connect<A, OP, DP>(
     mapStateToProps: Null,


### PR DESCRIPTION
This is a workaround for facebook/flow#3040: when used in a declaration file, `import type { T } from 'm'` breaks other files' usage of `m.T`.

`flow-typed` only has two definitions that use `import type`:

- `express_v4.x.x` includes `import type { Server } from 'http'`. With this definition installed, the user gets a Flow error anywhere they use the `http.Server` type. Unfortunately this error is raised for any dependencies that are themselves using the `express` definition, since the definition includes a `// @flow` pragma and Flow type checks all files with pragmas. 😭 

- `react-redux_v4.x.x` includes `import type { Dispatch, Store } from 'redux'`. This definition doesn't cause problems due to an odd quirk of facebook/flow#3040: it's only reproducible when the declaration with `import type { T } ...` is listed (by the filesystem or explicitly in `.flowconfig`) _after_ the declaration that exports `T`. So this one slips by because lexicographically, `'react-redux' < 'redux'`. 

This PR updates both to use the syntax `import m from 'm'` and `m.T`. I could have left `react-redux_v4.x.x` alone, but it felt right to get away from that strange order-dependent behavior.
