### PR TITLE
declare Bluebird as subtype of Native Promise, add tests

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.32/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.32/bluebird_v3.x.x.js
@@ -41,62 +41,59 @@ declare type Bluebird$PromisifyAllOptions = {
   promisifier?: (originalMethod: Function) => () => Bluebird$Promise<any> ;
 };
 
-declare type Bluebird$Promisable<T> = Bluebird$Promise<T> | Promise<T> | T;
+declare type $Promisable<T> = Promise<T> | T;
 
-declare class Bluebird$Promise<R> {
+declare class Bluebird$Promise<+R> extends Promise<R> {
   static Defer: Class<Bluebird$Defer>;
   static PromiseInspection: Class<Bluebird$PromiseInspection<*>>;
 
-  static all<T, Elem: Bluebird$Promisable<T>>(Promises: Array<Elem>): Bluebird$Promise<Array<T>>;
-  static props(input: Bluebird$Promisable<Object|Map<*,*>>): Bluebird$Promise<*>;
-  static any<T, Elem: Bluebird$Promisable<T>>(Promises: Array<Elem>): Bluebird$Promise<T>;
-  static race<T, Elem: Bluebird$Promisable<T>>(Promises: Array<Elem>): Bluebird$Promise<T>;
+  static props(input: $Promisable<Object|Map<*,*>>): Bluebird$Promise<*>;
+  static any<T, Elem: $Promisable<T>>(Promises: Array<Elem>): Bluebird$Promise<T>;
+  static race<T, Elem: $Promisable<T>>(Promises: Array<Elem>): Bluebird$Promise<T>;
   static reject<T>(error?: any): Bluebird$Promise<T>;
-  static resolve<T>(object?: Bluebird$Promisable<T>): Bluebird$Promise<T>;
-  static some<T, Elem: Bluebird$Promisable<T>>(Promises: Array<Elem>, count: number): Bluebird$Promise<Array<T>>;
-
+  static resolve<T>(object?: $Promisable<T>): Bluebird$Promise<T>;
+  static some<T, Elem: $Promisable<T>>(Promises: Array<Elem>, count: number): Bluebird$Promise<Array<T>>;
   static join<T, A>(
-    value1: Bluebird$Promisable<A>,
+    value1: $Promisable<A>,
     handler: (a: A) => T
   ): Bluebird$Promise<T>;
   static join<T, A, B>(
-    value1: Bluebird$Promisable<A>,
-    value2: Bluebird$Promisable<B>,
+    value1: $Promisable<A>,
+    value2: $Promisable<B>,
     handler: (a: A, b: B) => T
   ): Bluebird$Promise<T>;
   static join<T, A, B, C>(
-    value1: Bluebird$Promisable<A>,
-    value2: Bluebird$Promisable<B>,
-    value3: Bluebird$Promisable<C>,
+    value1: $Promisable<A>,
+    value2: $Promisable<B>,
+    value3: $Promisable<C>,
     handler: (a: A, b: B, c: C) => T
   ): Bluebird$Promise<T>;
-
-  static map<T, U, Elem: Bluebird$Promisable<T>>(
+  static map<T, U, Elem: $Promisable<T>>(
     Promises: Array<Elem>,
     mapper: (item: T, index: number, arrayLength: number) => U,
     options?: Bluebird$ConcurrencyOption
   ): Bluebird$Promise<Array<U>>;
-  static mapSeries<T, U, Elem: Bluebird$Promisable<T>>(
+  static mapSeries<T, U, Elem: $Promisable<T>>(
     Promises: Array<Elem>,
     mapper: (item: T, index: number, arrayLength: number) => U
   ): Bluebird$Promise<Array<U>>;
-  static reduce<T, U, Elem: Bluebird$Promisable<T>>(
+  static reduce<T, U, Elem: $Promisable<T>>(
     Promises: Array<Elem>,
-    reducer: (total: U, current: T, index: number, arrayLength: number) => U,
-    initialValue?: Bluebird$Promisable<U>
+    reducer: (total: U, current: T, index: number, arrayLength: number) => $Promisable<U>,
+    initialValue?: $Promisable<U>
   ): Bluebird$Promise<U>;
-  static filter<T, Elem: Bluebird$Promisable<T>>(
+  static filter<T, Elem: $Promisable<T>>(
     Promises: Array<Elem>,
-    filterer: (item: T, index: number, arrayLength: number) => Bluebird$Promisable<bool>,
+    filterer: (item: T, index: number, arrayLength: number) => $Promisable<bool>,
     option?: Bluebird$ConcurrencyOption
   ): Bluebird$Promise<Array<T>>;
-  static each<T, Elem: Bluebird$Promisable<T>>(
+  static each<T, Elem: $Promisable<T>>(
     Promises: Array<Elem>,
-    iterator: (item: T, index: number, arrayLength: number) => Bluebird$Promisable<mixed>,
+    iterator: (item: T, index: number, arrayLength: number) => $Promisable<mixed>,
   ): Bluebird$Promise<Array<T>>;
-  static try<T>(fn: () => Bluebird$Promisable<T>, args: ?Array<any>, ctx: ?any): Bluebird$Promise<T>;
-  static attempt<T>(fn: () => Bluebird$Promisable<T>, args: ?Array<any>, ctx: ?any): Bluebird$Promise<T>;
-  static delay<T>(value: Bluebird$Promisable<T>, ms: number): Bluebird$Promise<T>;
+  static try<T>(fn: () => $Promisable<T>, args: ?Array<any>, ctx: ?any): Bluebird$Promise<T>;
+  static attempt<T>(fn: () => $Promisable<T>, args: ?Array<any>, ctx: ?any): Bluebird$Promise<T>;
+  static delay<T>(value: $Promisable<T>, ms: number): Bluebird$Promise<T>;
   static delay(ms: number): Bluebird$Promise<void>;
   static config(config: Bluebird$BluebirdConfig): void;
 
@@ -110,13 +107,13 @@ declare class Bluebird$Promise<R> {
 
   // It doesn't seem possible to have type-generics for a variable number of arguments.
   // Handle up to 3 arguments, then just give up and accept 'any'.
-  static method<T, R: Bluebird$Promisable<T>>(fn: () => R): () => Bluebird$Promise<T>;
-  static method<T, R: Bluebird$Promisable<T>, A>(fn: (a: A) => R): (a: A) => Bluebird$Promise<T>;
-  static method<T, R: Bluebird$Promisable<T>, A, B>(fn: (a: A, b: B) => R): (a: A, b: B) => Bluebird$Promise<T>;
-  static method<T, R: Bluebird$Promisable<T>, A, B, C>(fn: (a: A, b: B, c: C) => R): (a: A, b: B, c: C) => Bluebird$Promise<T>;
-  static method<T, R: Bluebird$Promisable<T>>(fn: (...args: any) => R): (...args: any) => Bluebird$Promise<T>;
+  static method<T, R: $Promisable<T>>(fn: () => R): () => Bluebird$Promise<T>;
+  static method<T, R: $Promisable<T>, A>(fn: (a: A) => R): (a: A) => Bluebird$Promise<T>;
+  static method<T, R: $Promisable<T>, A, B>(fn: (a: A, b: B) => R): (a: A, b: B) => Bluebird$Promise<T>;
+  static method<T, R: $Promisable<T>, A, B, C>(fn: (a: A, b: B, c: C) => R): (a: A, b: B, c: C) => Bluebird$Promise<T>;
+  static method<T, R: $Promisable<T>>(fn: (...args: any) => R): (...args: any) => Bluebird$Promise<T>;
 
-  static cast<T>(value: Bluebird$Promisable<T>): Bluebird$Promise<T>;
+  static cast<T>(value: $Promisable<T>): Bluebird$Promise<T>;
   static bind(ctx: any): Bluebird$Promise<void>;
   static is(value: any): boolean;
   static longStackTraces(): void;
@@ -125,13 +122,13 @@ declare class Bluebird$Promise<R> {
   static fromCallback<T>(resolver: (fn: (error: ?Error, value?: T) => any) => any, options?: Bluebird$MultiArgsOption): Bluebird$Promise<T>;
 
   constructor(callback: (
-    resolve: (result?: Bluebird$Promisable<R>) => void,
+    resolve: (result?: $Promisable<R>) => void,
     reject: (error?: any) => void
   ) => mixed): void;
-  then<U>(onFulfill?: (value: R) => Bluebird$Promisable<U>, onReject?: (error: any) => Bluebird$Promisable<U>): Bluebird$Promise<U>;
-  catch<U>(onReject?: (error: any) => ?Bluebird$Promisable<U>): Bluebird$Promise<U>;
-  caught<U>(onReject?: (error: any) => ?Bluebird$Promisable<U>): Bluebird$Promise<U>;
-  error<U>(onReject?: (error: any) => ?Bluebird$Promisable<U>): Bluebird$Promise<U>;
+  then<U>(onFulfill?: (value: R) => $Promisable<U>, onReject?: (error: any) => $Promisable<U>): Bluebird$Promise<U>;
+  catch<U>(onReject?: (error: any) => ?$Promisable<U>): Bluebird$Promise<U>;
+  caught<U>(onReject?: (error: any) => ?$Promisable<U>): Bluebird$Promise<U>;
+  error<U>(onReject?: (error: any) => ?$Promisable<U>): Bluebird$Promise<U>;
   done<U>(onFulfill?: (value: R) => mixed, onReject?: (error: any) => mixed): void;
   finally<T>(onDone?: (value: R) => mixed): Bluebird$Promise<T>;
   lastly<T>(onDone?: (value: R) => mixed): Bluebird$Promise<T>;
@@ -148,14 +145,14 @@ declare class Bluebird$Promise<R> {
   any<T>(): Bluebird$Promise<T>;
   some<T>(count: number): Bluebird$Promise<Array<T>>;
   race<T>(): Bluebird$Promise<T>;
-  map<T, U>(mapper: (item: T, index: number, arrayLength: number) => Bluebird$Promisable<U>, options?: Bluebird$ConcurrencyOption): Bluebird$Promise<Array<U>>;
-  mapSeries<T, U>(mapper: (item: T, index: number, arrayLength: number) => Bluebird$Promisable<U>): Bluebird$Promise<Array<U>>;
+  map<T, U>(mapper: (item: T, index: number, arrayLength: number) => $Promisable<U>, options?: Bluebird$ConcurrencyOption): Bluebird$Promise<Array<U>>;
+  mapSeries<T, U>(mapper: (item: T, index: number, arrayLength: number) => $Promisable<U>): Bluebird$Promise<Array<U>>;
   reduce<T, U>(
-    reducer: (total: T, item: U, index: number, arrayLength: number) => Bluebird$Promisable<T>,
-    initialValue?: Bluebird$Promisable<T>
+    reducer: (total: T, item: U, index: number, arrayLength: number) => $Promisable<T>,
+    initialValue?: $Promisable<T>
   ): Bluebird$Promise<T>;
-  filter<T>(filterer: (item: T, index: number, arrayLength: number) => Bluebird$Promisable<bool>, options?: Bluebird$ConcurrencyOption): Bluebird$Promise<Array<T>>;
-  each<T, U>(iterator: (item: T, index: number, arrayLength: number) => Bluebird$Promisable<U>): Bluebird$Promise<Array<T>>;
+  filter<T>(filterer: (item: T, index: number, arrayLength: number) => $Promisable<bool>, options?: Bluebird$ConcurrencyOption): Bluebird$Promise<Array<T>>;
+  each<T, U>(iterator: (item: T, index: number, arrayLength: number) => $Promisable<U>): Bluebird$Promise<Array<T>>;
   asCallback<T>(callback: (error: ?any, value?: T) => any, options?: Bluebird$SpreadOption): void;
   return<T>(value: T): Bluebird$Promise<T>;
   spread<T>(...args: Array<T>): Bluebird$Promise<*>;

--- a/definitions/npm/bluebird_v3.x.x/flow_v0.33.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.33.x-/bluebird_v3.x.x.js
@@ -1,0 +1,180 @@
+type Bluebird$RangeError = Error;
+type Bluebird$CancellationErrors = Error;
+type Bluebird$TimeoutError = Error;
+type Bluebird$RejectionError = Error;
+type Bluebird$OperationalError = Error;
+
+type Bluebird$ConcurrencyOption = {
+  concurrency: number,
+};
+type Bluebird$SpreadOption = {
+  spread: boolean;
+};
+type Bluebird$MultiArgsOption = {
+  multiArgs: boolean;
+};
+type Bluebird$BluebirdConfig = {
+  warnings?: boolean,
+  longStackTraces?: boolean,
+  cancellation?: boolean,
+  monitoring?: boolean
+};
+
+declare class Bluebird$PromiseInspection<T> {
+  isCancelled(): boolean;
+  isFulfilled(): boolean;
+  isRejected(): boolean;
+  pending(): boolean;
+  reason(): any;
+  value(): T;
+}
+
+type Bluebird$PromisifyOptions = {|
+  multiArgs?: boolean,
+  context: any
+|};
+
+declare type Bluebird$PromisifyAllOptions = {
+  suffix?: string;
+  filter?: (name: string, func: Function, target?: any, passesDefaultFilter?: boolean) => boolean;
+  // The promisifier gets a reference to the original method and should return a function which returns a promise
+  promisifier?: (originalMethod: Function) => () => Bluebird$Promise<any> ;
+};
+
+declare type $Promisable<T> = Promise<T> | T;
+
+declare class Bluebird$Promise<+R> extends Promise<R>{
+  static Defer: Class<Bluebird$Defer>;
+  static PromiseInspection: Class<Bluebird$PromiseInspection<*>>;
+
+  static all<T, Elem: $Promisable<T>>(Promises: $Promisable<Iterable<Elem>>): Bluebird$Promise<Array<T>>;
+  static props(input: $Promisable<Object | Map<*,*>>): Bluebird$Promise<*>;
+  static any<T, Elem: $Promisable<T>>(Promises: Array<Elem>): Bluebird$Promise<T>;
+  static race<T, Elem: $Promisable<T>>(Promises: Array<Elem>): Bluebird$Promise<T>;
+  static reject<T>(error?: any): Bluebird$Promise<T>;
+  static resolve<T>(object?: $Promisable<T>): Bluebird$Promise<T>;
+  static some<T, Elem: $Promisable<T>>(Promises: Array<Elem>, count: number): Bluebird$Promise<Array<T>>;
+  static join<T, A>(
+    value1: $Promisable<A>,
+    handler: (a: A) => T
+  ): Bluebird$Promise<T>;
+  static join<T, A, B>(
+    value1: $Promisable<A>,
+    value2: $Promisable<B>,
+    handler: (a: A, b: B) => T
+  ): Bluebird$Promise<T>;
+  static join<T, A, B, C>(
+    value1: $Promisable<A>,
+    value2: $Promisable<B>,
+    value3: $Promisable<C>,
+    handler: (a: A, b: B, c: C) => T
+  ): Bluebird$Promise<T>;
+  static map<T, U, Elem: $Promisable<T>>(
+    Promises: Array<Elem>,
+    mapper: (item: T, index: number, arrayLength: number) => U,
+    options?: Bluebird$ConcurrencyOption
+  ): Bluebird$Promise<Array<U>>;
+  static mapSeries<T, U, Elem: $Promisable<T>>(
+    Promises: Array<Elem>,
+    mapper: (item: T, index: number, arrayLength: number) => U
+  ): Bluebird$Promise<Array<U>>;
+  static reduce<T, U, Elem: $Promisable<T>>(
+    Promises: Array<Elem>,
+    reducer: (total: U, current: T, index: number, arrayLength: number) => $Promisable<U>,
+    initialValue?: $Promisable<U>
+  ): Bluebird$Promise<U>;
+  static filter<T, Elem: $Promisable<T>>(
+    Promises: Array<Elem>,
+    filterer: (item: T, index: number, arrayLength: number) => $Promisable<bool>,
+    option?: Bluebird$ConcurrencyOption
+  ): Bluebird$Promise<Array<T>>;
+  static each<T, Elem: $Promisable<T>>(
+    Promises: Array<Elem>,
+    iterator: (item: T, index: number, arrayLength: number) => $Promisable<mixed>,
+  ): Bluebird$Promise<Array<T>>;
+  static try<T>(fn: () => $Promisable<T>, args: ?Array<any>, ctx: ?any): Bluebird$Promise<T>;
+  static attempt<T>(fn: () => $Promisable<T>, args: ?Array<any>, ctx: ?any): Bluebird$Promise<T>;
+  static delay<T>(value: $Promisable<T>, ms: number): Bluebird$Promise<T>;
+  static delay(ms: number): Bluebird$Promise<void>;
+  static config(config: Bluebird$BluebirdConfig): void;
+
+  static defer(): Bluebird$Defer;
+  static setScheduler(scheduler: (callback: (...args: Array<any>) => void) => void): void;
+  static promisify(nodeFunction: Function, receiver?: Bluebird$PromisifyOptions): Function;
+  static promisifyAll(target: Object|Array<Object>, options?: Bluebird$PromisifyAllOptions): void;
+
+  static coroutine(generatorFunction: Function): Function;
+  static spawn<T>(generatorFunction: Function): Promise<T>;
+
+  // It doesn't seem possible to have type-generics for a variable number of arguments.
+  // Handle up to 3 arguments, then just give up and accept 'any'.
+  static method<T, R: $Promisable<T>>(fn: () => R): () => Bluebird$Promise<T>;
+  static method<T, R: $Promisable<T>, A>(fn: (a: A) => R): (a: A) => Bluebird$Promise<T>;
+  static method<T, R: $Promisable<T>, A, B>(fn: (a: A, b: B) => R): (a: A, b: B) => Bluebird$Promise<T>;
+  static method<T, R: $Promisable<T>, A, B, C>(fn: (a: A, b: B, c: C) => R): (a: A, b: B, c: C) => Bluebird$Promise<T>;
+  static method<T, R: $Promisable<T>>(fn: (...args: any) => R): (...args: any) => Bluebird$Promise<T>;
+
+  static cast<T>(value: $Promisable<T>): Bluebird$Promise<T>;
+  static bind(ctx: any): Bluebird$Promise<void>;
+  static is(value: any): boolean;
+  static longStackTraces(): void;
+
+  static onPossiblyUnhandledRejection(handler: (reason: any) => any): void;
+  static fromCallback<T>(resolver: (fn: (error: ?Error, value?: T) => any) => any, options?: Bluebird$MultiArgsOption): Bluebird$Promise<T>;
+
+  constructor(callback: (
+    resolve: (result?: $Promisable<R>) => void,
+    reject: (error?: any) => void
+  ) => mixed): void;
+  then<U>(onFulfill?: (value: R) => $Promisable<U>, onReject?: (error: any) => $Promisable<U>): Bluebird$Promise<U>;
+  catch<U>(onReject?: (error: any) => ?$Promisable<U>): Bluebird$Promise<U>;
+  caught<U>(onReject?: (error: any) => ?$Promisable<U>): Bluebird$Promise<U>;
+  error<U>(onReject?: (error: any) => ?$Promisable<U>): Bluebird$Promise<U>;
+  done<U>(onFulfill?: (value: R) => mixed, onReject?: (error: any) => mixed): void;
+  finally<T>(onDone?: (value: R) => mixed): Bluebird$Promise<T>;
+  lastly<T>(onDone?: (value: R) => mixed): Bluebird$Promise<T>;
+  tap<T>(onDone?: (value: R) => mixed): Bluebird$Promise<T>;
+  delay(ms: number): Bluebird$Promise<R>;
+  timeout(ms: number, message?: string): Bluebird$Promise<R>;
+  cancel(): void;
+
+  bind(ctx: any): Bluebird$Promise<R>;
+  call(propertyName: string, ...args: Array<any>): Bluebird$Promise<any>;
+  throw(reason: Error): Bluebird$Promise<R>;
+  thenThrow(reason: Error): Bluebird$Promise<R>;
+  all<T>(): Bluebird$Promise<Array<T>>;
+  any<T>(): Bluebird$Promise<T>;
+  some<T>(count: number): Bluebird$Promise<Array<T>>;
+  race<T>(): Bluebird$Promise<T>;
+  map<T, U>(mapper: (item: T, index: number, arrayLength: number) => $Promisable<U>, options?: Bluebird$ConcurrencyOption): Bluebird$Promise<Array<U>>;
+  mapSeries<T, U>(mapper: (item: T, index: number, arrayLength: number) => $Promisable<U>): Bluebird$Promise<Array<U>>;
+  reduce<T, U>(
+    reducer: (total: T, item: U, index: number, arrayLength: number) => $Promisable<T>,
+    initialValue?: $Promisable<T>
+  ): Bluebird$Promise<T>;
+  filter<T>(filterer: (item: T, index: number, arrayLength: number) => $Promisable<bool>, options?: Bluebird$ConcurrencyOption): Bluebird$Promise<Array<T>>;
+  each<T, U>(iterator: (item: T, index: number, arrayLength: number) => $Promisable<U>): Bluebird$Promise<Array<T>>;
+  asCallback<T>(callback: (error: ?any, value?: T) => any, options?: Bluebird$SpreadOption): void;
+  return<T>(value: T): Bluebird$Promise<T>;
+  spread<T>(...args: Array<T>): Bluebird$Promise<*>;
+
+  reflect(): Bluebird$Promise<Bluebird$PromiseInspection<*>>;
+
+  isFulfilled(): bool;
+  isRejected(): bool;
+  isPending(): bool;
+  isResolved(): bool;
+
+  value(): R;
+  reason(): any;
+}
+
+declare class Bluebird$Defer {
+  promise: Bluebird$Promise<*>;
+  resolve: (value: any) => any;
+  reject: (value: any) => any;
+}
+
+declare module 'bluebird' {
+  declare var exports: typeof Bluebird$Promise;
+}

--- a/definitions/npm/bluebird_v3.x.x/test_bluebird-v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/test_bluebird-v3.x.x.js
@@ -89,14 +89,26 @@ Bluebird.resolve(['arr', { some: 'value' }, 42])
   .spread((someString: string, map: Object, answer: number) => answer)
   .then(answer => answer * 2);
 
-Bluebird.reduce([5, Bluebird.resolve(6), Promise.resolve(7)],
-  function (memo, next) { return memo + next })
-Bluebird.reduce([5, Bluebird.resolve(6), Promise.resolve(7)],
-  function (memo, next) { return memo + next },
-  1)
-Bluebird.reduce([5, Bluebird.resolve(6), Promise.resolve(7)],
-  function (memo, next) { return memo + next },
-  Bluebird.resolve(1))
-Bluebird.reduce([5, Bluebird.resolve(6), Promise.resolve(7)],
-  function (memo, next) { return memo + next },
-  Promise.resolve(1))
+Bluebird.reduce([5, Bluebird.resolve(6), Promise.resolve(7)], (memo, next) => memo + next);
+Bluebird.reduce([5, Bluebird.resolve(6), Promise.resolve(7)], (memo, next) => memo + next, 1);
+Bluebird.reduce([5, Bluebird.resolve(6), Promise.resolve(7)], (memo, next) => memo + next, Bluebird.resolve(1));
+Bluebird.reduce([5, Bluebird.resolve(6), Promise.resolve(7)], (memo, next) => memo + next, Promise.resolve(1))
+
+Bluebird.reduce([1, Bluebird.resolve(2), Promise.resolve(3)], (prev, num) => Promise.resolve(prev * num))
+Bluebird.reduce([1, Bluebird.resolve(2), Promise.resolve(3)], (prev, num) => Bluebird.resolve(prev * num))
+//$ExpectError
+Bluebird.reduce([1, Bluebird.resolve(2), Promise.resolve(3)], (prev, num) => Bluebird.resolve(prev * num), 'hello')
+
+type PromiseOutput<T> = () => Promise<T>;
+let givePromise1: PromiseOutput<number> = () => Promise.resolve(1);
+let givePromise2: PromiseOutput<number> = () => Bluebird.resolve(2);
+// $ExpectError
+let givePromise3: PromiseOutput<number> = () => Bluebird.resolve('hello');
+
+type PromiseInput<T> = (input: Promise<T>) => Function
+let takePromise: PromiseInput<number> = (promise) => promise.then
+takePromise(Promise.resolve(1));
+takePromise(Bluebird.resolve(1));
+// $ExpectError
+takePromise(Bluebird.resolve('hello'));
+


### PR DESCRIPTION
The Bluebird API effectively provides the same interface as the Native Promise API (despite having a different under-the-hood implementation) with some additional functionality as well. As a result, it can be thought of as a subtype of the Promise type. By declaring Bluebird as a subclass of Native Promise (since the Native Promise is a Class), most existing code which has been constructed to operate with Promise type instances can now also operate with Bluebird type instances without having to be rewritten and made aware of the Bluebird library. The test cases I added to the Bluebird library best illustrate the benefits that come from making this sub-typing relationship.

However, in attempting this, there was an issue with the `Promise.all` declaration from Flow version v0.32 to v0.33. As a result, I let the v0.32 flow version type library infer the type signature of Bluebird's Promise.all from it's "superclass" (the Native Promise) and this allowed it to pass existing tests. I then fixed the implementation of `Promise.all` in flow version v0.33 and up (when that method was modified in `core.js`) so that it can function as the Native Promise.all method does as well as support additional Promise manipulation functionality. (See here for more info http://bluebirdjs.com/docs/api/promise.all.html). Thus, the only difference between `v0.32` and `v0.33-` is the addition of the type signature for the `all` static method.

Lastly, I also noticed a bug and submitted a previous PR regarding the static `reduce` method for Bluebird. However, that PR did not include new unit tests for that so I've also added tests for that as well and combined it here with this PR. (See here for info about the type signature for `reduce` http://bluebirdjs.com/docs/api/promise.reduce.html)