### PR TITLE
Remove trailing spaces and new lines from git commit

### DIFF
--- a/cli/src/lib/git.js
+++ b/cli/src/lib/git.js
@@ -28,10 +28,13 @@ async function getGitPath() {
 export async function getDiff() {
   const gitPath = await getGitPath();
   try {
-    const {stdout:commit} = await child_process.spawnP(
+    let {stdout:commit} = await child_process.spawnP(
       gitPath,
       ['merge-base', 'origin/master', 'HEAD'],
     );
+    // Remove trailing spaces and new lines
+    commit = commit.replace(/^\s+|\s+$/g, '');
+
     const {stdout} = await child_process.spawnP(
       gitPath,
       ['diff', '--name-only', commit],


### PR DESCRIPTION
I noticed a bug when running `run-tests --onlyChanged` for https://github.com/flowtype/flow-typed/pull/697 where it doesn't seem to pick up any changed files. Traced the issue to the fact that the command that gets the current master commit doesn't trim the trailing new line and so the diff command fails (it also fails silently which I'm not sure is desired but I didn't want to change it).

Anyway this PR trims the new lines so that the command works as expected.