### PR TITLE
Allow non-string arguments in chalk libdef

### DIFF
--- a/definitions/npm/chalk_v1.x.x/flow_v0.21.x-/chalk_v1.x.x.js
+++ b/definitions/npm/chalk_v1.x.x/flow_v0.21.x-/chalk_v1.x.x.js
@@ -3,7 +3,7 @@ type $npm$chalk$StyleElement = {
   close: string;
 };
 
-type $npm$chalk$Chain = $npm$chalk$Style & (...text: string[]) => string;
+type $npm$chalk$Chain = $npm$chalk$Style & (...text: any[]) => string;
 
 type $npm$chalk$Style = {
   // General


### PR DESCRIPTION
Chalk colour methods [coerce all arguments to string](https://github.com/chalk/chalk/blob/9b60021fa605a6ebf62fbfd42d02c45597b10e6e/index.js#L65-L70), so the libdef should accept `any`.