### PR TITLE
[koa] Made second argument in cookies.get optional

### DIFF
--- a/definitions/npm/koa_v2.x.x/flow_v0.47.x-/koa_v2.x.x.js
+++ b/definitions/npm/koa_v2.x.x/flow_v0.47.x-/koa_v2.x.x.js
@@ -204,7 +204,7 @@ declare module 'koa' {
     overwrite: boolean, //  whether to overwrite previously set cookies of the same name (false by default).
   };
   declare type Cookies = {
-    get: (name: string, options: {signed: boolean}) => string|void,
+    get: (name: string, options?: {signed: boolean}) => string|void,
     set: ((name: string, value: string, options?: CookiesSetOptions) => Context)&
     // delete cookie (an outbound header with an expired date is used.)
     ( (name: string) => Context),


### PR DESCRIPTION
Since it isn't required. See [docs](http://koajs.com/#ctx-cookies-get-name-options-).