### PR TITLE
node-mysql libdef

### DIFF
--- a/definitions/npm/mysql_v2.x.x/flow_v0.44.x/mysql_v2.x.x.js
+++ b/definitions/npm/mysql_v2.x.x/flow_v0.44.x/mysql_v2.x.x.js
@@ -1,0 +1,147 @@
+// TODO: Events on event emitters
+// TODO: Ssl structure type in $npm$mysql$ConnectionOptions
+// TODO: PoolNamespace internal structure
+// TODO: Packets internal structure
+
+declare type $npm$mysql$ConnectionOptions = {
+  host?: string,
+  port?: number,
+  localAddress?: string,
+  socketPath?: string,
+  user: string,
+  password: string,
+  database?: string,
+  charset?: string,
+  timezone?: string,
+  connectTimeout?: number,
+  stringifyObjects?: boolean,
+  insecureAuth?: boolean,
+  typeCast?: boolean,
+  queryFormat?: (query: string, values: ?mixed, timezone: string) => string,
+  supportBigNumbers?: boolean,
+  bigNumberStrings?: boolean,
+  dateStrings?: boolean | Array<string>,
+  debug?: boolean | Array<string>, // Array form contains ids of packets for logging
+  trace?: boolean,
+  multipleStatements?: boolean,
+  flags?: string,
+  ssl?: string | Object
+};
+
+declare type $npm$mysql$QueryOptions = {
+  sql: string,
+  typeCast?: boolean | (field: Object, next: Function) => any,
+  nestTables?: boolean | string, // string form is a separator used to produce column names
+  values?: Array<mixed>,
+  timeout?: number
+} | string;
+
+declare type $npm$mysql$QueryResults = Array<Object> & {
+  insertId?: string | number,
+  affectedRows?: number,
+  changedRows?: number
+};
+
+declare type $npm$mysql$QueryField = {
+  name: string,
+  type: string,
+  length: number,
+  table: string,
+  db: string
+}
+
+declare type $npm$mysql$QueryCallback = (error: ?Error, results: $npm$mysql$QueryResults, fields?: Array<$npm$mysql$QueryField>) => *;
+
+declare class $npm$mysql$Query extends events$EventEmitter {
+  // readableStreamOptions declared in Flow /lib/node.js
+  stream(options?: readableStreamOptions): stream$Readable;
+}
+
+declare class $npm$mysql$Connection extends events$EventEmitter {
+  threadId: number;
+  connect(callback?: (error: ?Error) => *): void;
+
+  release(): void;
+  destroy(): void;
+
+  end(callback?: (error: ?Error) => *): void;
+
+  query(sql: $npm$mysql$QueryOptions, values?: Array<mixed>, callback?: $npm$mysql$QueryCallback): $npm$mysql$Query;
+  query(sql: $npm$mysql$QueryOptions, callback?: $npm$mysql$QueryCallback): $npm$mysql$Query;
+
+  changeUser(options: {
+    user?: string,
+    password?: string,
+    charset?: string,
+    database?: string
+  }, callback: (error: ?Error) => *): void;
+
+  beginTransaction(options: $npm$mysql$QueryOptions, callback: $npm$mysql$QueryCallback): void;
+  beginTransaction(callback: $npm$mysql$QueryCallback): void;
+  commit(options: $npm$mysql$QueryOptions, callback: $npm$mysql$QueryCallback): void;
+  commit(callback: $npm$mysql$QueryCallback): void;
+  rollback(options: $npm$mysql$QueryOptions, callback: $npm$mysql$QueryCallback): void;
+  rollback(callback: $npm$mysql$QueryCallback): void;
+
+  ping(options: $npm$mysql$QueryOptions, callback: $npm$mysql$QueryCallback): void;
+  ping(callback: $npm$mysql$QueryCallback): void;
+
+  escapeId(val: mixed, forbidQualified?: boolean): string;
+  escape(val: mixed, stringifyObjects?: boolean, timeZone: string): string;
+  format(sql: string, valus: Array<mixed>): string;
+};
+
+declare class $npm$mysql$Pool extends events$EventEmitter {
+  getConnection(callback: (error: ?Error) => *): void;
+  end(callback?: (error: ?Error) => *): void;
+  query(sql: $npm$mysql$QueryOptions, values?: Array<mixed>, callback?: $npm$mysql$QueryCallback): $npm$mysql$Query;
+  query(sql: $npm$mysql$QueryOptions, callback?: $npm$mysql$QueryCallback): $npm$mysql$Query;
+
+  escapeId(val: mixed, forbidQualified?: boolean): string;
+  escape(val: mixed, stringifyObjects?: boolean, timeZone: string): string;
+}
+
+declare type $npm$mysql$PoolOptions = $npm$mysql$ConnectionOptions & {
+  acquireTimeout?: number,
+  connectionLimit?: number,
+  waitForConnections?: boolean,
+  queueLimit?: number
+};
+
+declare type $npm$mysql$PoolClusterSelector = 'RR' | 'ORDER' | 'RANDOM';
+
+declare type $npm$mysql$PoolClusterOptions = {
+  defaultSelector?: $npm$mysql$PoolClusterSelector,
+  canRetry?: boolean,
+  removeNodeErrorCount?: number,
+  restoreNodeTimeout?: number
+}
+
+declare class $npm$mysql$PoolCluster extends events$EventEmitter {
+  add(config: $npm$mysql$PoolOptions | string): void;
+  add(name: string, config: $npm$mysql$PoolOptions | string): void;
+  remove(name: string): void;
+
+  getConnection(pattern: string | RegExp, selector: $npm$mysql$PoolClusterSelector, callback: (error: ?Error, connection?: $npm$mysql$Connection) => *): void;
+  getConnection(pattern: string | RegExp, callback: (error: ?Error, connection?: $npm$mysql$Connection) => *): void;
+  getConnection(callback: (error: ?Error, connection?: $npm$mysql$Connection) => *): void;
+
+  // Truth to be told, of returns not a Pool, but PoolNamespace instance but it is the same for the most part
+  of(pattern: string | RegExp, selector?: $npm$mysql$PoolClusterSelector): $npm$mysql$Pool;
+
+  end(callback?: (error: ?Error) => *): void;
+}
+
+declare module 'mysql' {
+  declare export type Connection = $npm$mysql$Connection;
+  declare export type Pool = $npm$mysql$Pool;
+  declare export type PoolCluster = $npm$mysql$PoolCluster;
+
+  declare function createConnection(options: $npm$mysql$ConnectionOptions | string): $npm$mysql$Connection;
+  declare function createPool(options: $npm$mysql$PoolOptions | string): $npm$mysql$Pool;
+  declare function createPoolCluster(options?: $npm$mysql$PoolClusterOptions): $npm$mysql$PoolCluster;
+
+  declare function escapeId(val: mixed, forbidQualified?: boolean): string;
+  declare function escape(val: mixed, stringifyObjects?: boolean, timeZone: string): string;
+  declare function format(sql: string, valus: Array<mixed>): string;
+}

