### PR TITLE
Jest. Add expect().toHaveBeenLastCalledWith

### DIFF
--- a/definitions/npm/jest_v19.x.x/flow_v0.33.x-/jest_v19.x.x.js
+++ b/definitions/npm/jest_v19.x.x/flow_v0.33.x-/jest_v19.x.x.js
@@ -187,6 +187,11 @@ type JestExpectType = {
    */
   toHaveBeenCalledWith(...args: Array<any>): void,
   /**
+   * If you have a mock function, you can use .toHaveBeenLastCalledWith to test what
+   * arguments it was last called with.
+   */
+  toHaveBeenLastCalledWith(...args: Array<any>): void,
+  /**
    * Check that an object has a .length property and it is set to a certain
    * numeric value.
    */

--- a/definitions/npm/jest_v19.x.x/test_jest-v19.x.x.js
+++ b/definitions/npm/jest_v19.x.x/test_jest-v19.x.x.js
@@ -28,6 +28,8 @@ expect('someVal').toBeCalledWith('a')
 // $ExpectError property `toHaveBeeenCalledWith` not found in object type
 expect('someVal').toHaveBeeenCalledWith('a')
 
+expect('someVal').toHaveBeenLastCalledWith('a')
+
 // $ExpectError property `fn` not found in Array
 mockFn.mock.calls.fn()
 


### PR DESCRIPTION
Add types for `toHaveBeenLastCalledWith` method in `Jest's` expect.

https://jest-bot.github.io/jest/docs/expect.html#tohavebeenlastcalledwitharg1-arg2-