### PR TITLE
add type definitions for partial and compose

### DIFF
--- a/definitions/npm/underscore_v1.x.x/flow_v0.13.x-/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.13.x-/underscore_v1.x.x.js
@@ -155,7 +155,7 @@ declare module "underscore" {
 
   // TODO: negate
 
-  declare function compose(...functions: Function): Function;
+  declare function compose(...functions: Function[]): Function;
 
   /**
    * Objects

--- a/definitions/npm/underscore_v1.x.x/flow_v0.13.x-/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.13.x-/underscore_v1.x.x.js
@@ -133,7 +133,7 @@ declare module "underscore" {
 
   // TODO: bindAll
 
-  // TODO: partial
+  declare function partial(fn: Function, ...arguments: Array<any>): Function;
 
   // TODO: memoize
 
@@ -155,7 +155,7 @@ declare module "underscore" {
 
   // TODO: negate
 
-  // TODO: compose
+  declare function compose(...functions: Function): Function;
 
   /**
    * Objects

--- a/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
+++ b/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
@@ -144,7 +144,14 @@ _.find([1, 2, 3], {val: 1});
 _.throttle(function(a) {a.length}, 10)('hello');
 _.debounce(function(a) {a.length}, 10)('hello');
 
+_.partial(function (a, b) { return a + b }, 1)(2);
+
 _.defer(function(){});
+
+_.compose(
+  function (upper_case:string):string { return upper_case + ', hello!'; },
+  function (name:string):string { return name.toUpperCase(); }
+): (name: string) => string;
 
 (_.partition([1,5,2,4], function(i: number) { return i<4 }): [Array<number>, Array<number>]);
 (_.partition({x: 'foo', y: 'bar'}, function(v: string, k: string) { return k === 'bar' }): [Array<string>, Array<string>]);

--- a/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
+++ b/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
@@ -148,10 +148,14 @@ _.partial(function (a, b) { return a + b }, 1)(2);
 
 _.defer(function(){});
 
-_.compose(
-  function (upper_case:string):string { return upper_case + ', hello!'; },
-  function (name:string):string { return name.toUpperCase(); }
-): (name: string) => string;
+(
+
+  _.compose(
+    function (name:string):string { return name + ', hello!'; },
+    function (user:Object):string { return user.name; }
+  ): (user: Object) => string
+
+)
 
 (_.partition([1,5,2,4], function(i: number) { return i<4 }): [Array<number>, Array<number>]);
 (_.partition({x: 'foo', y: 'bar'}, function(v: string, k: string) { return k === 'bar' }): [Array<string>, Array<string>]);

--- a/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
+++ b/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
@@ -155,7 +155,7 @@ _.defer(function(){});
     function (user:Object):string { return user.name; }
   ): (user: Object) => string
 
-)
+);
 
 (_.partition([1,5,2,4], function(i: number) { return i<4 }): [Array<number>, Array<number>]);
 (_.partition({x: 'foo', y: 'bar'}, function(v: string, k: string) { return k === 'bar' }): [Array<string>, Array<string>]);


### PR DESCRIPTION
This pull request add type definitions for [`_.partial`](http://underscorejs.org/#partial) and [`_.compose`](http://underscorejs.org/#compose).

The type definition for `compose` is very simple and I really don't know how do I describe the fact that the first function's return value is the return value of the function that is returned from `compose`:

```javascript
declare function compose(...functions: Function): Function;

// USAGE:
(

_.compose(
  function (name:string):string { return name + ', hello!'; },
  function (user:Object):string { return user.name; }
): (user: Object) => string

)
```

I'd be happy to provide a more stricter type definition but I really don't know how to approach that. I'd be happy to read any feedback. Thanks.