### PR TITLE
Drop @flow pragma from definitions

### DIFF
--- a/definitions/npm/bcrypt_v0.8.x/flow_v0.29.x-/bcrypt_v0.8.x.js
+++ b/definitions/npm/bcrypt_v0.8.x/flow_v0.29.x-/bcrypt_v0.8.x.js
@@ -1,5 +1,3 @@
-// @flow
-
 declare module bcrypt {
   declare function genSaltSync(rounds?: number): string;
   declare function genSalt(rounds: number, callback: (err: Error, salt: string) => void): void;

--- a/definitions/npm/bunyan_v1.x.x/flow_v0.21.x-/bunyan_v1.x.x.js
+++ b/definitions/npm/bunyan_v1.x.x/flow_v0.21.x-/bunyan_v1.x.x.js
@@ -1,4 +1,3 @@
-// @flow
 declare module 'bunyan' {
     declare var TRACE: 10;
     declare var DEBUG: 20;

--- a/definitions/npm/chai_v3.5.x/flow_v0.24.0-/chai_v3.5.x.js
+++ b/definitions/npm/chai_v3.5.x/flow_v0.24.0-/chai_v3.5.x.js
@@ -1,4 +1,3 @@
-/* @flow */
 declare module "chai" {
 
     declare type ExpectChain<T> = {

--- a/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
@@ -1,4 +1,3 @@
-// @flow
 import type { Server } from 'http';
 
 declare type express$RouterOptions = {

--- a/definitions/npm/express_v4.x.x/flow_v0.28.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.28.x-/express_v4.x.x.js
@@ -1,4 +1,3 @@
-// @flow
 import type { Server } from 'http';
 
 declare type express$RouterOptions = {

--- a/definitions/npm/fetch-ponyfill_v3.x.x/flow_v0.28.x-/fetch-ponyfill_v3.x.x.js
+++ b/definitions/npm/fetch-ponyfill_v3.x.x/flow_v0.28.x-/fetch-ponyfill_v3.x.x.js
@@ -1,5 +1,3 @@
-// @flow
-
 declare module 'fetch-ponyfill' {
 
   declare type InitOptions = {

--- a/definitions/npm/js-cookie_v2.x.x/flow_v0.25.x-/js-cookie_v2.x.x.js
+++ b/definitions/npm/js-cookie_v2.x.x/flow_v0.25.x-/js-cookie_v2.x.x.js
@@ -1,4 +1,3 @@
-// @flow
 declare module 'js-cookie' {
     declare type CookieOptions = {
         expires?: number | Date,

--- a/definitions/npm/paths-js_v0.4.x/flow_v0.32.x-/paths-js_v0.4.x.js
+++ b/definitions/npm/paths-js_v0.4.x/flow_v0.32.x-/paths-js_v0.4.x.js
@@ -1,4 +1,3 @@
-// @flow
 declare module "paths-js/all" {
 
   declare type Point = [number, number];

--- a/definitions/npm/ramda_v0.21.x/flow_v0.23.x-v0.27.x/ramda_v0.21.x.js
+++ b/definitions/npm/ramda_v0.21.x/flow_v0.23.x-v0.27.x/ramda_v0.21.x.js
@@ -1,4 +1,3 @@
-/* @flow */
 /* eslint-disable no-unused-vars, no-redeclare */
 
 type Transformer<A,B> = {

--- a/definitions/npm/ramda_v0.21.x/flow_v0.28.x-v0.30.x/ramda_v0.21.x.js
+++ b/definitions/npm/ramda_v0.21.x/flow_v0.28.x-v0.30.x/ramda_v0.21.x.js
@@ -1,4 +1,3 @@
-/* @flow */
 /* eslint-disable no-unused-vars, no-redeclare */
 
 type Transformer<A,B> = {

--- a/definitions/npm/react-highlight-words_v0.4.x/flow_v0.28.x-/react-highlight-words_v0.4.x.js
+++ b/definitions/npm/react-highlight-words_v0.4.x/flow_v0.28.x-/react-highlight-words_v0.4.x.js
@@ -1,4 +1,3 @@
-// @flow
 declare module 'react-highlight-words' {
   declare type Props = {
     autoEscape?: bool,

--- a/definitions/npm/react-recaptcha_v2.x.x/flow_v0.26.x-/react-recaptcha_v2.x.x.js
+++ b/definitions/npm/react-recaptcha_v2.x.x/flow_v0.26.x-/react-recaptcha_v2.x.x.js
@@ -1,4 +1,3 @@
-// @flow
 declare module 'react-recaptcha' {
   declare type DefaultProps = {
     elementID: string,

--- a/definitions/npm/redux-form_v5.x.x/flow_v0.22.1-/redux-form_v5.x.x.js
+++ b/definitions/npm/redux-form_v5.x.x/flow_v0.22.1-/redux-form_v5.x.x.js
@@ -1,4 +1,3 @@
-// @flow
 import React from 'react';
 
 declare module 'redux-form' {

--- a/definitions/npm/redux-saga_v0.11.x/flow_v0.28.x-/redux-saga_v0.11.x.js
+++ b/definitions/npm/redux-saga_v0.11.x/flow_v0.28.x-/redux-saga_v0.11.x.js
@@ -1,5 +1,3 @@
-/* @flow */
-
 /* eslint-disable */
 
 /**

--- a/definitions/npm/redux-saga_v0.13.x/flow_v0.36.x-/redux-saga_v0.13.x.js
+++ b/definitions/npm/redux-saga_v0.13.x/flow_v0.36.x-/redux-saga_v0.13.x.js
@@ -1,5 +1,3 @@
-/* @flow */
-
 /* eslint-disable */
 
 /**

--- a/definitions/npm/tape_v4.5.x/flow_v0.25.x-/tape_v4.5.x.js
+++ b/definitions/npm/tape_v4.5.x/flow_v0.25.x-/tape_v4.5.x.js
@@ -1,5 +1,3 @@
-/* @flow */
-
 /* eslint-disable  */
 
 declare type tape$TestOpts = {

--- a/definitions/npm/webfontloader_v1.x.x/flow_v0.23.x-/webfontloader_v1.x.x.js
+++ b/definitions/npm/webfontloader_v1.x.x/flow_v0.23.x-/webfontloader_v1.x.x.js
@@ -1,5 +1,3 @@
-// @flow
-
 declare module 'webfontloader' {
   declare type WebFontConfig = {
     loading?: () => mixed,


### PR DESCRIPTION
This keeps users' `flow` commands from re-type-checking all of their dependencies' `flow-typed` definitions.

By default Flow type-checks all files with `@flow` pragmas, including those found in `node_modules`. It doesn't know to ignore nested `flow_typed` directories, so definitions with `@flow` pragmas get type-checked along with everything else.