### PR TITLE
eventemitter3_v2.x.x: Add flow definitions

### DIFF
--- a/definitions/npm/eventemitter3_v2.x.x/flow_v0.38.x-/eventemitter3_v2.x.x.js
+++ b/definitions/npm/eventemitter3_v2.x.x/flow_v0.38.x-/eventemitter3_v2.x.x.js
@@ -1,0 +1,26 @@
+declare module 'eventemitter3' {
+  declare type ListenerFn = (...args: any[]) => void
+  declare class EventEmitter {
+    static constructor(): EventEmitter,
+    static prefixed: string | boolean,
+    eventNames(): (string | Symbol)[],
+    listeners(event: string | Symbol, existence?: false): ListenerFn[],
+    listeners(event: string | Symbol, existence: true): boolean,
+    on(event: string | Symbol, listener: ListenerFn, context?: any): this,
+    addListener(event: string | Symbol, listener: ListenerFn, context?: any): this,
+    once(event: string | Symbol, listener: ListenerFn, context?: any): this,
+    removeAllListeners(event?: string | Symbol): this,
+    removeListener(event: string | Symbol, listener?: ListenerFn, context?: any, once?: boolean): this,
+    off(event: string | Symbol, listener?: ListenerFn, context?: any, once?: boolean): this,
+    emit(event: string, ...params?: any[]): this
+  }
+  declare module.exports: Class<EventEmitter>
+}
+
+// Filename aliases
+declare module 'eventemitter3/index' {
+  declare module.exports: $Exports<'eventemitter3'>
+}
+declare module 'eventemitter3/index.js' {
+  declare module.exports: $Exports<'eventemitter3'>
+}

--- a/definitions/npm/eventemitter3_v2.x.x/test_eventemitter3-v2.js
+++ b/definitions/npm/eventemitter3_v2.x.x/test_eventemitter3-v2.js
@@ -1,0 +1,40 @@
+// @flow
+import EventEmitter from 'eventemitter3';
+import type { ListenerFn } from 'eventemitter3'
+
+class A extends EventEmitter { }
+
+const a: EventEmitter = new A();
+
+a.on('test', () => {});
+// $ExpectError
+a.on('test');
+
+a.off('test');
+// $ExpectError
+a.off();
+
+a.removeListener('test');
+// $ExpectError
+a.removeListener();
+
+a.once('test', () => {});
+// $ExpectError
+a.once('test');
+
+a.emit('test', 'something');
+a.emit('test');
+
+// a.emit(); Supposedly a bug in Flow, should expect an error here
+
+// Although the library has a stub for this for compatibility, I ignored
+// it from the definition
+// $ExpectError
+a.setMaxListeners();
+
+// $ExpectError
+a.getMaxListeners();
+
+(a.listeners('emit', true): boolean);
+
+(a.listeners('emit', false): ListenerFn[]);


### PR DESCRIPTION
https://github.com/primus/eventemitter3

The definitions are essentially the same as the [TypeScript definitions](https://github.com/primus/eventemitter3/blob/master/index.d.ts)