### PR TITLE
Add koa@2.x definition.

### DIFF
--- a/definitions/npm/koa_v2.x.x/flow_v0.37.x-/koa_v2.x.x.js
+++ b/definitions/npm/koa_v2.x.x/flow_v0.37.x-/koa_v2.x.x.js
@@ -1,0 +1,313 @@
+// Its a bit different from Typescript def, i thought something in d.ts is typo.
+// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/types-2.0/koa/index.d.ts#L158
+// So i retyped this from source-code of koa2.
+declare module 'koa' {
+  // Currently, import type doesnt work well ?
+  // so copy `Server` from flow/lib/node.js#L820
+  declare class Server extends net$Server {
+    listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server,
+    listen(path: string, callback?: Function): Server,
+    listen(handle: Object, callback?: Function): Server,
+    close(callback?: Function): Server,
+    maxHeadersCount: number,
+    setTimeout(msecs: number, callback: Function): Server,
+    timeout: number,
+  }
+  declare type ServerType = Server;
+
+  declare type JSON = | string | number | boolean | null | JSONObject | JSONArray;
+  declare type JSONObject = { [key: string]: JSON };
+  declare type JSONArray = Array<JSON>;
+
+  declare type SimpleHeader = {
+    'set-cookie'?: Array<string>,
+    [key: string]: string,
+  };
+
+  declare type RequestJSON = {
+    'method': string,
+    'url': string,
+    'header': SimpleHeader,
+  };
+  declare type RequestInspect = void|RequestJSON;
+  declare type Request = {
+    app: Application,
+    req: http$IncomingMessage,
+    res: http$ServerResponse,
+    ctx: Context,
+    response: Response,
+
+    fresh: boolean,
+    header: SimpleHeader,
+    headers: SimpleHeader, // alias as header
+    host: string,
+    hostname: string,
+    href: string,
+    idempotent: boolean,
+    ip: string,
+    ips: string[],
+    method: string,
+    origin: string,
+    originalUrl: string,
+    path: string,
+    protocol: string,
+    query: {[key: string]: string}, // always string
+    querystring: string,
+    search: string,
+    secure: boolean, // Shorthand for ctx.protocol == "https" to check if a request was issued via TLS.
+    socket: net$Socket,
+    stale: boolean,
+    subdomains: string[],
+    type: string,
+    url: string,
+
+    charset: string|void,
+    length: number|void,
+
+//  Those functions comes from https://github.com/jshttp/accepts/blob/master/index.js
+//  request.js$L445
+//  https://github.com/jshttp/accepts/blob/master/test/type.js
+    accepts: ((args: string[]) => string|false)&
+    // ToDo: There is an issue https://github.com/facebook/flow/issues/3009
+    // if you meet some error here, temporarily add an additional annotation
+    // like: `request.accepts((['json', 'text']:Array<string>))` to fix it.
+    ((arg: string, ...args: string[]) => string|false) &
+    ( () => string[] ) , // return the old value.
+
+//  https://github.com/jshttp/accepts/blob/master/index.js#L153
+//  https://github.com/jshttp/accepts/blob/master/test/charset.js
+    acceptsCharsets: ( (args: string[]) => buffer$Encoding|false)&
+    // ToDo: https://github.com/facebook/flow/issues/3009
+    // if you meet some error here, see L70.
+    ( (arg: string, ...args: string[]) => buffer$Encoding|false ) &
+    ( () => string[] ),
+
+//  https://github.com/jshttp/accepts/blob/master/index.js#L119
+//  https://github.com/jshttp/accepts/blob/master/test/encoding.js
+    acceptsEncodings: ( (args: string[]) => string|false)&
+    // ToDo: https://github.com/facebook/flow/issues/3009
+    // if you meet some error here, see L70.
+    ( (arg: string, ...args: string[]) => string|false ) &
+    ( () => string[] ),
+
+//  https://github.com/jshttp/accepts/blob/master/index.js#L185
+//  https://github.com/jshttp/accepts/blob/master/test/language.js
+    acceptsLanguages: ( (args: string[]) => string|false) &
+    // ToDo: https://github.com/facebook/flow/issues/3009
+    // if you meet some error here, see L70.
+    ( (arg: string, ...args: string[]) => string|false ) &
+    ( () => string[] ),
+
+    get: (field: string) => string,
+
+/* https://github.com/jshttp/type-is/blob/master/test/test.js
+* Check if the incoming request contains the "Content-Type"
+* header field, and it contains any of the give mime `type`s.
+* If there is no request body, `null` is returned.
+* If there is no content type, `false` is returned.
+* Otherwise, it returns the first `type` that matches.
+*/
+    is: ( (args: string[]) => null|false|string)&
+    ( (arg: string, ...args: string[]) => null|false|string ) &
+    ( () => string ), // should return the mime type
+
+    toJSON: () => RequestJSON,
+    inspect: () => RequestInspect,
+
+    [key: string]: mixed, // props added by middlewares.
+  };
+
+  declare type ResponseJSON = {
+    'status': mixed,
+    'message': mixed,
+    'header': mixed,
+  };
+  declare type ResponseInspect = {
+    'status': mixed,
+    'message': mixed,
+    'header': mixed,
+    'body': mixed,
+  };
+  declare type Response = {
+    app: Application,
+    req: http$IncomingMessage,
+    res: http$ServerResponse,
+    ctx: Context,
+    request: Request,
+
+    // docs/api/response.md#L113.
+    body: string|Buffer|stream$Stream|Object|null, // JSON contains null
+    etag: string,
+    header: SimpleHeader,
+    headers: SimpleHeader, // alias as header
+    headerSent: boolean,
+    // can be set with string|Date, but get with Date.
+    // set lastModified(v: string|Date), // 0.36 doesn't support this.
+    lastModified: Date,
+    message: string,
+    socket: net$Socket,
+    status: number,
+    type: string,
+    writable: boolean,
+
+    // charset: string,  // doesn't find in response.js
+    length: number|void,
+
+    append: (field: string, val: string | string[]) => void,
+    attachment: (filename?: string) => void,
+    get: (field: string) => string,
+    // https://github.com/jshttp/type-is/blob/master/test/test.js
+    // https://github.com/koajs/koa/blob/v2.x/lib/response.js#L382
+    is: ( (arg: string[]) => false|string) &
+    ( (arg: string, ...args: string[]) => false|string ) &
+    ( () => string ), // should return the mime type
+    redirect: (url: string, alt?: string) => void,
+    remove: (field: string) => void,
+    // https://github.com/koajs/koa/blob/v2.x/lib/response.js#L418
+    set: ((field: string, val: string | string[]) => void)&
+      ((field: {[key: string]: string | string[]}) => void),
+
+    vary: (field: string) => void,
+
+    // https://github.com/koajs/koa/blob/v2.x/lib/response.js#L519
+    toJSON(): ResponseJSON,
+    inspect(): ResponseInspect,
+
+    [key: string]: mixed, // props added by middlewares.
+  }
+
+  declare type ContextJSON = {
+    request: RequestJSON,
+    response: ResponseJSON,
+    app: ApplicationJSON,
+    originalUrl: string,
+    req: '<original node req>',
+    res: '<original node res>',
+    socket: '<original node socket>',
+  };
+  // https://github.com/pillarjs/cookies
+  declare type CookiesSetOptions = {
+    maxAge: number, // milliseconds from Date.now() for expiry
+    expires: Date, //cookie's expiration date (expires at the end of session by default).
+    path: string, //  the path of the cookie (/ by default).
+    domain: string, // domain of the cookie (no default).
+    secure: boolean, // false by default for HTTP, true by default for HTTPS
+    httpOnly: boolean, //  a boolean indicating whether the cookie is only to be sent over HTTP(S),
+    // and not made available to client JavaScript (true by default).
+    signed: boolean, // whether the cookie is to be signed (false by default)
+    overwrite: boolean, //  whether to overwrite previously set cookies of the same name (false by default).
+  };
+  declare type Cookies = {
+    get: (name: string, options: {signed: boolean}) => string|void,
+    set: ((name: string, value: string, options?: CookiesSetOptions) => Context)&
+    // delete cookie (an outbound header with an expired date is used.)
+    ( (name: string) => Context),
+  };
+  // The default props of context come from two files
+  // `application.createContext` & `context.js`
+  declare type Context = {
+    accept: $PropertyType<Request, 'accept'>,
+    app: Application,
+    cookies: Cookies,
+    name?: string, // ?
+    originalUrl: string,
+    req: http$IncomingMessage,
+    request: Request,
+    res: http$ServerResponse,
+    respond?: boolean, // should not be used, allow bypassing koa application.js#L193
+    response: Response,
+    state: Object,
+
+    // context.js#L55
+    assert: (test: mixed, status: number, message?: string, opts?: mixed) => void,
+    // context.js#L107
+    // if (!(err instanceof Error)) err = new Error(`non-error thrown: ${err}`);
+    onerror: (err?: mixed) => void,
+    // context.js#L70
+    throw: (( statusOrErr: string|number|Error, errOrStatus?: string|number|Error,
+      opts?: Object) => void) &
+      (( statusOrErr: string|number|Error, opts?: Object) => void),
+    toJSON(): ContextJSON,
+    inspect(): ContextJSON,
+
+    // ToDo: add const for some props,
+    // while the `const props` feature of Flow is landing in future
+    // cherry pick from response
+    attachment: $PropertyType<Response, 'attachment'>,
+    redirect: $PropertyType<Response, 'redirect'>,
+    remove: $PropertyType<Response, 'remove'>,
+    vary: $PropertyType<Response, 'vary'>,
+    set: $PropertyType<Response, 'set'>,
+    append: $PropertyType<Response, 'append'>,
+    flushHeaders: $PropertyType<Response, 'flushHeaders'>,
+    status: $PropertyType<Response, 'status'>,
+    message: $PropertyType<Response, 'message'>,
+    body: $PropertyType<Response, 'body'>,
+    length: $PropertyType<Response, 'length'>,
+    type: $PropertyType<Response, 'type'>,
+    lastModified: $PropertyType<Response, 'lastModified'>,
+    etag: $PropertyType<Response, 'etag'>,
+    headerSent: $PropertyType<Response, 'headerSent'>,
+    writable: $PropertyType<Response, 'writable'>,
+
+    // cherry pick from request
+    acceptsLanguages: $PropertyType<Request, 'acceptsLanguages'>,
+    acceptsEncodings: $PropertyType<Request, 'acceptsEncodings'>,
+    acceptsCharsets: $PropertyType<Request, 'acceptsCharsets'>,
+    accepts: $PropertyType<Request, 'accepts'>,
+    get: $PropertyType<Request, 'get'>,
+    is: $PropertyType<Request, 'is'>,
+    querystring: $PropertyType<Request, 'querystring'>,
+    idempotent: $PropertyType<Request, 'idempotent'>,
+    socket: $PropertyType<Request, 'socket'>,
+    search: $PropertyType<Request, 'search'>,
+    method: $PropertyType<Request, 'method'>,
+    query: $PropertyType<Request, 'query'>,
+    path: $PropertyType<Request, 'path'>,
+    url: $PropertyType<Request, 'url'>,
+    origin: $PropertyType<Request, 'origin'>,
+    href: $PropertyType<Request, 'href'>,
+    subdomains: $PropertyType<Request, 'subdomains'>,
+    protocol: $PropertyType<Request, 'protocol'>,
+    host: $PropertyType<Request, 'host'>,
+    hostname: $PropertyType<Request, 'hostname'>,
+    header: $PropertyType<Request, 'header'>,
+    headers: $PropertyType<Request, 'headers'>,
+    secure: $PropertyType<Request, 'secure'>,
+    stale: $PropertyType<Request, 'stale'>,
+    fresh: $PropertyType<Request, 'fresh'>,
+    ips: $PropertyType<Request, 'ips'>,
+    ip: $PropertyType<Request, 'ip'>,
+
+    [key: string]: mixed, // props added by middlewares.
+  }
+
+  declare type Middleware =
+    (ctx: Context, next: () => Promise<void>) => Promise<void>|void;
+  declare type ApplicationJSON = {
+    'subdomainOffset': mixed,
+    'proxy': mixed,
+    'env': string,
+  };
+  declare class Application extends events$EventEmitter {
+    context: Context,
+    // request handler for node's native http server.
+    callback: (req: http$IncomingMessage, res: http$ServerResponse) => void,
+    env: string,
+    keys?: Array<string>|Object, // https://github.com/crypto-utils/keygrip
+    middleware: Array<Middleware>,
+    name?: string, // optionally give your application a name
+    proxy: boolean, // when true proxy header fields will be trusted
+    request: Request,
+    response: Response,
+    server: Server,
+    subdomainOffset: number,
+
+    listen: $PropertyType<Server, 'listen'>,
+    toJSON(): ApplicationJSON,
+    inspect(): ApplicationJSON,
+    use(fn: Middleware): this,
+  }
+
+  declare module.exports: Class<Application>;
+}

