### PR TITLE
Update rxjs.Observable/sampleTime with optional scheduler argument, and add the TestScheduler to typed exports

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -260,7 +260,7 @@ declare class rxjs$Observable<+T> {
 
   sample(notifier: rxjs$Observable<any>): rxjs$Observable<T>;
 
-  sampleTime(delay: number): rxjs$Observable<T>;
+  sampleTime(delay: number, scheduler?: rxjs$SchedulerClass): rxjs$Observable<T>;
 
   publishReplay(bufferSize?: number, windowTime?: number, scheduler?: rxjs$SchedulerClass): rxjs$ConnectableObservable<T>;
 
@@ -788,5 +788,11 @@ declare module 'rxjs/Subject' {
 declare module 'rxjs/Subscription' {
   declare module.exports: {
     Subscription: typeof rxjs$Subscription
+  }
+}
+
+declare module 'rxjs/testing/TestScheduler' {
+  declare module.exports: {
+    TestScheduler: typeof rxjs$SchedulerClass
   }
 }


### PR DESCRIPTION
Hi there!
With the advent of Flow 0.47.0's arity-based checking, it's more important than ever to account for optional arguments. It would also be useful to type out some of rxjs's testing suite.