### PR TITLE
Fix jest on flow 0.46+

### DIFF
--- a/definitions/npm/jest_v18.x.x/flow_v0.33.x-/jest_v18.x.x.js
+++ b/definitions/npm/jest_v18.x.x/flow_v0.33.x-/jest_v18.x.x.js
@@ -286,7 +286,7 @@ type JestObjectType = {
    * The third argument can be used to create virtual mocks -- mocks of modules
    * that don't exist anywhere in the system.
    */
-  mock(moduleName: string, moduleFactory?: any): JestObjectType,
+  mock(moduleName: string, moduleFactory?: any, options?: Object): JestObjectType,
   /**
    * Resets the module registry - the cache of all required modules. This is
    * useful to isolate modules where local state might conflict between tests.

--- a/definitions/npm/jest_v19.x.x/flow_v0.33.x-/jest_v19.x.x.js
+++ b/definitions/npm/jest_v19.x.x/flow_v0.33.x-/jest_v19.x.x.js
@@ -296,7 +296,7 @@ type JestObjectType = {
    * The third argument can be used to create virtual mocks -- mocks of modules
    * that don't exist anywhere in the system.
    */
-  mock(moduleName: string, moduleFactory?: any): JestObjectType,
+  mock(moduleName: string, moduleFactory?: any, options?: Object): JestObjectType,
   /**
    * Resets the module registry - the cache of all required modules. This is
    * useful to isolate modules where local state might conflict between tests.

--- a/definitions/npm/jest_v20.x.x/flow_v0.33.x-/jest_v20.x.x.js
+++ b/definitions/npm/jest_v20.x.x/flow_v0.33.x-/jest_v20.x.x.js
@@ -304,7 +304,7 @@ type JestObjectType = {
    * The third argument can be used to create virtual mocks -- mocks of modules
    * that don't exist anywhere in the system.
    */
-  mock(moduleName: string, moduleFactory?: any): JestObjectType,
+  mock(moduleName: string, moduleFactory?: any, options?: Object): JestObjectType,
   /**
    * Resets the module registry - the cache of all required modules. This is
    * useful to isolate modules where local state might conflict between tests.


### PR DESCRIPTION
With added function arity check in 0.46+ we need to set type of the third argument of jest.mock function explicitly.