### PR TITLE
Add definitions for js-beautify 1.6

### DIFF
--- a/definitions/npm/js-beautify_v1.6.x/flow_v0.25.x-/js-beautify_v1.6.x.js
+++ b/definitions/npm/js-beautify_v1.6.x/flow_v0.25.x-/js-beautify_v1.6.x.js
@@ -1,0 +1,72 @@
+declare module 'js-beautify' {
+  declare type JSBeautifyJSOptions = {
+    indent_size?: number,
+    indent_char?: string,
+    indent_with_tabs?: boolean,
+    eol?: string,
+    end_with_newline?: boolean,
+    indent_level?: number,
+    preserve_newlines?: boolean,
+    max_preserve_newlines?: number,
+    space_in_paren?: boolean,
+    space_in_empty_paren?: boolean,
+    jslint_happy?: boolean,
+    space_after_anon_function?: boolean,
+    brace_style?: "collapse"
+      |"collapse,preserve-inline"
+      |"expand"
+      |"expand,preserve-inline"
+      |"end-expand"
+      |"end-expand,preserve-inline"
+      |"none"
+      |"none,preserve-inline",
+    break_chained_methods?: boolean,
+    keep_array_indentation?: boolean,
+    unescape_strings?: boolean,
+    wrap_line_length?: number,
+    e4x?: boolean,
+    comma_first?: boolean,
+    operator_position?: "before-newline"|"after-newline"|"preserve-newline",
+    eval_code?: boolean,
+    space_before_conditional?: boolean
+  };
+
+  declare type JSBeautifyCSSOptions = {
+    indent_size?: number,
+    indent_char?: string,
+    indent_with_tabs?: boolean,
+    eol?: string,
+    end_with_newline?: boolean,
+    selector_separator_newline?: boolean,
+    newline_between_rules?: boolean
+  };
+
+  declare type JSBeautifyHTMLOptions = {
+    indent_size?: number,
+    indent_char?: string,
+    indent_with_tabs?: boolean,
+    eol?: string,
+    end_with_newline?: boolean,
+    preserve_newlines?: boolean,
+    max_preserve_newlines?: number,
+    indent_inner_html?: boolean,
+    brace_style?: string,
+    indent_scripts?: "keep"|"separate"|"normal",
+    wrap_line_length?: number,
+    wrap_attributes?: "auto"|"force"|"force-aligned",
+    wrap_attributes_indent_size?: number,
+    unformatted?: string|Array<string>,
+    content_unformatted?: string|Array<string>,
+    extra_liners?: string|Array<string>,
+  };
+
+  declare module.exports: {
+    (code: string, options?: JSBeautifyJSOptions): string,
+    js: (code: string, options?: JSBeautifyJSOptions) => string,
+    css: (code: string, options?: JSBeautifyCSSOptions) => string,
+    html: (code: string, options?: JSBeautifyHTMLOptions) => string,
+    js_beautify: (code: string, options?: JSBeautifyJSOptions) => string,
+    css_beautify: (code: string, options?: JSBeautifyCSSOptions) => string,
+    html_beautify: (code: string, options?: JSBeautifyHTMLOptions) => string
+  };
+}

--- a/definitions/npm/js-beautify_v1.6.x/test_js-beautify_v1.6.x.js
+++ b/definitions/npm/js-beautify_v1.6.x/test_js-beautify_v1.6.x.js
@@ -1,0 +1,31 @@
+// @flow
+import beautify, { html, css, js, css_beautify, html_beautify, js_beautify } from 'js-beautify';
+
+var code: string = '';
+// default import
+var a: string = beautify(code, { indent_size: 2, no_preserve_newlines: true, wrap_line_length: 0 });
+
+//named
+var b: string = html(code, { indent_size: 2, no_preserve_newlines: true, wrap_line_length: 0 });
+var c: string = css(code, { indent_size: 2, no_preserve_newlines: true, wrap_line_length: 0 });
+var d: string = js(code, { indent_size: 2, no_preserve_newlines: true, wrap_line_length: 0 });
+var e: string = css_beautify(code, { indent_size: 2, no_preserve_newlines: true, wrap_line_length: 0 });
+var f: string = js_beautify(code, { indent_size: 2, no_preserve_newlines: true, wrap_line_length: 0 });
+var g: string = html_beautify(code, { indent_size: 2, no_preserve_newlines: true, wrap_line_length: 0 });
+
+//commonjs
+var beautifyCommonJs = require('js-beautify');
+var h: string = beautifyCommonJs(code);
+var i: string = beautifyCommonJs.css_beautify(code, {});
+var j: string = beautifyCommonJs.js_beautify(code, {});
+var k: string = beautifyCommonJs.html_beautify(code, {});
+var l: string = beautifyCommonJs.css(code);
+var m: string = beautifyCommonJs.js(code);
+var n: string = beautifyCommonJs.html(code);
+
+// $ExpectError
+var o: number = beautifyCommonJs.html(code);
+
+// $ExpectError
+var p: string = beautifyCommonJs.html(1);
+


### PR DESCRIPTION
https://github.com/beautify-web/js-beautify

I only set the range to 1.6.x for now as I didn't want to go through the changelog and see how the options changed in the different versions, although it seems they also consider adding new options as bugfix versions (1.6.10/1.6.11).