--- a/definitions/npm/mysql_v2.x.x/flow_v0.44.x/mysql_v2.x.x.js
+++ b/definitions/npm/mysql_v2.x.x/flow_v0.44.x/mysql_v2.x.x.js
@@ -1,147 +1,142 @@
 // TODO: Events on event emitters
-// TODO: Ssl structure type in $npm$mysql$ConnectionOptions
+// TODO: Ssl structure type in ConnectionOptions
 // TODO: PoolNamespace internal structure
 // TODO: Packets internal structure
 
-declare type $npm$mysql$ConnectionOptions = {
-  host?: string,
-  port?: number,
-  localAddress?: string,
-  socketPath?: string,
-  user: string,
-  password: string,
-  database?: string,
-  charset?: string,
-  timezone?: string,
-  connectTimeout?: number,
-  stringifyObjects?: boolean,
-  insecureAuth?: boolean,
-  typeCast?: boolean,
-  queryFormat?: (query: string, values: ?mixed, timezone: string) => string,
-  supportBigNumbers?: boolean,
-  bigNumberStrings?: boolean,
-  dateStrings?: boolean | Array<string>,
-  debug?: boolean | Array<string>, // Array form contains ids of packets for logging
-  trace?: boolean,
-  multipleStatements?: boolean,
-  flags?: string,
-  ssl?: string | Object
-};
-
-declare type $npm$mysql$QueryOptions = {
-  sql: string,
-  typeCast?: boolean | (field: Object, next: Function) => any,
-  nestTables?: boolean | string, // string form is a separator used to produce column names
-  values?: Array<mixed>,
-  timeout?: number
-} | string;
-
-declare type $npm$mysql$QueryResults = Array<Object> & {
-  insertId?: string | number,
-  affectedRows?: number,
-  changedRows?: number
-};
-
-declare type $npm$mysql$QueryField = {
-  name: string,
-  type: string,
-  length: number,
-  table: string,
-  db: string
-}
-
-declare type $npm$mysql$QueryCallback = (error: ?Error, results: $npm$mysql$QueryResults, fields?: Array<$npm$mysql$QueryField>) => *;
-
-declare class $npm$mysql$Query extends events$EventEmitter {
-  // readableStreamOptions declared in Flow /lib/node.js
-  stream(options?: readableStreamOptions): stream$Readable;
-}
-
-declare class $npm$mysql$Connection extends events$EventEmitter {
-  threadId: number;
-  connect(callback?: (error: ?Error) => *): void;
-
-  release(): void;
-  destroy(): void;
-
-  end(callback?: (error: ?Error) => *): void;
-
-  query(sql: $npm$mysql$QueryOptions, values?: Array<mixed>, callback?: $npm$mysql$QueryCallback): $npm$mysql$Query;
-  query(sql: $npm$mysql$QueryOptions, callback?: $npm$mysql$QueryCallback): $npm$mysql$Query;
-
-  changeUser(options: {
-    user?: string,
-    password?: string,
-    charset?: string,
-    database?: string
-  }, callback: (error: ?Error) => *): void;
-
-  beginTransaction(options: $npm$mysql$QueryOptions, callback: $npm$mysql$QueryCallback): void;
-  beginTransaction(callback: $npm$mysql$QueryCallback): void;
-  commit(options: $npm$mysql$QueryOptions, callback: $npm$mysql$QueryCallback): void;
-  commit(callback: $npm$mysql$QueryCallback): void;
-  rollback(options: $npm$mysql$QueryOptions, callback: $npm$mysql$QueryCallback): void;
-  rollback(callback: $npm$mysql$QueryCallback): void;
-
-  ping(options: $npm$mysql$QueryOptions, callback: $npm$mysql$QueryCallback): void;
-  ping(callback: $npm$mysql$QueryCallback): void;
-
-  escapeId(val: mixed, forbidQualified?: boolean): string;
-  escape(val: mixed, stringifyObjects?: boolean, timeZone: string): string;
-  format(sql: string, valus: Array<mixed>): string;
-};
-
-declare class $npm$mysql$Pool extends events$EventEmitter {
-  getConnection(callback: (error: ?Error) => *): void;
-  end(callback?: (error: ?Error) => *): void;
-  query(sql: $npm$mysql$QueryOptions, values?: Array<mixed>, callback?: $npm$mysql$QueryCallback): $npm$mysql$Query;
-  query(sql: $npm$mysql$QueryOptions, callback?: $npm$mysql$QueryCallback): $npm$mysql$Query;
-
-  escapeId(val: mixed, forbidQualified?: boolean): string;
-  escape(val: mixed, stringifyObjects?: boolean, timeZone: string): string;
-}
-
-declare type $npm$mysql$PoolOptions = $npm$mysql$ConnectionOptions & {
-  acquireTimeout?: number,
-  connectionLimit?: number,
-  waitForConnections?: boolean,
-  queueLimit?: number
-};
-
-declare type $npm$mysql$PoolClusterSelector = 'RR' | 'ORDER' | 'RANDOM';
-
-declare type $npm$mysql$PoolClusterOptions = {
-  defaultSelector?: $npm$mysql$PoolClusterSelector,
-  canRetry?: boolean,
-  removeNodeErrorCount?: number,
-  restoreNodeTimeout?: number
-}
-
-declare class $npm$mysql$PoolCluster extends events$EventEmitter {
-  add(config: $npm$mysql$PoolOptions | string): void;
-  add(name: string, config: $npm$mysql$PoolOptions | string): void;
-  remove(name: string): void;
-
-  getConnection(pattern: string | RegExp, selector: $npm$mysql$PoolClusterSelector, callback: (error: ?Error, connection?: $npm$mysql$Connection) => *): void;
-  getConnection(pattern: string | RegExp, callback: (error: ?Error, connection?: $npm$mysql$Connection) => *): void;
-  getConnection(callback: (error: ?Error, connection?: $npm$mysql$Connection) => *): void;
-
-  // Truth to be told, of returns not a Pool, but PoolNamespace instance but it is the same for the most part
-  of(pattern: string | RegExp, selector?: $npm$mysql$PoolClusterSelector): $npm$mysql$Pool;
-
-  end(callback?: (error: ?Error) => *): void;
-}
-
 declare module 'mysql' {
-  declare export type Connection = $npm$mysql$Connection;
-  declare export type Pool = $npm$mysql$Pool;
-  declare export type PoolCluster = $npm$mysql$PoolCluster;
+  declare type ConnectionOptions = {
+    host?: string,
+    port?: number,
+    localAddress?: string,
+    socketPath?: string,
+    user: string,
+    password: string,
+    database?: string,
+    charset?: string,
+    timezone?: string,
+    connectTimeout?: number,
+    stringifyObjects?: boolean,
+    insecureAuth?: boolean,
+    typeCast?: boolean,
+    queryFormat?: (query: string, values: ?mixed, timezone: string) => string,
+    supportBigNumbers?: boolean,
+    bigNumberStrings?: boolean,
+    dateStrings?: boolean | Array<string>,
+    debug?: boolean | Array<string>, // Array form contains ids of packets for logging
+    trace?: boolean,
+    multipleStatements?: boolean,
+    flags?: string,
+    ssl?: string | Object
+  };
 
-  declare function createConnection(options: $npm$mysql$ConnectionOptions | string): $npm$mysql$Connection;
-  declare function createPool(options: $npm$mysql$PoolOptions | string): $npm$mysql$Pool;
-  declare function createPoolCluster(options?: $npm$mysql$PoolClusterOptions): $npm$mysql$PoolCluster;
+  declare type QueryOptions = {
+    sql: string,
+    typeCast?: boolean | (field: Object, next: Function) => any,
+    nestTables?: boolean | string, // string form is a separator used to produce column names
+    values?: Array<mixed>,
+    timeout?: number
+  } | string;
+
+  declare type QueryResults = Array<Object> & {
+    insertId?: string | number,
+    affectedRows?: number,
+    changedRows?: number
+  };
+
+  declare type QueryField = {
+    name: string,
+    type: string,
+    length: number,
+    table: string,
+    db: string
+  }
+
+  declare class Query extends events$EventEmitter {
+    // readableStreamOptions declared in Flow /lib/node.js
+    stream(options?: readableStreamOptions): stream$Readable;
+  }
+
+  declare class Connection extends events$EventEmitter {
+    threadId: number;
+    connect(callback?: (error: ?Error) => *): void;
+
+    release(): void;
+    destroy(): void;
+
+    end(callback?: (error: ?Error) => *): void;
+
+    query(sql: QueryOptions, values?: Array<mixed>, callback?: QueryCallback): Query;
+    query(sql: QueryOptions, callback?: QueryCallback): Query;
+
+    changeUser(options: {
+      user?: string,
+      password?: string,
+      charset?: string,
+      database?: string
+    }, callback: (error: ?Error) => *): void;
+
+    beginTransaction(options: QueryOptions, callback: QueryCallback): void;
+    beginTransaction(callback: QueryCallback): void;
+    commit(options: QueryOptions, callback: QueryCallback): void;
+    commit(callback: QueryCallback): void;
+    rollback(options: QueryOptions, callback: QueryCallback): void;
+    rollback(callback: QueryCallback): void;
+
+    ping(options: QueryOptions, callback: QueryCallback): void;
+    ping(callback: QueryCallback): void;
+
+    escapeId(val: mixed, forbidQualified?: boolean): string;
+    escape(val: mixed, stringifyObjects?: boolean, timeZone: string): string;
+    format(sql: string, valus: Array<mixed>): string;
+  }
+
+  declare class Pool extends events$EventEmitter {
+    getConnection(callback: (error: ?Error) => *): void;
+    end(callback?: (error: ?Error) => *): void;
+    query(sql: QueryOptions, values?: Array<mixed>, callback?: QueryCallback): Query;
+    query(sql: QueryOptions, callback?: QueryCallback): Query;
+
+    escapeId(val: mixed, forbidQualified?: boolean): string;
+    escape(val: mixed, stringifyObjects?: boolean, timeZone: string): string;
+  }
+
+  declare type PoolOptions = ConnectionOptions & {
+    acquireTimeout?: number,
+    connectionLimit?: number,
+    waitForConnections?: boolean,
+    queueLimit?: number
+  };
+
+  declare type PoolClusterSelector = 'RR' | 'ORDER' | 'RANDOM';
+
+  declare type PoolClusterOptions = {
+    defaultSelector?: PoolClusterSelector,
+    canRetry?: boolean,
+    removeNodeErrorCount?: number,
+    restoreNodeTimeout?: number
+  }
+
+  declare type QueryCallback = (error: ?Error, results: QueryResults, fields?: Array<QueryField>) => *;
+
+  declare class PoolCluster extends events$EventEmitter {
+    add(config: PoolOptions | string): void;
+    add(name: string, config: PoolOptions | string): void;
+    remove(name: string): void;
+
+    getConnection(pattern: string | RegExp, selector: PoolClusterSelector, callback: (error: ?Error, connection?: Connection) => *): void;
+    getConnection(pattern: string | RegExp, callback: (error: ?Error, connection?: Connection) => *): void;
+    getConnection(callback: (error: ?Error, connection?: Connection) => *): void;
+
+    // Truth to be told, of returns not a Pool, but PoolNamespace instance but it is the same for the most part
+    of(pattern: string | RegExp, selector?: PoolClusterSelector): Pool;
+
+    end(callback?: (error: ?Error) => *): void;
+  }
 
   declare function escapeId(val: mixed, forbidQualified?: boolean): string;
   declare function escape(val: mixed, stringifyObjects?: boolean, timeZone: string): string;
   declare function format(sql: string, valus: Array<mixed>): string;
+  declare function createConnection(options: ConnectionOptions | string): Connection;
+  declare function createPool(options: PoolOptions | string): Pool;
+  declare function createPoolCluster(options?: PoolClusterOptions): PoolCluster;
 }

