### PR TITLE
Add support for bluebird disposer and using.

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-v0.32.x/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-v0.32.x/bluebird_v3.x.x.js
@@ -43,7 +43,11 @@ declare type Bluebird$PromisifyAllOptions = {
 
 declare type $Promisable<T> = Promise<T> | T;
 
-declare class Bluebird$Promise<+R> extends Promise<R> {
+declare class Bluebird$Disposable<R> {
+
+}
+
+declare class Bluebird$Promise<+R> extends Promise<R>{
   static Defer: Class<Bluebird$Defer>;
   static PromiseInspection: Class<Bluebird$PromiseInspection<*>>;
 
@@ -167,6 +171,11 @@ declare class Bluebird$Promise<+R> extends Promise<R> {
 
   value(): R;
   reason(): any;
+
+  disposer(disposer: (value: R, promise: Promise<*>) => void): Bluebird$Disposable<R>;
+
+  static using<T, A>(disposable: Bluebird$Disposable<T>, handler: (value: T) => $Promisable<A>): Bluebird$Promise<A>;
+
 }
 
 declare class Bluebird$Defer {
@@ -176,5 +185,6 @@ declare class Bluebird$Defer {
 }
 
 declare module 'bluebird' {
-  declare var exports: typeof Bluebird$Promise;
+  declare export default typeof Bluebird$Promise;
+  declare export type Disposable<T> = Bluebird$Disposable<T>;
 }

--- a/definitions/npm/bluebird_v3.x.x/flow_v0.33.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.33.x-/bluebird_v3.x.x.js
@@ -43,6 +43,10 @@ declare type Bluebird$PromisifyAllOptions = {
 
 declare type $Promisable<T> = Promise<T> | T;
 
+declare class Bluebird$Disposable<R> {
+
+}
+
 declare class Bluebird$Promise<+R> extends Promise<R>{
   static Defer: Class<Bluebird$Defer>;
   static PromiseInspection: Class<Bluebird$PromiseInspection<*>>;
@@ -168,6 +172,11 @@ declare class Bluebird$Promise<+R> extends Promise<R>{
 
   value(): R;
   reason(): any;
+
+  disposer(disposer: (value: R, promise: Promise<*>) => void): Bluebird$Disposable<R>;
+
+  static using<T, A>(disposable: Bluebird$Disposable<T>, handler: (value: T) => $Promisable<A>): Bluebird$Promise<A>;
+
 }
 
 declare class Bluebird$Defer {
@@ -177,5 +186,6 @@ declare class Bluebird$Defer {
 }
 
 declare module 'bluebird' {
-  declare var exports: typeof Bluebird$Promise;
+  declare export default typeof Bluebird$Promise;
+  declare export type Disposable<T> = Bluebird$Disposable<T>;
 }

--- a/definitions/npm/bluebird_v3.x.x/test_bluebird-v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/test_bluebird-v3.x.x.js
@@ -1,5 +1,6 @@
 // @flow
 import Bluebird from 'bluebird';
+import type { Disposable } from 'bluebird';
 
 const defer: Bluebird.Defer = Bluebird.defer();
 const promise: Bluebird<*> = defer.promise;
@@ -133,3 +134,10 @@ Bluebird.resolve().thenReturn(5).then((result: number) => {});
 Bluebird.resolve().return(5).then((result: string) => {});
 // $ExpectError
 Bluebird.resolve().thenReturn(5).then((result: string) => {});
+
+let disposable: Disposable<boolean> = Bluebird.resolve(true).disposer((value: boolean) => {});
+Bluebird.using(disposable, (value: boolean) => 9).then((result: number) => {});
+// $ExpectError
+Bluebird.using(disposable, (value: number) => 9);
+// $ExpectError
+Bluebird.using(disposable, (value: boolean) => 9).then((result: boolean) => {});


### PR DESCRIPTION
This PR adds initial support for Bluebird disposer and using. See http://bluebirdjs.com/docs/api/promise.using.html and http://bluebirdjs.com/docs/api/disposer.html. This PR does not support multiple disposables being passed to `using` or Promises. However, this is enough for basic usage.