### PR TITLE
moment_v2.x.x.js typo, isDatE -> isDate

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.28.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.28.x-/moment_v2.x.x.js
@@ -203,7 +203,7 @@ declare class moment$Moment {
   isLeapYear(): bool;
   clone(): moment$Moment;
   static isMoment(obj: any): bool;
-  static isDatE(obj: any): bool;
+  static isDate(obj: any): bool;
   static locale(locale: string, localeData?: Object): string;
   static locale(locales: Array<string>): string;
   locale(locale: string, customization?: Object|null): moment$Moment;

--- a/definitions/npm/moment_v2.x.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.x.x/test_moment-v2.js
@@ -29,3 +29,4 @@ moment().isSame();
 moment().isAfter();
 moment().isSameOrBefore();
 moment().isSameOrAfter();
+moment.isDate(new Date());


### PR DESCRIPTION
Fixes a simple typo in moment definition. Fixes #564.