### PR TITLE
Update FirebaseValue type

### DIFF
--- a/definitions/npm/firebase_v4.x.x/flow_v0.46.x-/firebase_v4.x.x.js
+++ b/definitions/npm/firebase_v4.x.x/flow_v0.46.x-/firebase_v4.x.x.js
@@ -6,7 +6,6 @@ declare interface FirebaseConfig {
   apiKey: string;
   authDomain?: string;
   databaseURL: string;
-  projectId: string;
   storageBucket?: string;
   messagingSenderId?: string;
 }
@@ -223,7 +222,7 @@ declare type OAuthProvider = | FacebookAuthProvider
                              | TwitterAuthProvider;
 
 /****** database ******/
-declare type FirebaseValue = {} | Array<FirebaseValue> | string | number | boolean | null;
+declare type FirebaseValue = any;
 declare type OnCompleteCallback = (error: ?Object) => void;
 declare type QueryEventType = | 'value'
                               | 'child_added'


### PR DESCRIPTION
I think the FirebaseValue type makes it hard to work with the firebase API with flow. I looked at how typescript has their firebase value and its type any. See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/firebase/index.d.ts#L20

Also I don't think projectId is used in firebase anymore. In the docs the projectId isn't mentioned 
 in https://firebase.google.com/docs/web/setup