### PR TITLE
package definition for the npm out package

### DIFF
--- a/definitions/npm/out_v1.x.x/flow_v0.28.x-/out_v1.x.x.js
+++ b/definitions/npm/out_v1.x.x/flow_v0.28.x-/out_v1.x.x.js
@@ -1,0 +1,7 @@
+declare module 'out' {
+  declare module.exports: {
+    (message: string, ...args: Array<mixed>): void;
+    error(...args: Array<Error | mixed>): void;
+    to(targets: Array<tty$WriteStream | stream$Writable>): void;
+  }
+}

--- a/definitions/npm/out_v1.x.x/test_out_v1.x.x.js
+++ b/definitions/npm/out_v1.x.x/test_out_v1.x.x.js
@@ -1,0 +1,20 @@
+import out from 'out';
+
+out('hello');
+out('hello', 1);
+out('hello', 2);
+
+// $ExpectError
+out({});
+
+// $ExpectError
+out(5);
+
+/* check out.to function */
+
+out.to([process.stdout]);
+out.to([]);
+
+// $ExpectError
+out.to();
+


### PR DESCRIPTION
This is far from being the world's most popular package (see: https://github.com/DamonOehlman/out) , but I've used it a lot of my projects for writing `stderr` output (default setting).  I'm currently converting a couple of older projects to use flow annotations so would would be grateful if this was available in the definition repo.