### PR TITLE
Bunyan: make child options optional and add writable function

### DIFF
--- a/definitions/npm/bunyan_v1.x.x/flow_v0.21.x-/bunyan_v1.x.x.js
+++ b/definitions/npm/bunyan_v1.x.x/flow_v0.21.x-/bunyan_v1.x.x.js
@@ -31,11 +31,14 @@ declare module 'bunyan' {
         },
         [key: string]: any
     };
+    declare type Writable = {
+      write(rec: BunyanRecord): void
+  }
     declare class Logger extends events$EventEmitter {
         constructor(options: LoggerOptions): any;
         addStream(stream: Stream): void;
         addSerializers(serializers: Serializers): void;
-        child(opts: LoggerOptions, simple?: boolean): Logger;
+        child(opts?: LoggerOptions, simple?: boolean): Logger;
         reopenFileStreams(): void;
         level(): string | number;
         level(value: number | string): void;
@@ -102,7 +105,7 @@ declare module 'bunyan' {
         type?: string;
         level?: number | string;
         path?: string;
-        stream?: stream$Writable | tty$WriteStream | Stream;
+        stream?: stream$Writable | tty$WriteStream | Stream | Writable;
         closeOnExit?: boolean;
         period?: string;
         count?: number;


### PR DESCRIPTION
This fixes two minor things:
- options passed to the child function are optional, as seen [here](https://github.com/trentm/node-bunyan/blob/master/lib/bunyan.js#L689)
- a type is also considered writable if it has a function property 'write', as seen [here](https://github.com/trentm/node-bunyan/blob/master/lib/bunyan.js#L312)