### PR TITLE
Update typings for lodash v4

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.38.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.38.x-/lodash_v4.x.x.js
@@ -46,9 +46,10 @@ declare module 'lodash' {
     | matchesPropertyIterateeShorthand
     | propertyIterateeShorthand;
 
+  declare type _ValueOnlyIteratee<T> = (value: T) => mixed;
+  declare type ValueOnlyIteratee<T> = _ValueOnlyIteratee<T>|string;
   declare type _Iteratee<T> = (item: T, index: number, array: ?Array<T>) => mixed;
   declare type Iteratee<T> = _Iteratee<T>|Object|string;
-  declare type Iteratee2<T, U> = ((item: T, index: number, array: ?Array<T>) => U)|Object|string;
   declare type FlatMapIteratee<T, U> = ((item: T, index: number, array: ?Array<T>) => Array<U>)|Object|string;
   declare type Comparator<T> = (item: T, item2: T) => bool;
 
@@ -66,7 +67,7 @@ declare module 'lodash' {
     compact<T,N:?T>(array: Array<N>): Array<T>;
     concat<T>(base: Array<T>, ...elements: Array<any>): Array<T|any>;
     difference<T>(array: ?Array<T>, values?: Array<T>): Array<T>;
-    differenceBy<T>(array: ?Array<T>, values: Array<T>, iteratee: Iteratee<T>): T[];
+    differenceBy<T>(array: ?Array<T>, values: Array<T>, iteratee: ValueOnlyIteratee<T>): T[];
     differenceWith<T>(array: T[], values: T[], comparator?: Comparator<T>): T[];
     drop<T>(array: ?Array<T>, n?: number): Array<T>;
     dropRight<T>(array: ?Array<T>, n?: number): Array<T>;
@@ -86,10 +87,10 @@ declare module 'lodash' {
     initial<T>(array: ?Array<T>): Array<T>;
     intersection<T>(...arrays: Array<Array<T>>): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
-    intersectionBy<T>(a1: Array<T>, iteratee?: Iteratee<T>): Array<T>;
-    intersectionBy<T>(a1: Array<T>, a2: Array<T>, iteratee?: Iteratee<T>): Array<T>;
-    intersectionBy<T>(a1: Array<T>, a2: Array<T>, a3: Array<T>, iteratee?: Iteratee<T>): Array<T>;
-    intersectionBy<T>(a1: Array<T>, a2: Array<T>, a3: Array<T>, a4: Array<T>, iteratee?: Iteratee<T>): Array<T>;
+    intersectionBy<T>(a1: Array<T>, iteratee?: ValueOnlyIteratee<T>): Array<T>;
+    intersectionBy<T>(a1: Array<T>, a2: Array<T>, iteratee?: ValueOnlyIteratee<T>): Array<T>;
+    intersectionBy<T>(a1: Array<T>, a2: Array<T>, a3: Array<T>, iteratee?: ValueOnlyIteratee<T>): Array<T>;
+    intersectionBy<T>(a1: Array<T>, a2: Array<T>, a3: Array<T>, a4: Array<T>, iteratee?: ValueOnlyIteratee<T>): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
     intersectionWith<T>(a1: Array<T>, comparator: Comparator<T>): Array<T>;
     intersectionWith<T>(a1: Array<T>, a2: Array<T>, comparator: Comparator<T>): Array<T>;
@@ -101,7 +102,7 @@ declare module 'lodash' {
     nth<T>(array: T[], n?: number): T;
     pull<T>(array: ?Array<T>, ...values?: Array<T>): Array<T>;
     pullAll<T>(array: ?Array<T>, values: Array<T>): Array<T>;
-    pullAllBy<T>(array: ?Array<T>, values: Array<T>, iteratee?: Iteratee<T>): Array<T>;
+    pullAllBy<T>(array: ?Array<T>, values: Array<T>, iteratee?: ValueOnlyIteratee<T>): Array<T>;
     pullAllWith<T>(array?: T[], values: T[], comparator?: Function): T[];
     pullAt<T>(array: ?Array<T>, ...indexed?: Array<number>): Array<T>;
     pullAt<T>(array: ?Array<T>, indexed?: Array<number>): Array<T>;
@@ -109,10 +110,10 @@ declare module 'lodash' {
     reverse<T>(array: ?Array<T>): Array<T>;
     slice<T>(array: ?Array<T>, start?: number, end?: number): Array<T>;
     sortedIndex<T>(array: ?Array<T>, value: T): number;
-    sortedIndexBy<T>(array: ?Array<T>, value: T, iteratee?: Iteratee<T>): number;
+    sortedIndexBy<T>(array: ?Array<T>, value: T, iteratee?: ValueOnlyIteratee<T>): number;
     sortedIndexOf<T>(array: ?Array<T>, value: T): number;
     sortedLastIndex<T>(array: ?Array<T>, value: T): number;
-    sortedLastIndexBy<T>(array: ?Array<T>, value: T, iteratee?: Iteratee<T>): number;
+    sortedLastIndexBy<T>(array: ?Array<T>, value: T, iteratee?: ValueOnlyIteratee<T>): number;
     sortedLastIndexOf<T>(array: ?Array<T>, value: T): number;
     sortedUniq<T>(array: ?Array<T>): Array<T>;
     sortedUniqBy<T>(array: ?Array<T>, iteratee?: (value: T) => mixed): Array<T>;
@@ -123,27 +124,27 @@ declare module 'lodash' {
     takeWhile<T>(array: ?Array<T>, predicate?: Predicate<T>): Array<T>;
     union<T>(...arrays?: Array<Array<T>>): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
-    unionBy<T>(a1: Array<T>, iteratee?: Iteratee<T>): Array<T>;
-    unionBy<T>(a1: Array<T>, a2: Array<T>, iteratee?: Iteratee<T>): Array<T>;
-    unionBy<T>(a1: Array<T>, a2: Array<T>, a3: Array<T>, iteratee?: Iteratee<T>): Array<T>;
-    unionBy<T>(a1: Array<T>, a2: Array<T>, a3: Array<T>, a4: Array<T>, iteratee?: Iteratee<T>): Array<T>;
+    unionBy<T>(a1: Array<T>, iteratee?: ValueOnlyIteratee<T>): Array<T>;
+    unionBy<T>(a1: Array<T>, a2: Array<T>, iteratee?: ValueOnlyIteratee<T>): Array<T>;
+    unionBy<T>(a1: Array<T>, a2: Array<T>, a3: Array<T>, iteratee?: ValueOnlyIteratee<T>): Array<T>;
+    unionBy<T>(a1: Array<T>, a2: Array<T>, a3: Array<T>, a4: Array<T>, iteratee?: ValueOnlyIteratee<T>): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
     unionWith<T>(a1: Array<T>, comparator?: Comparator<T>): Array<T>;
     unionWith<T>(a1: Array<T>, a2: Array<T>, comparator?: Comparator<T>): Array<T>;
     unionWith<T>(a1: Array<T>, a2: Array<T>, a3: Array<T>, comparator?: Comparator<T>): Array<T>;
     unionWith<T>(a1: Array<T>, a2: Array<T>, a3: Array<T>, a4: Array<T>, comparator?: Comparator<T>): Array<T>;
     uniq<T>(array: ?Array<T>): Array<T>;
-    uniqBy<T>(array: ?Array<T>, iteratee?: Iteratee<T>): Array<T>;
+    uniqBy<T>(array: ?Array<T>, iteratee?: ValueOnlyIteratee<T>): Array<T>;
     uniqWith<T>(array: ?Array<T>, comparator?: Comparator<T>): Array<T>;
     unzip<T>(array: ?Array<T>): Array<T>;
     unzipWith<T>(array: ?Array<T>, iteratee?: Iteratee<T>): Array<T>;
     without<T>(array: ?Array<T>, ...values?: Array<T>): Array<T>;
     xor<T>(...array: Array<Array<T>>): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
-    xorBy<T>(a1: Array<T>, iteratee?: Iteratee<T>): Array<T>;
-    xorBy<T>(a1: Array<T>, a2: Array<T>, iteratee?: Iteratee<T>): Array<T>;
-    xorBy<T>(a1: Array<T>, a2: Array<T>, a3: Array<T>, iteratee?: Iteratee<T>): Array<T>;
-    xorBy<T>(a1: Array<T>, a2: Array<T>, a3: Array<T>, a4: Array<T>, iteratee?: Iteratee<T>): Array<T>;
+    xorBy<T>(a1: Array<T>, iteratee?: ValueOnlyIteratee<T>): Array<T>;
+    xorBy<T>(a1: Array<T>, a2: Array<T>, iteratee?: ValueOnlyIteratee<T>): Array<T>;
+    xorBy<T>(a1: Array<T>, a2: Array<T>, a3: Array<T>, iteratee?: ValueOnlyIteratee<T>): Array<T>;
+    xorBy<T>(a1: Array<T>, a2: Array<T>, a3: Array<T>, a4: Array<T>, iteratee?: ValueOnlyIteratee<T>): Array<T>;
     //Workaround until (...parameter: T, parameter2: U) works
     xorWith<T>(a1: Array<T>, comparator?: Comparator<T>): Array<T>;
     xorWith<T>(a1: Array<T>, a2: Array<T>, comparator?: Comparator<T>): Array<T>;
@@ -163,8 +164,8 @@ declare module 'lodash' {
     zipWith<T>(a1: NestedArray<T>, a2: NestedArray<T>, a3: NestedArray<T>, a4: NestedArray<T>, iteratee?: Iteratee<T>): Array<T>;
 
     // Collection
-    countBy<T>(array: ?Array<T>, iteratee?: Iteratee<T>): Object;
-    countBy<T: Object>(object: T, iteratee?: OIteratee<T>): Object;
+    countBy<T>(array: ?Array<T>, iteratee?: ValueOnlyIteratee<T>): Object;
+    countBy<T: Object>(object: T, iteratee?: ValueOnlyIteratee<T>): Object;
     // alias of _.forEach
     each<T>(array: ?Array<T>, iteratee?: Iteratee<T>): Array<T>;
     each<T: Object>(object: T, iteratee?: OIteratee<T>): T;
@@ -189,15 +190,15 @@ declare module 'lodash' {
     forEach<T: Object>(object: T, iteratee?: OIteratee<T>): T;
     forEachRight<T>(array: ?Array<T>, iteratee?: Iteratee<T>): Array<T>;
     forEachRight<T: Object>(object: T, iteratee?: OIteratee<T>): T;
-    groupBy<T>(array: ?Array<T>, iteratee?: Iteratee<T>): Object;
-    groupBy<T: Object>(object: T, iteratee?: OIteratee<T>): Object;
+    groupBy<V, T>(array: ?Array<T>, iteratee?: ValueOnlyIteratee<T>): {[key: V]: ?Array<T>};
+    groupBy<V, A, T: {[id: string]: A}>(object: T, iteratee?: ValueOnlyIteratee<A>): {[key: V]: ?Array<A>};
     includes<T>(array: ?Array<T>, value: T, fromIndex?: number): bool;
     includes<T: Object>(object: T, value: any, fromIndex?: number): bool;
     includes(str: string, value: string, fromIndex?: number): bool;
     invokeMap<T>(array: ?Array<T>, path: ((value: T) => Array<string>|string)|Array<string>|string, ...args?: Array<any>): Array<any>;
     invokeMap<T: Object>(object: T, path: ((value: any) => Array<string>|string)|Array<string>|string, ...args?: Array<any>): Array<any>;
-    keyBy<T, V>(array: ?Array<T>, iteratee?: Iteratee2<T, V>): {[key: V]: ?T};
-    keyBy<V, T: Object>(object: T, iteratee?: OIteratee<T>): Object;
+    keyBy<T, V>(array: ?Array<T>, iteratee?: ValueOnlyIteratee<T>): {[key: V]: ?T};
+    keyBy<V, A, T: {[id: string]: A}>(object: T, iteratee?: ValueOnlyIteratee<A>): {[key: V]: ?A};
     map<T, U>(array: ?Array<T>, iteratee?: MapIterator<T, U>): Array<U>;
     map<V, T: Object, U>(object: ?T, iteratee?: OMapIterator<V, T, U>): Array<U>;
     map(str: ?string, iteratee?: (char: string, index: number, str: string) => any): string;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.38.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.38.x-/test_lodash-v4.x.x.js
@@ -2,6 +2,20 @@
 import _ from 'lodash';
 
 /**
+ * _.countBy
+ */
+_.countBy([6.1, 4.2, 6.3], Math.floor);
+_.countBy(['one', 'two', 'three'], 'length');
+
+
+/**
+ * _.differenceBy
+ */
+_.differenceBy([2.1, 1.2], [2.3, 3.4], Math.floor);
+_.differenceBy([{ 'x': 2 }, { 'x': 1 }], [{ 'x': 1 }], 'x');
+
+
+/**
  * _.find
  */
 _.find([1, 2, 3], x => x * 1 == 3);
@@ -37,6 +51,51 @@ _.find(users, 'active');
 
 
 /**
+ * _.groupBy
+ */
+var numbersGroupedByMathFloor = _.groupBy([6.1, 4.2, 6.3], Math.floor);
+if (numbersGroupedByMathFloor[6]) {
+  numbersGroupedByMathFloor[6][0] / numbersGroupedByMathFloor[6][1]
+}
+var stringsGroupedByLength = _.groupBy(['one', 'two', 'three'], 'length');
+if (stringsGroupedByLength[3]) {
+  stringsGroupedByLength[3][0].toLowerCase();
+}
+var numbersObj: {[key: string]: number} = {a: 6.1, b: 4.2, c: 6.3};
+var numbersGroupedByMathFloor2 = _.groupBy(numbersObj, Math.floor);
+if (numbersGroupedByMathFloor2[6]) {
+  numbersGroupedByMathFloor2[6][0] / numbersGroupedByMathFloor2[6][1]
+}
+var stringObj: {[key: string]: string} = {a: 'one', b: 'two', c: 'three'};
+var stringsGroupedByLength2 = _.groupBy(stringObj, 'length');
+if (stringsGroupedByLength2[3]) {
+  stringsGroupedByLength2[3][0].toLowerCase();
+}
+
+
+/**
+ * _.intersectionBy
+ */
+_.intersectionBy([2.1, 1.2], [2.3, 3.4], Math.floor);
+_.intersectionBy([{ 'x': 1 }], [{ 'x': 2 }, { 'x': 1 }], 'x');
+
+
+/**
+ * _.keyBy
+ */
+_.keyBy([
+  { 'dir': 'left', 'code': 97 },
+  { 'dir': 'right', 'code': 100 }
+], function(o) {
+  return String.fromCharCode(o.code);
+});
+_.keyBy([
+  { 'dir': 'left', 'code': 97 },
+  { 'dir': 'right', 'code': 100 }
+], 'dir');
+
+
+/**
  * _.map examples from the official doc
  */
 function square(n) {
@@ -53,6 +112,27 @@ var users = [
 
 // The `_.property` iteratee shorthand.
 _.map(users, 'user');
+
+
+/**
+ * _.pullAllBy
+ */
+_.pullAllBy([{ 'x': 1 }, { 'x': 2 }, { 'x': 3 }, { 'x': 1 }], [{ 'x': 1 }, { 'x': 3 }], 'x');
+
+
+/**
+ * _.unionBy
+ */
+_.unionBy([2.1], [1.2, 2.3], Math.floor);
+_.unionBy([{ 'x': 1 }], [{ 'x': 2 }, { 'x': 1 }], 'x');
+
+
+/**
+ * _.uniqBy
+ */
+_.uniqBy([2.1, 1.2, 2.3], Math.floor);
+_.uniqBy([{ 'x': 1 }, { 'x': 2 }, { 'x': 1 }], 'x');
+
 
 /**
  * _.clone
@@ -88,6 +168,19 @@ _.range(0, 10)[4] == 'a';
 
 
 /**
+ * _.sortedIndexBy
+ */
+_.sortedIndexBy([{ 'x': 4 }, { 'x': 5 }], { 'x': 4 }, function(o) { return o.x; });
+_.sortedIndexBy([{ 'x': 4 }, { 'x': 5 }], { 'x': 4 }, 'x');
+
+
+/**
+ * _.sortedLastIndexBy
+ */
+_.sortedLastIndexBy([{ 'x': 4 }, { 'x': 5 }], { 'x': 4 }, function(o) { return o.x; });
+_.sortedLastIndexBy([{ 'x': 4 }, { 'x': 5 }], { 'x': 4 }, 'x');
+
+/**
  * _.extend
  */
 _.extend({a: 1}, {b: 2}).a
@@ -96,6 +189,13 @@ _.extend({a: 1}, {b: 2}).b
 _.extend({a: 1}, {b: 2}).c
 // $ExpectError property `c`. Poperty not found in object literal
 _.assignIn({a: 1}, {b: 2}).c
+
+
+/**
+ * _.xorBy
+ */
+_.xorBy([2.1, 1.2], [2.3, 3.4], Math.floor);
+_.xorBy([{ 'x': 1 }], [{ 'x': 2 }, { 'x': 1 }], 'x');
 
 
 /**


### PR DESCRIPTION
There are two changes in this commit:

1. Updated iteratees for a number of functions to accept only the collection value as a parameter, matching the lodash docs.

These include:
* differenceBy
* pullAllBy
* sortedIndexBy
* sortedLastIndexBy
* unionBy
* uniqBy
* xorBy
* countBy
* groupBy
* keyBy

2. Update the return values of groupBy and keyBy to be typed objects with the same value type as the input collection’s type.

NOTE: To make the second change, I needed to add parameters to the `groupBy` and `keyBy` types. I'm not completely sure I did this correctly, but I followed existing patterns and added some tests that should exercise this. Please review this area in particular.

cc @marudor 