### PR TITLE
Do not fail on 'Invalid comparator' error

### DIFF
--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -579,12 +579,20 @@ export function filterLibDefs(
       let filterMatch = false;
       switch (filter.type) {
         case 'exact':
-          filterMatch =
-            packageNameMatch(def.pkgName, filter.pkgName) &&
-            libdefMatchesPackageVersion(
-              filter.pkgVersionStr,
-              def.pkgVersionStr,
-            );
+          if (packageNameMatch(def.pkgName, filter.pkgName)) {
+            try {
+              filterMatch = libdefMatchesPackageVersion(filter.pkgVersionStr, def.pkgVersionStr);
+            } catch(error) {
+              if (error.message.indexOf('Invalid comparator') > -1) {
+                console.error(
+                  `\u2022 Unprocessible version of '${filter.pkgName}' ` +
+                  `in package.json: '${filter.pkgVersionStr}'.`
+                );
+              } else {
+                throw error;
+              }
+            }
+          }
           break;
 
         case 'exact-name':

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -579,12 +579,12 @@ export function filterLibDefs(
       let filterMatch = false;
       switch (filter.type) {
         case 'exact':
-          if (packageNameMatch(def.pkgName, filter.pkgName)) {
-            filterMatch = libdefMatchesPackageVersion(
+          filterMatch =
+            packageNameMatch(def.pkgName, filter.pkgName) &&
+            libdefMatchesPackageVersion(
               filter.pkgVersionStr,
               def.pkgVersionStr,
             );
-          }
           break;
 
         case 'exact-name':

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -580,18 +580,10 @@ export function filterLibDefs(
       switch (filter.type) {
         case 'exact':
           if (packageNameMatch(def.pkgName, filter.pkgName)) {
-            try {
-              filterMatch = libdefMatchesPackageVersion(filter.pkgVersionStr, def.pkgVersionStr);
-            } catch(error) {
-              if (error.message.indexOf('Invalid comparator') > -1) {
-                console.error(
-                  `\u2022 Unprocessible version of '${filter.pkgName}' ` +
-                  `in package.json: '${filter.pkgVersionStr}'.`
-                );
-              } else {
-                throw error;
-              }
-            }
+            filterMatch = libdefMatchesPackageVersion(
+              filter.pkgVersionStr,
+              def.pkgVersionStr,
+            );
           }
           break;
 

--- a/cli/src/lib/npm/__tests__/npmLibDefs-test.js
+++ b/cli/src/lib/npm/__tests__/npmLibDefs-test.js
@@ -7,6 +7,7 @@ import {
   _validateVersionPart as validateVersionPart,
   getInstalledNpmLibDefs,
   getNpmLibDefs,
+  findNpmLibDef,
 } from '../npmLibDefs';
 
 import path from 'path';
@@ -294,6 +295,39 @@ describe('npmLibDefs', () => {
     //     ['totally-not-real-pkg', ['Package does not exist on npm!']],
     //   ]);
     // });
+  });
+
+  describe('findNpmLibDef', () => {
+    describe('when no cached libDefs found', () => {
+      it('returns null', async () => {
+        const pkgName = 'jest-test-npm-package';
+        const pkgVersion = 'v1.0.0';
+        const flowVersion = { kind: 'all' };
+
+        const filtered = await findNpmLibDef(pkgName, pkgVersion, flowVersion);
+
+        expect(filtered).toBeNull();
+      });
+    });
+
+    describe('when non-semver package provided', () => {
+      it('doesn\'t throw error', async () => {
+        const pkgName = 'flow-bin';
+        const pkgVersion = 'github:flowtype/flow-bin';
+        const flowVersion = { kind: 'all' };
+
+        let filtered;
+        let error;
+        try {
+          filtered = await findNpmLibDef(pkgName, pkgVersion, flowVersion);
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).toBeUndefined();
+        expect(filtered).toBeNull();
+      });
+    });
   });
 
   describe('getInstalledNpmLibDefs', () => {

--- a/cli/src/lib/npm/npmLibDefs.js
+++ b/cli/src/lib/npm/npmLibDefs.js
@@ -299,6 +299,10 @@ function pkgVersionMatch(pkgSemver: string, libDefSemverRaw: string) {
     return semver.satisfies(libDefSemver, pkgSemver);
   }
 
+  if (!(semver.validRange(pkgSemver) && semver.validRange(libDefSemver))) {
+    return false;
+  }
+
   const pkgRange = new semver.Range(pkgSemver);
   const libDefRange = new semver.Range(libDefSemver);
 


### PR DESCRIPTION
Trying to install definitions with `flow-typed install` I faced an `Invalid comparator` error due to GitHub repo dependency in my _package.json_ file.

This solution avoids `Invalid comparator` errors by ignoring non-semver packages and and installing stubs for them.

Closes #1127