### PR TITLE
Add definition for undescore.js delay

### DIFF
--- a/definitions/npm/underscore_v1.x.x/flow_v0.13.x-v0.37.x/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.13.x-v0.37.x/underscore_v1.x.x.js
@@ -136,7 +136,7 @@ declare module "underscore" {
 
   declare function memoize(fn: Function): Function;
 
-  // TODO: delay
+  declare function delay(fn: Function, wait: number, ...arguments: Array<any>): void;
 
   declare function defer(fn: Function, ...arguments: Array<any>): void;
 

--- a/definitions/npm/underscore_v1.x.x/flow_v0.13.x-v0.37.x/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.13.x-v0.37.x/underscore_v1.x.x.js
@@ -136,7 +136,7 @@ declare module "underscore" {
 
   declare function memoize(fn: Function): Function;
 
-  declare function delay(fn: Function, wait: number, ...arguments: Array<any>): void;
+  declare function delay(fn: Function, wait?: number, ...arguments?: Array<any>): number;
 
   declare function defer(fn: Function, ...arguments: Array<any>): void;
 

--- a/definitions/npm/underscore_v1.x.x/flow_v0.38.x-/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.38.x-/underscore_v1.x.x.js
@@ -136,7 +136,7 @@ declare module "underscore" {
 
   declare function memoize(fn: Function): Function;
 
-  // TODO: delay
+  declare function delay(fn: Function, wait: number, ...arguments: Array<any>): void;
 
   declare function defer(fn: Function, ...arguments: Array<any>): void;
 

--- a/definitions/npm/underscore_v1.x.x/flow_v0.38.x-/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.38.x-/underscore_v1.x.x.js
@@ -136,7 +136,7 @@ declare module "underscore" {
 
   declare function memoize(fn: Function): Function;
 
-  declare function delay(fn: Function, wait: number, ...arguments: Array<any>): void;
+  declare function delay(fn: Function, wait?: number, ...arguments?: Array<any>): number;
 
   declare function defer(fn: Function, ...arguments: Array<any>): void;
 

--- a/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
+++ b/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
@@ -146,6 +146,7 @@ _.debounce(function(a) {a.length}, 10)('hello');
 
 _.memoize(function(){})();
 _.partial(function (a, b) { return a + b }, 1)(2);
+_.delay(function(){}, 0);
 _.defer(function(){});
 
 (


### PR DESCRIPTION
## What this does
Adds in a definition for the underscore `delay` function. Mirrored off of the existing `defer` and `throttle` definitions.

## Notes/caveats
- I attempted to add an $ExpectedError line to the underscore test with the following call:
```
_.delay(() => {}); // No delay specified
```
But I was getting an 'Unused suppression error. Not certain what I was doing wrong there.

- I would prefer to not use the `Array<any>` function here, and figure out a way to match the arguments to the function passed in, but that requires a little more thought.