### PR TITLE
Add type definitions for `chai-subset`

### DIFF
--- a/definitions/npm/chai_v3.5.x/flow_v0.24.0-/chai_v3.5.x.js
+++ b/definitions/npm/chai_v3.5.x/flow_v0.24.0-/chai_v3.5.x.js
@@ -54,8 +54,8 @@ declare module "chai" {
         keys: (key: string | Array<string>, ...keys: Array<string>) => ExpectChain<T>,
 
         throw: <E>(
-            err: Class<E> | Error | RegExp | string,                                                                                   
-            errMsgMatcher?: RegExp | string,                                                                                           
+            err: Class<E> | Error | RegExp | string,
+            errMsgMatcher?: RegExp | string,
             msg?: string) => ExpectChain<T>,
 
         respondTo: (method: string) => ExpectChain<T>,
@@ -101,6 +101,9 @@ declare module "chai" {
         rejectedWith: (value: mixed) => Promise<mixed> & ExpectChain<T>,
         rejected: () => Promise<mixed> & ExpectChain<T>,
         notify: (callback: () => mixed) => ExpectChain<T>,
+
+        // chai-subset
+        containSubset: (obj: Object | Object[]) => ExpectChain<T>
     };
 
     declare function expect<T>(actual: T): ExpectChain<T>;
@@ -188,7 +191,7 @@ declare module "chai" {
       static deepPropertyNotVal(obj: Object, prop: string, val: mixed, msg?: string): void;
 
       static lengthOf(exp: mixed, len: number, msg?: string): void;
-      
+
       static throws<E>(
           func: () => any,
           err?: Class<E> | Error | RegExp | string,

--- a/definitions/npm/chai_v3.5.x/test_chai_v3.5.x.js
+++ b/definitions/npm/chai_v3.5.x/test_chai_v3.5.x.js
@@ -122,3 +122,9 @@ expect(Promise.resolve(true)).to.eventually.be.resolved().then(function() {}).ca
 expect(Promise.resolve(true)).to.eventually.be.resolvedWith(true).then(function() {}).catch(function() {});
 expect(Promise.resolve(true)).to.eventually.be.rejected().then(function() {}).catch(function() {});
 expect(Promise.resolve(true)).to.eventually.be.rejectedWith(Error).then(function() {}).catch(function() {});
+
+// tests for chai-subset
+expect({}).to.containSubset({});
+expect([{}]).to.containSubset([{}]);
+// $ExpectError
+expect({}).to.containSubset(0);


### PR DESCRIPTION
This adds the missing definitions for the chai plugin [`chai-subset`](https://www.npmjs.com/package/chai-subset). It only adds a single `containSubset()` assertion.

Note: ESLint warned about the weak type `Object` I used
However, it was used in the definitions thoroughly anyway and I believe it to be correct (**any** instance of `Object` can be put into `containSubset()`)