### PR TITLE
Backbone partial modules

### DIFF
--- a/definitions/npm/backbone-collection_v1.x.x/flow_v0.25.x-/backbone-collection_v1.x.x.js
+++ b/definitions/npm/backbone-collection_v1.x.x/flow_v0.25.x-/backbone-collection_v1.x.x.js
@@ -5,6 +5,8 @@ declare type Backbone$Attrs = { [name: string]: any };
 declare type Backbone$Id = number | string;
 
 declare module "backbone-collection" {
+  declare var version: string;
+
   declare type eventCallback = (event: Event) => void | mixed;
 
   /**

--- a/definitions/npm/backbone-collection_v1.x.x/flow_v0.25.x-/backbone-collection_v1.x.x.js
+++ b/definitions/npm/backbone-collection_v1.x.x/flow_v0.25.x-/backbone-collection_v1.x.x.js
@@ -1,0 +1,211 @@
+// subset of the `backbone` module
+declare module 'backbone-collection' {
+  declare type eventCallback = (event: Event) => void | mixed;
+  declare type Attrs = {[name: string]: mixed};
+  declare type CRUDMethod = 'create' | 'read' | 'update' | 'delete';
+
+  /**
+   * Events Module - http://backbonejs.org/#Events
+   */
+  declare class Events {
+    // Not sure the best way of adding these to the declaration files
+    on(event: string, callback: eventCallback, context?: Object): void;
+    once(event: string, callback: eventCallback, context?: Object): void;
+    bind(event: string, callback: eventCallback, context?: Object): void;
+    off(event: ?string, callback?: ?eventCallback, context?: Object): void;
+    unbind(event: ?string, callback?: ?eventCallback, context?: Object): void;
+    trigger(event: string, ...args?: Array<mixed>): void;
+    listenTo(other: Events, event: string, callback: eventCallback): void;
+    listenToOnce(other: Events, event: string, callback: eventCallback): void;
+    stopListening(other: Events, callback?: ?eventCallback, context?: Object): void;
+    static on(event: string, callback: eventCallback, context?: Object): void;
+    static bind(event: string, callback: eventCallback, context?: Object): void;
+    static off(event: ?string, callback?: ?eventCallback, context?: Object): void;
+    static unbind(event: ?string, callback?: ?eventCallback, context?: Object): void;
+    static trigger(event: string, ...args?: Array<mixed>): void;
+    static listenTo(other: Events, event: string, callback: eventCallback): void;
+    static stopListening(other: Events, callback?: ?eventCallback, context?: Object): void;
+  }
+
+  /**
+   * Model Class - http://backbonejs.org/#Model
+   */
+  declare type ModelOpts = {
+    collection?: Collection<*>,
+    parse?: Function,
+    [optionName: string]: mixed
+  };
+
+  declare class Model mixins Events {
+    static extend<P, CP>(instanceProperies: P, classProperties?: CP): Class<Model & P> & CP;
+    constructor(attributes?: Attrs, options?: ModelOpts): void;
+    static initialize(attributes?: Attrs, options?: ModelOpts): void;
+    initialize(): void;
+    get(attr: ?string): any,
+    set(attrs: Attrs, options?: Object): this;
+    set(attr: string, value: mixed, options?: Object): this;
+    escape(attr: string): mixed;
+    has(attr: string): boolean;
+    unset(attr: string, options?: { unset?: boolean }): this;
+    clear(options?: Object): this;
+    id: string | number;
+    idAttribute: string;
+    cid: string;
+    cidPrefix: string;
+    attributes: Attrs;
+    changed: ?Object;
+    defaults(attr: Object): void;
+    defaults(attr: () => void): void;
+    toJSON(): Attrs;
+    sync: sync;
+    //Start jQuery XHR
+    // @TODO should return a jQuery XHR, but I cannot define this without the dependency on jquery lib def
+    fetch(options?: Object): any;
+    save(attrs: Attrs, options?: Object): any;
+    save(attr: string, value: mixed, options?: Object): any;
+    destroy(options?: Object): any;
+    // End jQuery XHR
+    validate(attrs: Attrs, options?: Object): boolean;
+    validationError: ?Object;
+    isValid(): boolean;
+    url(): string;
+    urlRoot: string | () => string;
+    parse(response: Object, options?: Object): any;
+    clone: this;
+    isNew(): boolean;
+    hasChanged(attribute?: string): boolean;
+    chagnedAttributes(attributes?: {[attr: string]: mixed}): boolean;
+    previous(attribute: string): mixed;
+    previousAttributes(): Attrs;
+    // Start Underscore methods
+    // @TODO Underscore Methods should be defined by the library definition
+    keys(): string[];
+    values(): mixed[];
+    pairs: Function;
+    invert: Function;
+    pick: Function;
+    omit: Function;
+    chain(): Function;
+    isEmpty(): boolean;
+    // End underscore methods
+  }
+
+  /**
+   * Collection Class - http://backbonejs.org/#Collection
+   */
+  declare class Collection<TModel> mixins Events {
+    static extend<P, CP>(instanceProperies: P, classProperties?: CP): Class<Collection<*> & P> & CP;
+    constructor(models?: TModel, options?: Object): this;
+    initialize(models?: TModel, options?: Object): this;
+    model: TModel;
+    modelId(attributes: TModel): string;
+    models: TModel[];
+    toJSON(options?: Object): TModel[];
+    sync: sync;
+    // Underscore Methods
+    // @TODO should be defined by the underscore library defintion and not as generic functions.
+    forEach: Function; //(each)
+    map: Function; //(collect)
+    reduce: Function; // (foldl, inject)
+    reduceRight: Function; //(foldr)
+    find: Function; // (detect)
+    findIndex: Function;
+    findLastIndex: Function;
+    filter: Function; //(select)
+    reject: Function;
+    every: Function; //(all)
+    some: Function; //(any)
+    contains: Function; //(includes)
+    invoke: Function;
+    max: Function;
+    min: Function;
+    sortBy: Function;
+    groupBy: Function;
+    shuffle: Function;
+    toArray: Function;
+    size: Function;
+    first: Function; //(head, take)
+    initial: Function;
+    rest: Function; //(tail, drop)
+    last: Function;
+    without: Function;
+    indexOf: Function;
+    lastIndexOf: Function;
+    isEmpty: Function;
+    chain: Function;
+    difference: Function;
+    sample: Function;
+    partition: Function;
+    countBy: Function;
+    indexBy: Function;
+    // end underscore methods
+    add(models: Array<TModel>, options?: Object): void;
+    remove(models: Array<TModel| string | number>, options?: Object): void;
+    reset(models?: Array<TModel>, options?: Object): void;
+    set(models: Array<TModel>, options?: Object): void;
+    get(id: ?string): ?TModel;
+    at(index: number): ?TModel;
+    push(model: TModel, options?: Object): void;
+    pop(otions?: Object): void;
+    unshift(model: TModel, options?: Object): void;
+    shift(options?: Object): TModel;
+    slice(begin: number, end: number): Array<TModel>;
+    length: number;
+    comparator: string | (attr: string) => any | (attrA: TModel, attrB: TModel) => number;
+    sort(options?: Object): Array<TModel>;
+    pluck(attribute: string): Array<TModel>;
+    where(attributes: {[attributeName: string]: mixed}): Array<TModel>;
+    findWhere(attributes: {[attributeName: string]: mixed}): TModel;
+    url: () => string | string;
+    parse(response: Object, options: Object): Object;
+    clone(): this;
+    fetch(options?: Object): void;
+    create(attributes: Object, options?: Object): void;
+  }
+
+
+  /**
+   * Router Class http://backbonejs.org/#Router
+   */
+  declare class Router mixins Events {
+      static extend<P, CP>(instanceProperies: P, classProperties?: CP): Class<Router & P> & CP;
+      routes: {
+        [route: string]: string | ((e: Event) => mixed | void);
+      };
+      constructor(options?: Object): this;
+      initialize(options?: Object): this;
+      route(route: string, name: string, callback?: (e: Event) => mixed | void): this;
+      navigate(fragment: string, options?: { trigger?: boolean, replace?:  boolean}): this;
+      execute(callback: Function, args: Array<mixed>, name: string): void | mixed;
+  }
+
+  /**
+   * History - http://backbonejs.org/#History
+   */
+  declare class History mixins Events {
+    static extend<P, CP>(instanceProperies: P, classProperties?: CP): Class<History & P> & CP;
+    static started: boolean;
+    constructor(options?: Object): this;
+    initialize(options?: Object): this;
+    start(options?: { pushState?: boolean, hashChange?: boolean, root?: string}): this;
+  }
+  declare var history: History;
+
+  /**
+   * Sync - http://backbonejs.org/#Sync
+   */
+  declare function sync(method: CRUDMethod, model: Model, options?: Object):  any; // Should really be a jQuery XHR.
+  declare function ajax(request: Object): any;
+  declare var emulateHTTP: boolean;
+  declare var emulateJSON: boolean;
+
+  /**
+   * Declaring the export for backbone as well.
+   */
+  declare class Backbone {
+    // subset of the `backbone` module
+    Collection: typeof Collection;
+  }
+
+  declare var exports: Backbone;
+}

