### PR TITLE
install.js: add option to skip stub generation

### DIFF
--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -131,6 +131,7 @@ describe("install (command)", () => {
           explicitLibDefs: [],
           verbose: false,
           overwrite: false,
+          skip: false,
         });
         expect(result).toBe(1);
         expect(_mock(console.error).mock.calls).toEqual([[
@@ -151,6 +152,7 @@ describe("install (command)", () => {
           explicitLibDefs: ["INVALID"],
           verbose: false,
           overwrite: false,
+          skip: false,
         });
         expect(result).toBe(1);
         expect(_mock(console.error).mock.calls).toEqual([[
@@ -173,6 +175,7 @@ describe("install (command)", () => {
           explicitLibDefs: [],
           verbose: false,
           overwrite: false,
+          skip: false,
         });
         expect(result).toBe(1);
         expect(_mock(console.error).mock.calls).toEqual([[
@@ -325,6 +328,7 @@ describe("install (command)", () => {
           _: [],
           overwrite: false,
           verbose: false,
+          skip: false,
         });
 
         // Installs libdefs
@@ -368,11 +372,44 @@ describe("install (command)", () => {
           _: [],
           overwrite: false,
           verbose: false,
+          skip: false,
         });
 
         // Installs a stub for someUntypedDep
         expect(await fs.exists(
           path.join(FLOWPROJ_DIR, "flow-typed", "npm", "someUntypedDep_vx.x.x.js")
+        )).toBe(true);
+      });
+    });
+
+    pit("doesn't stub unavailable libdefs when --skip is passed", () => {
+      return fakeProjectEnv(async (FLOWPROJ_DIR) => {
+        // Create some dependencies
+        await Promise.all([
+          writePkgJson(path.join(FLOWPROJ_DIR, "package.json"), {
+            name: "test",
+            devDependencies: {
+              "flow-bin": "^0.43.0",
+            },
+            dependencies: {
+              "someUntypedDep": "1.2.3",
+            },
+          }),
+          mkdirp(path.join(FLOWPROJ_DIR, "node_modules", "someUntypedDep")),
+          mkdirp(path.join(FLOWPROJ_DIR, "node_modules", "flow-bin")),
+        ]);
+
+        // Run the install command
+        await run({
+          _: [],
+          overwrite: false,
+          verbose: false,
+          skip: true,
+        });
+
+        // Installs a stub for someUntypedDep
+        expect(await fs.exists(
+          path.join(FLOWPROJ_DIR, "flow-typed", "npm")
         )).toBe(true);
       });
     });
@@ -399,6 +436,7 @@ describe("install (command)", () => {
           _: [],
           overwrite: false,
           verbose: false,
+          skip: false,
         });
 
         const libdefFilePath = path.join(
@@ -418,6 +456,7 @@ describe("install (command)", () => {
           _: [],
           overwrite: false,
           verbose: false,
+          skip: false,
         });
 
         // Verify that the tweaked libdef file wasn't overwritten
@@ -449,6 +488,7 @@ describe("install (command)", () => {
           _: [],
           overwrite: false,
           verbose: false,
+          skip: false,
         });
 
         const libdefFilePath = path.join(
@@ -466,6 +506,7 @@ describe("install (command)", () => {
         await run({
           _: [],
           overwrite: true,
+          skip: false,
           verbose: false,
         });
 

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -72,6 +72,7 @@ export type Args = {
   _: Array<string>,
   flowVersion?: string,
   overwrite: boolean,
+  skip: boolean,
   verbose: bool,
 };
 export function setup(yargs: Yargs) {
@@ -87,6 +88,12 @@ export function setup(yargs: Yargs) {
       verbose: {
         describe: "Print additional, verbose info while installing libdefs",
         type: "boolean",
+        demand: false,
+      },
+      skip: {
+        alias: 's',
+        describe: 'Do not generate stubs for missing libdefs',
+        type: 'boolean',
         demand: false,
       },
     });
@@ -107,6 +114,7 @@ export async function run(args: Args) {
     explicitLibDefs,
     verbose: args.verbose,
     overwrite: args.overwrite,
+    skip: args.skip,
   });
   if (npmLibDefResult !== 0) {
     return npmLibDefResult;
@@ -153,6 +161,7 @@ type installNpmLibDefsArgs = {|
   explicitLibDefs: Array<string>,
   verbose: boolean,
   overwrite: boolean,
+  skip: boolean,
 |};
 async function installNpmLibDefs({
   cwd,
@@ -160,6 +169,7 @@ async function installNpmLibDefs({
   explicitLibDefs,
   verbose,
   overwrite,
+  skip,
 }: installNpmLibDefsArgs): Promise<number> {
   const flowProjectRoot = await findFlowRoot(cwd);
   if (flowProjectRoot === null) {
@@ -346,7 +356,7 @@ async function installNpmLibDefs({
       }
     }));
 
-    if (untypedMissingLibDefs.length > 0) {
+    if (untypedMissingLibDefs.length > 0 && !skip) {
       console.log('• Generating stubs for untyped dependencies...');
       await Promise.all(
         untypedMissingLibDefs.map(async ([pkgName, pkgVerStr]) => {


### PR DESCRIPTION
When `--skip` is passed, untyped dependencies won't be stubbed. This
adds back the functionality from #686 that was lost.