### PR TITLE
Fix moment_v2.x.x.js typedef for utcOffset()

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.34.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.34.x-/moment_v2.x.x.js
@@ -178,8 +178,8 @@ declare class moment$Moment {
   endOf(unit: string): this;
   local(): this;
   utc(): this;
-  utcOffset(offset: number|string): void;
-  utcOffset(): number|string;
+  utcOffset(offset: number|string): this;
+  utcOffset(): number;
   format(format?: string): string;
   fromNow(removeSuffix?: bool): string;
   from(value: moment$Moment|string|number|Date|Array<number>, removePrefix?: bool): string;

--- a/definitions/npm/moment_v2.x.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.x.x/test_moment-v2.js
@@ -51,3 +51,13 @@ moment().calendar(null, {
 moment().calendar(null, {
   sameElse: () => {},
 });
+
+
+// UTC offsets
+let n: number;
+n = moment().utcOffset();
+n = m.utcOffset(0).utcOffset();
+n = m.utcOffset(-1.5).utcOffset();
+n = m.utcOffset(-90).utcOffset();
+n = m.utcOffset('-01:30').utcOffset();
+n = m.utcOffset('+00:10').utcOffset();


### PR DESCRIPTION
Fixes `utcOffset()` typedef for moment_v2.x.x.js.  This was already started in #519, but this adds the correct definition and a test case for it.
