### PR TITLE
add react-jss_v6.1.x type declaration

### DIFF
--- a/definitions/npm/react-jss_v6.1.x/flow_v0.30.x-/react-jss_v6.1.x.js
+++ b/definitions/npm/react-jss_v6.1.x/flow_v0.30.x-/react-jss_v6.1.x.js
@@ -1,0 +1,50 @@
+declare module 'react-jss' {
+  /*
+    P = Props
+    OP = OwnProps
+    Def = DefaultProps
+    St = State
+  */
+
+  declare type Null = null | void;
+
+  declare type StatelessComponent<P> = (props: P) => ?React$Element<any>;
+
+  declare class ConnectedComponent<OP, P, Def, St> extends React$Component<void, OP, void> {
+    static InnerComponent: Class<React$Component<Def, P, St>>;
+    static defaultProps: void;
+    props: OP;
+    state: void;
+  }
+
+  declare type ConnectedComponentClass<OP, P, Def, St> = Class<ConnectedComponent<OP, P, Def, St>>;
+
+  declare type Connector<OP, P> = {
+    (component: StatelessComponent<P>): ConnectedComponentClass<OP, P, void, void>;
+    <Def, St>(component: Class<React$Component<Def, P, St>>): ConnectedComponentClass<OP, P, Def, St>;
+    (component: Null): ConnectedComponentClass<OP, P, void, void>;
+  };
+
+  declare export type Classes<Styles> = { [classname: $Keys<Styles>]: string };
+
+  declare export type Sheet<Styles> = {
+    attached: boolean,
+    classes: Classes<Styles>,
+    deployed: boolean,
+    linked: boolean,
+    options: Object,
+    renderer: mixed,
+    rules: mixed,
+  };
+
+  declare type InjectedProps<Styles> = {
+    classes: Classes<Styles>,
+    sheet: Sheet<Styles>,
+  };
+
+  declare export default function injectSheet<OP, Styles: {}>(
+    styles: Styles
+  ): Connector<OP, $Supertype<InjectedProps<Styles> & OP>>;
+
+  declare export function create(): typeof injectSheet
+};

--- a/definitions/npm/react-jss_v6.1.x/test_react-jss_v6.1.x.js
+++ b/definitions/npm/react-jss_v6.1.x/test_react-jss_v6.1.x.js
@@ -1,0 +1,122 @@
+// @flow
+import React from 'react';
+import injectSheet, { create } from 'react-jss';
+import type { Classes, Sheet } from 'react-jss';
+
+
+const styles = {
+  root: {
+    backgroundColor: 'red',
+  },
+  [`@media (min-width: ${10}px)`]: {
+    root: {
+      width: 200
+    }
+  }
+};
+
+type Styles = typeof styles;
+
+type Props = {
+  classes: Classes<Styles>,
+  sheet: Sheet<Styles>,
+  content: string,
+}
+
+const FunctionComponent = (props: Props) => {
+  if (!props.sheet.attached) {
+    return null;
+  }
+
+  return <div className={props.classes.root}>{props.content}</div>;
+};
+
+const FunctionComponentUsesWrongClassname = (props: Props) => {
+  // $ExpectError - property `nonExistentClassName` is not found in "styles"
+  return <div className={props.classes.nonExistentClassName}>{props.content}</div>;
+};
+
+class ClassComponent extends React.Component {
+  props: Props;
+
+  render() {
+    const { classes, sheet, content } = this.props;
+
+    if (!sheet.attached) {
+      return null;
+    }
+
+    return <div className={classes.root}>{content}</div>
+  }
+}
+
+
+// ===================================
+// "create" signature
+// ===================================
+
+const customInjectSheet = create();
+
+// $ExpectError - missing "styles" argument
+customInjectSheet()(FunctionComponent);
+
+// $ExpectError - wrong type of "styles" argument
+customInjectSheet(123)(FunctionComponent);
+
+// no errors
+customInjectSheet(styles)(FunctionComponent);
+
+
+// ===================================
+// "injectSheet" signature
+// ===================================
+
+// $ExpectError - missing "styles" argument
+injectSheet()(FunctionComponent);
+
+// $ExpectError - wrong type of "styles" argument
+injectSheet(123)(FunctionComponent);
+
+// no errors
+injectSheet(styles)(FunctionComponent);
+
+
+// ===================================
+// Wrapping function components
+// ===================================
+
+const WrappedFunctionComponent = injectSheet(styles)(FunctionComponent);
+
+// $ExpectError - missing prop "content"
+<WrappedFunctionComponent />;
+
+// $ExpectError - wrong type of prop "content"
+<WrappedFunctionComponent content={1} />;
+
+// No errors
+<WrappedFunctionComponent content="Hi there!" />;
+
+
+// ===================================
+// Wrapping class components
+// ===================================
+
+const WrappedClassComponent = injectSheet({ root: { backgroundColor: 'red' } })(ClassComponent);
+
+// $ExpectError - missing prop "content"
+<WrappedClassComponent />;
+
+// $ExpectError - wrong type of prop "content"
+<WrappedClassComponent content={true} />;
+
+// No errors
+<WrappedClassComponent content="Lorem ipsum!" />;
+
+
+// ===================================
+// Wrapping Null components
+// ===================================
+
+const GlobalStylesComponent = injectSheet(styles)();
+
+<GlobalStylesComponent />;


### PR DESCRIPTION
Add typedefs for `react-jss`. This implementation covers the most "useful" parts of the API. 

I would ask @kof to review if the typedefs are correct from the library author perspective.