### PR TITLE
Enable underscore `_.reduce` on objects

### DIFF
--- a/definitions/npm/underscore_v1.x.x/flow_v0.13.x-v0.37.x/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.13.x-v0.37.x/underscore_v1.x.x.js
@@ -15,11 +15,16 @@ declare module "underscore" {
   declare function collect<K, T, U>(a: {[key:K]: T}, iteratee: (val: T, k: K)=>U): U[];
 
   declare function reduce<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+  declare function reduce<T, MemoT>(o: {[key:string]: T}, iterator: (m: MemoT, val: T, key: string)=>MemoT, initialMemo?: MemoT): MemoT;
   declare function inject<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+  declare function inject<T, MemoT>(o: {[key:string]: T}, iterator: (m: MemoT, val: T, key: string)=>MemoT, initialMemo?: MemoT): MemoT;
   declare function foldl<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+  declare function foldl<T, MemoT>(o: {[key:string]: T}, iterator: (m: MemoT, val: T, key: string)=>MemoT, initialMemo?: MemoT): MemoT;
 
   declare function reduceRight<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+  declare function reduceRight<T, MemoT>(o: {[key:string]: T}, iterator: (m: MemoT, val: T, key: string)=>MemoT, initialMemo?: MemoT): MemoT;
   declare function foldr<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+  declare function foldr<T, MemoT>(o: {[key:string]: T}, iterator: (m: MemoT, val: T, key: string)=>MemoT, initialMemo?: MemoT): MemoT;
 
   declare function find<T>(list: T[], predicate: (val: T)=>boolean): ?T;
   declare function detect<T>(list: T[], predicate: (val: T)=>boolean): ?T;

--- a/definitions/npm/underscore_v1.x.x/flow_v0.38.x-/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.38.x-/underscore_v1.x.x.js
@@ -15,11 +15,16 @@ declare module "underscore" {
   declare function collect<K, T, U>(a: {[key:K]: T}, iteratee: (val: T, k: K)=>U): U[];
 
   declare function reduce<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+  declare function reduce<T, MemoT>(o: {[key:string]: T}, iterator: (m: MemoT, val: T, key: string)=>MemoT, initialMemo?: MemoT): MemoT;
   declare function inject<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+  declare function inject<T, MemoT>(o: {[key:string]: T}, iterator: (m: MemoT, val: T, key: string)=>MemoT, initialMemo?: MemoT): MemoT;
   declare function foldl<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+  declare function foldl<T, MemoT>(o: {[key:string]: T}, iterator: (m: MemoT, val: T, key: string)=>MemoT, initialMemo?: MemoT): MemoT;
 
   declare function reduceRight<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+  declare function reduceRight<T, MemoT>(o: {[key:string]: T}, iterator: (m: MemoT, val: T, key: string)=>MemoT, initialMemo?: MemoT): MemoT;
   declare function foldr<T, MemoT>(a: Array<T>, iterator: (m: MemoT, o: T)=>MemoT, initialMemo?: MemoT): MemoT;
+  declare function foldr<T, MemoT>(o: {[key:string]: T}, iterator: (m: MemoT, val: T, key: string)=>MemoT, initialMemo?: MemoT): MemoT;
 
   declare function find<T>(list: T[], predicate: (val: T)=>boolean): ?T;
   declare function detect<T>(list: T[], predicate: (val: T)=>boolean): ?T;

--- a/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
+++ b/definitions/npm/underscore_v1.x.x/test_underscore-v1.js
@@ -133,6 +133,9 @@ _.find([1, 2, 3], {val: 1});
 
 (_.pluck([{name: 'bob'}, {name: 'jane'}], 'name'): Array<string>);
 (_.reduce([1, 2, 3], function(m, o) { return m + o }, 0): number);
+(_.reduce({a: 1, b: 2, c: 3}, function(m, v, k) { return m + v }, 0): number);
+// $ExpectError Third value of the iteratee refers to the key.
+(_.reduce({a: 1, b: 2, c: 3}, function(m, v, k) { return m + k }, 0): number);
 (_.all([2, 4, 5], function(i) { return i % 2 == 0 }): boolean);
 // $ExpectError Property not found in Number
 (_.all([2, 4, 5], function(i) { return i.length }): boolean);


### PR DESCRIPTION
`_.reduce` is a collection method, so both arrays and objects should be taken care of.