### PR TITLE
Add shortid v2.2.x  def

### DIFF
--- a/definitions/npm/shortid_v2.2.x/flow_v0.27.x-/shortid_v2.2.x.js
+++ b/definitions/npm/shortid_v2.2.x/flow_v0.27.x-/shortid_v2.2.x.js
@@ -1,0 +1,13 @@
+type ShortIdModule = {
+  (): string,
+  generate(): string,
+  seed(seed: number): ShortIdModule,
+  worker(workerId: number): ShortIdModule,
+  characters(characters: string): string,
+  decode(id: string): { version: number, worker: number },
+  isValid(id: mixed): boolean,
+};
+
+declare module 'shortid' {
+  declare module.exports: ShortIdModule;
+};

--- a/definitions/npm/shortid_v2.2.x/test_shortid_v2.2.x.js
+++ b/definitions/npm/shortid_v2.2.x/test_shortid_v2.2.x.js
@@ -1,0 +1,39 @@
+// @flow
+
+import shortid from 'shortid';
+
+(shortid(): string);
+
+(shortid.generate(): string);
+
+shortid.seed(10);
+shortid.seed(10).seed(20);
+// $ExpectError
+shortid.seed();
+// $ExpectError
+shortid.seed('hello');
+
+shortid.worker(10);
+shortid.worker(10).worker(20);
+// $ExpectError
+shortid.worker();
+// $ExpectError
+shortid.worker('hello');
+
+const chars: string = shortid.characters('abcd');
+// $ExpectError
+shortid.characters();
+// $ExpectError
+shortid.characters(2);
+
+(shortid.decode('qwerty').version: number);
+(shortid.decode('qwerty').worker: number);
+// $ExpectError
+(shortid.decode('qwerty').other: number);
+// $ExpectError
+shortid.decode(1);
+
+(shortid.isValid('qwerty'): boolean);
+(shortid.isValid(123): boolean);
+(shortid.isValid({}): boolean);
+(shortid.isValid(): boolean);


### PR DESCRIPTION
This adds typedefs and tests for https://github.com/dylang/shortid, tested down to flow 0.27 not sure if supporting any lower is useful.