### PR TITLE
Fix getActions() method in redux-mock-store libdef

### DIFF
--- a/definitions/npm/redux-mock-store_v1.2.x/flow_v0.34.x-/redux-mock-store_v1.2.x.js
+++ b/definitions/npm/redux-mock-store_v1.2.x/flow_v0.34.x-/redux-mock-store_v1.2.x.js
@@ -1,22 +1,28 @@
-// @flow
-
 declare module 'redux-mock-store' {
-  declare type Middlewares = ?Array<Function>;
-  declare type Action = { type: string };
-  declare type Actions = Array<Action>;
-  declare interface Store<State> {
+  /*
+    S = State
+    A = Action
+  */
+
+  declare type mockStore = {
+    <S, A>(state: S): mockStoreWithoutMiddleware<S, A>
+  };
+  declare type mockStoreWithoutMiddleware<S, A> = {
+    getState(): S,
+    getActions(): Array<A>,
+    dispatch(action: A): A,
     clearActions(): void,
-    dispatch(action: Action): Action,
-    getActions(): Actions,
-    getState(): State,
-    replaceReducer(nextReducer: Function): void,
-    subscribe(callback: Function): Function
-  }
-  declare function mockStore<S>(state: S): Store<S>;
-  declare function configureStore<S>(
-    middlewares: Middlewares
-  ): (state: S) => Store<S>;
-  declare module.exports: <S>(
-    middlewares: Middlewares
-  ) => (state: S) => Store<S>;
+    subscribe(callback: Function): void,
+    replaceReducer(nextReducer: Function): void
+  };
+
+  declare function exports(middlewares: ?Array<Function>): mockStore;
+}
+
+// Filename aliases
+declare module 'redux-mock-store/src/index' {
+  declare module.exports: $Exports<'redux-mock-store'>;
+}
+declare module 'redux-mock-store/src/index.js' {
+  declare module.exports: $Exports<'redux-mock-store'>;
 }


### PR DESCRIPTION
Fixes #842 as the previous amendment didn't fix it the way I was expecting.