### PR TITLE
Adding `addMatchers` for Jasmine

### DIFF
--- a/definitions/npm/jasmine_v2.4.x/flow_all/jasmine_v2.4.x.js
+++ b/definitions/npm/jasmine_v2.4.x/flow_all/jasmine_v2.4.x.js
@@ -62,12 +62,28 @@ type JasmineClockType = {
   mockDate(date: Date): void
 };
 
+declare type JasmineMatcherResult = {
+  pass: boolean;
+  message?: string | () => string;
+}
+
+declare type JasmineMatcherStruct = {
+  compare<T: any>(actual: T, expected: T): JasmineMatcherResult;
+}
+
+declare type JasmineMatcher = (utils?: mixed, customEqualityTesters?: mixed) => JasmineMatcherStruct
+
+declare type JasmineMatchers = {
+  [key: string]: JasmineMatcher
+}
+
 declare var jasmine: {
-  createSpy(name?: string): JasmineSpyType,
-  any(val: mixed): void,
-  anything(): void,
-  objectContaining(val: Object): void,
-  arrayContaining(val: mixed[]): void,
-  stringMatching(val: string): void,
-  clock(): JasmineClockType
-};
+  createSpy(name: string): JasmineSpyType;
+  any(val: mixed): void;
+  anything(): void;
+  objectContaining(val: Object): void;
+  arrayContaining(val: mixed[]): void;
+  stringMatching(val: string): void;
+  clock(): JasmineClockType;
+  addMatchers(val: JasmineMatchers): void;
+}

--- a/definitions/npm/jasmine_v2.4.x/flow_all/jasmine_v2.4.x.js
+++ b/definitions/npm/jasmine_v2.4.x/flow_all/jasmine_v2.4.x.js
@@ -78,12 +78,12 @@ declare type JasmineMatchers = {
 }
 
 declare var jasmine: {
-  createSpy(name: string): JasmineSpyType;
-  any(val: mixed): void;
-  anything(): void;
-  objectContaining(val: Object): void;
-  arrayContaining(val: mixed[]): void;
-  stringMatching(val: string): void;
-  clock(): JasmineClockType;
-  addMatchers(val: JasmineMatchers): void;
+  createSpy(name?: string): JasmineSpyType,
+  any(val: mixed): void,
+  anything(): void,
+  objectContaining(val: Object): void,
+  arrayContaining(val: mixed[]): void,
+  stringMatching(val: string): void,
+  clock(): JasmineClockType,
+  addMatchers(val: JasmineMatchers): void
 }

--- a/definitions/npm/jasmine_v2.4.x/test_jasmine_v2.4.x_addMatchers.js
+++ b/definitions/npm/jasmine_v2.4.x/test_jasmine_v2.4.x_addMatchers.js
@@ -1,0 +1,98 @@
+/* @flow */
+
+/**
+ * addMatchers
+ */
+
+jasmine.addMatchers({
+  toHaveFoo1: (utils, customEqualityTesters) => {
+    return {
+      compare: (actual: string, expected: string) => {
+        return {
+          pass: true,
+          message: "Nothing to see here"
+        };
+      }
+    }
+  }
+});
+
+jasmine.addMatchers({
+  toHaveFoo2: () => {
+    return {
+      compare: (actual, expected) => {
+        return {
+          pass: actual === expected,
+          message: "Nothing to see here"
+        };
+      }
+    }
+  }
+});
+
+jasmine.addMatchers({
+  toHaveFoo3: () => {
+    return {
+      compare: (a, b) => {
+        return {
+          pass: a === b,
+          message: () => 'A is not B'
+        };
+      }
+    }
+  }
+});
+
+
+jasmine.addMatchers({
+  toHaveFoo4: () => {
+    var check = (a, b) => a == b;
+    return {
+      compare: (a, b) => {
+        return {
+          pass: check(a, b),
+          message: () => 'A is not B'
+        };
+      }
+    }
+  }
+});
+
+// $ExpectError
+var badResult1: JasmineMatcherResult = false;
+
+// $ExpectError
+var badResult2: JasmineMatcherResult = {
+  message: 'Did not pass',
+};
+
+var badResult3: JasmineMatcherResult = {
+  pass: true,
+
+  // $ExpectError
+  message: () => false
+};
+
+// $ExpectError
+var badStruct1: JasmineMatcherStruct = 1;
+
+// $ExpectError
+var badStruct2: JasmineMatcherStruct = {
+  notCompare: (actual, expected): JasmineMatcherResult => {
+    return {
+      pass: true
+    }
+  }
+}
+
+// $ExpectError
+var badMatcher1: JasmineMatcher = (utils, customEqualityTesters, extra) => {
+  compare: (actual, expected): JasmineMatcherResult => {
+    return {
+      pass: true
+    }
+  }
+}
+
+// $ExpectError
+jasmine.addMatchers('a');


### PR DESCRIPTION
The `addMatchers` function in Jasmine 2.4.x was missing; this adds it.