### PR TITLE
http => https for  REMOTE_REPO_URL

### DIFF
--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -34,7 +34,7 @@ const CACHE_DIR = path.join(os.homedir(), '.flow-typed');
 const CACHE_REPO_DIR = path.join(CACHE_DIR, 'repo');
 const GIT_REPO_DIR = path.join(__dirname, '..', '..', '..');
 
-const REMOTE_REPO_URL = 'http://github.com/flowtype/flow-typed.git';
+const REMOTE_REPO_URL = 'https://github.com/flowtype/flow-typed.git';
 const LAST_UPDATED_FILE = path.join(CACHE_DIR, 'lastUpdated');
 
 async function cloneCacheRepo(verbose?: VerboseOutput) {


### PR DESCRIPTION
For all flow-typed commands get error with http request on github:
`• flow-typed cache not found, fetching from GitHub...ERROR: Unable to clone the local cache repo.
UNCAUGHT ERROR: Error: Error cloning repo: undefined`