### PR TITLE
_.find may return void

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.38.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.38.x-/lodash_v4.x.x.js
@@ -176,9 +176,9 @@ declare module 'lodash' {
     every<T: Object>(object: T, iteratee?: OIteratee<T>): bool;
     filter<T>(array: ?Array<T>, predicate?: Predicate<T>): Array<T>;
     filter<A, T: {[id: string]: A}>(object: T, predicate?: OPredicate<A, T>): Array<A>;
-    find<T>(array: ?Array<T>, predicate?: Predicate<T>): T;
+    find<T>(array: ?Array<T>, predicate?: Predicate<T>): T|void;
     find<V, A, T: {[id: string]: A}>(object: T, predicate?: OPredicate<A, T>): V;
-    findLast<T>(array: ?Array<T>, predicate?: Predicate<T>): T;
+    findLast<T>(array: ?Array<T>, predicate?: Predicate<T>): T|void;
     findLast<V, A, T: {[id: string]: A}>(object: T, predicate?: OPredicate<A, T>): V;
     flatMap<T, U>(array: ?Array<T>, iteratee?: FlatMapIteratee<T, U>): Array<U>;
     flatMap<T: Object, U>(object: T, iteratee?: OFlatMapIteratee<T, U>): Array<U>;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.38.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.38.x-/test_lodash-v4.x.x.js
@@ -29,6 +29,9 @@ _.find([{x:1}, {x:2}, {x:3}], v => v.x == 3);
 _.find({x: 1, y: 2}, (a: number, b: string) => a);
 _.find({x: 1, y: 2}, { x: 3 });
 
+// $ExpectError undefined. This type is incompatible with object type.
+var result: Object = _.find(users, 'active');
+
 /**
  * _.find examples from the official doc
  */


### PR DESCRIPTION
As per [the lodash docs](https://lodash.com/docs/4.17.4#find): `_.find ... Returns the matched element, else undefined.`

The type signature of the declaration didn't match that, causing potential `undefined` errors to be ignored. Same applies for the lesser-known `findLast`.

If this is merged, I guess a lot of people's code will have new errors once they get the updated libdefs. But correctness is obviously more important.