### PR TITLE
Add missing Backbone definitions

### DIFF
--- a/definitions/npm/backbone_v1.x.x/flow_v0.25.x-/backbone_v1.x.x.js
+++ b/definitions/npm/backbone_v1.x.x/flow_v0.25.x-/backbone_v1.x.x.js
@@ -13,11 +13,13 @@ declare module 'backbone' {
   declare class Events {
     // Not sure the best way of adding these to the declaration files
     on(event: string, callback: eventCallback, context?: Object): void;
+    once(event: string, callback: eventCallback, context?: Object): void;
     bind(event: string, callback: eventCallback, context?: Object): void;
     off(event: ?string, callback?: ?eventCallback, context?: Object): void;
     unbind(event: ?string, callback?: ?eventCallback, context?: Object): void;
     trigger(event: string, ...args?: Array<mixed>): void;
     listenTo(other: Events, event: string, callback: eventCallback): void;
+    listenToOnce(other: Events, event: string, callback: eventCallback): void;
     stopListening(other: Events, callback?: ?eventCallback, context?: Object): void;
     static on(event: string, callback: eventCallback, context?: Object): void;
     static bind(event: string, callback: eventCallback, context?: Object): void;
@@ -41,26 +43,43 @@ declare module 'backbone' {
     static extend<P, CP>(instanceProperies: P, classProperties?: CP): Class<Model & P> & CP;
     constructor(attributes?: Attrs, options?: ModelOpts): void;
     static initialize(attributes?: Attrs, options?: ModelOpts): void;
-    idAttribute: string;
-    id: string | number;
-    attributes: Attrs;
-    cid: string;
-    cidPrefix: string;
-    chagned: ?Object,
-    validationError: ?Object;
     initialize(): void;
-    toJSON(): Attrs;
-    sync: sync;
+    get(attr: string): any;
     set(attrs: Attrs, options?: Object): this;
     set(attr: string, value: mixed, options?: Object): this;
+    escape(attr: string): mixed;
     has(attr: string): boolean;
     unset(attr: string, options?: { unset?: boolean }): this;
     clear(options?: Object): this;
-    escape(attr: string): mixed;
-    previous(attr: string): mixed;
-    previousAttributes(): Attrs;
-    // @TODO should return a jQuery XHR, but I cannot define this without the dependency on jquery lib def.
+    id: string | number;
+    idAttribute: string;
+    cid: string;
+    cidPrefix: string;
+    attributes: Attrs;
+    changed: ?Object;
+    defaults(attr: Object): void;
+    defaults(attr: () => void): void;
+    toJSON(): Attrs;
+    sync: sync;
+    //Start jQuery XHR
+    // @TODO should return a jQuery XHR, but I cannot define this without the dependency on jquery lib def
     fetch(options?: Object): any;
+    save(attrs: Attrs, options?: Object): any;
+    save(attr: string, value: mixed, options?: Object): any;
+    destroy(options?: Object): any;
+    // End jQuery XHR
+    validate(attrs: Attrs, options?: Object): boolean;
+    validationError: ?Object;
+    isValid(): boolean;
+    url(): string;
+    urlRoot: string | () => string;
+    parse(response: Object, options?: Object): any;
+    clone: this;
+    isNew: boolean;
+    hasChanged(attribute?: string): boolean;
+    chagnedAttributes(attributes?: {[attr: string]: mixed}): boolean;
+    previous(attribute: string): mixed;
+    previousAttirbutes(): Attrs;
     // Start Underscore methods
     // @TODO Underscore Methods should be defined by the library definition
     keys(): string[];
@@ -72,15 +91,6 @@ declare module 'backbone' {
     chain(): Function;
     isEmpty(): boolean;
     // End underscore methods
-    isValid(): boolean;
-    url(): string;
-    urlRoot: string | () => string,
-    clone: this;
-    isNew: boolean;
-    hasChanged(attribute?: string): boolean;
-    chagnedAttributes(attributes?: {[attr: string]: mixed}): boolean;
-    previous(attribute: string): mixed;
-    previousAttirbutes(): Attrs;
   }
 
   /**
@@ -141,10 +151,10 @@ declare module 'backbone' {
     push(model: TModel, options?: Object): void;
     pop(otions?: Object): void;
     unshift(model: TModel, options?: Object): void;
-    unshift(model: TModel, options?: Object): void;
     shift(options?: Object): TModel;
     slice(begin: number, end: number): Array<TModel>;
     length: number;
+    comparator: string | (attr: string) => any | (attrA: TModel, attrB: TModel) => number;
     sort(options?: Object): Array<TModel>;
     pluck(attribute: string): Array<TModel>;
     where(attributes: {[attributeName: string]: mixed}): Array<TModel>;


### PR DESCRIPTION
Events: once, listenToOnce
Model: save, destroy, validate, parse
Collection: comparator

Removed duplicate `unshift` under Collection

Reordered Model to match order in docs