### PR TITLE
Handle Function in redux-actions/handleActions

### DIFF
--- a/definitions/npm/redux-actions_v2.x.x/flow_v0.34.x-/redux-actions_v2.x.x.js
+++ b/definitions/npm/redux-actions_v2.x.x/flow_v0.34.x-/redux-actions_v2.x.x.js
@@ -81,7 +81,7 @@ declare module 'redux-actions' {
   ): Reducer<State, Action>;
 
   declare function handleActions<State, Action>(
-    reducers: { [key: string]: Reducer<State, Action> | ReducerMap<State, Action> },
+    reducers: { [key: string | Function]: Reducer<State, Action> | ReducerMap<State, Action> },
     defaultState?: State
   ): Reducer<State, Action>;
 


### PR DESCRIPTION
`handleActions` in `redux-actions` can handle anything with `toString()` method as a action type (https://github.com/acdlite/redux-actions/blob/master/src/handleAction.js#L11). In fact, actions created using `createAction` has `toString()` defined to return action type (https://github.com/acdlite/redux-actions/blob/master/src/createAction.js#L39).

I extended type to `string | Function`, because these two are the most common (either action type or action itself).