### PR TITLE
Accept string as valid collection type in lodash’s _.size

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.28.x-v0.37.x/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.28.x-v0.37.x/lodash_v4.x.x.js
@@ -217,7 +217,7 @@ declare module 'lodash' {
     sampleSize<V, T: Object>(object: T, n?: number): Array<V>;
     shuffle<T>(array: ?Array<T>): Array<T>;
     shuffle<V, T: Object>(object: T): Array<V>;
-    size(collection: Array<any>|Object): number;
+    size(collection: Array<any>|Object|string): number;
     some<T>(array: ?Array<T>, predicate?: Predicate<T>): bool;
     some<A, T: {[id: string]: A}>(object?: ?T, predicate?: OPredicate<A, T>): bool;
     sortBy<T>(array: ?Array<T>, ...iteratees?: Array<Iteratee<T>>): Array<T>;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.38.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.38.x-/lodash_v4.x.x.js
@@ -218,7 +218,7 @@ declare module 'lodash' {
     sampleSize<V, T: Object>(object: T, n?: number): Array<V>;
     shuffle<T>(array: ?Array<T>): Array<T>;
     shuffle<V, T: Object>(object: T): Array<V>;
-    size(collection: Array<any>|Object): number;
+    size(collection: Array<any>|Object|string): number;
     some<T>(array: ?Array<T>, predicate?: Predicate<T>): bool;
     some<A, T: {[id: string]: A}>(object?: ?T, predicate?: OPredicate<A, T>): bool;
     sortBy<T>(array: ?Array<T>, ...iteratees?: Array<Iteratee<T>>): Array<T>;


### PR DESCRIPTION
Per [lodash size docs](https://lodash.com/docs/4.17.4#size) `string` is a valid type for the collection argument