### PR TITLE
Allow Bluebird.map() mapper function to return U or Promise<U>.

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-v0.32.x/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-v0.32.x/bluebird_v3.x.x.js
@@ -70,12 +70,12 @@ declare class Bluebird$Promise<+R> extends Promise<R> {
   ): Bluebird$Promise<T>;
   static map<T, U, Elem: $Promisable<T>>(
     Promises: Array<Elem>,
-    mapper: (item: T, index: number, arrayLength: number) => U,
+    mapper: (item: T, index: number, arrayLength: number) => $Promisable<U>,
     options?: Bluebird$ConcurrencyOption
   ): Bluebird$Promise<Array<U>>;
   static mapSeries<T, U, Elem: $Promisable<T>>(
     Promises: Array<Elem>,
-    mapper: (item: T, index: number, arrayLength: number) => U
+    mapper: (item: T, index: number, arrayLength: number) => $Promisable<U>
   ): Bluebird$Promise<Array<U>>;
   static reduce<T, U, Elem: $Promisable<T>>(
     Promises: Array<Elem>,

--- a/definitions/npm/bluebird_v3.x.x/flow_v0.33.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.33.x-/bluebird_v3.x.x.js
@@ -71,12 +71,12 @@ declare class Bluebird$Promise<+R> extends Promise<R>{
   ): Bluebird$Promise<T>;
   static map<T, U, Elem: $Promisable<T>>(
     Promises: Array<Elem>,
-    mapper: (item: T, index: number, arrayLength: number) => U,
+    mapper: (item: T, index: number, arrayLength: number) => $Promisable<U>,
     options?: Bluebird$ConcurrencyOption
   ): Bluebird$Promise<Array<U>>;
   static mapSeries<T, U, Elem: $Promisable<T>>(
     Promises: Array<Elem>,
-    mapper: (item: T, index: number, arrayLength: number) => U
+    mapper: (item: T, index: number, arrayLength: number) => $Promisable<U>
   ): Bluebird$Promise<Array<U>>;
   static reduce<T, U, Elem: $Promisable<T>>(
     Promises: Array<Elem>,

--- a/definitions/npm/bluebird_v3.x.x/test_bluebird-v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/test_bluebird-v3.x.x.js
@@ -21,6 +21,11 @@ Bluebird.all([
   1
 ]);
 
+function mapper(x: number): Promise<number> {
+  return Bluebird.resolve(x);
+}
+let mapResult: Promise<number[]> = Bluebird.map([1], mapper);
+let mapSeriesResult: Promise<number[]> = Bluebird.mapSeries([1], mapper);
 
 Bluebird.resolve([1,2,3]).then(function(arr) {
   let l = arr.length;


### PR DESCRIPTION
Also for Bluebird.mapSeries().

As per http://bluebirdjs.com/docs/api/promise.map.html: "Promises returned by the mapper function are awaited for and the returned promise doesn't fulfill until all mapped promises have fulfilled as well."