### PR TITLE
react-redux: Re-order union for MapDispatchToProps

### DIFF
--- a/definitions/npm/react-redux_v4.x.x/flow_v0.30.x-/react-redux_v4.x.x.js
+++ b/definitions/npm/react-redux_v4.x.x/flow_v0.30.x-/react-redux_v4.x.x.js
@@ -14,7 +14,7 @@ declare module 'react-redux' {
 
   declare type MapStateToProps<S, OP: Object, SP: Object> = (state: S, ownProps: OP) => SP | MapStateToProps<S, OP, SP>;
 
-  declare type MapDispatchToProps<A, OP: Object, DP: Object> = ((dispatch: Dispatch<A>, ownProps: OP) => DP) | DP;
+  declare type MapDispatchToProps<A, OP: Object, DP: Object> = DP | ((dispatch: Dispatch<A>, ownProps: OP) => DP);
 
   declare type MergeProps<SP, DP: Object, OP: Object, P: Object> = (stateProps: SP, dispatchProps: DP, ownProps: OP) => P;
 


### PR DESCRIPTION
Flow was having trouble picking which member to use:

```js
function mapStateToProps(state, ownProps) {
  return {...};
}

function mapDispatchToProps(dispatch, ownProps) {
  return {...};
}

connect(mapStateToProps, mapDispatchToProps)(Component);
```

```
 84: module.exports = connect(mapStateToProps, mapDispatchToProps)(Component);
                                               ^^^^^^^^^^^^^^^^^^ function. Could not decide which case to select
 77:     mapDispatchToProps: MapDispatchToProps<A, OP, DP>,
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union type. See lib: flow-typed/npm/react-redux_v4.x.x.js:77
  Case 1 may work:
   20:   declare type MapDispatchToProps<A, OP: Object, DP: Object> = ((dispatch: Dispatch<A>, ownProps: OP) => DP) | DP;
                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: flow-typed/npm/react-redux_v4.x.x.js:20
  But if it doesn't, case 2 looks promising too:
   84: module.exports = connect(mapStateToProps, mapDispatchToProps)(Component);
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `DP` of function call
  Please provide additional annotation(s) to determine whether case 1 works (or consider merging it with case 2):
   75: function mapDispatchToProps(dispatch, ownProps) {
                                   ^^^^^^^^ parameter `dispatch`
```

cc @gcanti