### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install -g flow-typed
 
 $ cd /path/to/my/project
 $ npm install
-$ flow-typed install
+$ flow-typed install rxjs@5.0.x
 'rxjs_v5.0.x.js' installed at /path/to/my/project/flow-typed/npm/rxjs_v5.0.xjs
 ```
 


### PR DESCRIPTION
Example of how to install a flow-typed definition does not include actual command line definition format. Updated to include.