--- a/definitions/npm/backbone-collection_v1.x.x/flow_v0.25.x-/backbone-collection_v1.x.x.js
+++ b/definitions/npm/backbone-collection_v1.x.x/flow_v0.25.x-/backbone-collection_v1.x.x.js
@@ -1,210 +1,211 @@
 // subset of the `backbone` module
-declare module 'backbone-collection' {
+
+// repeated in backbone, backbone-model, and backbone-collection
+declare type Backbone$Attrs = { [name: string]: any };
+declare type Backbone$Id = number | string;
+
+declare module "backbone-collection" {
   declare type eventCallback = (event: Event) => void | mixed;
-  declare type Attrs = {[name: string]: mixed};
-  declare type CRUDMethod = 'create' | 'read' | 'update' | 'delete';
 
   /**
    * Events Module - http://backbonejs.org/#Events
    */
   declare class Events {
     // Not sure the best way of adding these to the declaration files
-    on(event: string, callback: eventCallback, context?: Object): void;
-    once(event: string, callback: eventCallback, context?: Object): void;
-    bind(event: string, callback: eventCallback, context?: Object): void;
-    off(event: ?string, callback?: ?eventCallback, context?: Object): void;
-    unbind(event: ?string, callback?: ?eventCallback, context?: Object): void;
-    trigger(event: string, ...args?: Array<mixed>): void;
-    listenTo(other: Events, event: string, callback: eventCallback): void;
-    listenToOnce(other: Events, event: string, callback: eventCallback): void;
-    stopListening(other: Events, callback?: ?eventCallback, context?: Object): void;
-    static on(event: string, callback: eventCallback, context?: Object): void;
-    static bind(event: string, callback: eventCallback, context?: Object): void;
-    static off(event: ?string, callback?: ?eventCallback, context?: Object): void;
-    static unbind(event: ?string, callback?: ?eventCallback, context?: Object): void;
-    static trigger(event: string, ...args?: Array<mixed>): void;
-    static listenTo(other: Events, event: string, callback: eventCallback): void;
-    static stopListening(other: Events, callback?: ?eventCallback, context?: Object): void;
+    on(event: string, callback: eventCallback, context?: Object): void,
+    once(event: string, callback: eventCallback, context?: Object): void,
+    bind(event: string, callback: eventCallback, context?: Object): void,
+    off(event: ?string, callback?: ?eventCallback, context?: Object): void,
+    unbind(event: ?string, callback?: ?eventCallback, context?: Object): void,
+    trigger(event: string, ...args?: Array<mixed>): void,
+    listenTo(other: Events, event: string, callback: eventCallback): void,
+    listenToOnce(other: Events, event: string, callback: eventCallback): void,
+    stopListening(
+      other: Events,
+      callback?: ?eventCallback,
+      context?: Object
+    ): void,
+    static on(event: string, callback: eventCallback, context?: Object): void,
+    static bind(event: string, callback: eventCallback, context?: Object): void,
+    static off(
+      event: ?string,
+      callback?: ?eventCallback,
+      context?: Object
+    ): void,
+    static unbind(
+      event: ?string,
+      callback?: ?eventCallback,
+      context?: Object
+    ): void,
+    static trigger(event: string, ...args?: Array<mixed>): void,
+    static listenTo(
+      other: Events,
+      event: string,
+      callback: eventCallback
+    ): void,
+    static stopListening(
+      other: Events,
+      callback?: ?eventCallback,
+      context?: Object
+    ): void
   }
 
   /**
    * Model Class - http://backbonejs.org/#Model
    */
   declare type ModelOpts = {
+    [optionName: string]: mixed,
     collection?: Collection<*>,
-    parse?: Function,
-    [optionName: string]: mixed
+    parse?: Function
   };
 
-  declare class Model mixins Events {
-    static extend<P, CP>(instanceProperies: P, classProperties?: CP): Class<Model & P> & CP;
-    constructor(attributes?: Attrs, options?: ModelOpts): void;
-    static initialize(attributes?: Attrs, options?: ModelOpts): void;
-    initialize(): void;
+  declare class Model {
+    static extend<P, CP>(
+      instanceProperies: P,
+      classProperties?: CP
+    ): Class<Model & P> & CP,
+    constructor(attributes?: Backbone$Attrs, options?: ModelOpts): void,
+    static initialize(attributes?: Backbone$Attrs, options?: ModelOpts): void,
+    initialize(): void,
     get(attr: ?string): any,
-    set(attrs: Attrs, options?: Object): this;
-    set(attr: string, value: mixed, options?: Object): this;
-    escape(attr: string): mixed;
-    has(attr: string): boolean;
-    unset(attr: string, options?: { unset?: boolean }): this;
-    clear(options?: Object): this;
-    id: string | number;
-    idAttribute: string;
-    cid: string;
-    cidPrefix: string;
-    attributes: Attrs;
-    changed: ?Object;
-    defaults(attr: Object): void;
-    defaults(attr: () => void): void;
-    toJSON(): Attrs;
-    sync: sync;
+    set(attrs: Backbone$Attrs, options?: Object): this,
+    set(attr: string, value: mixed, options?: Object): this,
+    escape(attr: string): mixed,
+    has(attr: string): boolean,
+    unset(attr: string, options?: { unset?: boolean }): this,
+    clear(options?: Object): this,
+    id: Backbone$Id,
+    idAttribute: string,
+    cid: string,
+    cidPrefix: string,
+    attributes: Backbone$Attrs,
+    changed: Object,
+    defaults(): Backbone$Attrs,
+    toJSON(): Backbone$Attrs,
     //Start jQuery XHR
     // @TODO should return a jQuery XHR, but I cannot define this without the dependency on jquery lib def
-    fetch(options?: Object): any;
-    save(attrs: Attrs, options?: Object): any;
-    save(attr: string, value: mixed, options?: Object): any;
-    destroy(options?: Object): any;
+    fetch(options?: Object): any,
+    save(attrs: Backbone$Attrs, options?: Object): any,
+    save(attr: string, value: mixed, options?: Object): any,
+    destroy(options?: Object): any,
     // End jQuery XHR
-    validate(attrs: Attrs, options?: Object): boolean;
-    validationError: ?Object;
-    isValid(): boolean;
-    url(): string;
-    urlRoot: string | () => string;
-    parse(response: Object, options?: Object): any;
-    clone: this;
-    isNew(): boolean;
-    hasChanged(attribute?: string): boolean;
-    chagnedAttributes(attributes?: {[attr: string]: mixed}): boolean;
-    previous(attribute: string): mixed;
-    previousAttributes(): Attrs;
+    validate(attrs: Backbone$Attrs, options?: Object): boolean,
+    validationError: ?Object,
+    isValid(): boolean,
+    url(): string,
+    urlRoot: string | (() => string),
+    parse(response: Object, options?: Object): any,
+    clone(): this,
+    isNew(): boolean,
+    hasChanged(attribute?: string): boolean,
+    changedAttributes(attributes?: { [attr: string]: mixed }): boolean,
+    previous(attribute: string): mixed,
+    previousAttributes(): Backbone$Attrs,
     // Start Underscore methods
     // @TODO Underscore Methods should be defined by the library definition
-    keys(): string[];
-    values(): mixed[];
-    pairs: Function;
-    invert: Function;
-    pick: Function;
-    omit: Function;
-    chain(): Function;
-    isEmpty(): boolean;
+    keys(): string[],
+    values(): mixed[],
+    pairs: Function,
+    invert: Function,
+    pick: Function,
+    omit: Function,
+    chain(): Function,
+    isEmpty(): boolean
     // End underscore methods
   }
 
   /**
    * Collection Class - http://backbonejs.org/#Collection
    */
-  declare class Collection<TModel> mixins Events {
-    static extend<P, CP>(instanceProperies: P, classProperties?: CP): Class<Collection<*> & P> & CP;
-    constructor(models?: TModel, options?: Object): this;
-    initialize(models?: TModel, options?: Object): this;
-    model: TModel;
-    modelId(attributes: TModel): string;
-    models: TModel[];
-    toJSON(options?: Object): TModel[];
-    sync: sync;
+  declare class Collection<TModel> {
+    static extend<P, CP>(
+      instanceProperies: P,
+      classProperties?: CP
+    ): Class<Collection<*> & P> & CP,
+    constructor(
+      models?: ?Array<TModel | Backbone$Attrs>,
+      options?: Object
+    ): void,
+    initialize(
+      models?: ?Array<TModel | Backbone$Attrs>,
+      options?: Object
+    ): void,
+    model: Class<TModel>,
+    modelId(attributes: TModel): string,
+    models: TModel[],
+    toJSON(options?: Object): Array<Backbone$Attrs>,
     // Underscore Methods
     // @TODO should be defined by the underscore library defintion and not as generic functions.
-    forEach: Function; //(each)
-    map: Function; //(collect)
-    reduce: Function; // (foldl, inject)
-    reduceRight: Function; //(foldr)
-    find: Function; // (detect)
-    findIndex: Function;
-    findLastIndex: Function;
-    filter: Function; //(select)
-    reject: Function;
-    every: Function; //(all)
-    some: Function; //(any)
-    contains: Function; //(includes)
-    invoke: Function;
-    max: Function;
-    min: Function;
-    sortBy: Function;
-    groupBy: Function;
-    shuffle: Function;
-    toArray: Function;
-    size: Function;
-    first: Function; //(head, take)
-    initial: Function;
-    rest: Function; //(tail, drop)
-    last: Function;
-    without: Function;
-    indexOf: Function;
-    lastIndexOf: Function;
-    isEmpty: Function;
-    chain: Function;
-    difference: Function;
-    sample: Function;
-    partition: Function;
-    countBy: Function;
-    indexBy: Function;
+    forEach: Function, //(each)
+    map: Function, //(collect)
+    reduce: Function, // (foldl, inject)
+    reduceRight: Function, //(foldr)
+    find: Function, // (detect)
+    findIndex: Function,
+    findLastIndex: Function,
+    filter: Function, //(select)
+    reject: Function,
+    every: Function, //(all)
+    some: Function, //(any)
+    contains: Function, //(includes)
+    invoke: Function,
+    max: Function,
+    min: Function,
+    sortBy: Function,
+    groupBy: Function,
+    shuffle: Function,
+    toArray: Function,
+    size: Function,
+    first: Function, //(head, take)
+    initial: Function,
+    rest: Function, //(tail, drop)
+    last: Function,
+    without: Function,
+    indexOf: Function,
+    lastIndexOf: Function,
+    isEmpty: Function,
+    chain: Function,
+    difference: Function,
+    sample: Function,
+    partition: Function,
+    countBy: Function,
+    indexBy: Function,
     // end underscore methods
-    add(models: Array<TModel>, options?: Object): void;
-    remove(models: Array<TModel| string | number>, options?: Object): void;
-    reset(models?: Array<TModel>, options?: Object): void;
-    set(models: Array<TModel>, options?: Object): void;
-    get(id: ?string): ?TModel;
-    at(index: number): ?TModel;
-    push(model: TModel, options?: Object): void;
-    pop(otions?: Object): void;
-    unshift(model: TModel, options?: Object): void;
-    shift(options?: Object): TModel;
-    slice(begin: number, end: number): Array<TModel>;
-    length: number;
-    comparator: string | (attr: string) => any | (attrA: TModel, attrB: TModel) => number;
-    sort(options?: Object): Array<TModel>;
-    pluck(attribute: string): Array<TModel>;
-    where(attributes: {[attributeName: string]: mixed}): Array<TModel>;
-    findWhere(attributes: {[attributeName: string]: mixed}): TModel;
-    url: () => string | string;
-    parse(response: Object, options: Object): Object;
-    clone(): this;
-    fetch(options?: Object): void;
-    create(attributes: Object, options?: Object): void;
+    add(models: TModel | Array<TModel>, options?: Object): void,
+    remove(
+      models: TModel | Backbone$Id | Array<TModel | Backbone$Id>,
+      options?: Object
+    ): ?TModel,
+    reset(models?: Array<TModel>, options?: Object): void,
+    set(models: Array<TModel>, options?: Object): void,
+    get(id: ?Backbone$Id): ?TModel,
+    at(index: number): ?TModel,
+    push(model: TModel, options?: Object): void,
+    pop(otions?: Object): void,
+    unshift(model: TModel, options?: Object): void,
+    shift(options?: Object): TModel,
+    slice(begin: number, end: number): Array<TModel>,
+    length: number,
+    comparator:
+      | string
+      | ((attr: string) => any | ((attrA: TModel, attrB: TModel) => number)),
+    sort(options?: Object): Array<TModel>,
+    pluck(attribute: string): Array<TModel>,
+    where(attributes: { [attributeName: string]: mixed }): Array<TModel>,
+    findWhere(attributes: { [attributeName: string]: mixed }): TModel,
+    url: () => string | string,
+    parse(response: Object, options: Object): Object[],
+    clone(): this,
+    fetch(options?: Object): void,
+    create(attributes: Object, options?: Object): void
   }
-
-
-  /**
-   * Router Class http://backbonejs.org/#Router
-   */
-  declare class Router mixins Events {
-      static extend<P, CP>(instanceProperies: P, classProperties?: CP): Class<Router & P> & CP;
-      routes: {
-        [route: string]: string | ((e: Event) => mixed | void);
-      };
-      constructor(options?: Object): this;
-      initialize(options?: Object): this;
-      route(route: string, name: string, callback?: (e: Event) => mixed | void): this;
-      navigate(fragment: string, options?: { trigger?: boolean, replace?:  boolean}): this;
-      execute(callback: Function, args: Array<mixed>, name: string): void | mixed;
-  }
-
-  /**
-   * History - http://backbonejs.org/#History
-   */
-  declare class History mixins Events {
-    static extend<P, CP>(instanceProperies: P, classProperties?: CP): Class<History & P> & CP;
-    static started: boolean;
-    constructor(options?: Object): this;
-    initialize(options?: Object): this;
-    start(options?: { pushState?: boolean, hashChange?: boolean, root?: string}): this;
-  }
-  declare var history: History;
-
-  /**
-   * Sync - http://backbonejs.org/#Sync
-   */
-  declare function sync(method: CRUDMethod, model: Model, options?: Object):  any; // Should really be a jQuery XHR.
-  declare function ajax(request: Object): any;
-  declare var emulateHTTP: boolean;
-  declare var emulateJSON: boolean;
 
   /**
    * Declaring the export for backbone as well.
    */
   declare class Backbone {
     // subset of the `backbone` module
-    Collection: typeof Collection;
+    Collection: typeof Collection
   }
 
   declare var exports: Backbone;

--- a/definitions/npm/backbone-collection_v1.x.x/test_backbone-collection-v1.x.x.js
+++ b/definitions/npm/backbone-collection_v1.x.x/test_backbone-collection-v1.x.x.js
@@ -1,0 +1,89 @@
+// @flow
+import Backbone from "backbone-model";
+const { Model } = Backbone;
+
+const otherBackbone: typeof Backbone = Backbone.noConflict();
+
+(otherBackbone.Model: typeof Backbone.Model);
+
+// $ExpectError should be a view type
+(otherBackbone.View: void);
+
+(Backbone.version: string);
+
+(Backbone.$: any);
+
+(Backbone._: any);
+
+(Backbone.Events.on: Function);
+interface Fooable extends Model {
+  foo(): string,
+  view: Backbone.View
+}
+const TaskModel: Class<Fooable> = Backbone.Model.extend({
+  foo(): string {
+    return "";
+  }
+});
+
+const instance = new TaskModel();
+instance.fetch({});
+
+instance.get("field");
+instance.get(null);
+
+instance.isNew();
+instance.clone();
+
+class TasksCollection extends Backbone.Collection {
+  model: TaskModel;
+}
+
+const tasks = new TasksCollection();
+
+// $ExpectError
+tasks.toJSON([]);
+
+(tasks.length: number);
+
+// $ExpectError should not allow to be non number
+tasks.length = false;
+
+(tasks.pluck("name"): Array<any>);
+
+// $ExpectError
+(task.pluck(2): Array<any>);
+
+(tasks.forEach: Function);
+(tasks.sync(): Function);
+// $ExpectError
+instance.fetch(null);
+// $ExpectError
+instance.set(10);
+
+instance.toJSON();
+
+// $ExpectError
+(instance.foo(): number);
+
+class TasksRouter extends Backbone.Router {
+  constructor() {
+    super();
+    this.routes = {
+      // $ExpectError
+      "10": false
+    };
+  }
+}
+
+const router = new TasksRouter();
+
+router.route("/create", "createRoute");
+
+// $ExpectError
+router.route("/create", "delete", null);
+
+// $ExpectError
+Backbone.history.start({ root: false });
+
+Backbone.history.start({ pushState: true });

--- a/definitions/npm/backbone-model_v1.x.x/flow_v0.25.x-/backbone-model_v1.x.x.js
+++ b/definitions/npm/backbone-model_v1.x.x/flow_v0.25.x-/backbone-model_v1.x.x.js
@@ -1,92 +1,194 @@
 // subset of the `backbone` module
-declare module 'backbone-model' {
+
+// repeated in backbone, backbone-model, and backbone-collection
+declare type Backbone$Attrs = { [name: string]: any };
+declare type Backbone$Id = number | string;
+
+declare module "backbone-model" {
   declare type eventCallback = (event: Event) => void | mixed;
-  declare type Attrs = {[name: string]: mixed};
-  declare type CRUDMethod = 'create' | 'read' | 'update' | 'delete';
 
   /**
    * Events Module - http://backbonejs.org/#Events
    */
   declare class Events {
     // Not sure the best way of adding these to the declaration files
-    on(event: string, callback: eventCallback, context?: Object): void;
-    once(event: string, callback: eventCallback, context?: Object): void;
-    bind(event: string, callback: eventCallback, context?: Object): void;
-    off(event: ?string, callback?: ?eventCallback, context?: Object): void;
-    unbind(event: ?string, callback?: ?eventCallback, context?: Object): void;
-    trigger(event: string, ...args?: Array<mixed>): void;
-    listenTo(other: Events, event: string, callback: eventCallback): void;
-    listenToOnce(other: Events, event: string, callback: eventCallback): void;
-    stopListening(other: Events, callback?: ?eventCallback, context?: Object): void;
-    static on(event: string, callback: eventCallback, context?: Object): void;
-    static bind(event: string, callback: eventCallback, context?: Object): void;
-    static off(event: ?string, callback?: ?eventCallback, context?: Object): void;
-    static unbind(event: ?string, callback?: ?eventCallback, context?: Object): void;
-    static trigger(event: string, ...args?: Array<mixed>): void;
-    static listenTo(other: Events, event: string, callback: eventCallback): void;
-    static stopListening(other: Events, callback?: ?eventCallback, context?: Object): void;
+    on(event: string, callback: eventCallback, context?: Object): void,
+    once(event: string, callback: eventCallback, context?: Object): void,
+    bind(event: string, callback: eventCallback, context?: Object): void,
+    off(event: ?string, callback?: ?eventCallback, context?: Object): void,
+    unbind(event: ?string, callback?: ?eventCallback, context?: Object): void,
+    trigger(event: string, ...args?: Array<mixed>): void,
+    listenTo(other: Events, event: string, callback: eventCallback): void,
+    listenToOnce(other: Events, event: string, callback: eventCallback): void,
+    stopListening(
+      other: Events,
+      callback?: ?eventCallback,
+      context?: Object
+    ): void,
+    static on(event: string, callback: eventCallback, context?: Object): void,
+    static bind(event: string, callback: eventCallback, context?: Object): void,
+    static off(
+      event: ?string,
+      callback?: ?eventCallback,
+      context?: Object
+    ): void,
+    static unbind(
+      event: ?string,
+      callback?: ?eventCallback,
+      context?: Object
+    ): void,
+    static trigger(event: string, ...args?: Array<mixed>): void,
+    static listenTo(
+      other: Events,
+      event: string,
+      callback: eventCallback
+    ): void,
+    static stopListening(
+      other: Events,
+      callback?: ?eventCallback,
+      context?: Object
+    ): void
   }
 
   /**
    * Model Class - http://backbonejs.org/#Model
    */
   declare type ModelOpts = {
+    [optionName: string]: mixed,
     collection?: Collection<*>,
-    parse?: Function,
-    [optionName: string]: mixed
+    parse?: Function
   };
 
-  declare class Model mixins Events {
-    static extend<P, CP>(instanceProperies: P, classProperties?: CP): Class<Model & P> & CP;
-    constructor(attributes?: Attrs, options?: ModelOpts): void;
-    static initialize(attributes?: Attrs, options?: ModelOpts): void;
-    initialize(): void;
+  declare class Model {
+    static extend<P, CP>(
+      instanceProperies: P,
+      classProperties?: CP
+    ): Class<Model & P> & CP,
+    constructor(attributes?: Backbone$Attrs, options?: ModelOpts): void,
+    static initialize(attributes?: Backbone$Attrs, options?: ModelOpts): void,
+    initialize(): void,
     get(attr: ?string): any,
-    set(attrs: Attrs, options?: Object): this;
-    set(attr: string, value: mixed, options?: Object): this;
-    escape(attr: string): mixed;
-    has(attr: string): boolean;
-    unset(attr: string, options?: { unset?: boolean }): this;
-    clear(options?: Object): this;
-    id: string | number;
-    idAttribute: string;
-    cid: string;
-    cidPrefix: string;
-    attributes: Attrs;
-    changed: ?Object;
-    defaults(attr: Object): void;
-    defaults(attr: () => void): void;
-    toJSON(): Attrs;
+    set(attrs: Backbone$Attrs, options?: Object): this,
+    set(attr: string, value: mixed, options?: Object): this,
+    escape(attr: string): mixed,
+    has(attr: string): boolean,
+    unset(attr: string, options?: { unset?: boolean }): this,
+    clear(options?: Object): this,
+    id: Backbone$Id,
+    idAttribute: string,
+    cid: string,
+    cidPrefix: string,
+    attributes: Backbone$Attrs,
+    changed: Object,
+    defaults(): Backbone$Attrs,
+    toJSON(): Backbone$Attrs,
     //Start jQuery XHR
     // @TODO should return a jQuery XHR, but I cannot define this without the dependency on jquery lib def
-    fetch(options?: Object): any;
-    save(attrs: Attrs, options?: Object): any;
-    save(attr: string, value: mixed, options?: Object): any;
-    destroy(options?: Object): any;
+    fetch(options?: Object): any,
+    save(attrs: Backbone$Attrs, options?: Object): any,
+    save(attr: string, value: mixed, options?: Object): any,
+    destroy(options?: Object): any,
     // End jQuery XHR
-    validate(attrs: Attrs, options?: Object): boolean;
-    validationError: ?Object;
-    isValid(): boolean;
-    url(): string;
-    urlRoot: string | () => string;
-    parse(response: Object, options?: Object): any;
-    clone(): this;
-    isNew(): boolean;
-    hasChanged(attribute?: string): boolean;
-    chagnedAttributes(attributes?: {[attr: string]: mixed}): boolean;
-    previous(attribute: string): mixed;
-    previousAttributes(): Attrs;
+    validate(attrs: Backbone$Attrs, options?: Object): boolean,
+    validationError: ?Object,
+    isValid(): boolean,
+    url(): string,
+    urlRoot: string | (() => string),
+    parse(response: Object, options?: Object): any,
+    clone(): this,
+    isNew(): boolean,
+    hasChanged(attribute?: string): boolean,
+    changedAttributes(attributes?: { [attr: string]: mixed }): boolean,
+    previous(attribute: string): mixed,
+    previousAttributes(): Backbone$Attrs,
     // Start Underscore methods
     // @TODO Underscore Methods should be defined by the library definition
-    keys(): string[];
-    values(): mixed[];
-    pairs: Function;
-    invert: Function;
-    pick: Function;
-    omit: Function;
-    chain(): Function;
-    isEmpty(): boolean;
+    keys(): string[],
+    values(): mixed[],
+    pairs: Function,
+    invert: Function,
+    pick: Function,
+    omit: Function,
+    chain(): Function,
+    isEmpty(): boolean
     // End underscore methods
+  }
+
+  /**
+   * Collection Class - http://backbonejs.org/#Collection
+   */
+  declare class Collection<TModel> {
+    static extend<P, CP>(
+      instanceProperies: P,
+      classProperties?: CP
+    ): Class<Collection<*> & P> & CP,
+    constructor(models?: TModel, options?: Object): void,
+    initialize(models?: TModel, options?: Object): void,
+    model: TModel,
+    modelId(attributes: TModel): string,
+    models: TModel[],
+    toJSON(options?: Object): TModel[],
+    // Underscore Methods
+    // @TODO should be defined by the underscore library defintion and not as generic functions.
+    forEach: Function, //(each)
+    map: Function, //(collect)
+    reduce: Function, // (foldl, inject)
+    reduceRight: Function, //(foldr)
+    find: Function, // (detect)
+    findIndex: Function,
+    findLastIndex: Function,
+    filter: Function, //(select)
+    reject: Function,
+    every: Function, //(all)
+    some: Function, //(any)
+    contains: Function, //(includes)
+    invoke: Function,
+    max: Function,
+    min: Function,
+    sortBy: Function,
+    groupBy: Function,
+    shuffle: Function,
+    toArray: Function,
+    size: Function,
+    first: Function, //(head, take)
+    initial: Function,
+    rest: Function, //(tail, drop)
+    last: Function,
+    without: Function,
+    indexOf: Function,
+    lastIndexOf: Function,
+    isEmpty: Function,
+    chain: Function,
+    difference: Function,
+    sample: Function,
+    partition: Function,
+    countBy: Function,
+    indexBy: Function,
+    // end underscore methods
+    add(models: Array<TModel>, options?: Object): void,
+    remove(models: Array<TModel | Backbone$Id>, options?: Object): void,
+    reset(models?: Array<TModel>, options?: Object): void,
+    set(models: Array<TModel>, options?: Object): void,
+    get(id: ?string): ?TModel,
+    at(index: number): ?TModel,
+    push(model: TModel, options?: Object): void,
+    pop(otions?: Object): void,
+    unshift(model: TModel, options?: Object): void,
+    shift(options?: Object): TModel,
+    slice(begin: number, end: number): Array<TModel>,
+    length: number,
+    comparator:
+      | string
+      | ((attr: string) => any | ((attrA: TModel, attrB: TModel) => number)),
+    sort(options?: Object): Array<TModel>,
+    pluck(attribute: string): Array<TModel>,
+    where(attributes: { [attributeName: string]: mixed }): Array<TModel>,
+    findWhere(attributes: { [attributeName: string]: mixed }): TModel,
+    url: () => string | string,
+    parse(response: Object, options: Object): Object,
+    clone(): this,
+    fetch(options?: Object): void,
+    create(attributes: Object, options?: Object): void
   }
 
   /**
@@ -94,7 +196,7 @@ declare module 'backbone-model' {
    */
   declare class Backbone {
     // subset of the `backbone` module
-    Model: typeof Model;
+    Model: typeof Model
   }
 
   declare var exports: Backbone;

--- a/definitions/npm/backbone-model_v1.x.x/flow_v0.25.x-/backbone-model_v1.x.x.js
+++ b/definitions/npm/backbone-model_v1.x.x/flow_v0.25.x-/backbone-model_v1.x.x.js
@@ -1,0 +1,101 @@
+// subset of the `backbone` module
+declare module 'backbone-model' {
+  declare type eventCallback = (event: Event) => void | mixed;
+  declare type Attrs = {[name: string]: mixed};
+  declare type CRUDMethod = 'create' | 'read' | 'update' | 'delete';
+
+  /**
+   * Events Module - http://backbonejs.org/#Events
+   */
+  declare class Events {
+    // Not sure the best way of adding these to the declaration files
+    on(event: string, callback: eventCallback, context?: Object): void;
+    once(event: string, callback: eventCallback, context?: Object): void;
+    bind(event: string, callback: eventCallback, context?: Object): void;
+    off(event: ?string, callback?: ?eventCallback, context?: Object): void;
+    unbind(event: ?string, callback?: ?eventCallback, context?: Object): void;
+    trigger(event: string, ...args?: Array<mixed>): void;
+    listenTo(other: Events, event: string, callback: eventCallback): void;
+    listenToOnce(other: Events, event: string, callback: eventCallback): void;
+    stopListening(other: Events, callback?: ?eventCallback, context?: Object): void;
+    static on(event: string, callback: eventCallback, context?: Object): void;
+    static bind(event: string, callback: eventCallback, context?: Object): void;
+    static off(event: ?string, callback?: ?eventCallback, context?: Object): void;
+    static unbind(event: ?string, callback?: ?eventCallback, context?: Object): void;
+    static trigger(event: string, ...args?: Array<mixed>): void;
+    static listenTo(other: Events, event: string, callback: eventCallback): void;
+    static stopListening(other: Events, callback?: ?eventCallback, context?: Object): void;
+  }
+
+  /**
+   * Model Class - http://backbonejs.org/#Model
+   */
+  declare type ModelOpts = {
+    collection?: Collection<*>,
+    parse?: Function,
+    [optionName: string]: mixed
+  };
+
+  declare class Model mixins Events {
+    static extend<P, CP>(instanceProperies: P, classProperties?: CP): Class<Model & P> & CP;
+    constructor(attributes?: Attrs, options?: ModelOpts): void;
+    static initialize(attributes?: Attrs, options?: ModelOpts): void;
+    initialize(): void;
+    get(attr: ?string): any,
+    set(attrs: Attrs, options?: Object): this;
+    set(attr: string, value: mixed, options?: Object): this;
+    escape(attr: string): mixed;
+    has(attr: string): boolean;
+    unset(attr: string, options?: { unset?: boolean }): this;
+    clear(options?: Object): this;
+    id: string | number;
+    idAttribute: string;
+    cid: string;
+    cidPrefix: string;
+    attributes: Attrs;
+    changed: ?Object;
+    defaults(attr: Object): void;
+    defaults(attr: () => void): void;
+    toJSON(): Attrs;
+    //Start jQuery XHR
+    // @TODO should return a jQuery XHR, but I cannot define this without the dependency on jquery lib def
+    fetch(options?: Object): any;
+    save(attrs: Attrs, options?: Object): any;
+    save(attr: string, value: mixed, options?: Object): any;
+    destroy(options?: Object): any;
+    // End jQuery XHR
+    validate(attrs: Attrs, options?: Object): boolean;
+    validationError: ?Object;
+    isValid(): boolean;
+    url(): string;
+    urlRoot: string | () => string;
+    parse(response: Object, options?: Object): any;
+    clone(): this;
+    isNew(): boolean;
+    hasChanged(attribute?: string): boolean;
+    chagnedAttributes(attributes?: {[attr: string]: mixed}): boolean;
+    previous(attribute: string): mixed;
+    previousAttributes(): Attrs;
+    // Start Underscore methods
+    // @TODO Underscore Methods should be defined by the library definition
+    keys(): string[];
+    values(): mixed[];
+    pairs: Function;
+    invert: Function;
+    pick: Function;
+    omit: Function;
+    chain(): Function;
+    isEmpty(): boolean;
+    // End underscore methods
+  }
+
+  /**
+   * Declaring the export for backbone as well.
+   */
+  declare class Backbone {
+    // subset of the `backbone` module
+    Model: typeof Model;
+  }
+
+  declare var exports: Backbone;
+}

--- a/definitions/npm/backbone-model_v1.x.x/test_backbone-model-v1.x.x.js
+++ b/definitions/npm/backbone-model_v1.x.x/test_backbone-model-v1.x.x.js
@@ -1,0 +1,39 @@
+// @flow
+import Backbone from "backbone-model";
+const { Model } = Backbone;
+
+// $ExpectError
+(Backbone.$: any);
+
+// $ExpectError
+(Backbone._: any);
+
+// $ExpectError
+(Backbone.Events.on: Function);
+
+interface Fooable extends Model {
+  foo(): string,
+  // $ExpectError
+  view: Backbone.View
+}
+
+const TaskModel: Class<Fooable> = Backbone.Model.extend({
+  foo(): string {
+    return "";
+  }
+});
+
+const instance = new TaskModel();
+instance.fetch({});
+
+instance.get("field");
+instance.get(null);
+
+instance.isNew();
+instance.clone();
+
+export default class Entity extends Backbone.Model {
+  constructor(attrs: Backbone$Attrs = {}, options: Object = {}): void {
+    super(attrs, options);
+  }
+}

--- a/definitions/npm/backbone_v1.x.x/flow_v0.20.x-/backbone_v1.x.x.js
+++ b/definitions/npm/backbone_v1.x.x/flow_v0.20.x-/backbone_v1.x.x.js
@@ -1,3 +1,7 @@
+// repeated in backbone, backbone-model, and backbone-collection
+declare type Backbone$Attrs = { [name: string]: any };
+declare type Backbone$Id = number | string;
+
 declare module 'backbone' {
   declare var $: any; // @TODO this is no correct, but it is difficult to require another definition from here.
   declare var _: any; // @TODO this is no correct, but it is difficult to require another definition from here.
@@ -39,131 +43,136 @@ declare module 'backbone' {
     [optionName: string]: mixed
   };
 
-  declare class Model mixins Events {
-    static extend<P, CP>(instanceProperies: P, classProperties?: CP): Class<Model & P> & CP;
-    constructor(attributes?: Attrs, options?: ModelOpts): void;
-    static initialize(attributes?: Attrs, options?: ModelOpts): void;
-    initialize(): void;
+declare class Model {
+    static extend<P, CP>(
+      instanceProperies: P,
+      classProperties?: CP
+    ): Class<Model & P> & CP,
+    constructor(attributes?: Backbone$Attrs, options?: ModelOpts): void,
+    static initialize(attributes?: Backbone$Attrs, options?: ModelOpts): void,
+    initialize(): void,
     get(attr: ?string): any,
-    set(attrs: Attrs, options?: Object): this;
-    set(attr: string, value: mixed, options?: Object): this;
-    escape(attr: string): mixed;
-    has(attr: string): boolean;
-    unset(attr: string, options?: { unset?: boolean }): this;
-    clear(options?: Object): this;
-    id: string | number;
-    idAttribute: string;
-    cid: string;
-    cidPrefix: string;
-    attributes: Attrs;
-    changed: ?Object;
-    defaults(attr: Object): void;
-    defaults(attr: () => void): void;
-    toJSON(): Attrs;
-    sync: sync;
+    set(attrs: Backbone$Attrs, options?: Object): this,
+    set(attr: string, value: mixed, options?: Object): this,
+    escape(attr: string): mixed,
+    has(attr: string): boolean,
+    unset(attr: string, options?: { unset?: boolean }): this,
+    clear(options?: Object): this,
+    id: Backbone$Id,
+    idAttribute: string,
+    cid: string,
+    cidPrefix: string,
+    attributes: Backbone$Attrs,
+    changed: Object,
+    defaults(): Backbone$Attrs,
+    toJSON(): Backbone$Attrs,
     //Start jQuery XHR
     // @TODO should return a jQuery XHR, but I cannot define this without the dependency on jquery lib def
-    fetch(options?: Object): any;
-    save(attrs: Attrs, options?: Object): any;
-    save(attr: string, value: mixed, options?: Object): any;
-    destroy(options?: Object): any;
+    fetch(options?: Object): any,
+    save(attrs: Backbone$Attrs, options?: Object): any,
+    save(attr: string, value: mixed, options?: Object): any,
+    destroy(options?: Object): any,
     // End jQuery XHR
-    validate(attrs: Attrs, options?: Object): boolean;
-    validationError: ?Object;
-    isValid(): boolean;
-    url(): string;
-    urlRoot: string | () => string;
-    parse(response: Object, options?: Object): any;
-    clone(): this;
-    isNew(): boolean;
-    hasChanged(attribute?: string): boolean;
-    chagnedAttributes(attributes?: {[attr: string]: mixed}): boolean;
-    previous(attribute: string): mixed;
-    previousAttributes(): Attrs;
+    validate(attrs: Backbone$Attrs, options?: Object): boolean,
+    validationError: ?Object,
+    isValid(): boolean,
+    url(): string,
+    urlRoot: string | (() => string),
+    parse(response: Object, options?: Object): any,
+    clone(): this,
+    isNew(): boolean,
+    hasChanged(attribute?: string): boolean,
+    changedAttributes(attributes?: { [attr: string]: mixed }): boolean,
+    previous(attribute: string): mixed,
+    previousAttributes(): Backbone$Attrs,
     // Start Underscore methods
     // @TODO Underscore Methods should be defined by the library definition
-    keys(): string[];
-    values(): mixed[];
-    pairs: Function;
-    invert: Function;
-    pick: Function;
-    omit: Function;
-    chain(): Function;
-    isEmpty(): boolean;
+    keys(): string[],
+    values(): mixed[],
+    pairs: Function,
+    invert: Function,
+    pick: Function,
+    omit: Function,
+    chain(): Function,
+    isEmpty(): boolean
     // End underscore methods
   }
 
   /**
    * Collection Class - http://backbonejs.org/#Collection
    */
-  declare class Collection<TModel> mixins Events {
-    static extend<P, CP>(instanceProperies: P, classProperties?: CP): Class<Collection<*> & P> & CP;
-    constructor(models?: TModel, options?: Object): this;
-    initialize(models?: TModel, options?: Object): this;
-    model: TModel;
-    modelId(attributes: TModel): string;
-    models: TModel[];
-    toJSON(options?: Object): TModel[];
-    sync: sync;
+  declare class Collection<TModel> {
+    static extend<P, CP>(
+      instanceProperies: P,
+      classProperties?: CP
+    ): Class<Collection<*> & P> & CP,
+    constructor(models?: TModel, options?: Object): void,
+    initialize(models?: TModel, options?: Object): void,
+    model: TModel,
+    modelId(attributes: TModel): string,
+    models: TModel[],
+    toJSON(options?: Object): TModel[],
     // Underscore Methods
     // @TODO should be defined by the underscore library defintion and not as generic functions.
-    forEach: Function; //(each)
-    map: Function; //(collect)
-    reduce: Function; // (foldl, inject)
-    reduceRight: Function; //(foldr)
-    find: Function; // (detect)
-    findIndex: Function;
-    findLastIndex: Function;
-    filter: Function; //(select)
-    reject: Function;
-    every: Function; //(all)
-    some: Function; //(any)
-    contains: Function; //(includes)
-    invoke: Function;
-    max: Function;
-    min: Function;
-    sortBy: Function;
-    groupBy: Function;
-    shuffle: Function;
-    toArray: Function;
-    size: Function;
-    first: Function; //(head, take)
-    initial: Function;
-    rest: Function; //(tail, drop)
-    last: Function;
-    without: Function;
-    indexOf: Function;
-    lastIndexOf: Function;
-    isEmpty: Function;
-    chain: Function;
-    difference: Function;
-    sample: Function;
-    partition: Function;
-    countBy: Function;
-    indexBy: Function;
+    forEach: Function, //(each)
+    map: Function, //(collect)
+    reduce: Function, // (foldl, inject)
+    reduceRight: Function, //(foldr)
+    find: Function, // (detect)
+    findIndex: Function,
+    findLastIndex: Function,
+    filter: Function, //(select)
+    reject: Function,
+    every: Function, //(all)
+    some: Function, //(any)
+    contains: Function, //(includes)
+    invoke: Function,
+    max: Function,
+    min: Function,
+    sortBy: Function,
+    groupBy: Function,
+    shuffle: Function,
+    toArray: Function,
+    size: Function,
+    first: Function, //(head, take)
+    initial: Function,
+    rest: Function, //(tail, drop)
+    last: Function,
+    without: Function,
+    indexOf: Function,
+    lastIndexOf: Function,
+    isEmpty: Function,
+    chain: Function,
+    difference: Function,
+    sample: Function,
+    partition: Function,
+    countBy: Function,
+    indexBy: Function,
     // end underscore methods
-    add(models: Array<TModel>, options?: Object): void;
-    remove(models: Array<TModel| string | number>, options?: Object): void;
-    reset(models?: Array<TModel>, options?: Object): void;
-    set(models: Array<TModel>, options?: Object): void;
-    get(id: ?string): ?TModel;
-    at(index: number): ?TModel;
-    push(model: TModel, options?: Object): void;
-    pop(otions?: Object): void;
-    unshift(model: TModel, options?: Object): void;
-    shift(options?: Object): TModel;
-    slice(begin: number, end: number): Array<TModel>;
-    length: number;
-    comparator: string | (attr: string) => any | (attrA: TModel, attrB: TModel) => number;
-    sort(options?: Object): Array<TModel>;
-    pluck(attribute: string): Array<TModel>;
-    where(attributes: {[attributeName: string]: mixed}): Array<TModel>;
-    findWhere(attributes: {[attributeName: string]: mixed}): TModel;
-    url: () => string | string;
-    parse(response: Object, options: Object): Object;
-    clone(): this;
-    fetch(options?: Object): void;
-    create(attributes: Object, options?: Object): void;
+    add(models: Array<TModel>, options?: Object): void,
+    remove(models: Array<TModel | Backbone$Id>, options?: Object): void,
+    reset(models?: Array<TModel>, options?: Object): void,
+    set(models: Array<TModel>, options?: Object): void,
+    get(id: ?string): ?TModel,
+    at(index: number): ?TModel,
+    push(model: TModel, options?: Object): void,
+    pop(otions?: Object): void,
+    unshift(model: TModel, options?: Object): void,
+    shift(options?: Object): TModel,
+    slice(begin: number, end: number): Array<TModel>,
+    length: number,
+    comparator:
+      | string
+      | ((attr: string) => any | ((attrA: TModel, attrB: TModel) => number)),
+    sort(options?: Object): Array<TModel>,
+    pluck(attribute: string): Array<TModel>,
+    where(attributes: { [attributeName: string]: mixed }): Array<TModel>,
+    findWhere(attributes: { [attributeName: string]: mixed }): TModel,
+    url: () => string | string,
+    parse(response: Object, options: Object): Object,
+    clone(): this,
+    fetch(options?: Object): void,
+    create(attributes: Object, options?: Object): void
   }
 
 

--- a/definitions/npm/backbone_v1.x.x/flow_v0.20.x-/backbone_v1.x.x.js
+++ b/definitions/npm/backbone_v1.x.x/flow_v0.20.x-/backbone_v1.x.x.js
@@ -44,7 +44,7 @@ declare module 'backbone' {
     constructor(attributes?: Attrs, options?: ModelOpts): void;
     static initialize(attributes?: Attrs, options?: ModelOpts): void;
     initialize(): void;
-    get(attr: string): any;
+    get(attr: ?string): any,
     set(attrs: Attrs, options?: Object): this;
     set(attr: string, value: mixed, options?: Object): this;
     escape(attr: string): mixed;
@@ -74,12 +74,12 @@ declare module 'backbone' {
     url(): string;
     urlRoot: string | () => string;
     parse(response: Object, options?: Object): any;
-    clone: this;
-    isNew: boolean;
+    clone(): this;
+    isNew(): boolean;
     hasChanged(attribute?: string): boolean;
     chagnedAttributes(attributes?: {[attr: string]: mixed}): boolean;
     previous(attribute: string): mixed;
-    previousAttirbutes(): Attrs;
+    previousAttributes(): Attrs;
     // Start Underscore methods
     // @TODO Underscore Methods should be defined by the library definition
     keys(): string[];
@@ -143,10 +143,10 @@ declare module 'backbone' {
     indexBy: Function;
     // end underscore methods
     add(models: Array<TModel>, options?: Object): void;
-    remove(models: Array<TModel>, options?: Object): void;
+    remove(models: Array<TModel| string | number>, options?: Object): void;
     reset(models?: Array<TModel>, options?: Object): void;
     set(models: Array<TModel>, options?: Object): void;
-    get(id: string): ?TModel;
+    get(id: ?string): ?TModel;
     at(index: number): ?TModel;
     push(model: TModel, options?: Object): void;
     pop(otions?: Object): void;

--- a/definitions/npm/backbone_v1.x.x/test_backbone-v1.x.x.js
+++ b/definitions/npm/backbone_v1.x.x/test_backbone-v1.x.x.js
@@ -30,7 +30,11 @@ const TaskModel: Class<Fooable> = Backbone.Model.extend({
 const instance = new TaskModel();
 instance.fetch({});
 
+instance.get('field');
+instance.get(null);
 
+instance.isNew();
+instance.clone();
 
 class TasksCollection extends Backbone.Collection {
     model: TaskModel;


### PR DESCRIPTION
https://www.npmjs.com/package/backbone-model and https://www.npmjs.com/package/backbone-collection provide subsets of https://www.npmjs.com/package/backbone

This adds rules for those. And fixes some in the existing `backbone` one.

Is there a way to DRY this out?