### PR TITLE
Adding explicit export of using()

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.33.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.33.x-/bluebird_v3.x.x.js
@@ -188,4 +188,5 @@ declare class Bluebird$Defer {
 declare module 'bluebird' {
   declare export default typeof Bluebird$Promise;
   declare export type Disposable<T> = Bluebird$Disposable<T>;
+  declare export function using<T, A>(disposable: Bluebird$Disposable<T>, handler: (value: T) => $Promisable<A>): Bluebird$Promise<A>;
 }


### PR DESCRIPTION
When using CommonJS modules using syntax as seen below, Flow will actually fail to recognize the export of the static `using` method, giving the error `property `using` (Property not found in CommonJS exports of "bluebird")`. This makes the library annoying to use in non-ES6 environments; by adding a copy of the function declaration to the explicit exports instead of implicitly relying on the static function, Flow will now accept the existence of the function.

```javascript
const Promise = require('bluebird');
const using = Promise.using;
```