### PR TITLE
switch from using the reserved word default

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.38.x-v0.46.x/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.38.x-v0.46.x/lodash_v4.x.x.js
@@ -460,10 +460,10 @@ declare module 'lodash' {
     cond(pairs: NestedArray<Function>): Function;
     conforms(source: Object): Function;
     constant<T>(value: T): () => T;
-    defaultTo<T1:string|boolean|Object,T2>(value: T1, default: T2): T1;
+    defaultTo<T1:string|boolean|Object,T2>(value: T1, defaultValue: T2): T1;
     // NaN is a number instead of its own type, otherwise it would behave like null/void
-    defaultTo<T1:number,T2>(value: T1, default: T2): T1|T2;
-    defaultTo<T1:void|null,T2>(value: T1, default: T2): T2;
+    defaultTo<T1:number,T2>(value: T1, defaultValue: T2): T1|T2;
+    defaultTo<T1:void|null,T2>(value: T1, defaultValue: T2): T2;
     flow(...funcs?: Array<Function>): Function;
     flow(funcs?: Array<Function>): Function;
     flowRight(...funcs?: Array<Function>): Function;


### PR DESCRIPTION
Noticed while running `prettier` through our typedefs that this definition produced an error:

```
flow-typed/npm/lodash_v4.x.x.js
flow-typed/npm/lodash_v4.x.x.js: SyntaxError: default is a reserved word (466:55)
  464 |     conforms(source: Object): Function;
  465 |     constant<T>(value: T): () => T;
> 466 |     defaultTo<T1:string|boolean|Object,T2>(value: T1, default: T2): T1;
      |                                                       ^
  467 |     // NaN is a number instead of its own type, otherwise it would behave like null/void
  468 |     defaultTo<T1:number,T2>(value: T1, default: T2): T1|T2;
  469 |     defaultTo<T1:void|null,T2>(value: T1, default: T2): T2;
```