### PR TITLE
Add matchPath to react-router-dom

### DIFF
--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-/react-router-dom_v4.x.x.js
@@ -154,4 +154,10 @@ declare module 'react-router-dom' {
   declare type FunctionComponent<P> = (props: P) => ?React$Element<any>;
   declare type ClassComponent<D, P, S> = Class<React$Component<D, P, S>>;
   declare export function withRouter<P, S>(Component: ClassComponent<void, P, S> | FunctionComponent<P>): ClassComponent<void, $Diff<P, ContextRouter>, S>;
+
+  declare type MatchPathOptions = {
+    exact?: boolean,
+    strict?: boolean,
+  }
+  declare export function matchPath(pathname: string, path: string, options?: MatchPathOptions): null | Match
 }

--- a/definitions/npm/react-router-dom_v4.x.x/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v4.x.x/test_react-router-dom.js
@@ -3,6 +3,7 @@ import {
   HashRouter,
   Link,
   NavLink,
+  matchPath, type Match
 } from 'react-router-dom';
 
 // BrowserRouter
@@ -72,3 +73,17 @@ import {
 
 // $ExpectError
 <NavLink />
+
+// matchPath
+const match: null | Match = matchPath('/the/pathname', '/the/:dynamicId', {
+  exact: true,
+  strict: false
+})
+const match2: null | Match = matchPath('/the/pathname', '/the/:dynamicId')
+
+// $ExpectError
+matchPath('/the/pathname')
+// $ExpectError
+matchPath()
+// $ExpectError
+const matchError: string = matchPath('/the/pathname', 'the/:dynamicId')


### PR DESCRIPTION
c&p `matchPath` from `react-router`, it was missing from the [original PR](https://github.com/flowtype/flow-typed/pull/638).