### PR TITLE
Improve CLI commands texts

### DIFF
--- a/cli/src/commands/create-stub.js
+++ b/cli/src/commands/create-stub.js
@@ -1,7 +1,7 @@
 // @flow
 
 export const name = 'create-stub';
-export const description = 'Creates a libdef stub for an untyped npm package';
+export const description = 'Create a libdef stub for an untyped npm package';
 
 import {createStub} from '../lib/stubUtils.js';
 import {findFlowRoot} from '../lib/flowProjectUtils.js';

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -24,7 +24,7 @@ import type {LibDef} from "../lib/libDefs.js";
 import type {Version} from "../lib/semver.js";
 
 export const name = 'install';
-export const description = 'Installs a libdef to the ./flow-typed directory';
+export const description = 'Install a libdef into the ./flow-typed directory';
 
 import typeof Yargs from "yargs";
 
@@ -39,7 +39,7 @@ export function setup(yargs: Yargs) {
     .options({
       flowVersion: {
         alias: 'f',
-        describe: 'The version of Flow fetched libdefs must be compatible with',
+        describe: 'The version of Flow that the fetched libdefs must be compatible with',
         type: 'string',
       },
       overwrite: {
@@ -51,7 +51,7 @@ export function setup(yargs: Yargs) {
       },
       verbose: {
         describe: 'Print additional, verbose information while installing ' +
-                  'libdefs.',
+                  'libdefs',
         type: 'boolean',
         demand: false,
       },

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -357,7 +357,7 @@ async function runTests(
 }
 
 export const name = "run-tests";
-export const description = "Run definition tests of library definitions in the flow-typed project.";
+export const description = "Run definition tests for library definitions in the flow-typed project";
 export async function run(argv: Argv): Promise<number> {
   if (!isInFlowTypedRepo()) {
     console.log(

--- a/cli/src/commands/search.js
+++ b/cli/src/commands/search.js
@@ -26,7 +26,7 @@ export function _formatDefTable(defs: Array<LibDef>): string {
 
 export const name = "search";
 export const description =
-  "Performs a simple search (by name) of available libdefs";
+  "Perform a simple search (by name) of available libdefs";
 
 export async function run(args: Argv): Promise<number> {
   if (!args._ || !(args._.length > 1)) {

--- a/cli/src/commands/update-cache.js
+++ b/cli/src/commands/update-cache.js
@@ -6,14 +6,14 @@ import type {Argv} from "yargs";
 import typeof Yargs from "yargs";
 
 export const name = 'update-cache';
-export const description = 'Updates the flow-typed definitions cache';
+export const description = 'Update the flow-typed definitions cache';
 
 export function setup(yargs: Yargs) {
   return yargs
     .usage(`$0 ${name} - ${description}`)
     .options({
       debug: {
-        describe: 'Enables verbose messages for the update procedure',
+        describe: 'Enable verbose messages for the update procedure',
         alias: 'd',
         type: 'boolean',
         demand: false,

--- a/cli/src/commands/validateDefs.js
+++ b/cli/src/commands/validateDefs.js
@@ -13,7 +13,7 @@ import {
 } from "../lib/validationErrors";
 
 export const name = "validate-defs";
-export const description = "Validates the structure of the /definitions dir.";
+export const description = "Validate the structure of the /definitions dir";
 export type Args = {
   _: Array<string>,
 };

--- a/cli/src/commands/version.js
+++ b/cli/src/commands/version.js
@@ -6,16 +6,15 @@ import type {Argv} from "yargs";
 import typeof Yargs from "yargs";
 
 export const name = "version";
-export const description = "Prints the CLI version.";
+export const description = "Print the CLI version";
 export function setup(yargs: Yargs) {
   return yargs
     .options({
       showDelegatorVersion: {
         alias: 'g',
         demand: false,
-        describe: 'Include info about the globally-installed CLI if the ' +
-                  'it delegated to a local package-installed version of the ' +
-                  'CLI.',
+        describe: 'Include info about the globally-installed CLI package ' +
+                  'if it has delegated to a locally-installed one',
         type: 'boolean',
       },
     })


### PR DESCRIPTION
- Remove periods to have standard lines (it is usually the case for other CLIs help text I've looked, e.g. git)
- Change the tense to imperative, to match with `yargs` text `"Show help"` and other CLI tools
- Clarify a few cases

Hope it helps, just starting to review the codebase of the project.