### PR TITLE
Fix knex *raw methods for flow v0.47.0

### DIFF
--- a/definitions/npm/knex_v0.12.x/flow_v0.38.x-/knex_v0.12.x.js
+++ b/definitions/npm/knex_v0.12.x/flow_v0.38.x-/knex_v0.12.x.js
@@ -35,7 +35,7 @@ declare class Knex$QueryBuilder mixins Promise {
   whereNotExists(column: string): this,
   whereBetween(column: string, range: number[]): this,
   whereNotBetween(column: string, range: number[]): this,
-  whereRaw(raw: any): this,
+  whereRaw(sql: string, bindings?: Knex$RawBindings): this,
   orWhere(builder: Knex$QueryBuilderFn): this,
   orWhere(column: string, value: any): this,
   orWhere(column: string, operator: string, value: any): this,
@@ -50,7 +50,7 @@ declare class Knex$QueryBuilder mixins Promise {
   orWhereNotExists(column: string): this,
   orWhereBetween(column: string, range: number[]): this,
   orWhereNotBetween(column: string, range: number[]): this,
-  orWhereRaw(raw: any): this,
+  orWhereRaw(sql: string, bindings?: Knex$RawBindings): this,
   innerJoin(table: string, c1: string, operator: string, c2: string): this,
   innerJoin(table: string, c1: string, c2: string): this,
   innerJoin(builder: Knex$QueryBuilder, c1?: string, c2?: string): this,
@@ -77,12 +77,12 @@ declare class Knex$QueryBuilder mixins Promise {
   crossJoin(column: string, c1: string, c2: string): this,
   crossJoin(column: string, c1: string, operator: string, c2: string): this,
   crossJoin(table: string, builder: Knex$QueryBuilderFn): this,
-  joinRaw(sql: string, bindings?: mixed[]): this,
+  joinRaw(sql: string, bindings?: Knex$RawBindings): this,
   distinct(): this,
   groupBy(column: string): this,
-  groupByRaw(): this,
+  groupByRaw(sql: string, bindings?: Knex$RawBindings): this,
   orderBy(column: string, direction?: 'desc' | 'asc'): this,
-  orderByRaw(): this,
+  orderByRaw(sql: string, bindings?: Knex$RawBindings): this,
   offset(offset: number): this,
   limit(limit: number): this,
   having(column: string, operator: string, value: mixed): this,
@@ -96,7 +96,7 @@ declare class Knex$QueryBuilder mixins Promise {
   havingNotBetween<T>(column: string, range: [T, T]): this,
   havingRaw(column: string, operator: string, value: mixed): this,
   havingRaw(column: string, value: mixed): this,
-  havingRaw(raw: string): this,
+  havingRaw(raw: string, bindings?: Knex$RawBindings): this,
   union(): this,
   unionAll(): this,
   count(column?: string): this,
@@ -124,7 +124,7 @@ declare class Knex$Knex mixins Knex$QueryBuilder, Promise, events$EventEmitter {
   static (config: Knex$Config): Knex$Knex,
   static QueryBuilder: typeof Knex$QueryBuilder,
   $call: (tableName: string) => Knex$QueryBuilder,
-  raw(sqlString: string): any,
+  raw(sqlString: string, bindings?: Knex$RawBindings): any,
   client: any,
   destroy(): Promise<void>
 }
@@ -140,6 +140,9 @@ declare type Knex$PostgresConfig = {
   },
   searchPath?: string
 };
+
+declare type Knex$RawBindings = Array<mixed> | {[key: string]: mixed };
+
 declare type Knex$MysqlConfig = {
   client?: 'mysql',
   connection?: {

--- a/definitions/npm/knex_v0.12.x/test_knex-v0.12.js
+++ b/definitions/npm/knex_v0.12.x/test_knex-v0.12.js
@@ -6,18 +6,37 @@ Knex({
   client: 'foo',
 });
 
-knex.select('foo').withSchema('a').from('bar').where('foo', 2).orWhere('bar', 'foo').whereNot('asd', 1).whereIn('batz', [1, 2]);
-knex.select(knex.raw(''))
+knex
+  .select('foo')
+  .withSchema('a')
+  .from('bar')
+  .where('foo', 2)
+  .orWhere('bar', 'foo')
+  .whereNot('asd', 1)
+  .whereIn('batz', [1, 2]);
+knex.select(knex.raw(''));
 
-knex.innerJoin('bar', function () { return this; });
-knex.leftJoin('bar', function () { return this; });
-knex.rightJoin('bar', function () { return this; });
-knex.rightOuterJoin('bar', function () { return this; });
-knex.fullOuterJoin('bar', function () { return this; });
-knex.crossJoin('bar', function () { return this; });
+knex.innerJoin('bar', function() {
+  return this;
+});
+knex.leftJoin('bar', function() {
+  return this;
+});
+knex.rightJoin('bar', function() {
+  return this;
+});
+knex.rightOuterJoin('bar', function() {
+  return this;
+});
+knex.fullOuterJoin('bar', function() {
+  return this;
+});
+knex.crossJoin('bar', function() {
+  return this;
+});
 
 knex('foo').insert({
-  a: 1
+  a: 1,
 });
 knex('bar').del();
 // $ExpectError
@@ -48,3 +67,27 @@ knex('foo').havingBetween('count', [1, 5]);
 // $ExpectError
 knex('foo').havingBetween('count', [1, 2, 3]);
 knex('foo').havingRaw('count > 10');
+
+/**
+ * Bindings with *raw methods
+ */
+
+knex.raw('', ['a', 1]);
+knex.raw('', {name: 'foo'});
+knex('foo').havingRaw('');
+knex('foo').havingRaw('', ['a']);
+knex('foo').whereRaw('');
+knex('foo').whereRaw('', ['a']);
+knex('foo').joinRaw('');
+knex('foo').joinRaw('', ['a']);
+
+// $ExpectError
+knex('foo').raw();
+// $ExpectError
+knex('foo').raw('', '');
+// $ExpectError
+knex('foo').havingRaw();
+// $ExpectError
+knex('foo').whereRaw();
+// $ExpectError
+knex('foo').joinRaw();


### PR DESCRIPTION
Knex *raw methods can be passed parameter bindings as a second argument.

Documentation about this feature : http://knexjs.org/#Raw-Bindings

This PR introduces a `Knex$RawBindings` type to cover those cases.

Tests also attached.