### PR TITLE
Knex: Export query builder type

### DIFF
--- a/definitions/npm/knex_v0.12.x/flow_v0.33.x-/knex_v0.12.x.js
+++ b/definitions/npm/knex_v0.12.x/flow_v0.33.x-/knex_v0.12.x.js
@@ -157,5 +157,6 @@ declare module 'knex' {
     line: string,
     routine: string,
   }
+  declare type $QueryBuilder = Knex$QueryBuilder;
   declare var exports: typeof Knex$Knex;
 }


### PR DESCRIPTION
Exports the $QueryBuilder type. I found it useful to pass around partially constructed queries. Not sure if this is the right way to do this.