### PR TITLE
react-addons-perf

### DIFF
--- a/definitions/npm/react-addons-perf_v15.x.x/flow_v0.23.x-/react-addons-perf_v15.x.x.js
+++ b/definitions/npm/react-addons-perf_v15.x.x/flow_v0.23.x-/react-addons-perf_v15.x.x.js
@@ -1,0 +1,12 @@
+declare type ReactAddonTest$FunctionOrComponentClass = React$Component<any, any, any> | Function;
+
+declare module 'react-addons-perf' {
+  declare function start(): void;
+  declare function stop(): void;
+  declare function printWasted(): void;
+  declare function getLastMeasurements(): mixed;
+  declare function printInclusive(): void;
+  declare function printExclusive(): void;
+  declare function printOperations(): void;
+}
+

--- a/definitions/npm/react-addons-perf_v15.x.x/flow_v0.23.x-/react-addons-perf_v15.x.x.js
+++ b/definitions/npm/react-addons-perf_v15.x.x/flow_v0.23.x-/react-addons-perf_v15.x.x.js
@@ -1,5 +1,3 @@
-declare type ReactAddonTest$FunctionOrComponentClass = React$Component<any, any, any> | Function;
-
 declare module 'react-addons-perf' {
   declare function start(): void;
   declare function stop(): void;

--- a/definitions/npm/react-addons-perf_v15.x.x/test_react-addons-perf.js
+++ b/definitions/npm/react-addons-perf_v15.x.x/test_react-addons-perf.js
@@ -1,0 +1,16 @@
+// @flow
+
+import Perf from 'react-addons-perf';
+
+
+const ok = () => {
+  Perf.start();
+  setTimeout(Perf.stop, 1000);
+};
+
+const fail = () => {
+  // $ExpectError
+  Perf.doesntExist();
+};
+
+


### PR DESCRIPTION
First ever commit to here so I expect to have probably missed a step.

I first configured `flow_all`, and then just bumped the `flow-v0.x` version until it didn’t fail anymore.

```
./run_def_tests.sh react-addons-perf
```
