### PR TITLE
[express@4.x.x] Allow mixed paths

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
@@ -52,6 +52,8 @@ declare type express$CookieOptions = {
   signed?: boolean
 };
 
+declare type express$Path = string | RegExp;
+
 declare type express$RenderCallback = (err: Error | null, html?: string) => mixed;
 
 declare type express$SendFileOptions = {
@@ -97,7 +99,7 @@ declare type express$Middleware =
 declare interface express$RouteMethodType<T> {
   (middleware: express$Middleware): T;
   (...middleware: Array<express$Middleware>): T;
-  (path: string|RegExp|string[], ...middleware: Array<express$Middleware>): T;
+  (path: express$Path|express$Path[], ...middleware: Array<express$Middleware>): T;
 }
 declare class express$Route {
   all: express$RouteMethodType<this>;
@@ -137,7 +139,7 @@ declare class express$Router extends express$Route {
   static (): express$Router;
   use(middleware: express$Middleware): this;
   use(...middleware: Array<express$Middleware>): this;
-  use(path: string|RegExp|string[], ...middleware: Array<express$Middleware>): this;
+  use(path: express$Path|express$Path[], ...middleware: Array<express$Middleware>): this;
   use(path: string, router: express$Router): this;
 }
 

--- a/definitions/npm/express_v4.x.x/flow_v0.28.x-v0.31.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.28.x-v0.31.x/express_v4.x.x.js
@@ -52,6 +52,8 @@ declare type express$CookieOptions = {
   signed?: boolean
 };
 
+declare type express$Path = string | RegExp;
+
 declare type express$RenderCallback = (err: Error | null, html?: string) => mixed;
 
 declare type express$SendFileOptions = {
@@ -97,7 +99,7 @@ declare type express$Middleware =
 declare interface express$RouteMethodType<T> {
   (middleware: express$Middleware): T;
   (...middleware: Array<express$Middleware>): T;
-  (path: string|RegExp|string[], ...middleware: Array<express$Middleware>): T;
+  (path: express$Path|express$Path[], ...middleware: Array<express$Middleware>): T;
 }
 declare class express$Route {
   all: express$RouteMethodType<this>;
@@ -137,7 +139,7 @@ declare class express$Router extends express$Route {
   static (): express$Router;
   use(middleware: express$Middleware): this;
   use(...middleware: Array<express$Middleware>): this;
-  use(path: string|RegExp|string[], ...middleware: Array<express$Middleware>): this;
+  use(path: express$Path|express$Path[], ...middleware: Array<express$Middleware>): this;
   use(path: string, router: express$Router): this;
 }
 

--- a/definitions/npm/express_v4.x.x/flow_v0.28.x-v0.31.x/test_overrideUseMethodClassExtension.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.28.x-v0.31.x/test_overrideUseMethodClassExtension.js
@@ -11,6 +11,8 @@ declare class test_express$CustomResponse extends express$Response {
 }
 declare type test_express$CustomNextFunction = express$NextFunction;
 
+declare type test_express$CustomPath = string | RegExp;
+
 declare type test_express$CustomMiddleware =
   ((req: test_express$CustomRequest, res: test_express$CustomResponse, next: test_express$CustomNextFunction) => mixed) |
   ((error: Error, req: test_express$CustomRequest, res: test_express$CustomResponse, next: test_express$CustomNextFunction) => mixed);
@@ -19,7 +21,7 @@ declare class test_express$CustomApplication extends express$Application {
   constructor(expressConstructor: () => express$Application): this;
   use(middleware: test_express$CustomMiddleware): this;
   use(...middleware: Array<test_express$CustomMiddleware>): this;
-  use(path: string|RegExp|string[], ...middleware: Array<test_express$CustomMiddleware>): this;
+  use(path: test_express$CustomPath|test_express$CustomPath[], ...middleware: Array<test_express$CustomMiddleware>): this;
   use(path: string, router: express$Router): this;
 }
 

--- a/definitions/npm/express_v4.x.x/flow_v0.32.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.32.x-/express_v4.x.x.js
@@ -58,6 +58,8 @@ declare type express$CookieOptions = {
   signed?: boolean
 };
 
+declare type express$Path = string | RegExp;
+
 declare type express$RenderCallback = (err: Error | null, html?: string) => mixed;
 
 declare type express$SendFileOptions = {
@@ -104,7 +106,7 @@ declare type express$Middleware =
 declare interface express$RouteMethodType<T> {
   (middleware: express$Middleware): T;
   (...middleware: Array<express$Middleware>): T;
-  (path: string|RegExp|string[], ...middleware: Array<express$Middleware>): T;
+  (path: express$Path|express$Path[], ...middleware: Array<express$Middleware>): T;
 }
 declare class express$Route {
   all: express$RouteMethodType<this>;
@@ -144,7 +146,7 @@ declare class express$Router extends express$Route {
   static (options?: express$RouterOptions): express$Router;
   use(middleware: express$Middleware): this;
   use(...middleware: Array<express$Middleware>): this;
-  use(path: string|RegExp|string[], ...middleware: Array<express$Middleware>): this;
+  use(path: express$Path|express$Path[], ...middleware: Array<express$Middleware>): this;
   use(path: string, router: express$Router): this;
   handle(req: http$IncomingMessage, res: http$ServerResponse, next: express$NextFunction): void;
   param(

--- a/definitions/npm/express_v4.x.x/flow_v0.32.x-/test_overrideUseMethodClassExtension.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.32.x-/test_overrideUseMethodClassExtension.js
@@ -9,6 +9,9 @@ declare class test_express$CustomRequest extends express$Request {
 declare class test_express$CustomResponse extends express$Response {
   bar: string;
 }
+
+declare type test_express$CustomPath = string | RegExp;
+
 declare type test_express$CustomNextFunction = express$NextFunction;
 
 declare type test_express$CustomMiddleware =
@@ -19,7 +22,7 @@ declare class test_express$CustomApplication extends express$Application {
   constructor(expressConstructor: () => express$Application): this;
   use(middleware: test_express$CustomMiddleware): this;
   use(...middleware: Array<test_express$CustomMiddleware>): this;
-  use(path: string|RegExp|string[], ...middleware: Array<test_express$CustomMiddleware>): this;
+  use(path: test_express$CustomPath|test_express$CustomPath[], ...middleware: Array<test_express$CustomMiddleware>): this;
   use(path: string, router: express$Router): this;
 }
 

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -143,7 +143,7 @@ app.use((err: Error, req: express$Request, res: express$Response, next: express$
     next(err);
 });
 
-// $ExpectError Path could not be Object
+// $ExpectError path could not be an Object
 const invalidPath: express$Path = {};
 
 let validPath: express$Path = 'string_path';

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -142,3 +142,16 @@ app.use((err: Error, req: express$Request, res: express$Response, next: express$
     next();
     next(err);
 });
+
+// $ExpectError Path could not be Object
+const invalidPath: express$Path = {};
+
+let validPath: express$Path = 'string_path';
+validPath = 'pattern?path';
+validPath = new RegExp('some.*regexp');
+
+const validPaths = ['string', 'pattern?', /a[b-f]+g/];
+
+app.get(validPaths, (req: express$Request, res: express$Response) => {
+  res.end();
+});


### PR DESCRIPTION
In [express docs](http://expressjs.com/en/4x/api.html#path-examples) mixed paths (containing `RegExp` along with `string`) are allowed for `get()`, `use()`, etc. but current flow typings restrict them.

Here is the fix providing a new `express$Path` type and using it in `express$RouteMethodType` interface.