### PR TITLE
Generates stubs without trailing whitespace

### DIFF
--- a/cli/src/lib/stubUtils.js
+++ b/cli/src/lib/stubUtils.js
@@ -88,8 +88,8 @@ async function writeStub(
     ' *',
     ' * Fill this stub out by replacing all the `any` types.',
     ' *',
-    ' * Once filled out, we encourage you to share your work with the ',
-    ' * community by sending a pull request to: ',
+    ' * Once filled out, we encourage you to share your work with the',
+    ' * community by sending a pull request to:',
     ' * https://github.com/flowtype/flow-typed',
     ' */\n\n'
   ].join('\n');


### PR DESCRIPTION
Avoids upsetting consumer projects' lint tools by default.