### PR TITLE
Add react-18next v2.x.x libdef

### DIFF
--- a/definitions/npm/react-i18next_v2.x.x/flow_v0.36.x-v0.39.x/react-i18next_v2.x.x.js
+++ b/definitions/npm/react-i18next_v2.x.x/flow_v0.36.x-v0.39.x/react-i18next_v2.x.x.js
@@ -1,0 +1,33 @@
+declare module 'react-i18next' {
+  declare type TFunction = (key?: ?string, data?: ?Object) => string;
+  declare type Locales = string | Array<string>;
+
+  declare type StatelessComponent<P> = (props: P) => ?React$Element<any>;
+
+  declare type Comp<P> = StatelessComponent<P> | Class<React$Component<*, P, *>>;
+
+  declare type Translator<OP, P> = {
+    (component: StatelessComponent<P>): Class<React$Component<void, OP, void>>;
+    <Def, St>(component: Class<React$Component<Def, P, St>>): Class<React$Component<Def, OP, St>>;
+  }
+
+  declare function translate<OP, P>(locales: Locales): Translator<OP, P>;
+
+  declare type NamespacesProps = {
+    components: Array<Comp<*>>,
+    i18n: { loadNamespaces: Function },
+  };
+
+  declare function loadNamespaces(props: NamespacesProps): Promise<void>;
+
+  declare type ProviderProps = { i18n: Object, children: React$Element<any> };
+
+  declare var I18nextProvider: Class<React$Component<void, ProviderProps, void>>;
+
+  declare type InterpolateProps = {
+    children?: React$Element<any>,
+    className?: string,
+  };
+
+  declare var Interpolate: Class<React$Component<void, InterpolateProps, void>>;
+}

--- a/definitions/npm/react-i18next_v2.x.x/test_react-i18next_v2.x.x.js
+++ b/definitions/npm/react-i18next_v2.x.x/test_react-i18next_v2.x.x.js
@@ -1,0 +1,101 @@
+// @flow
+
+import React from 'react'
+import {
+  loadNamespaces,
+  translate,
+  I18nextProvider,
+  Interpolate,
+} from 'react-i18next'
+import type { TFunction, Translator } from 'react-i18next'
+
+const i18n = { loadNamespaces: () => {} };
+
+<I18nextProvider i18n={ i18n } children={ <div /> } />;
+
+// $ExpectError - missing children prop
+<I18nextProvider i18n={ i18n } />;
+// $ExpectError - missing i18n prop
+<I18nextProvider children={ <div /> } />;
+
+
+// passing
+loadNamespaces({ components: [], i18n });
+loadNamespaces({ components: [() => <div />], i18n });
+
+// $ExpectError - too few arguments
+loadNamespaces();
+// $ExpectError - wrong type
+loadNamespaces('');
+// $ExpectError - wrong component type
+loadNamespaces({ components: [{}], i18n });
+
+type OwnProps = { s: string };
+type Props = OwnProps & { t: TFunction };
+
+const Comp = ({ s, t }: Props) => (
+  <div
+    prop1={ t('') }
+    prop2={ ' ' + s }
+  />
+);
+
+class ClassComp extends React.Component {
+  props: Props;
+  render() {
+    const { s, t } = this.props;
+    return <div prop={ t('') } />;
+  }
+}
+
+// $ExpectError - wrong argument type
+const FlowErrorComp = ({ s, t }: Props) => (
+  <div
+    prop1={ t('', '') } // misuse of t()
+    prop2={ ' ' + s }
+  />
+);
+
+class FlowErrorClassComp extends React.Component {
+  props: Props;
+  render() {
+    // $ExpectError - wrong argument type
+    const { s, t } = this.props;
+    return <div prop={ t({}) } />; // misuse of t()
+  }
+}
+
+// $ExpectError - too few arguments
+translate();
+// $ExpectError - wrong argument type
+translate({});
+
+const translator: Translator<OwnProps, Props> = translate('');
+const WrappedStatelessComp = translator(Comp);
+
+// passing
+<WrappedStatelessComp s="" />;
+
+// $ExpectError - missing prop "s"
+<WrappedStatelessComp />;
+// $ExpectError - wrong type
+<WrappedStatelessComp s={ 1 } />;
+
+const WrappedClassComp = translator(ClassComp);
+
+// passing
+<WrappedClassComp s="" />;
+
+// $ExpectError - missing prop "s"
+<WrappedClassComp />;
+// $ExpectError - wrong type
+<WrappedClassComp s={ 1 } />;
+
+// passing
+<Interpolate />;
+<Interpolate children={ <div /> } className="string" />;
+
+// $ExpectError - className prop wrong type
+<Interpolate className={ null } />;
+// $ExpectError - children prop wrong type
+<Interpolate children={ {} } />;


### PR DESCRIPTION
Copied this from v1.10.x. The API didn't change (major version was due to a new major version of the i18next dependency).