### PR TITLE
Fix jest v20 toThrow / toThrowError

### DIFF
--- a/definitions/npm/jest_v20.x.x/flow_v0.33.x-/jest_v20.x.x.js
+++ b/definitions/npm/jest_v20.x.x/flow_v0.33.x-/jest_v20.x.x.js
@@ -230,13 +230,13 @@ type JestExpectType = {
   toMatchSnapshot(name?: string): void,
   /**
    * Use .toThrow to test that a function throws when it is called.
+   * If you want to test that a specific error gets thrown, you can provide an
+   * argument to toThrow. The argument can be a string for the error message,
+   * a class for the error, or a regex that should match the error.
+   *
+   * Alias: .toThrowError
    */
-  toThrow(message?: string | Error): void,
-  /**
-   * Use .toThrowError to test that a function throws a specific error when it
-   * is called. The argument can be a string for the error message, a class for
-   * the error, or a regex that should match the error.
-   */
+  toThrow(message?: string | Error | RegExp): void,
   toThrowError(message?: string | Error | RegExp): void,
   /**
    * Use .toThrowErrorMatchingSnapshot to test that a function throws a error

--- a/definitions/npm/jest_v20.x.x/test_jest-v20.x.x.js
+++ b/definitions/npm/jest_v20.x.x/test_jest-v20.x.x.js
@@ -72,6 +72,10 @@ expect(() => {
     throw err;
 }).toThrowError(err);
 
+expect(() => {}).toThrow('err');
+expect(() => {}).toThrow(/err/);
+expect(() => {}).toThrow(err);
+
 // Test method chaining fixes
 jest
   .doMock('testModule1', () => { })


### PR DESCRIPTION
Jest v20 made `.toThrow` and `.toThrowError` aliases.

See jest documentation : https://facebook.github.io/jest/docs/expect.html#tothrowerror