### PR TITLE
Update expect's toMatch assertion to accept any pattern

### DIFF
--- a/definitions/npm/expect_v1.x.x/flow_v0.43.x-/expect_v1.x.x.js
+++ b/definitions/npm/expect_v1.x.x/flow_v0.43.x-/expect_v1.x.x.js
@@ -31,8 +31,8 @@ declare class $npm$expect$Expectation<T> {
   toNotThrow<E>(error?: $npm$expect$ErrorMatcher<E>, message?: string): this;
   toBeA(constructor: mixed, message?: string): this;
   toNotBeA(constructor: mixed, message?: string): this;
-  toMatch(pattern: RegExp | Object, message?: string): this;
-  toNotMatch(pattern: RegExp | Object, message?: string): this;
+  toMatch(pattern: any, message?: string): this;
+  toNotMatch(pattern: any, message?: string): this;
 
   toBeLessThan(n: T & number, message?: string): this;
   toBeLessThanOrEqualTo(n: T & number, message?: string): this;


### PR DESCRIPTION
Updating libdefs broke some tests of mine which were passing an Array to `toMatch`.

This assertion uses [tmatch](https://github.com/tapjs/tmatch), which accepts just about everything.