### PR TITLE
Add deep-freeze type definition

### DIFF
--- a/definitions/npm/deep-freeze_v0.0.1/flow_v0.25.x-/deep-freeze_v0.0.1.js
+++ b/definitions/npm/deep-freeze_v0.0.1/flow_v0.25.x-/deep-freeze_v0.0.1.js
@@ -1,0 +1,3 @@
+declare module 'deep-freeze' {
+  declare module.exports: <T>(o: T) => T;
+}

--- a/definitions/npm/deep-freeze_v0.0.1/flow_v0.25.x-/test_deep-freeze-v0.0.1.js
+++ b/definitions/npm/deep-freeze_v0.0.1/flow_v0.25.x-/test_deep-freeze-v0.0.1.js
@@ -1,0 +1,13 @@
+// @flow
+
+import deepFreeze from 'deep-freeze';
+
+const obj: {foo: string} = deepFreeze({foo: 'bar'});
+const arr: Array<string> = deepFreeze(['foo', 'bar']);
+const num: number = deepFreeze(42);
+
+// $ExpectError input type must match output type
+const notObj: {foo: string} = deepFreeze(['foo', 'bar']);
+
+// $ExpectError input type must match output type
+const notArr: Array<string> = deepFreeze({foo: 'bar'});


### PR DESCRIPTION
Deep freeze recursively freezes all properties of an object/items in an array.  It does nothing to any other types.  It also returns the value you pass into it.