### PR TITLE
Adding initial types for redux-act

### DIFF
--- a/definitions/npm/redux-act_v1.x.x/flow_v0.34.x-/redux-act_v1.x.x.js
+++ b/definitions/npm/redux-act_v1.x.x/flow_v0.34.x-/redux-act_v1.x.x.js
@@ -1,9 +1,11 @@
+type Reducer$On<S> = (actionCreator: mixed, reduceFunction: (S) => mixed) => mixed;
+type Reducer$Off = (actionCreator: mixed) => mixed;
+type Reducer$OnOff<S> = (on: Reducer$On<S>, off: Reducer$Off) => void;
+
 declare module 'redux-act' {
   declare module.exports: {
     createReducer<ReducerState>(
-      handlers: {
-        [key: string]: (ReducerState, payload: mixed) => ReducerState,
-      },
+      handlers: {|[key: string]: (ReducerState, payload: mixed) => ReducerState|} | Reducer$OnOff<ReducerState>,
       defaultState?: ReducerState,
     ): {
       (): (state: ReducerState, payload?: mixed, meta?: mixed) => ReducerState,
@@ -11,8 +13,8 @@ declare module 'redux-act' {
       // TODO: Document parameters & add tests
       options: () => mixed,
       has: (actionCreator: mixed) => boolean,
-      on: (actionCreator: mixed, reduceFunction: () => mixed) => void,
-      off: (actionCreator: mixed) => void,
+      on: Reducer$On<ReducerState>,
+      off: Reducer$Off,
       assignAll: ({}|Array<mixed>, {}|Array<mixed>) => mixed,
       bindAll: ({}|Array<mixed>, {}|Array<mixed>) => mixed,
       batch: ({}|Array<mixed>) => mixed,

--- a/definitions/npm/redux-act_v1.x.x/flow_v0.34.x-/redux-act_v1.x.x.js
+++ b/definitions/npm/redux-act_v1.x.x/flow_v0.34.x-/redux-act_v1.x.x.js
@@ -1,0 +1,49 @@
+declare module 'redux-act' {
+  declare module.exports: {
+    createReducer<ReducerState>(
+      handlers: {
+        [key: string]: (ReducerState, payload: mixed) => ReducerState,
+      },
+      defaultState?: ReducerState,
+    ): {
+      (): (state: ReducerState, payload?: mixed, meta?: mixed) => ReducerState,
+
+      // TODO: Document parameters & add tests
+      options: () => mixed,
+      has: (actionCreator: mixed) => boolean,
+      on: (actionCreator: mixed, reduceFunction: () => mixed) => void,
+      off: (actionCreator: mixed) => void,
+      assignAll: ({}|Array<mixed>, {}|Array<mixed>) => mixed,
+      bindAll: ({}|Array<mixed>, {}|Array<mixed>) => mixed,
+      batch: ({}|Array<mixed>) => mixed,
+      disbatch: (mixed, void|Array<mixed>) => mixed,
+    },
+
+    createAction<ReducerPayload, ReducerMetadata>(
+      description: string,
+      payloadReducer?: () => ReducerPayload,
+      metaReducer?: () => ReducerMetadata,
+    ): {
+      (): (payload: ReducerPayload) => mixed,
+      toString: () => string,
+      getType: () => string,
+
+      // TODO: Document parameters & add tests
+      assignTo: (mixed) => void,
+      bindTo: (mixed) => mixed,
+      assigned: () => boolean,
+      bound: () => boolean,
+      dispatched: () => boolean,
+      raw: () => mixed,
+    },
+
+    // TODO: Document properties & add tests
+    types: {
+      add: (string) => void,
+      remove: (string) => void,
+      has: (string) => boolean,
+      all: () => Array<string>,
+      clear: () => void,
+    },
+  };
+}

--- a/definitions/npm/redux-act_v1.x.x/flow_v0.34.x-/test_redux-act_v1.x.x.js
+++ b/definitions/npm/redux-act_v1.x.x/flow_v0.34.x-/test_redux-act_v1.x.x.js
@@ -1,0 +1,34 @@
+// @flow
+import { createAction, createReducer } from 'redux-act';
+
+createAction('foo');
+createAction('bar');
+createAction('bar', (id, name) => { id, name });
+// $ExpectError
+createAction({});
+// $ExpectError
+createAction();
+
+createReducer({
+  // Sadly .toString() is necessary: https://github.com/facebook/flow/issues/3287
+  [createAction('foo').toString()]: (state, payload) => {
+    return {
+      isEditing: true,
+    };
+  },
+}, {
+  isEditing: false,
+})
+
+createReducer({
+  // $ExpectError
+  foo: {},
+  bar() {},
+}, 123);
+
+const increment = createAction('increment');
+const decrement = createAction('decrement');
+createReducer({
+  [increment.toString()]: (state) => state + 1,
+  [decrement.toString()]: (state) => state - 1,
+}, 0);

--- a/definitions/npm/redux-act_v1.x.x/flow_v0.34.x-/test_redux-act_v1.x.x.js
+++ b/definitions/npm/redux-act_v1.x.x/flow_v0.34.x-/test_redux-act_v1.x.x.js
@@ -20,15 +20,23 @@ createReducer({
   isEditing: false,
 })
 
-createReducer({
-  // $ExpectError
-  foo: {},
-  bar() {},
-}, 123);
+// $ExpectError
+createReducer({ foo: {}, bar() {} }, 123);
 
 const increment = createAction('increment');
 const decrement = createAction('decrement');
+
 createReducer({
   [increment.toString()]: (state) => state + 1,
   [decrement.toString()]: (state) => state - 1,
 }, 0);
+
+createReducer((on) => {
+  on(increment.toString(), (state) => state + 1);
+  on(decrement.toString(), (state) => state - 1);
+}, 10);
+
+createReducer((on, off) => {
+  on(increment.toString(), (state) => state + 1);
+  off(decrement.toString());
+}, 10);


### PR DESCRIPTION
Adding flow types and tests for the two commonly used functions in `redux-act`:
- `createAction`
- `createReducer`