### PR TITLE
Add support for styled-components/native

### DIFF
--- a/definitions/npm/styled-components_v1.4.x/flow_v0.25.x-/styled-components_v1.4.x.js
+++ b/definitions/npm/styled-components_v1.4.x/flow_v0.25.x-/styled-components_v1.4.x.js
@@ -1,33 +1,42 @@
 // @flow
 
+type $npm$styledComponents$Interpolation = ((executionContext: Object) => string) | string | number;
+type $npm$styledComponents$NameGenerator = (hash: number) => string
+
+type $npm$styledComponents$StyledComponent = (
+  strings: Array<string>,
+  ...interpolations: Array<$npm$styledComponents$Interpolation>
+) => ReactClass<*>;
+
+
+type $npm$styledComponents$Theme = {[key: string]: mixed};
+type $npm$styledComponents$ThemeProviderProps = {
+  theme: ((outerTheme: $npm$styledComponents$Theme) => void) | $npm$styledComponents$Theme
+};
+type $npm$styledComponents$Component =
+  | React$Component<*, *, *>
+  | (props: *) => React$Element<*>;
+
+class Npm$StyledComponents$ThemeProvider extends React$Component {
+  props: $npm$styledComponents$ThemeProviderProps;
+}
+
 declare module 'styled-components' {
-  declare type Interpolation = ((executionContext: Object) => string) | string | number;
-  declare type NameGenerator = (hash: number) => string
+  declare type Interpolation = $npm$styledComponents$Interpolation;
+  declare type NameGenerator = $npm$styledComponents$NameGenerator;
 
-  declare type StyledComponent = (
-    strings: Array<string>,
-    ...interpolations: Array<Interpolation>
-  ) => ReactClass<*>;
+  declare type StyledComponent = $npm$styledComponents$StyledComponent;
 
-
-  declare type Theme = {[key: string]: mixed};
-  declare type ThemeProviderProps = {
-    theme: ((outerTheme: Theme) => void) | Theme
-  };
-  declare type Component =
-    | React$Component<*, *, *>
-    | (props: *) => React$Element<*>;
-
-  declare class ThemeProvider extends React$Component {
-    props: ThemeProviderProps;
-  }
+  declare type Theme = $npm$styledComponents$Theme;
+  declare type ThemeProviderProps = $npm$styledComponents$ThemeProviderProps;
+  declare type Component = $npm$styledComponents$Component;
 
   declare module.exports: {
     injectGlobal: (strings: Array<string>, ...interpolations: Array<Interpolation>) => void,
     css: (strings: Array<string>, ...interpolations: Array<Interpolation>) => Array<Interpolation>,
     keyframes: (strings: Array<string>, ...interpolations: Array<Interpolation>) => string,
     withTheme: (component: Component) => React$Component<*, ThemeProviderProps, *>,
-    ThemeProvider: typeof ThemeProvider,
+    ThemeProvider: typeof Npm$StyledComponents$ThemeProvider,
     (baseComponent: Component): StyledComponent,
     a: StyledComponent,
     abbr: StyledComponent,
@@ -163,5 +172,72 @@ declare module 'styled-components' {
     svg: StyledComponent,
     text: StyledComponent,
     tspan: StyledComponent,
+  };
+}
+
+declare module 'styled-components/native' {
+  declare type Interpolation = $npm$styledComponents$Interpolation;
+  declare type NameGenerator = $npm$styledComponents$NameGenerator;
+
+  declare type StyledComponent = $npm$styledComponents$StyledComponent;
+
+  declare type Theme = $npm$styledComponents$Theme;
+  declare type ThemeProviderProps = $npm$styledComponents$ThemeProviderProps;
+  declare type Component = $npm$styledComponents$Component;
+
+  declare module.exports: {
+    css: (strings: Array<string>, ...interpolations: Array<Interpolation>) => Array<Interpolation>,
+    withTheme: (component: Component) => React$Component<*, ThemeProviderProps, *>,
+    ThemeProvider: typeof Npm$StyledComponents$ThemeProvider,
+
+    (baseComponent: Component): StyledComponent,
+
+    ActivityIndicator: StyledComponent,
+    ActivityIndicatorIOS: StyledComponent,
+    ART: StyledComponent,
+    Button: StyledComponent,
+    DatePickerIOS: StyledComponent,
+    DrawerLayoutAndroid: StyledComponent,
+    FlatList: StyledComponent,
+    Image: StyledComponent,
+    ImageEditor: StyledComponent,
+    ImageStore: StyledComponent,
+    KeyboardAvoidingView: StyledComponent,
+    ListView: StyledComponent,
+    MapView: StyledComponent,
+    Modal: StyledComponent,
+    Navigator: StyledComponent,
+    NavigatorIOS: StyledComponent,
+    Picker: StyledComponent,
+    PickerIOS: StyledComponent,
+    ProgressBarAndroid: StyledComponent,
+    ProgressViewIOS: StyledComponent,
+    RecyclerViewBackedScrollView: StyledComponent,
+    RefreshControl: StyledComponent,
+    ScrollView: StyledComponent,
+    SectionList: StyledComponent,
+    SegmentedControlIOS: StyledComponent,
+    Slider: StyledComponent,
+    SliderIOS: StyledComponent,
+    SnapshotViewIOS: StyledComponent,
+    StatusBar: StyledComponent,
+    SwipeableListView: StyledComponent,
+    Switch: StyledComponent,
+    SwitchAndroid: StyledComponent,
+    SwitchIOS: StyledComponent,
+    TabBarIOS: StyledComponent,
+    Text: StyledComponent,
+    TextInput: StyledComponent,
+    ToastAndroid: StyledComponent,
+    ToolbarAndroid: StyledComponent,
+    Touchable: StyledComponent,
+    TouchableHighlight: StyledComponent,
+    TouchableNativeFeedback: StyledComponent,
+    TouchableOpacity: StyledComponent,
+    TouchableWithoutFeedback: StyledComponent,
+    View: StyledComponent,
+    ViewPagerAndroid: StyledComponent,
+    VirtualizedList: StyledComponent,
+    WebView: StyledComponent,
   };
 }

--- a/definitions/npm/styled-components_v1.4.x/test_styled-components_v1.4.x.js
+++ b/definitions/npm/styled-components_v1.4.x/test_styled-components_v1.4.x.js
@@ -1,5 +1,11 @@
 import styled, {ThemeProvider, withTheme, keyframes} from 'styled-components'
 import type {Theme} from 'styled-components'
+import nativeStyled, {
+  ThemeProvider as NativeThemeProvider,
+  withTheme as nativeWithTheme,
+  keyframes as nativeKeyframe
+} from 'styled-components/native'
+import type {Theme as NativeTheme} from 'styled-components/native'
 
 const Title = styled.h1`
   font-size: 1.5em;
@@ -51,6 +57,64 @@ const NoExistingComponentWrapper = styled()`
 
 // $ExpectError
 const NumberWrapper = styled(num)`
+  padding: 4em;
+  background: papayawhip;
+`;
+
+// native
+
+const NativeTitle = nativeStyled.Text`
+  font-size: 1.5em;
+  text-align: center;
+  color: palevioletred;
+`;
+
+const ExtendedNativeTitle = nativeStyled(NativeTitle)`
+  font-size: 2em;
+`
+
+const NativeWrapper = nativeStyled.View`
+  padding: 4em;
+  background: ${({theme}) => theme.background};
+`;
+
+const nativeTheme: NativeTheme = {
+  background: "papayawhip"
+}
+
+const NativeComponent = () => (
+  <NativeThemeProvider theme={nativeTheme}>
+    <NativeWrapper>
+      <NativeTitle>
+        Hello World, this is my first native styled component!
+      </NativeTitle>
+    </NativeWrapper>
+  </NativeThemeProvider>
+)
+
+const NativeComponentWithTheme = nativeWithTheme(NativeComponent)
+
+const NativeOpacityKeyFrame = nativeKeyframes`
+  0%   { opacity: 0; }
+  100% { opacity: 1; }
+`;
+
+// $ExpectError
+const NativeNoExistingElementWrapper = nativeStyled.nonexisting`
+  padding: 4em;
+  background: papayawhip;
+`;
+
+const nativeNum = 9
+
+// $ExpectError
+const NativeNoExistingComponentWrapper = nativeStyled()`
+  padding: 4em;
+  background: papayawhip;
+`;
+
+// $ExpectError
+const NativeNumberWrapper = nativeStyled(num)`
   padding: 4em;
   background: papayawhip;
 `;


### PR DESCRIPTION
The original type definition omitted support for the React Native version of styled-components. This adds support for that module.

Fixes https://github.com/styled-components/styled-components/issues/708