### PR TITLE
Bluebird: ensure Bluebird.method accepts heterohenous input.

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-/bluebird_v3.x.x.js
@@ -97,7 +97,7 @@ declare class Bluebird$Promise<R> {
   static method<T, R: Bluebird$Promisable<T>>(fn: () => R): () => Bluebird$Promise<T>;
   static method<T, R: Bluebird$Promisable<T>, A>(fn: (a: A) => R): (a: A) => Bluebird$Promise<T>;
   static method<T, R: Bluebird$Promisable<T>, A, B>(fn: (a: A, b: B) => R): (a: A, b: B) => Bluebird$Promise<T>;
-  static method<T, R: Bluebird$Promisable<T>, A, B, C>(fn: (a: A, b: B, c: B) => R): (a: A, b: B, c: B) => Bluebird$Promise<T>;
+  static method<T, R: Bluebird$Promisable<T>, A, B, C>(fn: (a: A, b: B, c: C) => R): (a: A, b: B, c: C) => Bluebird$Promise<T>;
   static method<T, R: Bluebird$Promisable<T>>(fn: (...args: any) => R): (...args: any) => Bluebird$Promise<T>;
 
   static cast<T>(value: Bluebird$Promisable<T>): Bluebird$Promise<T>;

--- a/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-/bluebird_v3.x.x.js
@@ -94,11 +94,11 @@ declare class Bluebird$Promise<R> {
 
   // It doesn't seem possible to have type-generics for a variable number of arguments.
   // Handle up to 3 arguments, then just give up and accept 'any'.
-  static method<T>(fn: () => T): () => Bluebird$Promise<T>;
-  static method<T, A>(fn: (a: A) => T): (a: A) => Bluebird$Promise<T>;
-  static method<T, A, B>(fn: (a: A, b: B) => T): (a: A, b: B) => Bluebird$Promise<T>;
-  static method<T, A, B, C>(fn: (a: A, b: B, c: B) => T): (a: A, b: B, c: B) => Bluebird$Promise<T>;
-  static method<T>(fn: (...args: any) => T): (...args: any) => Bluebird$Promise<T>;
+  static method<T, R: Bluebird$Promisable<T>>(fn: () => R): () => Bluebird$Promise<T>;
+  static method<T, R: Bluebird$Promisable<T>, A>(fn: (a: A) => R): (a: A) => Bluebird$Promise<T>;
+  static method<T, R: Bluebird$Promisable<T>, A, B>(fn: (a: A, b: B) => R): (a: A, b: B) => Bluebird$Promise<T>;
+  static method<T, R: Bluebird$Promisable<T>, A, B, C>(fn: (a: A, b: B, c: B) => R): (a: A, b: B, c: B) => Bluebird$Promise<T>;
+  static method<T, R: Bluebird$Promisable<T>>(fn: (...args: any) => R): (...args: any) => Bluebird$Promise<T>;
 
   static cast<T>(value: Bluebird$Promisable<T>): Bluebird$Promise<T>;
   static bind(ctx: any): Bluebird$Promise<void>;

--- a/definitions/npm/bluebird_v3.x.x/test_bluebird-v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/test_bluebird-v3.x.x.js
@@ -26,28 +26,52 @@ Bluebird.resolve([1,2,3]).then(function(arr) {
   let l = arr.length;
   // $ExpectError Property not found in Array
   arr.then(r => r);
-})
+});
 
 let response = fetch('/').then(r => r.text())
 Bluebird.resolve(response).then(function(responseBody) {
   let length: number = responseBody.length;
   // $ExpectError Property not found in string
   responseBody.then(r => r);
-})
+});
 
-Bluebird.all([1, Bluebird.resolve(1), Promise.resolve(1)]).then(function(r: Array<number>) { })
-Bluebird.all(['hello', Bluebird.resolve('world'), Promise.resolve('!')]).then(function(r: Array<string>) { })
+Bluebird.all([1, Bluebird.resolve(1), Promise.resolve(1)]).then(function(r: Array<number>) { });
+Bluebird.all(['hello', Bluebird.resolve('world'), Promise.resolve('!')]).then(function(r: Array<string>) { });
 
 // $ExpectError
-Bluebird.all([1, Bluebird.resolve(1), Promise.resolve(1)]).then(function(r: Array<string>) { })
+Bluebird.all([1, Bluebird.resolve(1), Promise.resolve(1)]).then(function(r: Array<string>) { });
 
 function foo(a: number, b: string) {
-  throw new Error('oh no')
+  throw new Error('oh no');
 }
-let fooPromise = Bluebird.method(foo)
+let fooPromise = Bluebird.method(foo);
 fooPromise(1, 'b').catch(function(e: Error) {
-  let m: string = e.message
-})
+  let m: string = e.message;
+});
+
+function fooPlain (a: number, b: string) {
+  return 1;
+}
+let fooPlainPromise = Bluebird.method(fooPlain);
+fooPlainPromise(1, 'a').then(function (n: number) {
+  let n2 = n;
+});
+
+function fooNative (a: number, b: string) {
+  return Promise.resolve(2);
+}
+let fooNativePromise = Bluebird.method(fooNative);
+fooNativePromise(1, 'a').then(function (n: number) {
+  let n2 = n;
+});
+
+function fooBluebird (a: number, b: string) {
+  return Bluebird.resolve(3);
+}
+let fooBluebirdPromise = Bluebird.method(fooBluebird);
+fooBluebirdPromise(1, 'a').then(function (n: number) {
+  let n2 = n;
+});
 
 // $ExpectError
 fooPromise('a', 1)


### PR DESCRIPTION
Closes #557.