### PR TITLE
Adding support for express-subdomain

### DIFF
--- a/definitions/npm/express-subdomain_v1.x.x/flow_v0.25.x-/express-subdomain_v1.x.x.js
+++ b/definitions/npm/express-subdomain_v1.x.x/flow_v0.25.x-/express-subdomain_v1.x.x.js
@@ -1,0 +1,3 @@
+declare module 'express-subdomain' {
+  declare module.exports: (subdomain: string, middleware: Function) => Function
+}

--- a/definitions/npm/express-subdomain_v1.x.x/test_express-subdomain_v1.x.x.js
+++ b/definitions/npm/express-subdomain_v1.x.x/test_express-subdomain_v1.x.x.js
@@ -1,0 +1,13 @@
+// @flow
+import subdomain from 'express-subdomain'
+
+// $ExpectError
+subdomain(5)
+
+// $ExpectError
+subdomain('')
+
+// $ExpectError
+subdomain(5, (_: void): void => {})
+
+subdomain('subdomain', (_: void): void => {})


### PR DESCRIPTION
I wanted to import middleware types from the "express" module definition, but I couldn't figure it out after reading up here: https://github.com/flowtype/flow-typed/issues/16

@jeffmo 

It originally looked like this, but couldn't figure out why it wasn't working...
```js
import type {
  $npm$express$Response,
  $npm$express$Request,
  $npm$express$NextFunction,
} from 'express'

declare module 'express-subdomain' {
  declare type Request = $npm$express$Request
  declare type Response = $npm$express$Response
  declare type NextFunction = $npm$express$NextFunction

  declare type Middleware = (
    req: Request,
    res: Response,
    next: NextFunction,
  ) => mixed

  declare module.exports: (subdomain: string, middleware: Middleware) => Middleware
}

```

```js
// @flow
import subdomain from 'express-subdomain'
import type { Request, Response, NextFunction } from 'express-subdomain'

// $ExpectError
subdomain(5)

// $ExpectError
subdomain('')

// $ExpectError
subdomain(5, (req: Request, res: Response, next: NextFunction): void => {})

// $ExpectError
subdomain('subdomain', (error: ?Error, req: Request, res: Response, next: NextFunction): void => {})

// $ExpectError
subdomain('subdomain', (error: ?Error, req: Request, res: Response): void => {})

// $ExpectError
subdomain('subdomain', (error: ?Error, req: Request): void => {})

// $ExpectError
subdomain('subdomain', (error: ?Error): void => {})

// $ExpectError
subdomain('subdomain', 5)

subdomain('subdomain', (req: Request, res: Response, next: NextFunction): void => {})
subdomain('subdomain', (req: Request, res: Response): void => {})
subdomain('subdomain', (req: Request): void => {})
subdomain('subdomain', (_: void): void => {})
```