### PR TITLE
Update bluebird_v3.x.x Bluebird$BluebirdConfig

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.33.x-v0.46.x/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.33.x-v0.46.x/bluebird_v3.x.x.js
@@ -14,7 +14,9 @@ type Bluebird$MultiArgsOption = {
   multiArgs: boolean;
 };
 type Bluebird$BluebirdConfig = {
-  warnings?: boolean,
+  warnings?: boolean | {
+    wForgottenReturn?: boolean
+  },
   longStackTraces?: boolean,
   cancellation?: boolean,
   monitoring?: boolean


### PR DESCRIPTION
According to `http://bluebirdjs.com/docs/api/promise.config.html`, `Promise.config()` doesn't just take a boolean `warning` key but instead can take an object with a `wForgottenReturn` key. This should fix that.