### PR TITLE
declare bluebird$promise as subtype of native promise

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-/bluebird_v3.x.x.js
@@ -43,11 +43,11 @@ declare type Bluebird$PromisifyAllOptions = {
 
 declare type Bluebird$Promisable<T> = Bluebird$Promise<T> | Promise<T> | T;
 
-declare class Bluebird$Promise<R> {
+declare class Bluebird$Promise<+R> extends Promise<R> {
   static Defer: Class<Bluebird$Defer>;
   static PromiseInspection: Class<Bluebird$PromiseInspection<*>>;
 
-  static all<T, Elem: Bluebird$Promisable<T>>(Promises: Array<Elem>): Bluebird$Promise<Array<T>>;
+  static all<T, Elem: Bluebird$Promisable<T>>(promises: Bluebird$Promisable<Iterable<Elem>>): Bluebird$Promise<Array<T>>;
   static props(input: Bluebird$Promisable<Object|Map<*,*>>): Bluebird$Promise<*>;
   static any<T, Elem: Bluebird$Promisable<T>>(Promises: Array<Elem>): Bluebird$Promise<T>;
   static race<T, Elem: Bluebird$Promisable<T>>(Promises: Array<Elem>): Bluebird$Promise<T>;


### PR DESCRIPTION
The Bluebird Promise functions as a Subtype of the native Promise, so extending the class definition from the Native Promise will allow flow to infer this relationship.