### PR TITLE
Correct react-router ContextRouter definition

### DIFF
--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-/react-router-dom_v4.x.x.js
@@ -83,7 +83,9 @@ declare module 'react-router-dom' {
     url: string,
   }
 
-  declare export type ContextRouter = RouterHistory & {
+  declare export type ContextRouter = {
+    history: RouterHistory,
+    location: Location,
     match: Match,
   }
 

--- a/definitions/npm/react-router_v4.x.x/flow_v0.38.x-/react-router_v4.x.x.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.38.x-/react-router_v4.x.x.js
@@ -43,7 +43,9 @@ declare module 'react-router' {
     url: string,
   }
 
-  declare export type ContextRouter = RouterHistory & {
+  declare export type ContextRouter = {
+    history: RouterHistory,
+    location: Location,
     match: Match,
   }
 

--- a/definitions/npm/react-router_v4.x.x/test_react-router.js
+++ b/definitions/npm/react-router_v4.x.x/test_react-router.js
@@ -11,7 +11,7 @@ import {
   withRouter,
   matchPath,
 } from 'react-router';
-import type { Location, Match } from 'react-router';
+import type { Location, Match, ContextRouter } from 'react-router';
 
 // Location
 var locationOK: Location = {
@@ -119,6 +119,23 @@ const FooWithRouterError = withRouter(Foo);
 // $ExpectError
 const BarWithRouterError = withRouter(Bar);
 <BarWithRouterError name={3} />;
+
+// Test ContextRouter as props
+type WithRouterProps = ContextRouter & {
+  name: string,
+};
+
+// $ExpectError
+const IncorrectHistoryUsage = ({ history, name }: Foo2Props) => {
+  // Wrong arguments here, error will bubble up to the component declaration
+  history.push(['bla']);
+  return (
+    <div>
+      {name}
+    </div>
+  );
+};
+
 
 // matchPath
 const match: null | Match = matchPath('/the/pathname', '/the/:dynamicId', {


### PR DESCRIPTION
React-router v4 will inject specific props in components. My understanding of these definitions is that these props were defined as `ContextRouter`.

The definition of `ContextRouter` wasn't correct. This PR replaces `ContextRouter` with a definition that follows [React-router docs](https://reacttraining.com/react-router/web/api/Route/Route-props).

Rel: #341 