### PR TITLE
Updating pg's ClientConfig type to follow specs

### DIFF
--- a/definitions/npm/pg_v6.x.x/flow_v0.32.x-/pg_v6.x.x.js
+++ b/definitions/npm/pg_v6.x.x/flow_v0.32.x-/pg_v6.x.x.js
@@ -62,10 +62,10 @@ declare module pg {
     ssl: boolean,
     // name displayed in the pg_stat_activity view and included in CSV log entries
     // default value: process.env.PGAPPNAME
-    application_name: string,
+    application_name: string|void,
     // fallback value for the application_name configuration parameter
     // default value: false
-    fallback_application_name: string,
+    fallback_application_name: string|void,
 
     // pg-pool
     Client: mixed,

--- a/definitions/npm/pg_v6.x.x/flow_v0.32.x-/pg_v6.x.x.js
+++ b/definitions/npm/pg_v6.x.x/flow_v0.32.x-/pg_v6.x.x.js
@@ -57,15 +57,15 @@ declare module pg {
     //database port
     port: number,
     // database host. defaults to localhost
-    host: string,
+    host?: string,
     // whether to try SSL/TLS to connect to server. default value: false
-    ssl: boolean,
+    ssl?: boolean,
     // name displayed in the pg_stat_activity view and included in CSV log entries
     // default value: process.env.PGAPPNAME
-    application_name: string|void,
+    application_name?: string,
     // fallback value for the application_name configuration parameter
     // default value: false
-    fallback_application_name: string|void,
+    fallback_application_name?: string,
 
     // pg-pool
     Client: mixed,


### PR DESCRIPTION
According to pg's implementation, application_name and fallback_application_name aren't actually required, they will provide a default to be used if nothing is passed in. The person who wrote the pg definition even put a comment in the definition file stating as much. Because of this, I've changed the types of those 2 keys to string|void instead of string.

https://github.com/brianc/node-postgres/blob/83a946f61cb9e74c7f499e44d03a268c399bd623/lib/connection-parameters.js#L63