--- a/definitions/npm/mysql_v2.x.x/test_mysql_v2.x.x.js
+++ b/definitions/npm/mysql_v2.x.x/test_mysql_v2.x.x.js
@@ -1,0 +1,139 @@
+// @flow
+
+import mysql from 'mysql';
+import type { Connection, Pool } from 'mysql';
+
+// Connection
+
+let connection: Connection = mysql.createConnection({
+  host: 'localhost',
+  port: 1234,
+  user: 'test_user',
+  password: '1234'
+});
+
+connection = mysql.createConnection('mysql://root:1111@localhost/test');
+
+connection.connect();
+connection.connect((err) => {});
+
+connection.end();
+connection.end(() => {});
+connection.end((error: ?Error) => {});
+
+connection.destroy();
+
+connection.query('SELECT 1');
+connection.query('SELECT * FROM `table` WHERE id = ?', [1]);
+connection.query({sql: 'SELECT * FROM `table` WHERE id = ?', nestTables: true});
+connection.query('', [1,'d',{a:1},[{b:1}]]);
+
+// Streaming
+
+let query = connection.query('select 1');
+query.stream().pipe(process.stdout);
+
+// $ExpectError
+connection.query(123);
+
+// $ExpectError
+connection.query('123123', 123);
+
+// $ExpectError
+connection = mysql.createConnection({
+  xyz: 12
+});
+
+
+// Pool
+
+let pool: Pool = mysql.createPool({
+  host: 'localhost',
+  port: 1234,
+  user: 'test_user',
+  password: '1234'
+});
+pool = mysql.createPool({
+  host: 'localhost',
+  port: 1234,
+  user: 'test_user',
+  password: '1234',
+  connectionLimit: 15,
+  acquireTimeout: 15000,
+  queueLimit: 10,
+  waitForConnections: false
+});
+// $ExpectError
+pool = mysql.createPool({
+  host: 'localhost',
+  port: 1234,
+  user: 'test_user',
+  password: '1234',
+  connectionLimit: "13"
+});
+pool = mysql.createPool('mysql://root:1111@localhost/test');
+
+pool.end();
+pool.end(() => {});
+pool.end((error: ?Error) => {});
+
+pool.query('SELECT 1');
+pool.query('SELECT * FROM `table` WHERE id = ?', [1]);
+pool.query({sql: 'SELECT * FROM `table` WHERE id = ?', nestTables: true});
+pool.query('', [1,'d',{a:1},[{b:1}]]);
+
+// $ExpectError
+pool.query(123);
+
+// $ExpectError
+pool.query('123123', 123);
+
+
+// PoolCluster
+
+// create
+let poolCluster = mysql.createPoolCluster();
+let config = '';
+let masterConfig = '';
+let slave1Config = '';
+let slave2Config = '';
+
+// add configurations (the config is a pool config object)
+poolCluster.add(config); // add configuration with automatic name
+poolCluster.add('MASTER', masterConfig); // add a named configuration
+poolCluster.add('SLAVE1', slave1Config);
+poolCluster.add('SLAVE2', slave2Config);
+
+// remove configurations
+poolCluster.remove('SLAVE2'); // By nodeId
+poolCluster.remove('SLAVE*'); // By target group : SLAVE1-2
+
+// Target Group : ALL(anonymous, MASTER, SLAVE1-2), Selector : round-robin(default)
+poolCluster.getConnection(function (err, connection) {});
+
+// Target Group : MASTER, Selector : round-robin
+poolCluster.getConnection('MASTER', function (err, connection) {});
+
+// Target Group : SLAVE1-2, Selector : order
+// If can't connect to SLAVE1, return SLAVE2. (remove SLAVE1 in the cluster)
+poolCluster.on('remove', function (nodeId) {
+  console.log('REMOVED NODE : ' + nodeId); // nodeId = SLAVE1
+});
+
+// A pattern can be passed with *  as wildcard
+poolCluster.getConnection('SLAVE*', 'ORDER', function (err, connection) {});
+
+// The pattern can also be a regular expression
+poolCluster.getConnection(/^SLAVE[12]$/, function (err, connection) {});
+
+// of namespace : of(pattern, selector)
+poolCluster.of('*').getConnection(function (err, connection) {});
+
+pool = poolCluster.of('SLAVE*', 'RANDOM');
+pool.getConnection(function (err, connection) {});
+pool.getConnection(function (err, connection) {});
+
+// close all connections
+poolCluster.end(function (err) {
+  // all connections in the pool cluster have ended
+});


### PR DESCRIPTION
First approach - specs are done mostly for public, documented interfaces.

Many of the internal types, like `PoolNamespace` and various protocol
packets classes are not exposed for now, since they are not often used and
not even documented.