### PR TITLE
Revert bluebird to a commonjs module.

### DIFF
--- a/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-v0.32.x/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.32.x-v0.32.x/bluebird_v3.x.x.js
@@ -185,6 +185,7 @@ declare class Bluebird$Defer {
 }
 
 declare module 'bluebird' {
-  declare export default typeof Bluebird$Promise;
-  declare export type Disposable<T> = Bluebird$Disposable<T>;
+  declare var exports: typeof Bluebird$Promise;
+
+  declare type Disposable<T> = Bluebird$Disposable<T>;
 }

--- a/definitions/npm/bluebird_v3.x.x/flow_v0.33.x-/bluebird_v3.x.x.js
+++ b/definitions/npm/bluebird_v3.x.x/flow_v0.33.x-/bluebird_v3.x.x.js
@@ -186,6 +186,7 @@ declare class Bluebird$Defer {
 }
 
 declare module 'bluebird' {
-  declare export default typeof Bluebird$Promise;
-  declare export type Disposable<T> = Bluebird$Disposable<T>;
+  declare var exports: typeof Bluebird$Promise;
+
+  declare type Disposable<T> = Bluebird$Disposable<T>;
 }


### PR DESCRIPTION
This PR reverts bluebird to a commonjs module (it was changed as part of #901). This allows bluebird to still be used using `require`. Note that this will also solve #907.