### PR TITLE
fix definition for styled-components

### DIFF
--- a/definitions/npm/styled-components_v2.x.x/flow_v0.25.x-/styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.25.x-/styled-components_v2.x.x.js
@@ -14,7 +14,7 @@ type $npm$styledComponents$ThemeProviderProps = {
   theme: ((outerTheme: $npm$styledComponents$Theme) => void) | $npm$styledComponents$Theme
 };
 type $npm$styledComponents$Component =
-  | React$Component<*, *, *>
+  | ReactClass<*>
   | (props: *) => React$Element<*>;
 
 class Npm$StyledComponents$ThemeProvider extends React$Component {

--- a/definitions/npm/styled-components_v2.x.x/test_styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/test_styled-components_v2.x.x.js
@@ -1,6 +1,7 @@
 // @flow
 import {renderToString} from 'react-dom/server'
 import styled, {ThemeProvider, withTheme, keyframes, ServerStyleSheet, StyleSheetManager} from 'styled-components'
+import React from 'react'
 import type {Theme} from 'styled-components'
 
 const Title = styled.h1`
@@ -70,3 +71,12 @@ const html2 = renderToString(
 
 const css2 = sheet.getStyleTags()
 const css3 = sheet.getStyleElement()
+
+class TestReactClass extends React.Component {
+  render() { return <div />; }
+}
+
+const StyledClass = styled(TestReactClass)`
+  color: red;
+`;
+


### PR DESCRIPTION
expects Reactclass | stateless not React$Component (<ReactComponent />)