### PR TITLE
Missing getNode() and getNodes() definitions

### DIFF
--- a/definitions/npm/enzyme_v2.3.x/flow_v0.23.x-v0.27.x/enzyme_v2.3.x.js
+++ b/definitions/npm/enzyme_v2.3.x/flow_v0.23.x-v0.27.x/enzyme_v2.3.x.js
@@ -33,6 +33,8 @@ declare module 'enzyme' {
     text(): string;
     html(): string;
     get(index: number): React$Element<any>;
+    getNode(): React$Element<any>;
+    getNodes(): Array<React$Element<any>>;
     at(index: number): this;
     first(): this;
     last(): this;

--- a/definitions/npm/enzyme_v2.3.x/flow_v0.28.x-/enzyme_v2.3.x.js
+++ b/definitions/npm/enzyme_v2.3.x/flow_v0.28.x-/enzyme_v2.3.x.js
@@ -33,6 +33,8 @@ declare module 'enzyme' {
     text(): string;
     html(): string;
     get(index: number): React$Element<any>;
+    getNode(): React$Element<any>;
+    getNodes(): Array<React$Element<any>>;
     at(index: number): this;
     first(): this;
     last(): this;


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/823150/24828572/480f5040-1c36-11e7-8a94-1ad1911830cc.png)

https://github.com/airbnb/enzyme/blob/master/docs/api/ShallowWrapper/getNode.md
https://github.com/airbnb/enzyme/blob/master/docs/api/ShallowWrapper/getNodes.md

I'm not sure if I should use `getNodes(): Array<React$Element<any>>;` instead of `getNodes(): NodeOrNodes;`