### PR TITLE
enzyme: add exists method

### DIFF
--- a/definitions/npm/enzyme_v2.3.x/flow_v0.23.x-v0.27.x/enzyme_v2.3.x.js
+++ b/definitions/npm/enzyme_v2.3.x/flow_v0.23.x-v0.27.x/enzyme_v2.3.x.js
@@ -16,6 +16,7 @@ declare module 'enzyme' {
     containsMatchingElement(node: React$Element<any>): boolean;
     containsAllMatchingElements(nodes: NodeOrNodes): boolean;
     containsAnyMatchingElements(nodes: NodeOrNodes): boolean;
+    exists(): boolean;
     matchesElement(node: React$Element<any>): boolean;
     hasClass(className: string): boolean;
     is(selector: EnzymeSelector): boolean;

--- a/definitions/npm/enzyme_v2.3.x/flow_v0.28.x-/enzyme_v2.3.x.js
+++ b/definitions/npm/enzyme_v2.3.x/flow_v0.28.x-/enzyme_v2.3.x.js
@@ -16,6 +16,7 @@ declare module 'enzyme' {
     containsMatchingElement(node: React$Element<any>): boolean;
     containsAllMatchingElements(nodes: NodeOrNodes): boolean;
     containsAnyMatchingElements(nodes: NodeOrNodes): boolean;
+    exists(): boolean;
     matchesElement(node: React$Element<any>): boolean;
     hasClass(className: string): boolean;
     is(selector: EnzymeSelector): boolean;


### PR DESCRIPTION
Adding missing `exists()` method. 

- https://github.com/airbnb/enzyme/blob/master/docs/api/ShallowWrapper/exists.md
- https://github.com/airbnb/enzyme/blob/master/docs/api/ReactWrapper/exists.md