### PR TITLE
Add body-parser

### DIFF
--- a/definitions/npm/body-parser_v1.x.x/flow_v0.30.x-/body-parser_v1.x.x.js
+++ b/definitions/npm/body-parser_v1.x.x/flow_v0.30.x-/body-parser_v1.x.x.js
@@ -1,0 +1,40 @@
+import type { Middleware, $Request, $Response } from 'express';
+
+declare type bodyParser$Options = {
+  inflate?: boolean;
+  limit?: number | string;
+  type?: string | string[] | ((req: $Request) => any);
+  verify?: (req: $Request, res: $Response, buf: Buffer, encoding: string) => void;
+};
+
+declare type bodyParser$OptionsText = bodyParser$Options & {
+  reviever?: (key: string, value: any) => any;
+  strict?: boolean;
+};
+
+declare type bodyParser$OptionsJson = bodyParser$Options & {
+  reviever?: (key: string, value: any) => any;
+  strict?: boolean;
+};
+
+declare type bodyParser$OptionsUrlencoded = bodyParser$Options & {
+  extended?: boolean;
+  parameterLimit?: number;
+};
+
+declare module "body-parser" {
+
+    declare type Options = bodyParser$Options;
+    declare type OptionsText = bodyParser$OptionsText;
+    declare type OptionsJson = bodyParser$OptionsJson;
+    declare type OptionsUrlencoded = bodyParser$OptionsUrlencoded;
+
+    declare function json(options?: OptionsJson): Middleware;
+
+    declare function raw(options?: Options): Middleware;
+
+    declare function text(options?: OptionsText): Middleware;
+
+    declare function urlencoded(options?: OptionsUrlencoded): Middleware;
+
+}

--- a/definitions/npm/body-parser_v1.x.x/flow_v0.30.x-/test_body-parser.js
+++ b/definitions/npm/body-parser_v1.x.x/flow_v0.30.x-/test_body-parser.js
@@ -1,0 +1,26 @@
+/** @flow */
+import {
+    json,
+    raw,
+    text,
+    urlencoded,
+} from 'body-parser';
+import type {
+    OptionsText,
+    OptionsJson,
+    OptionsUrlencoded
+} from 'body-parser';
+
+json(({ strict: true }: OptionsJson))
+text(({ strict: true }: OptionsText))
+urlencoded(({ extended: true }: OptionsUrlencoded))
+
+
+// $ExpectError
+json(({ extended: true } : OptionsUrlencoded));
+
+// $ExpectError
+text(({ extended: true } : OptionsUrlencoded));
+
+// $ExpectError
+urlencoded(({ strict: true }: OptionsJson));


### PR DESCRIPTION
I tried to add express to the test:

```flow
import express from 'express'
import { json } from 'body-parser';

const app = express()

app.use(json())
```
but the test throws "express. Required module not found".
Is there any way to do this?

