### PR TITLE
Libdefs for yargs 7

### DIFF
--- a/definitions/npm/yargs_v7.x.x/flow_v0.42.x-/yargs_v7.x.x.js
+++ b/definitions/npm/yargs_v7.x.x/flow_v0.42.x-/yargs_v7.x.x.js
@@ -1,0 +1,212 @@
+declare module 'yargs' {
+  declare type Argv = {
+    _: Array<string>,
+    '$0': string,
+    [key: string]: mixed
+  };
+
+  declare type Options = $Shape<{
+    alias: string | Array<string>,
+    array: boolean,
+    boolean: boolean,
+    choices: Array<mixed>,
+    config: boolean,
+    configParser: (configPath: string) => {[key: string]: mixed},
+    conflicts: string | {[key: string]: string},
+    count: boolean,
+    default: mixed,
+    defaultDescription: string,
+    demandOption: boolean | string,
+    desc: string,
+    describe: string,
+    description: string,
+    global: boolean,
+    group: string,
+    implies: string | {[key: string]: string},
+    nargs: number,
+    normalize: boolean,
+    number: boolean,
+    requiresArg: boolean,
+    skipValidation: boolean,
+    string: boolean,
+    type: 'array' | 'boolean' | 'count' | 'number' | 'string',
+  }>;
+
+  declare type ModuleObject = {
+    command: string,
+    describe: string,
+    builder: {[key: string]: Options} | (yargsInstance: Yargs) => mixed,
+    handler: (argv: Argv) => void,
+  };
+
+  declare class Yargs {
+    (args: Array<string>): Yargs;
+
+    alias(key: string, alias: string): this;
+    alias(alias: {[key: string]: string | Array<string>}): this;
+    argv: Argv;
+    array(key: string | Array<string>): this;
+    boolean(paramter: string | Array<string>): this;
+    check(fn: (argv: Argv, options: Array<string>) => ?bool): this;
+    choices(key: string, allowed: Array<string>): this;
+    choices(allowed: {[key: string]: Array<string>}): this;
+    coerce(key: string, fn: (value: any) => mixed): this;
+    coerce(object: {[key: string]: (value: any) => mixed}): this;
+    coerce(keys: Array<string>, fn: (value: any) => mixed): this;
+
+    command(
+      cmd: string,
+      desc: string|false,
+      builder?: {[key: string]: Options} | (yargsInstance: Yargs) => mixed,
+      handler?: Function
+    ): this;
+
+    command(
+      cmd: string,
+      desc: string|false,
+      module: ModuleObject,
+    ): this;
+
+    command(
+      module: ModuleObject
+    ): this;
+
+    completion(
+      cmd: string,
+      description?: string,
+      fn?: (
+        current: string,
+        argv: Argv,
+        done: (competion: Array<string>) => void
+      ) => ?(Array<string>|Promise<Array<string>>)
+    ): this;
+
+    config(
+      key?: string,
+      description?: string,
+      parseFn?: (configPath: string) => { [key: string]: mixed }
+    ): this;
+    config(
+      key: string,
+      parseFn?: (configPath: string) => { [key: string]: mixed }
+    ): this;
+    config(config: { [key: string]: mixed }): this;
+
+    conflicts(keyA: string, keyB: string): this;
+    conflicts(keys: { [key: string]: string }): this;
+
+    count(name: string): this;
+
+    default(key: string, value: mixed, description?: string): this;
+    default(defaults: { [key: string]: mixed }): this;
+
+    // Deprecated: use demandOption() and demandCommand() instead.
+    demand(key: string, msg?: string | boolean): this;
+    demand(count: number, max?: number, msg?: string | boolean): this;
+
+    demandOption(key: string | Array<string>, msg: string | boolean): this;
+
+    demandCommand(min: number, minMsg?: string): this;
+    demandCommand(min: number, max: number, minMsg?: string, maxMsg?: string): this;
+
+    describe(key: string, description: string): this;
+    describe(describeObject: { [key: string]: string }): this;
+
+    detectLocale(shouldDetect: bool): this;
+
+    env(prefix?: string): this;
+
+    epilog(text: string): this;
+    epilogue(text: string): this;
+
+    example(cmd: string, desc: string): this;
+
+    exitProcess(enable: bool): this;
+
+    fail(fn: (failureMessage: string, err: Error, yargs: Yargs) => mixed): this;
+
+    getCompletion(args: Array<string>, fn: () => void): this;
+
+    global(globals: string | Array<string>, isGlobal?: boolean): this;
+
+    group(key: string | Array<string>, groupName: string): this;
+
+    help(option?: string, desc?: string): this;
+
+    implies(keyA: string, keyB: string): this;
+    implies(keys: { [key: string]: string }): this;
+
+    locale(
+      locale: 'de' | 'en' | 'es' | 'fr' | 'hi' | 'hu' | 'id' | 'it' | 'ja' |
+        'ko' | 'nb' | 'pirate' | 'pl' | 'pt' | 'pt_BR' | 'ru' | 'th' | 'tr' |
+        'zh_CN'
+    ): this;
+    locale(): string;
+
+    nargs(key: string, count: number): this;
+
+    normalize(key: string): this;
+
+    number(key: string | Array<string>): this;
+
+    option(key: string, options?: Options): this;
+    option(optionMap: { [key: string]: Options}): this;
+
+    options(key: string, options?: Options): this;
+    options(optionMap: { [key: string]: Options}): this;
+
+    parse(
+      args: string | Array<string>,
+      context?: {[key: string]: mixed},
+      parseCallback?: (err: Error, argv: Argv, output?: string) => void
+    ): Argv;
+    parse(
+      args: string | Array<string>,
+      parseCallback?: (err: Error, argv: Argv, output?: string) => void
+    ): Argv;
+
+    pkgConf(key: string, cwd?: string): this;
+
+    recommendCommands(): this;
+
+    // Alias of demand()
+    require(key: string, msg: string | boolean): this;
+    require(count: number, max?: number, msg?: string | boolean): this;
+
+    requiresArg(key: string | Array<string>): this;
+
+    reset(): this;
+
+    showCompletionScript(): this;
+
+    showHelp(consoleLevel?: 'error' | 'warn' | 'log'): this;
+
+    showHelpOnFail(enable: boolean, message?: string): this;
+
+    strict(): this;
+
+    skipValidation(key: string): this;
+
+    strict(global?: boolean): this;
+
+    string(key: string | Array<string>): this;
+
+    updateLocale(obj: {[key: string]: string}): this;
+    updateStrings(obj: {[key: string]: string}): this;
+
+    usage(message: string, opts?: {[key: string]: Options}): this;
+
+    version(): this;
+    version(version: string): this;
+    version(option: string | () => string, version: string): this;
+    version(
+      option: string | () => string,
+      description: string | () => string,
+      version: string
+    ): this;
+
+    wrap(columns: number | null): this;
+  }
+
+  declare var exports: Yargs;
+}

