### PR TITLE
Support chai-as-promised plugin for chai_v3.5.x

### DIFF
--- a/definitions/npm/chai_v3.5.x/flow_v0.24.0-/chai_v3.5.x.js
+++ b/definitions/npm/chai_v3.5.x/flow_v0.24.0-/chai_v3.5.x.js
@@ -91,7 +91,7 @@ declare module "chai" {
         calledWithMatch: (...args: Array<mixed>) => ExpectChain<T>,
         calledWithExactly: (...args: Array<mixed>) => ExpectChain<T>,
 
-        // chai-as-expected
+        // chai-as-promised
         eventually: ExpectChain<T>,
         resolvedWith: (value: mixed) => Promise<mixed> & ExpectChain<T>,
         resolved: () => Promise<mixed> & ExpectChain<T>,

--- a/definitions/npm/chai_v3.5.x/flow_v0.24.0-/chai_v3.5.x.js
+++ b/definitions/npm/chai_v3.5.x/flow_v0.24.0-/chai_v3.5.x.js
@@ -90,6 +90,14 @@ declare module "chai" {
         calledWith: (...args: Array<mixed>) => ExpectChain<T>,
         calledWithMatch: (...args: Array<mixed>) => ExpectChain<T>,
         calledWithExactly: (...args: Array<mixed>) => ExpectChain<T>,
+
+        // chai-as-expected
+        eventually: ExpectChain<T>,
+        resolvedWith: (value: mixed) => Promise<mixed> & ExpectChain<T>,
+        resolved: () => Promise<mixed> & ExpectChain<T>,
+        rejectedWith: (value: mixed) => Promise<mixed> & ExpectChain<T>,
+        rejected: () => Promise<mixed> & ExpectChain<T>,
+        notify: (callback: () => mixed) => ExpectChain<T>,
     };
 
     declare function expect<T>(actual: T): ExpectChain<T>;

--- a/definitions/npm/chai_v3.5.x/test_chai_v3.5.x.js
+++ b/definitions/npm/chai_v3.5.x/test_chai_v3.5.x.js
@@ -115,3 +115,10 @@ assert.instanceOf(instance, SampleClass, "instance check");
 // $ExpectError
 assert.instanceOf(instance, instance);
 assert.notInstanceOf(instance, Array);
+
+// tests for chai-as-promised
+expect(Promise.resolve(true)).to.eventually.equal(true).notify(function() {});
+expect(Promise.resolve(true)).to.eventually.be.resolved().then(function() {}).catch(function() {});
+expect(Promise.resolve(true)).to.eventually.be.resolvedWith(true).then(function() {}).catch(function() {});
+expect(Promise.resolve(true)).to.eventually.be.rejected().then(function() {}).catch(function() {});
+expect(Promise.resolve(true)).to.eventually.be.rejectedWith(Error).then(function() {}).catch(function() {});


### PR DESCRIPTION
I noticed that the `chai` types don't support `chai-as-promised` plugin (http://chaijs.com/plugins/chai-as-promised/) which we use.

So I went ahead and just created the declarations for `chai-as-promised` in the `chai` module, the same as was already done for `chai-sinon` and others.

Feel free to comment and request changes