--- a/definitions/npm/koa_v2.x.x/test_koa_v2.x.x.js
+++ b/definitions/npm/koa_v2.x.x/test_koa_v2.x.x.js
@@ -1,0 +1,374 @@
+// @flow
+const Koa = require('koa');
+import type {
+  Middleware,
+  Context,
+  Request,
+  Response,
+  ServerType,
+  ApplicationJSON,
+  ResponseJSON,
+  ResponseInspect,
+  SimpleHeader,
+  RequestJSON,
+  RequestInspect,
+} from 'koa';
+
+function test_Application() {
+  const app = new Koa();
+  const context: Context = app.context;
+  // $ExpectError
+  const _context: number = app.context;
+  const env: string = app.env;
+  // $ExpectError
+  const _env: number = app.env;
+  const keys: void|Array<string>|Object = app.keys;
+  // $ExpectError
+  const _keys: null = app.keys;
+  const middleware: Array<Middleware> = app.middleware;
+  // $ExpectError
+  const _middleware: Middleware = app.middleware;
+  const name: void|string = app.name;
+  // $ExpectError
+  const _name: number = app.name;
+  const proxy: boolean = app.proxy;
+  // $ExpectError
+  const _proxy: number = app.proxy;
+  const request: Request = app.request;
+  // $ExpectError
+  const _request: number = app.request;
+  const response: Response = app.response;
+  // $ExpectError
+  const _response: number = app.response;
+  const server: ServerType = app.server;
+  // $ExpectError
+  const _server: number = app.server;
+  const subdomainOffset: number = app.subdomainOffset;
+  // $ExpectError
+  const _subdomainOffset: string = app.subdomainOffset;
+  const listen: $PropertyType<ServerType, 'listen'> = app.listen;
+  // $ExpectError
+  const _listen: () => string = app.listen;
+  const toJSON: () => ApplicationJSON = app.toJSON;
+  // $ExpectError
+  const _toJSON: () => string = app.toJSON;
+  const inspect: () => ApplicationJSON = app.inspect;
+  // $ExpectError
+  const _inspect: () => string = app.inspect;
+  app.use( (ctx, next) => {
+    const ctx1: Context = ctx;
+    // $ExpectError
+    const _ctx1: number = ctx;
+    const next1: () => Promise<void> = next;
+    // $ExpectError
+    const _next1: () => Promise<string> = next;
+    return;
+  });
+  app.use(async (ctx, next) => {
+    // $ExpectError
+    return 'hello';
+  });
+}
+
+function test_response() {
+  declare var response:Response;
+  const req: http$IncomingMessage = response.req;
+  // $ExpectError
+  const _req: number = response.req;
+  const res: http$ServerResponse = response.res;
+  // $ExpectError
+  const _res: number = response.res;
+  const ctx: Context = response.ctx;
+  // $ExpectError
+  const _ctx: number = response.ctx;
+  const request: Request = response.request;
+  // $ExpectError
+  const _request: number = response.request;
+
+  const body: string|Buffer|stream$Stream|Object|null = response.body;
+  // $ExpectError
+  const _body: number = response.body;
+  const etag: string = response.etag;
+  // $ExpectError
+  const _etag: number = response.etag;
+  const header: SimpleHeader = response.header;
+  // $ExpectError
+  const _header: {[key: string]: string} = response.header;
+  const headers: SimpleHeader = response.headers;
+  // $ExpectError
+  const _headers: {[key: string]: string} = response.headers;
+  const headerSent: boolean = response.headerSent;
+  // $ExpectError
+  const _headerSent: number = response.headerSent;
+
+  const lastModified: Date = response.lastModified;
+  // $ExpectError
+  const _lastModified: boolean = response.lastModified;
+  const message: string = response.message;
+  // $ExpectError
+  const _message: number = response.message;
+  const socket: net$Socket = response.socket;
+  // $ExpectError
+  const _socket: number = response.socket;
+  const status: number = response.status;
+  // $ExpectError
+  const _status: string = response.status;
+  const type: string = response.type;
+  // $ExpectError
+  const _type: number = response.type;
+  const writable: boolean = response.writable;
+  // $ExpectError
+  const _writable: string = response.writable;
+
+  const length: number|void = response.length;
+  // $ExpectError
+  const _length: number = response.length;
+  const append: (field: string, val: string | string[]) => void = response.append;
+  // $ExpectError
+  response.append(1, true);
+  const attachment: (filename?: string) => void = response.attachment;
+  // $ExpectError
+  response.attachment(1);
+  const get: (field: string) => string = response.get;
+  // $ExpectError
+  const value: number = response.get(1);
+  const mimeType: string = response.is();
+  // $ExpectError
+  const _mimeType: string[] = response.is();
+  const mimeOrFalse1: string|false = response.is('html');
+  // $ExpectError
+  const _mimeOrFalse1: string = response.is('html');
+  const mimeOrFalse2: string|false = response.is(['html']);
+  // $ExpectError
+  const _mimeOrFalse2: string = response.is('html');
+  const redirect: (url: string, alt?: string) => void = response.redirect;
+  // $ExpectError
+  response.redirect(1, true);
+  const remove: (field: string) => void = response.remove;
+  // $ExpectError
+  response.remove(1);
+  response.set({
+    'Etag': '1234',
+    'Last-Modified': 'date',
+  });
+  // $ExpectError
+  response.set({
+    'Etag': 1234,
+    'Last-Modified': 123,
+  });
+  response.set('Etag', '1234');
+  // $ExpectError
+  response.set('Etag', 1234);
+  const vary: (field: string) => void = response.vary;
+  // $ExpectError
+  response.vary(1);
+  const toJSON: () => ResponseJSON = response.toJSON;
+  // $ExpectError
+  const _json: number = response.toJSON();
+  const inspect: () => ResponseInspect = response.inspect;
+  // $ExpectError
+  const _inspectJson: number = response.inspect();
+}
+
+function test_request() {
+  declare var request:Request;
+  const req: http$IncomingMessage = request.req;
+  // $ExpectError
+  const _req: number = request.req;
+  const res: http$ServerResponse = request.res;
+  // $ExpectError
+  const _res: number = request.res;
+  const ctx: Context = request.ctx;
+  // $ExpectError
+  const _ctx: number = request.ctx;
+  const response: Response = request.response;
+  // $ExpectError
+  const _response: number = request.response;
+  const fresh: boolean = request.fresh;
+  // $ExpectError
+  const _fresh: number = request.fresh;
+  const header: SimpleHeader = request.header;
+  // $ExpectError
+  const _header: {[key: string]: string}  = request.header;
+  const headers: SimpleHeader = request.headers;
+  // $ExpectError
+  const _headers: {[key: string]: string} = request.headers;
+  const host: string = request.host;
+  // $ExpectError
+  const _host: number = request.host;
+  const hostname: string = request.hostname;
+  // $ExpectError
+  const _hostname: number = request.hostname;
+  const href: string = request.href;
+  // $ExpectError
+  const _href: number = request.href;
+  const idempotent: boolean = request.idempotent;
+  // $ExpectError
+  const _idempotent: number = request.idempotent;
+  const ip: string = request.ip;
+  // $ExpectError
+  const _ip: number = request.ip;
+  const ips: string[] = request.ips;
+  // $ExpectError
+  const _ips: string = request.ips;
+  const method: string = request.method;
+  // $ExpectError
+  const _method: number = request.method;
+  const origin: string = request.origin;
+  // $ExpectError
+  const _origin: number = request.origin;
+  const originalUrl: string = request.originalUrl;
+  // $ExpectError
+  const _originalUrl: string[] = request.originalUrl;
+  const path: string = request.path;
+  // $ExpectError
+  const _path: number = request.path;
+  const protocol: string = request.protocol;
+  // $ExpectError
+  const _protocol: number = request.protocol;
+  const query: {[key: string]: string} = request.query;
+  // $ExpectError
+  const _query: {[key: string]: string|number} = request.query;
+  const querystring: string = request.querystring;
+  // $ExpectError
+  const _querystring: number = request.querystring;
+  const search: string = request.search;
+  // $ExpectError
+  const _search: number = request.search;
+  const secure: boolean = request.secure;
+  // $ExpectError
+  const _secure: number = request.secure;
+  const socket: net$Socket = request.socket;
+  // $ExpectError
+  const _socket: number = request.socket;
+  const stale: boolean = request.stale;
+  // $ExpectError
+  const _stale: number = request.stale;
+  const subdomains: string[] = request.subdomains;
+  // $ExpectError
+  const _subdomains: string = request.subdomains;
+  const type: string = request.type;
+  // $ExpectError
+  const _type: string[] = request.type;
+  const url: string = request.url;
+  // $ExpectError
+  const _url: number = request.url;
+
+  const charset: string|void = request.charset;
+  // $ExpectError
+  const _charset: string = request.charset;
+  const length: number|void = request.length;
+  // $ExpectError
+  const _length: number = request.length;
+
+  const type_: string[] = request.accepts();
+  // $ExpectError
+  const _type_: string = request.accepts();
+  const typeOrFalse1: string|false = request.accepts('text/html');
+  // $ExpectError
+  const _typeOrFalse1: string = request.accepts('text/html');
+  const typeOrFalse2: string|false = request.accepts('json', 'text');
+  // $ExpectError
+  const _typeOrFalse2: string[] = request.accepts('json', 'text');
+  // ToDo: https://github.com/facebook/flow/issues/3009
+  const typeOrFalse3: string|false = request.accepts((['json', 'text']:Array<string>));
+  // $ExpectError
+  const _typeOrFalse3: string[] = request.accepts((['json', 'text']:Array<string>));
+
+  const charsets: string[] = request.acceptsCharsets();
+  // $ExpectError
+  const _charsets: string = request.acceptsCharsets();
+  const charset1: buffer$Encoding|false =
+    request.acceptsCharsets('gzip', 'deflate', 'identity');
+  // $ExpectError
+  const _charset1: number =
+    request.acceptsCharsets('gzip', 'deflate', 'identity');
+  // ToDo: https://github.com/facebook/flow/issues/3009
+  const charset2: buffer$Encoding|false =
+    request.acceptsCharsets((['gzip', 'deflate', 'identity']:Array<string>));
+  // $ExpectError
+  const _charset2: number =
+    request.acceptsCharsets((['gzip', 'deflate', 'identity']:Array<string>));
+
+  const languages: string[] = request.acceptsLanguages();
+  // $ExpectError
+  const _languages: string = request.acceptsLanguages();
+  const language1: string|false = request.acceptsLanguages('es', 'en');
+  // $ExpectError
+  const _language1: string = request.acceptsLanguages('es', 'en');
+  const language2: string|false = request.acceptsLanguages((['es', 'en']:string[]));
+  // $ExpectError
+  const _language2: string = request.acceptsLanguages((['es', 'en']:string[]));
+
+  const get: (field: string) => string = request.get;
+  // $ExpectError
+  const _get: (field: number) => number = request.get;
+
+  const mimeType: string = request.is();
+  // $ExpectError
+  const _mimeType: number = request.is();
+  const mimeOrFalse1: string|false|null = request.is('html');
+  // $ExpectError
+  const _mimeOrFalse1: string = request.is('html');
+  const mimeOrFalse2: string|false|null = request.is(['html']);
+  // $ExpectError
+  const _mimeOrFalse2: string = request.is(['html']);
+  const toJSON: () => RequestJSON = request.toJSON;
+  // $ExpectError
+  const _toJSON: () => number = request.toJSON;
+  const inspect: () => RequestInspect = request.inspect;
+  // $ExpectError
+  const _inspect: () => RequestJSON = request.inspect;
+}
+
+/*
+ * simple test
+ * pick from koa's api docs
+ * https://github.com/koajs/koa/blob/v2.x/docs/api/index.md
+*/
+function test_index_md() {
+  const app:Koa = new Koa();
+  // $ExpectError
+  const _app:number = new Koa();
+  app.use((ctx) => {
+    ctx.body = 'Hello World';
+    // $ExpectError
+    ctx.body = 1;
+  });
+  app.listen(3000);
+  // $ExpectError
+  app.listen(true);
+
+  function test_cascading() {
+    // x-response-time
+    app.use(async function(ctx, next) {
+      const start = new Date();
+      await next();
+      const ms = new Date() - start;
+      ctx.set('X-Response-Time', `${ms}ms`);
+      // $ExpectError
+      ctx.set(ms, `${ms}ms`);
+      // $ExpectError
+      ctx.set(`${ms}ms`);
+    });
+
+    // logger
+    app.use(async function (ctx, next) {
+      const start = new Date();
+      await next();
+      const ms = new Date() - start;
+      console.log(`${ctx.method} ${ctx.url} - ${ms}`);
+    });
+
+    // response
+    app.use(ctx => {
+      ctx.body = 'Hello World';
+      // $ExpectError
+      ctx.body = 1;
+    });
+
+    app.listen(3000);
+    // $ExpectError
+    app.listen(true);
+  }
+}


### PR DESCRIPTION
Currently, there is an issue [flow/issues/3009](https://github.com/facebook/flow/issues/3009).
The overload functions (`accepts`, `acceptsCharsets`, `acceptsEncodings`, `acceptsLanguages`) in `Request` type need additional annotations to disambiguate cases.
ex: [in test file L274](https://github.com/flowtype/flow-typed/pull/573/files#diff-ef19f871389577e2759a1decdff9a2c2R274)
```
  const typeOrFalse3: string|false = request.accepts((['json', 'text']:Array<string>));
```
Maybe, this will be fixed later.