--- a/definitions/npm/yargs_v7.x.x/test_yargs.js
+++ b/definitions/npm/yargs_v7.x.x/test_yargs.js
@@ -1,0 +1,71 @@
+// @flow
+
+import yargs from "yargs";
+
+const argv = yargs
+  .usage('Usage: $0 <cmd> [options]')
+  .command('install', 'install a package (name@version)')
+  .command('publish', 'publish the package inside the current working directory')
+  .option('f', {
+    array: true,
+    description: 'an array of files',
+    default: 'test.js',
+    alias: 'file'
+  })
+  .alias('f', 'fil')
+  .option('h', {
+    alias: 'help',
+    description: 'display help message'
+  })
+  .string(['user', 'pass'])
+  .implies('user', 'pass')
+  .help('help')
+  .demand('q')
+  .version('1.0.1', 'version', 'display version information')
+  .alias('version', 'v')
+  .example('npm install npm@latest -g', 'install the latest version of npm')
+  .epilog('for more information visit https://github.com/chevex/yargs')
+  .showHelpOnFail(false, 'whoops, something went wrong! run with --help')
+  .argv;
+
+const argv2 = yargs(['-x'])
+  .usage('Usage: $0 <cmd> [options]')
+  .command('install', 'install a package (name@version)')
+  .command('publish', 'publish the package inside the current working directory')
+  .option('f', {
+    array: true,
+    description: 'an array of files',
+    default: 'test.js',
+    alias: 'file'
+  })
+  .alias('f', 'fil')
+  .option('h', {
+    alias: 'help',
+    description: 'display help message'
+  })
+  .string(['user', 'pass'])
+  .implies('user', 'pass')
+  .help('help')
+  .demand('q')
+  .version('1.0.1', 'version', 'display version information')
+  .alias('version', 'v')
+  .example('npm install npm@latest -g', 'install the latest version of npm')
+  .epilog('for more information visit https://github.com/chevex/yargs')
+  .showHelpOnFail(false, 'whoops, something went wrong! run with --help')
+  .argv;
+
+yargs(['-x'])
+  // $ExpectError
+  .alias(true, [])
+
+yargs(['-x'])
+  // $ExpectError
+  .help(() => {})
+
+// $ExpectError
+yargs.nope;
+
+// $ExpectError
+yargs.coerce({
+  date: 'foo'
+})


### PR DESCRIPTION
Adding new libdefs for [yargs 7](https://github.com/yargs/yargs). Builds on the libdefs for 4 and 5, and adds a much better test.