### PR TITLE
declare the default export for uuid

### DIFF
--- a/definitions/npm/uuid_v3.x.x/flow_v0.33.x-/uuid_v3.x.x.js
+++ b/definitions/npm/uuid_v3.x.x/flow_v0.33.x-/uuid_v3.x.x.js
@@ -9,4 +9,5 @@ declare module 'uuid' {
     random?: number[],
     rng?: () => number[] | Buffer,
   |}, buffer?: number[] | Buffer, offset?: number): string;
+  declare module.exports: v4;
 }


### PR DESCRIPTION
UUID exposes v4 as it's core function. Currently, calling `uuid()` will result in a flow error, as it expects either `uuid.v1()` or `uuid.v4()` explicitly.