### PR TITLE
fixed bug with invalid npm scope in install script

### DIFF
--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -187,7 +187,7 @@ async function installNpmLibDefs({
       }
 
       const [_, npmScope, pkgName, pkgVerStr] = termMatches;
-      const scopedPkgName = npmScope == null ? npmScope + pkgName : pkgName;
+      const scopedPkgName = npmScope != null ? npmScope + pkgName : pkgName;
       libdefsToSearchFor.set(scopedPkgName, pkgVerStr);
     }
     console.log(`• Searching for ${libdefsToSearchFor.size} libdefs...`);


### PR DESCRIPTION
I tried to install libdef for axios library (0.15.3) but flow-typed could find anything to install despite existing definition in repositiory (0.15.x). My flow version (0.40.0) also matches. So I started to inspect the code and saw that the name of the package is passed as "undefinedaxios" into search library. I tried to find the source of the bug and here is it.