### PR TITLE
Add DragDropContextProvider to react-dnd_v2.x.x

### DIFF
--- a/definitions/npm/react-dnd_v2.x.x/flow_v0.23.x-/react-dnd_v2.x.x.js
+++ b/definitions/npm/react-dnd_v2.x.x/flow_v0.23.x-/react-dnd_v2.x.x.js
@@ -200,6 +200,15 @@ type DragDropContext = <D, P, S, C: React$Component<D, P, S>>(
   backend: mixed
 ) => (component: Class<C>) => Class<ContextComponent<C, D, P, S>>;
 
+// Drag Drop Context Provider
+// ----------------------------------------------------------------------
+type DragDropContextProviderProps = {
+  backend: mixed,
+  window?: EventTarget
+};
+
+type DragDropContextProvider = Class<React$Component<void, DragDropContextProviderProps, void>>;
+
 // Top-level API
 // ----------------------------------------------------------------------
 declare module 'react-dnd' {
@@ -207,6 +216,7 @@ declare module 'react-dnd' {
     DragSource: DragSource,
     DropTarget: DropTarget,
     DragLayer: DragLayer,
-    DragDropContext: DragDropContext
+    DragDropContext: DragDropContext,
+    DragDropContextProvider: DragDropContextProvider
   }
 }

--- a/definitions/npm/react-dnd_v2.x.x/test_react-dnd-v2.js
+++ b/definitions/npm/react-dnd_v2.x.x/test_react-dnd-v2.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { DragSource, DropTarget, DragLayer, DragDropContext } from 'react-dnd';
+import { DragSource, DropTarget, DragLayer, DragDropContext, DragDropContextProvider } from 'react-dnd';
 
 // Test Drag Source
 // ----------------------------------------------------------------------
@@ -253,6 +253,18 @@ const DndBoard = DragDropContext({})(Board);
 (DndBoard: Class<ContextComponent<Board, BoardProps, BoardProps, void>>);
 // $ExpectError
 (DndBoard: string);
+
+// Test Drag Drop Context Provider
+// ----------------------------------------------------------------------
+<DragDropContextProvider backend={{}}/>;
+// $ExpectError
+<DragDropContextProvider/>;
+
+<DragDropContextProvider backend={{}} window={window}/>;
+<DragDropContextProvider backend={{}} window={document}/>;
+<DragDropContextProvider backend={{}} window={document.createElement('div')}/>;
+// $ExpectError
+<DragDropContextProvider backend={{}} window={{}}/>;
 
 // Test Functional React Components
 // ----------------------------------------------------------------------


### PR DESCRIPTION
Add missing definition of DragDropContextProvider

Reference:
https://github.com/react-dnd/react-dnd/blob/master/docs/01%20Top%20Level%20API/DragDropContextProvider.md