### PR TITLE
Add Bluebird.promisifyAll array form

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-/bluebird_v3.x.x.js
@@ -87,7 +87,7 @@ declare class Bluebird$Promise<R> {
   static defer(): Bluebird$Defer;
   static setScheduler(scheduler: (callback: (...args: Array<any>) => void) => void): void;
   static promisify(nodeFunction: Function, receiver?: Bluebird$PromisifyOptions): Function;
-  static promisifyAll(target: Object, options?: Bluebird$PromisifyAllOptions): void;
+  static promisifyAll(target: Object|Array<Object>, options?: Bluebird$PromisifyAllOptions): void;
 
   static coroutine(generatorFunction: Function): Function;
   static spawn<T>(generatorFunction: Function): Promise<T>;


### PR DESCRIPTION
`Bluebird.promisifyAll` also accepts an array form as per http://bluebirdjs.com/docs/api/promise.promisifyall.html#promisifying-multiple-classes-in-one-go