### PR TITLE
change req.body to any

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_v0.32.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.32.x-/express_v4.x.x.js
@@ -13,7 +13,7 @@ declare class express$RequestResponseBase {
 
 declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
   baseUrl: string;
-  body: mixed;
+  body: any;
   cookies: {[cookie: string]: string};
   fresh: boolean;
   hostname: string;


### PR DESCRIPTION
I know we want to avoid the any type when possible.  However using the mixed type consistently throws errors when attempting to pull values out of req.body.