### PR TITLE
Add proper typings for moment().calendar (moment >= v2.14.x)

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.34.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.34.x-/moment_v2.x.x.js
@@ -41,13 +41,15 @@ type moment$MomentCreationData = {
   strict: bool,
 };
 
+type moment$CalendarFormat = string | (moment$Moment) => string;
+
 type moment$CalendarFormats = {
-  sameDay?: string,
-  nextDay?: string,
-  nextWeek?: string,
-  lastDay?: string,
-  lastWeek?: string,
-  sameElse?: string,
+  sameDay?: moment$CalendarFormat,
+  nextDay?: moment$CalendarFormat,
+  nextWeek?: moment$CalendarFormat,
+  lastDay?: moment$CalendarFormat,
+  lastWeek?: moment$CalendarFormat,
+  sameElse?: moment$CalendarFormat,
 };
 
 declare class moment$LocaleData {

--- a/definitions/npm/moment_v2.x.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.x.x/test_moment-v2.js
@@ -4,7 +4,7 @@ import moment from 'moment';
 // Parse
 const m3: moment = moment([123, 123]);
 
-//$ExpectError
+// $ExpectError
 moment.unix('1234');
 
 // Display
@@ -30,3 +30,24 @@ moment().isAfter();
 moment().isSameOrBefore();
 moment().isSameOrAfter();
 moment.isDate(new Date());
+
+
+// CalendarTime
+moment().calendar(null, {
+  sameDay: 'HH:mm',
+});
+moment().calendar(null, {
+  sameDay: () => 'HH:mm',
+});
+// $ExpectError
+moment().calendar(null, {
+  sameDay: (a: number) => 'HH:mm',
+});
+// $ExpectError
+moment().calendar(null, {
+  sameDay: 2,
+});
+// $ExpectError
+moment().calendar(null, {
+  sameElse: () => {},
+});


### PR DESCRIPTION
This PR introduces proper typing for `moment().calendar` changes introduced in moment v2.14.0 ([see note here](http://momentjs.com/docs/#/displaying/calendar-time/).

This also bumps flow minimum version to 0.34 (which is now 6 months old) to support function signature typing.