### PR TITLE
Fix RxJS retry parameter type

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-v0.33.x/rxjs_v5.0.x.js
@@ -237,7 +237,7 @@ declare class rxjs$Observable<+T> {
 
   publishReplay(): rxjs$ConnectableObservable<T>;
 
-  retry(retryCount: number): rxjs$Observable<T>;
+  retry(retryCount: ?number): rxjs$Observable<T>;
 
   retryWhen(notifier: (errors: rxjs$Observable<Error>) => rxjs$Observable<any>): rxjs$Observable<T>;
 

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -264,7 +264,7 @@ declare class rxjs$Observable<+T> {
 
   publishReplay(bufferSize?: number, windowTime?: number, scheduler?: rxjs$SchedulerClass): rxjs$ConnectableObservable<T>;
 
-  retry(retryCount: number): rxjs$Observable<T>;
+  retry(retryCount: ?number): rxjs$Observable<T>;
 
   retryWhen(notifier: (errors: rxjs$Observable<Error>) => rxjs$Observable<any>): rxjs$Observable<T>;
 


### PR DESCRIPTION
retry function can have no paramaeters. See https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/retry.md