### PR TITLE
Add type definition for `_.identity`

### DIFF
--- a/definitions/npm/underscore_v1.x.x/flow_v0.38.x-/test_underscore.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.38.x-/test_underscore.js
@@ -5,3 +5,7 @@ import _ from 'underscore';
 _.zip([{x:1}], [{x:2,y:1}])[0][2]
 // $ExpectError array literal. Tuple arity mismatch.
 _.bindAll({msg: 'hi', greet: function(){ return this.msg;}}, ['greet', 'toString']);
+
+var identityIsString: string = _.identity('foo');
+// $ExpectError
+var identityIsNotString: string = _.identity(42);

--- a/definitions/npm/underscore_v1.x.x/flow_v0.38.x-/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.38.x-/underscore_v1.x.x.js
@@ -226,7 +226,7 @@ declare module "underscore" {
    * Utility
    */
   // TODO: noConflict
-  // TODO: identity
+  declare function identity<T>(o: T): T;
   // TODO: constant
   // TODO: noop
   // TODO: times


### PR DESCRIPTION
Adds type signature, and associated tests for the `identity` function in underscore.js.

Let me know if there's a better way to structure my test!