### PR TITLE
[lodash] Update _.noop type

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.38.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.38.x-/lodash_v4.x.x.js
@@ -476,7 +476,7 @@ declare module 'lodash' {
     methodOf(object?: ?Object, ...args?: Array<any>): Function;
     mixin<T: Function|Object>(object?: T, source: Object, options?: { chain: bool }): T;
     noConflict(): Lodash;
-    noop(): void;
+    noop(...args: Array<mixed>): void;
     nthArg(n?: number): Function;
     over(...iteratees: Array<Function>): Function;
     over(iteratees: Array<Function>): Function;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.38.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.38.x-/test_lodash-v4.x.x.js
@@ -312,3 +312,14 @@ timesNums = _.times(5, function(i: number) { return JSON.stringify(i); });
 // https://github.com/facebook/flow/issues/1948
 _.flatMap([1, 2, 3], (n): number[] => [n, n]);
 _.flatMap({a: 1, b: 2}, n => [n, n]);
+
+/**
+ * _.noop
+ */
+_.noop();
+_.noop(1);
+_.noop('a', 2, [], null);
+(_.noop: (string) => void);
+(_.noop: (number, string) => void);
+// $ExpectError functions are contravariant in return types
+(_.noop: (string) => string);


### PR DESCRIPTION
This changes the type of `_.noop` from `() => void` to `(...args: Array<mixed>) => void`.

This allows us to pass arguments to `_.noop`, which is useful for default values in handlers. For example:

```
type Handler = (SyntheticEvent) => void;
(_.noop: Handler);
```

I added tests:
- It should take arguments
- It should take many arguments of varying types
- It should be able to be cast to any function that returns void
- It should fail when casting to a function that returns non-void