### PR TITLE
react-css-modules: Add initial definitions

### DIFF
--- a/definitions/npm/react-css-modules_v3.x.x/flow_v0.42.x-/react-css-modules_v3.x.x.js
+++ b/definitions/npm/react-css-modules_v3.x.x/flow_v0.42.x-/react-css-modules_v3.x.x.js
@@ -1,0 +1,12 @@
+// @flow
+
+declare module 'react-css-modules' {
+  declare function exports<D, P, S, C: React$Component<D, P, S>, X>(
+    component: Class<C>,
+    styles: X,
+    options?: {|
+      allowMultiple?: boolean,
+      errorWhenNotFound?: boolean,
+    |}
+  ): Class<React$Component<D, $Diff<P, { styles: X }>, S>>
+}

--- a/definitions/npm/react-css-modules_v3.x.x/test_react-css-modules-v3.js
+++ b/definitions/npm/react-css-modules_v3.x.x/test_react-css-modules-v3.js
@@ -1,0 +1,45 @@
+// @flow
+
+import React, { Component } from 'react';
+import CSSModules from 'react-css-modules';
+
+const styles = { test: '123' };
+
+class ExampleModule extends Component {
+  props: {
+    foo: string,
+    styles: typeof styles,
+  };
+
+  render() {
+    return <div className={this.props.styles}>{this.props.foo}</div>;
+  }
+}
+
+const ExampleCSSModules = CSSModules(ExampleModule, styles);
+const ExampleCSSModules2 = CSSModules(ExampleModule, styles, { allowMultiple: true });
+
+// $ExpectError invalid module option.
+const BusedCSSModule = CSSModules(ExampleModule, styles, { wubbaLubba: 'dub-dub' });
+
+class Failure1 extends Component {
+  render() {
+
+    // $ExpectError Missing prop `foo` will be caught.
+    return <ExampleCSSModules />;
+  }
+}
+
+class Failure2 extends Component {
+  render() {
+
+    // $ExpectError Unwrapped component won't be passed `styles`.
+    return <ExampleModule foo="bar" />;
+  }
+}
+
+class Working extends Component {
+  render() {
+    return <ExampleCSSModules foo="bar" />;
+  }
+}

--- a/definitions/npm/react-css-modules_v3.x.x/test_react-css-modules-v3.js
+++ b/definitions/npm/react-css-modules_v3.x.x/test_react-css-modules-v3.js
@@ -20,7 +20,7 @@ const ExampleCSSModules = CSSModules(ExampleModule, styles);
 const ExampleCSSModules2 = CSSModules(ExampleModule, styles, { allowMultiple: true });
 
 // $ExpectError invalid module option.
-const BusedCSSModule = CSSModules(ExampleModule, styles, { wubbaLubba: 'dub-dub' });
+const BustedCSSModule = CSSModules(ExampleModule, styles, { wubbaLubba: 'dub-dub' });
 
 class Failure1 extends Component {
   render() {


### PR DESCRIPTION
Adds a definition for [React CSS Modules](https://github.com/gajus/react-css-modules) v3.x.x. Almost certainly works with v4.x.x as well-- Will test in a subsequent commit later next week.