### PR TITLE
Add 'clean' function to semver definition

### DIFF
--- a/definitions/npm/semver_v5.1.x/flow_v0.27.0-/semver_v5.1.x.js
+++ b/definitions/npm/semver_v5.1.x/flow_v0.27.0-/semver_v5.1.x.js
@@ -65,6 +65,7 @@ declare module 'semver' {
 
   // Not explicitly documented
   declare function parse(version: string): ?SemVer;
+  declare function clean(version: string): string | null;
 
   declare class Range {
     set: Array<Array<{semver: SemVer}>>;

--- a/definitions/npm/semver_v5.1.x/test_semver.js
+++ b/definitions/npm/semver_v5.1.x/test_semver.js
@@ -9,6 +9,9 @@ semver.cmp('1.2.3', '> ', '1.2.4');
 
 (semver.outside('1.2.3', '1.2', '>'): boolean);
 
+(semver.clean('v1.2.3'): string);
+(semver.clean('xxx'): null);
+
 // $ExpectError
 semver.outside('1.2.3', '1.2', '> ');
 


### PR DESCRIPTION
This function is mentioned in the [usage example](https://github.com/npm/node-semver) but not otherwise documented.

Here is the [source](https://github.com/npm/node-semver/blob/8fff3050401397e99aaf7a118015c0e33884c3f8/semver.js#L264-L268):

```js
exports.clean = clean;
function clean(version, loose) {
  var s = parse(version.trim().replace(/^[=v]+/, ''), loose);
  return s ? s.version : null;
}
```

It always returns either a version string or `null`.