### PR TITLE
Update Jest Jasmine type declaration

### DIFF
--- a/definitions/npm/jest_v18.x.x/flow_v0.33.x-/jest_v18.x.x.js
+++ b/definitions/npm/jest_v18.x.x/flow_v0.33.x-/jest_v18.x.x.js
@@ -431,6 +431,7 @@ declare var jasmine: {
   arrayContaining(value: Array<mixed>): void,
   clock(): JestClockType,
   createSpy(name: string): JestSpyType,
+  createSpyObj(baseName: string, methodNames: Array<string>): {[methodName: string]: JestSpyType},
   objectContaining(value: Object): void,
   stringMatching(value: string): void,
 }


### PR DESCRIPTION
Resolves #617.

Nothing major here, simply defining `createSpyObj` which was missing.