### PR TITLE
Bluebird: fix join() signature.

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-/bluebird_v3.x.x.js
@@ -54,7 +54,23 @@ declare class Bluebird$Promise<R> {
   static reject<T>(error?: any): Bluebird$Promise<T>;
   static resolve<T>(object?: Bluebird$Promisable<T>): Bluebird$Promise<T>;
   static some<T, Elem: Bluebird$Promisable<T>>(Promises: Array<Elem>, count: number): Bluebird$Promise<Array<T>>;
-  static join<T, Elem: Bluebird$Promisable<T>>(...Promises: Array<Elem>): Bluebird$Promise<Array<T>>;
+
+  static join<T, A>(
+    value1: Bluebird$Promisable<A>,
+    handler: (a: A) => T
+  ): Bluebird$Promise<T>;
+  static join<T, A, B>(
+    value1: Bluebird$Promisable<A>,
+    value2: Bluebird$Promisable<B>,
+    handler: (a: A, b: B) => T
+  ): Bluebird$Promise<T>;
+  static join<T, A, B, C>(
+    value1: Bluebird$Promisable<A>,
+    value2: Bluebird$Promisable<B>,
+    value3: Bluebird$Promisable<C>,
+    handler: (a: A, b: B, c: C) => T
+  ): Bluebird$Promise<T>;
+
   static map<T, U, Elem: Bluebird$Promisable<T>>(
     Promises: Array<Elem>,
     mapper: (item: T, index: number, arrayLength: number) => U,

--- a/definitions/npm/bluebird_v3.x.x/test_bluebird-v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/test_bluebird-v3.x.x.js
@@ -38,6 +38,13 @@ Bluebird.resolve(response).then(function(responseBody) {
 Bluebird.all([1, Bluebird.resolve(1), Promise.resolve(1)]).then(function(r: Array<number>) { })
 Bluebird.all(['hello', Bluebird.resolve('world'), Promise.resolve('!')]).then(function(r: Array<string>) { })
 
+Bluebird.join(1, Bluebird.resolve(2), function (a, b) { return a + b }).then(function (s) { return s + 1 })
+Bluebird.join(
+  1,
+  Bluebird.resolve(2),
+  Promise.resolve(3),
+  function (a, b) { return a + b }).then(function (s) { return s + 1 })
+
 // $ExpectError
 Bluebird.all([1, Bluebird.resolve(1), Promise.resolve(1)]).then(function(r: Array<string>) { })
 


### PR DESCRIPTION
Bluebird.join() is now not correct, `handler` should not have the same type as inputs for `join`. PR fixes this to correspond the [doc](http://bluebirdjs.com/docs/api/promise.join.html).