### PR TITLE
correct signature of react-router-dom matchPath function

### DIFF
--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-/react-router-dom_v4.x.x.js
@@ -156,8 +156,9 @@ declare module 'react-router-dom' {
   declare export function withRouter<P, S>(Component: ClassComponent<void, P, S> | FunctionComponent<P>): ClassComponent<void, $Diff<P, ContextRouter>, S>;
 
   declare type MatchPathOptions = {
+    path: string,
     exact?: boolean,
     strict?: boolean,
   }
-  declare export function matchPath(pathname: string, path: string, options?: MatchPathOptions): null | Match
+  declare export function matchPath(pathname: string, options: MatchPathOptions): null | Match
 }

--- a/definitions/npm/react-router-dom_v4.x.x/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v4.x.x/test_react-router-dom.js
@@ -75,15 +75,16 @@ import {
 <NavLink />
 
 // matchPath
-const match: null | Match = matchPath('/the/pathname', '/the/:dynamicId', {
+const match: null | Match = matchPath('/the/pathname', {
+  path: '/the/:dynamicId',
   exact: true,
   strict: false
 })
-const match2: null | Match = matchPath('/the/pathname', '/the/:dynamicId')
+const match2: null | Match = matchPath('/the/pathname', {path: '/the/:dynamicId'})
 
 // $ExpectError
 matchPath('/the/pathname')
 // $ExpectError
 matchPath()
 // $ExpectError
-const matchError: string = matchPath('/the/pathname', 'the/:dynamicId')
+const matchError: string = matchPath('/the/pathname', {path: 'the/:dynamicId'})


### PR DESCRIPTION
matchPath signature now matches react-router-dom 4.1.1

see [here](https://github.com/ReactTraining/react-router/blob/dc2149ec0c63bfc95b71e40c81431e34cfbfeda9/packages/react-router-dom/modules/matchPath.js#L1) and [here](https://github.com/ReactTraining/react-router/blob/dc2149ec0c63bfc95b71e40c81431e34cfbfeda9/packages/react-router/modules/matchPath.js#L29).