### PR TITLE
Add documentation about `flow install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,16 @@ This issue was first reported here:
 The `flow-typed` npm package provides a CLI that provides several commands for
 working with this repository:
 
+##### `flow-typed install [package-specification]`
+
+Installs libdefs from looking at your package.json.
+
+If `package-specification` was specified, only that one libdef will be installed.
+
+```bash
+flow-typed install foo@1.2.3
+```
+
 ##### `flow-typed validate-defs`
 
 Verifies that all files under the `/definitions/` directory are structured and 


### PR DESCRIPTION
I seemed that there was no way to [specify the package](https://github.com/kjirou/flow-typed/blob/master/cli/src/commands/install.js#L128-L144) in the document, so I added it.