### PR TITLE
Fix type ContextRouter

### DIFF
--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-/react-router-dom_v4.x.x.js
@@ -83,7 +83,9 @@ declare module 'react-router-dom' {
     url: string,
   }
 
-  declare export type ContextRouter = RouterHistory & {
+  declare export type ContextRouter = {
+    history: RouterHistory,
+    location: Location,
     match: Match,
   }
 


### PR DESCRIPTION
ContextRouter should be an object containing `{ history: RouterHistory, location: Location, match: Match }`, not `RouterHistory & { match: Match }`