### PR TITLE
Accurate signature for lodash times

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.28.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.28.x-/lodash_v4.x.x.js
@@ -491,7 +491,8 @@ declare module 'lodash' {
     stubObject(): {};
     stubString(): '';
     stubTrue(): true;
-    times(n: number, iteratee?: Function): Function;
+    times(n: number, ...rest: Array<void>): Array<number>;
+    times<T>(n: number, iteratee: ((i: number) => T)): Array<T>;
     toPath(value: any): Array<string>;
     uniqueId(prefix?: string): string;
 

--- a/definitions/npm/lodash_v4.x.x/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/test_lodash-v4.x.x.js
@@ -175,3 +175,12 @@ string = _.defaultTo('str', true);
 
 num = _.tap(1, function(n) { return false; });
 bool = _.thru(1, function(n) { return false; });
+
+var timesNums: number[];
+
+timesNums = _.times(5);
+// $ExpectError string. This type is incompatible with number
+var strings : string[] = _.times(5);
+timesNums = _.times(5, function(i: number) { return i + 1; });
+// $ExpectError string. This type is incompatible with number
+timesNums = _.times(5, function(i: number) { return JSON.stringify(i); });


### PR DESCRIPTION
_.times returns an array that can be optionally mapped with the iteratee argument.

```javascript
_.times(2) // => [1, 2]
_.times(3, String) //= ['1', '2', '3']
```