### PR TITLE
Allowed react-routerv4 Prompt.message to return true

### DIFF
--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-/react-router-dom_v4.x.x.js
@@ -122,7 +122,7 @@ declare module 'react-router-dom' {
 
   declare export class Prompt extends React$Component {
     props: {
-      message: string | (location: Location) => string,
+      message: string | (location: Location) => string | true,
       when?: boolean,
     }
   }

--- a/definitions/npm/react-router_v4.x.x/flow_v0.38.x-/react-router_v4.x.x.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.38.x-/react-router_v4.x.x.js
@@ -82,7 +82,7 @@ declare module 'react-router' {
 
   declare export class Prompt extends React$Component {
     props: {
-      message: string | (location: Location) => string,
+      message: string | (location: Location) => string | true,
       when?: boolean,
     }
   }

--- a/definitions/npm/react-router_v4.x.x/test_react-router.js
+++ b/definitions/npm/react-router_v4.x.x/test_react-router.js
@@ -62,6 +62,7 @@ var history: History;
 // Prompt
 <Prompt message="ok?" when={true} />;
 <Prompt message={(location) => "ok?"} />;
+<Prompt message={(location) => true} />;
 
 // $ExpectError
 <Prompt />;


### PR DESCRIPTION
Return a string to show a prompt to the user or true to allow the transition. [reference](https://reacttraining.com/react-router/#prompt.message-func)