### PR TITLE
Add jest-enzyme plugin to jest definition

### DIFF
--- a/definitions/npm/jest_v20.x.x/flow_v0.33.x-/jest_v20.x.x.js
+++ b/definitions/npm/jest_v20.x.x/flow_v0.33.x-/jest_v20.x.x.js
@@ -106,8 +106,30 @@ type JestPromiseType = {
   resolves: JestExpectType
 };
 
+/**
+ *  Plugin: jest-enzyme
+ */
+type EnzymeMatchersType = {
+  toBeChecked(): void,
+  toBeDisabled(): void,
+  toBeEmpty(): void,
+  toBePresent(): void,
+  toContainReact(component: React$Element<any>): void,
+  toHaveClassName(className: string): void,
+  toHaveHTML(html: string): void,
+  toHaveProp(propKey: string, propValue?: any): void,
+  toHaveRef(refName: string): void,
+  toHaveState(stateKey: string, stateValue?: any): void,
+  toHaveStyle(styleKey: string, styleValue?: any): void,
+  toHaveTagName(tagName: string): void,
+  toHaveText(text: string): void,
+  toIncludeText(text: string): void,
+  toHaveValue(value: any): void,
+  toMatchSelector(selector: string): void,
+};
+
 type JestExpectType = {
-  not: JestExpectType,
+  not: JestExpectType & EnzymeMatchersType,
   /**
    * If you have a mock function, you can use .lastCalledWith to test what
    * arguments it was last called with.
@@ -437,7 +459,7 @@ declare var xtest: typeof it;
 /** The expect function is used every time you want to test a value */
 declare var expect: {
   /** The object that you want to make assertions against */
-  (value: any): JestExpectType & JestPromiseType,
+  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType,
   /** Add additional Jasmine matchers to Jest's roster */
   extend(matchers: { [name: string]: JestMatcher }): void,
   /** Add a module that formats application-specific data structures. */


### PR DESCRIPTION
Hi,

after quite some searching I couldn’t find a "proper" way to extend the already declared jest `expect` definition. 

If I refer to facebook/flow/issues/396, and especially [how it's done for other frameworks, plugins](https://github.com/flowtype/flow-typed/blob/master/definitions/npm/chai_v3.5.x/flow_v0.24.0-/chai_v3.5.x.js#L75-L106) this is somehow acceptable for now?

Looking for directions. Thanks.



