### PR TITLE
Add missing coerce to yargs

### DIFF
--- a/definitions/npm/yargs_v7.x.x/flow_v0.42.x-/yargs_v7.x.x.js
+++ b/definitions/npm/yargs_v7.x.x/flow_v0.42.x-/yargs_v7.x.x.js
@@ -10,6 +10,7 @@ declare module 'yargs' {
     array: boolean,
     boolean: boolean,
     choices: Array<mixed>,
+    coerce: (arg: mixed) => mixed,
     config: boolean,
     configParser: (configPath: string) => {[key: string]: mixed},
     conflicts: string | {[key: string]: string},

--- a/definitions/npm/yargs_v7.x.x/test_yargs.js
+++ b/definitions/npm/yargs_v7.x.x/test_yargs.js
@@ -1,6 +1,7 @@
 // @flow
 
 import yargs from "yargs";
+import { resolve } from "path"
 
 const argv = yargs
   .usage('Usage: $0 <cmd> [options]')
@@ -42,6 +43,19 @@ const argv2 = yargs(['-x'])
   .option('h', {
     alias: 'help',
     description: 'display help message'
+  })
+  .options({
+    config: {
+      alias: 'c',
+      description: 'the config file',
+      default: 'config.json',
+      coerce: file => {
+        if (typeof file === 'string') {
+          return resolve(file)
+        }
+        return file
+      }
+    }
   })
   .string(['user', 'pass'])
   .implies('user', 'pass')


### PR DESCRIPTION
Added missing `coerce` to yargs `options` object, including a test (http://yargs.js.org/docs/#methods-optionskey-opt)