### PR TITLE
Add `calledTwice` and `calledThrice` definitions for `sinon-chai`

### DIFF
--- a/definitions/npm/chai_v3.5.x/flow_v0.24.0-/chai_v3.5.x.js
+++ b/definitions/npm/chai_v3.5.x/flow_v0.24.0-/chai_v3.5.x.js
@@ -85,6 +85,8 @@ declare module "chai" {
         called: () => ExpectChain<T>,
         callCount: (n: number) => ExpectChain<T>,
         calledOnce: () => ExpectChain<T>,
+        calledTwice: () => ExpectChain<T>,
+        calledThrice: () => ExpectChain<T>,
         calledBefore: (spy: mixed) => ExpectChain<T>,
         calledAfter: (spy: mixed) => ExpectChain<T>,
         calledWith: (...args: Array<mixed>) => ExpectChain<T>,


### PR DESCRIPTION
Add missing `.calledTwice()` and `.calledThrice()` definitions for `sinon-chai`.