### PR TITLE
Add leven type definition

### DIFF
--- a/definitions/npm/leven_v2.x.x/flow_v0.25.x-/leven_v2.x.x.js
+++ b/definitions/npm/leven_v2.x.x/flow_v0.25.x-/leven_v2.x.x.js
@@ -1,0 +1,3 @@
+declare module 'leven' {
+  declare module.exports: (a: string, b: string) => number;
+}

--- a/definitions/npm/leven_v2.x.x/flow_v0.25.x-/test_leven-v2.x.x.js
+++ b/definitions/npm/leven_v2.x.x/flow_v0.25.x-/test_leven-v2.x.x.js
@@ -1,0 +1,20 @@
+// @flow
+
+import leven from 'leven';
+
+const distanceA: number = leven('foo', 'boo');
+
+// $ExpectError leven returns a number not a string
+const distanceB: string = leven('foo', 'boo');
+
+// $ExpectError too few arguments
+const distanceC: number = leven();
+
+// $ExpectError too few arguments
+const distanceD: number = leven('foo');
+
+// $ExpectError leven expects two strings, not a number
+const distanceE: number = leven(1, 'boo');
+
+// $ExpectError leven expects two strings, not a number
+const distanceF: number = leven('foo', 1);


### PR DESCRIPTION
leven is a module that exports a function that takes two strings and returns a number representing how different the strings are (lower numbers are more similar strings).

It is very useful for suggesting corrections in error messages.