### PR TITLE
lodash: defs for flatmap to work on objects

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.28.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.28.x-/lodash_v4.x.x.js
@@ -38,6 +38,7 @@ declare module 'lodash' {
   
   declare type OIterateeWithResult<V, O, R> = Object|string|((value: V, key: string, object: O) => R);
   declare type OIteratee<O> = OIterateeWithResult<any, O, any>;
+  declare type OFlatMapIteratee<T, U> = OIterateeWithResult<any, T, Array<U>>;
 
   declare type Predicate<T> =
     | ((value: T, index: number, array: Array<T>) => any)
@@ -179,8 +180,11 @@ declare module 'lodash' {
     findLast<T>(array: ?Array<T>, predicate?: Predicate<T>): T;
     findLast<V, A, T: {[id: string]: A}>(object: T, predicate?: OPredicate<A, T>): V;
     flatMap<T, U>(array: ?Array<T>, iteratee?: FlatMapIteratee<T, U>): Array<U>;
+    flatMap<T: Object, U>(object: T, iteratee?: OFlatMapIteratee<T, U>): Array<U>;
     flatMapDeep<T, U>(array: ?Array<T>, iteratee?: FlatMapIteratee<T, U>): Array<U>;
+    flatMapDeep<T: Object, U>(object: T, iteratee?: OFlatMapIteratee<T, U>): Array<U>;
     flatMapDepth<T, U>(array: ?Array<T>, iteratee?: FlatMapIteratee<T, U>, depth?: number): Array<U>;
+    flatMapDepth<T: Object, U>(object: T, iteratee?: OFlatMapIteratee<T, U>, depth?: number): Array<U>;
     forEach<T>(array: ?Array<T>, iteratee?: Iteratee<T>): Array<T>;
     forEach<T: Object>(object: T, iteratee?: OIteratee<T>): T;
     forEachRight<T>(array: ?Array<T>, iteratee?: Iteratee<T>): Array<T>;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.28.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.28.x-/lodash_v4.x.x.js
@@ -49,7 +49,7 @@ declare module 'lodash' {
   declare type _Iteratee<T> = (item: T, index: number, array: ?Array<T>) => mixed;
   declare type Iteratee<T> = _Iteratee<T>|Object|string;
   declare type Iteratee2<T, U> = ((item: T, index: number, array: ?Array<T>) => U)|Object|string;
-  declare type FlatMapIteratee<T, U> = ((item: T, index: number, array: ?Array<T>) => Array<U>)|Object|string;
+  declare type FlatMapIteratee<T, U> = ((item: T, index: ?number, array: ?Array<T>) => Array<U>)|Object|string;
   declare type Comparator<T> = (item: T, item2: T) => bool;
 
   declare type MapIterator<T,U> =

--- a/definitions/npm/lodash_v4.x.x/flow_v0.28.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.28.x-/lodash_v4.x.x.js
@@ -49,7 +49,7 @@ declare module 'lodash' {
   declare type _Iteratee<T> = (item: T, index: number, array: ?Array<T>) => mixed;
   declare type Iteratee<T> = _Iteratee<T>|Object|string;
   declare type Iteratee2<T, U> = ((item: T, index: number, array: ?Array<T>) => U)|Object|string;
-  declare type FlatMapIteratee<T, U> = ((item: T, index: ?number, array: ?Array<T>) => Array<U>)|Object|string;
+  declare type FlatMapIteratee<T, U> = ((item: T, index: number, array: ?Array<T>) => Array<U>)|Object|string;
   declare type Comparator<T> = (item: T, item2: T) => bool;
 
   declare type MapIterator<T,U> =

--- a/definitions/npm/lodash_v4.x.x/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/test_lodash-v4.x.x.js
@@ -184,3 +184,7 @@ var strings : string[] = _.times(5);
 timesNums = _.times(5, function(i: number) { return i + 1; });
 // $ExpectError string. This type is incompatible with number
 timesNums = _.times(5, function(i: number) { return JSON.stringify(i); });
+
+// lodash.flatMap for collections and objects
+_.flatMap([1, 2, 3], n => [n, n]);
+_.flatMap({a: 1, b: 2}, n => [n, n]);

--- a/definitions/npm/lodash_v4.x.x/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/test_lodash-v4.x.x.js
@@ -186,5 +186,7 @@ timesNums = _.times(5, function(i: number) { return i + 1; });
 timesNums = _.times(5, function(i: number) { return JSON.stringify(i); });
 
 // lodash.flatMap for collections and objects
-_.flatMap([1, 2, 3], n => [n, n]);
+// this arrow function needs a type annotation due to a bug in flow
+// https://github.com/facebook/flow/issues/1948
+_.flatMap([1, 2, 3], (n): number[] => [n, n]);
 _.flatMap({a: 1, b: 2}, n => [n, n]);


### PR DESCRIPTION
Existing defs for flatMap only works for array, but it actually works for objects too ([lodash docs](https://lodash.com/docs/4.17.4#flatMap))

This pr:
- adds OFlatMapIteratee for flatMapping on objects
- adds appropriate defs for flatMap, flatMapDeep, flatMapDepth on objects