### PR TITLE
include milliseconds argument of Jasmine tick()

### DIFF
--- a/definitions/npm/jasmine_v2.4.x/flow_all/jasmine_v2.4.x.js
+++ b/definitions/npm/jasmine_v2.4.x/flow_all/jasmine_v2.4.x.js
@@ -56,7 +56,7 @@ type JasmineSpyType = {
 type JasmineClockType = {
   install(): void;
   uninstall(): void;
-  tick(): void;
+  tick(milliseconds: number): void;
   mockDate(date: Date): void;
 }
 

--- a/definitions/npm/jest_v14.x.x/flow_v0.23.x-/jest_v14.x.x.js
+++ b/definitions/npm/jest_v14.x.x/flow_v0.23.x-/jest_v14.x.x.js
@@ -32,7 +32,7 @@ type JestCallsType = {
 type JestClockType = {
   install(): void;
   mockDate(date: Date): void;
-  tick(): void;
+  tick(milliseconds: number): void;
   uninstall(): void;
 }
 

--- a/definitions/npm/jest_v16.x.x/flow_v0.33.x-/jest_v16.x.x.js
+++ b/definitions/npm/jest_v16.x.x/flow_v0.33.x-/jest_v16.x.x.js
@@ -29,7 +29,7 @@ type JestCallsType = {
 type JestClockType = {
   install(): void;
   mockDate(date: Date): void;
-  tick(): void;
+  tick(milliseconds: number): void;
   uninstall(): void;
 }
 

--- a/definitions/npm/jest_v17.x.x/flow_v0.33.x-/jest_v17.x.x.js
+++ b/definitions/npm/jest_v17.x.x/flow_v0.33.x-/jest_v17.x.x.js
@@ -74,7 +74,7 @@ type JestCallsType = {
 type JestClockType = {
   install(): void,
   mockDate(date: Date): void,
-  tick(): void,
+  tick(milliseconds: number): void,
   uninstall(): void,
 }
 

--- a/definitions/npm/jest_v18.x.x/flow_v0.33.x-/jest_v18.x.x.js
+++ b/definitions/npm/jest_v18.x.x/flow_v0.33.x-/jest_v18.x.x.js
@@ -74,7 +74,7 @@ type JestCallsType = {
 type JestClockType = {
   install(): void,
   mockDate(date: Date): void,
-  tick(): void,
+  tick(milliseconds: number): void,
   uninstall(): void,
 }
 

--- a/definitions/npm/jest_v19.x.x/flow_v0.33.x-/jest_v19.x.x.js
+++ b/definitions/npm/jest_v19.x.x/flow_v0.33.x-/jest_v19.x.x.js
@@ -74,7 +74,7 @@ type JestCallsType = {
 type JestClockType = {
   install(): void,
   mockDate(date: Date): void,
-  tick(): void,
+  tick(milliseconds: number): void,
   uninstall(): void,
 }
 

--- a/definitions/npm/jest_v20.x.x/flow_v0.33.x-/jest_v20.x.x.js
+++ b/definitions/npm/jest_v20.x.x/flow_v0.33.x-/jest_v20.x.x.js
@@ -74,7 +74,7 @@ type JestCallsType = {
 type JestClockType = {
   install(): void,
   mockDate(date: Date): void,
-  tick(): void,
+  tick(milliseconds: number): void,
   uninstall(): void
 };
 

--- a/definitions/npm/react-scripts_v0.7.x/flow_v0.33.x-/react-scripts_v0.7.x.js
+++ b/definitions/npm/react-scripts_v0.7.x/flow_v0.33.x-/react-scripts_v0.7.x.js
@@ -29,7 +29,7 @@ type JestCallsType = {
 type JestClockType = {
   install(): void;
   mockDate(date: Date): void;
-  tick(): void;
+  tick(milliseconds: number): void;
   uninstall(): void;
 }
 


### PR DESCRIPTION
Jasmine clock `tick()` takes the number of milliseconds to tick
https://github.com/jasmine/jasmine/blob/9cb2f06aa665870dbd5df5fd58a35863738961b3/src/core/Clock.js#L117