### PR TITLE
Improve moment.duration definitions a bit

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.34.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.34.x-/moment_v2.x.x.js
@@ -237,5 +237,6 @@ declare class moment$Moment {
 }
 
 declare module 'moment' {
-  declare module.exports: Class<moment$Moment>;
+  declare export default Class<moment$Moment>;
+  declare export var duration: $PropertyType<Class<moment$Moment>, 'duration'>;
 }

--- a/definitions/npm/moment_v2.x.x/flow_v0.34.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.34.x-/moment_v2.x.x.js
@@ -76,7 +76,9 @@ declare class moment$LocaleData {
   firstDayOfWeek(): number;
   firstDayOfYear(): number;
 }
+
 declare class moment$MomentDuration {
+  static (value: number|Object|string, unit?: string): moment$MomentDuration;
   humanize(suffix?: bool): string;
   milliseconds(): number;
   asMilliseconds(): number;
@@ -99,6 +101,7 @@ declare class moment$MomentDuration {
   toJSON(): string;
   toISOString(): string;
 }
+
 declare class moment$Moment {
   static ISO_8601: string;
   static (string?: string, format?: string|Array<string>, locale?: string, strict?: bool): moment$Moment;
@@ -230,7 +233,7 @@ declare class moment$Moment {
   static weekdaysShort(): string;
   static weekdaysMin(): string;
   static localeData(key?: string): moment$LocaleData;
-  static duration(value: number|Object|string, unit?: string): moment$MomentDuration;
+  static duration: Class<moment$MomentDuration>;
   static isDuration(obj: any): bool;
   static normalizeUnits(unit: string): string;
   static invalid(object: any): moment$Moment;
@@ -238,5 +241,5 @@ declare class moment$Moment {
 
 declare module 'moment' {
   declare export default Class<moment$Moment>;
-  declare export var duration: $PropertyType<Class<moment$Moment>, 'duration'>;
+  declare export var duration: Class<moment$MomentDuration>;
 }

--- a/definitions/npm/moment_v2.x.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.x.x/test_moment-v2.js
@@ -1,5 +1,9 @@
 // @flow
 import moment from 'moment';
+import { duration } from 'moment';
+
+// $ExpectError
+import { moment } from 'moment';
 
 // Parse
 const m3: moment = moment([123, 123]);
@@ -66,3 +70,16 @@ n = m.utcOffset('+00:10').utcOffset();
 n = m.utcOffset(0, true).utcOffset();
 n = m.utcOffset(0, false).utcOffset();
 n = m.utcOffset(0, true, true).utcOffset();
+
+
+// Durations
+let d: duration;
+d = duration(1, 'second');
+d = moment.duration(100);
+d = duration({
+  months: 2,
+  years: 3,
+});
+d.humanize();
+// $ExpectError
+d.months().years();

--- a/definitions/npm/moment_v2.x.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.x.x/test_moment-v2.js
@@ -2,12 +2,6 @@
 import moment from 'moment';
 import { duration } from 'moment';
 
-const momentCommonJS = require('moment');
-const { duration: durationCommonJS } = require('moment');
-
-(momentCommonJS: moment);
-(durationCommonJS: duration);
-
 // $ExpectError
 import { moment } from 'moment';
 
@@ -87,5 +81,7 @@ d = duration({
   years: 3,
 });
 d.humanize();
+d.months();
+d.years();
 // $ExpectError
 d.months().years();

--- a/definitions/npm/moment_v2.x.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.x.x/test_moment-v2.js
@@ -2,6 +2,12 @@
 import moment from 'moment';
 import { duration } from 'moment';
 
+const momentCommonJS = require('moment');
+const { duration: durationCommonJS } = require('moment');
+
+(momentCommonJS: moment);
+(durationCommonJS: duration);
+
 // $ExpectError
 import { moment } from 'moment';
 


### PR DESCRIPTION
This allows handy import like
```js
import { duration } from 'moment';
```

And adds some pretty simple duration type tests.