### PR TITLE
Allow a dependency to be listed in multiple package.json dep fields a…

### DIFF
--- a/cli/src/lib/__tests__/npmProjectUtils-test.js
+++ b/cli/src/lib/__tests__/npmProjectUtils-test.js
@@ -1,0 +1,48 @@
+// @flow
+import {getPackageJsonDependencies} from '../npmProjectUtils';
+
+describe('npmProjectUtils', () => {
+  describe('getPackageJsonDependencies', () => {
+    it('throws when a dep of differing versions is found in multiple dep fields', () => {
+      const pkgJson = {
+        pathStr: '',
+        content: {
+          name: '',
+          version: '',
+          devDependencies: {
+            'flow-bin': '^0.38.0'
+          },
+          peerDependencies: {
+            'flow-bin': '^0.37.4'
+          }
+        }
+      };
+
+      expect(() => {
+        getPackageJsonDependencies(pkgJson);
+      }).toThrow('Found multiple versions of flow-bin listed in package.json!');
+    });
+
+    it('does not throw when a dep of the same version is found in multiple dep fields', () => {
+      const pkgJson = {
+        pathStr: '',
+        content: {
+          name: '',
+          version: '',
+          devDependencies: {
+            'flow-bin': '^0.37.4'
+          },
+          peerDependencies: {
+            'flow-bin': '^0.37.4'
+          }
+        }
+      };
+
+      const actual = getPackageJsonDependencies(pkgJson);
+
+      expect(actual).toEqual({
+        'flow-bin': '^0.37.4'
+      });
+    });
+  });
+});

--- a/cli/src/lib/npmProjectUtils.js
+++ b/cli/src/lib/npmProjectUtils.js
@@ -14,7 +14,7 @@ type PkgJson = {|
     name: string,
     version: string,
 
-    bundledDependencies?: {[pkgName: string]: string},
+    bundledDependencies?: string[],
     dependencies?: {[pkgName: string]: string},
     devDependencies?: {[pkgName: string]: string},
     optionalDependencies?: {[pkgName: string]: string},
@@ -26,7 +26,6 @@ const PKG_JSON_DEP_FIELDS = [
   'dependencies',
   'devDependencies',
   'peerDependencies',
-  'bundledDependencies',
 ];
 export async function findPackageJsonDepVersionStr(
   pkgJson: PkgJson,
@@ -72,8 +71,9 @@ export function getPackageJsonDependencies(
     const contentSection = pkgJson.content[section];
     if (contentSection) {
       Object.keys(contentSection).forEach(pkgName => {
-        if (deps[pkgName]) {
-          throw new Error(`Found ${pkgName} listed twice in package.json!`);
+        const lastFoundVersion = deps[pkgName];
+        if (lastFoundVersion && lastFoundVersion !== contentSection[pkgName]) {
+          throw new Error(`Found multiple versions of ${pkgName} listed in package.json!`);
         }
         deps[pkgName] = contentSection[pkgName];
       });


### PR DESCRIPTION
…s long as the versions are equivalent. Refs #379 

According to the npm docs, [`bundledDependencies` is an array of dependency names](https://docs.npmjs.com/files/package.json#bundleddependencies). Also, a `bundledDependency` [must be in dependencies, devDependencies, optionalDependencies, or node_modules](https://github.com/npm/npm/issues/6435#issuecomment-58599735) so we don't need to look for version ranges in that field - either a dependency's version range will be defined in another field, or the dependency will be in node_modules, potentially with local modifications such that we cannot install libdefs for it.

The primary change relaxes validation to allow for a dependency to be in multiple package.json dependency fields, as long as the version ranges are the same. This should fix #379.