### PR TITLE
Radium 0.19 – Fixed Style and StyleRoot being incorrectly labelled as React$Element

### DIFF
--- a/definitions/npm/radium_v0.19.x/flow_v0.30.x-/radium_v0.19.x.js
+++ b/definitions/npm/radium_v0.19.x/flow_v0.30.x-/radium_v0.19.x.js
@@ -109,8 +109,8 @@ declare module 'radium' {
     (elem: React$Element<any>): React$Element<any>;
     (config: RadiumConfig): ConfiguredRadium;
     Plugins: Object;
-    Style: React$Element<any>;
-    StyleRoot: React$Element<any>;
+    Style: ClassComponent<any, any, any>;
+    StyleRoot: ClassComponent<any, any, any>;
     getState(state: Object, elementKey: string, value: ':active' | ':hover' | ':focus'): boolean;
     keyframes(animationObject: Object, name?: string): string;
   }


### PR DESCRIPTION
Hi, the Radium objects Style and StyleRoot were incorrectly labelled as React$Element instead of React Components

This is a PR to fix that issue