### PR TITLE
Added stack to express$Router definition

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_v0.28.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.28.x-/express_v4.x.x.js
@@ -135,6 +135,7 @@ declare class express$Router extends express$Route {
   use(...middleware: Array<express$Middleware>): this;
   use(path: string|RegExp|string[], ...middleware: Array<express$Middleware>): this;
   use(path: string, router: express$Router): this;
+  stack: mixed[];
 }
 
 declare class express$Application extends express$Router mixins events$EventEmitter {


### PR DESCRIPTION
Without this I can't execute tests to ensure routes have been added to an Express router e,g,

`  assert.ok(router.stack.length);`