### PR TITLE
Update main moment() function for new arguments

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.34.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.34.x-/moment_v2.x.x.js
@@ -102,7 +102,12 @@ declare class moment$MomentDuration {
 declare class moment$Moment {
   static ISO_8601: string;
   static (string?: string, format?: string|Array<string>, locale?: string, strict?: bool): moment$Moment;
-  static (initDate: ?Object|number|Date|Array<number>|moment$Moment|string): moment$Moment;
+  static (
+      initDate: ?Object|number|Date|Array<number>|moment$Moment|string,
+      validFormats?: ?Array<string>|string,
+      locale?: ?boolean|string,
+      strict?: ?boolean|string
+  ): moment$Moment;
   static unix(seconds: number): moment$Moment;
   static utc(): moment$Moment;
   static utc(number: number|Array<number>): moment$Moment;


### PR DESCRIPTION
As per this documentation: https://momentjs.com/docs/#/parsing/ moment() 2.3.0 now supports additional parameters in its main initialize function. This PR adds support for them.