### PR TITLE
Add rxjs5 bindNodeCallback static method

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -37,6 +37,13 @@ type rxjs$EventListenerOptions = {
 } | boolean;
 
 declare class rxjs$Observable<+T> {
+
+  static bindNodeCallback(
+      func: (e: Error, ...args: any) => void,
+      selector?: () => T,
+      scheduler?: rxjs$SchedulerClass
+  ): (...args: any) => rxjs$Observable<T>;
+
   static concat(...sources: rxjs$Observable<T>[]): rxjs$Observable<T>;
 
   static create(

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/test_rxjs.js
@@ -15,3 +15,19 @@ const distinct4: Observable<{a: string}> = Observable.of({a: 'a'}).distinct(
   field => field.a,
   Observable.never(),
 );
+
+// $ExpectError
+const nodeCallback1 = Observable.bindNodeCallback((num: number) => {});
+
+// $ExpectError
+const nodeCallback2: Observable<number> = Observable.bindNodeCallback(
+  (err: Error, num: number): void => {},
+  (): void => {}
+)(1);
+
+const nodeCallback2: Observable<number> = Observable.bindNodeCallback(
+  (err: Error, num: number): void => {},
+  (): number => 1,
+// $ExpectError
+  4
+)(1);


### PR DESCRIPTION
Hi all,

rxjs 5 supports `Observable.bindNodeCallback` here's the flow definition for it.

From:
http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html
https://github.com/ReactiveX/rxjs/blob/master/MIGRATION.md