### PR TITLE
keyBy accepts object map of any type

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/lodash_v4.x.x.js
@@ -198,7 +198,7 @@ declare module 'lodash' {
     invokeMap<T>(array: ?Array<T>, path: ((value: T) => Array<string>|string)|Array<string>|string, ...args?: Array<any>): Array<any>;
     invokeMap<T: Object>(object: T, path: ((value: any) => Array<string>|string)|Array<string>|string, ...args?: Array<any>): Array<any>;
     keyBy<T, V>(array: ?Array<T>, iteratee?: ValueOnlyIteratee<T>): {[key: V]: ?T};
-    keyBy<V, A, T: {[id: string]: A}>(object: T, iteratee?: ValueOnlyIteratee<A>): {[key: V]: ?A};
+    keyBy<V, A, I, T: {[id: I]: A}>(object: T, iteratee?: ValueOnlyIteratee<A>): {[key: V]: ?A};
     map<T, U>(array: ?Array<T>, iteratee?: MapIterator<T, U>): Array<U>;
     map<V, T: Object, U>(object: ?T, iteratee?: OMapIterator<V, T, U>): Array<U>;
     map(str: ?string, iteratee?: (char: string, index: number, str: string) => any): string;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/test_lodash-v4.x.x.js
@@ -118,6 +118,11 @@ _.keyBy([
   { 'dir': 'right', 'code': 100 }
 ], 'dir');
 
+// Example of keying a map of objects by a number type
+type ById<T: Object> = { [number]: T }
+var group: ById<Object> = { 1: { id: 4 }, 2: { id: 4 }, 3: { id: 7 } }
+_.keyBy(group, 'id')
+
 
 /**
  * _.map examples from the official doc

--- a/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/test_lodash-v4.x.x.js
@@ -119,8 +119,9 @@ _.keyBy([
 ], 'dir');
 
 // Example of keying a map of objects by a number type
-type ById<T: Object> = { [number]: T }
-var group: ById<Object> = { 1: { id: 4 }, 2: { id: 4 }, 3: { id: 7 } }
+type KeyByTest$ByNumber<T: Object> = { [number]: T }
+type KeyByTest$Record = { id: number }
+var group: KeyByTest$ByNumber<KeyByTest$Record> = { 1: { id: 4 }, 2: { id: 4 }, 3: { id: 7 } }
 _.keyBy(group, 'id')
 
 

--- a/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/test_lodash-v4.x.x.js
@@ -129,7 +129,7 @@ var keyByTest_map: KeyByTest$ByNumber<KeyByTest$Record> = {
   [keyByTest_array[2].id]: keyByTest_array[2],
 }
 
-var keyByTest$map2: KeyByTest$ByNumberMaybe<?KeyByTest$Record> = _.keyBy(keyByTest$map, 'id')
+var keyByTest_map2: KeyByTest$ByNumberMaybe<?KeyByTest$Record> = _.keyBy(keyByTest_map, 'id')
 
 
 /**

--- a/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/test_lodash-v4.x.x.js
@@ -121,8 +121,14 @@ _.keyBy([
 // Example of keying a map of objects by a number type
 type KeyByTest$ByNumber<T: Object> = { [number]: T }
 type KeyByTest$Record = { id: number }
-var group: KeyByTest$ByNumber<KeyByTest$Record> = { 1: { id: 4 }, 2: { id: 4 }, 3: { id: 7 } }
-_.keyBy(group, 'id')
+var keyByTest$array: Array<KeyByTest$Record> = [{ id: 4 }, { id: 4 }, { id: 7 }]
+var keyByTest$map: KeyByTest$ByNumber<KeyByTest$Record> = {
+  [keyByTest$array[0].id]: keyByTest$array[0],
+  [keyByTest$array[1].id]: keyByTest$array[1],
+  [keyByTest$array[2].id]: keyByTest$array[2],
+}
+
+var keyByTest$map2: KeyByTest$ByNumber<KeyByTest$Record> = _.keyBy(keyByTest$map, 'id')
 
 
 /**

--- a/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/test_lodash-v4.x.x.js
@@ -120,15 +120,16 @@ _.keyBy([
 
 // Example of keying a map of objects by a number type
 type KeyByTest$ByNumber<T: Object> = { [number]: T }
+type KeyByTest$ByNumberMaybe<T: ?Object> = { [number]: T }
 type KeyByTest$Record = { id: number }
-var keyByTest$array: Array<KeyByTest$Record> = [{ id: 4 }, { id: 4 }, { id: 7 }]
-var keyByTest$map: KeyByTest$ByNumber<KeyByTest$Record> = {
-  [keyByTest$array[0].id]: keyByTest$array[0],
-  [keyByTest$array[1].id]: keyByTest$array[1],
-  [keyByTest$array[2].id]: keyByTest$array[2],
+var keyByTest_array: Array<KeyByTest$Record> = [{ id: 4 }, { id: 4 }, { id: 7 }]
+var keyByTest_map: KeyByTest$ByNumber<KeyByTest$Record> = {
+  [keyByTest_array[0].id]: keyByTest_array[0],
+  [keyByTest_array[1].id]: keyByTest_array[1],
+  [keyByTest_array[2].id]: keyByTest_array[2],
 }
 
-var keyByTest$map2: KeyByTest$ByNumber<KeyByTest$Record> = _.keyBy(keyByTest$map, 'id')
+var keyByTest$map2: KeyByTest$ByNumberMaybe<?KeyByTest$Record> = _.keyBy(keyByTest$map, 'id')
 
 
 /**


### PR DESCRIPTION
Currently it is only possible to pass a map of objects to `keyBy`  where each object's key is a string:
`T: {[id: string]: A}`

I think we should be able to send in maps of objects that are mapped by other types though:

`T: {[id: number]: A}` should be a valid input? See: https://flow.org/en/docs/types/objects/#toc-objects-as-maps.

- [x] Updated the definition of `keyBy` to accept a generic type `I`
- [x] Added test