### PR TITLE
Use proper types for `addSnapshotSerializer`

### DIFF
--- a/definitions/npm/jest_v18.x.x/test_jest-v18.x.x.js
+++ b/definitions/npm/jest_v18.x.x/test_jest-v18.x.x.js
@@ -84,6 +84,14 @@ jest
   .resetModules()
   .resetModules();
 
+expect.addSnapshotSerializer({
+  print: (val, serialize) => `Foo: ${serialize(val.foo)}`,
+  test: val => val && val.hasOwnProperty('foo')
+})
+
+// $ExpectError
+expect.addSnapshotSerializer(JSON.stringify)
+
 expect.assertions(1);
 
 expect.anything();

--- a/definitions/npm/jest_v19.x.x/flow_v0.25.x-/jest_v19.x.x.js
+++ b/definitions/npm/jest_v19.x.x/flow_v0.25.x-/jest_v19.x.x.js
@@ -418,6 +418,52 @@ declare var xit: typeof it;
 /** A disabled individual test */
 declare var xtest: typeof it;
 
+type JestPrettyFormatColors = {
+  comment: { close: string, open: string },
+  content: { close: string, open: string },
+  prop: { close: string, open: string },
+  tag: { close: string, open: string },
+  value: { close: string, open: string },
+};
+
+type JestPrettyFormatIndent = string => string;
+type JestPrettyFormatRefs = Array<any>;
+type JestPrettyFormatPrint = any => string;
+type JestPrettyFormatStringOrNull = string | null;
+
+type JestPrettyFormatOptions = {|
+  callToJSON: boolean,
+  edgeSpacing: string,
+  escapeRegex: boolean,
+  highlight: boolean,
+  indent: number,
+  maxDepth: number,
+  min: boolean,
+  plugins: JestPrettyFormatPlugins,
+  printFunctionName: boolean,
+  spacing: string,
+  theme: {|
+    comment: string,
+    content: string,
+    prop: string,
+    tag: string,
+    value: string,
+  |},
+|};
+
+type JestPrettyFormatPlugin = {
+  print: (
+    val: any,
+    serialize: JestPrettyFormatPrint,
+    indent: JestPrettyFormatIndent,
+    opts: JestPrettyFormatOptions,
+    colors: JestPrettyFormatColors,
+  ) => string,
+  test: any => boolean,
+};
+
+type JestPrettyFormatPlugins = Array<JestPrettyFormatPlugin>;
+
 /** The expect function is used every time you want to test a value */
 declare var expect: {
   /** The object that you want to make assertions against */
@@ -425,7 +471,7 @@ declare var expect: {
   /** Add additional Jasmine matchers to Jest's roster */
   extend(matchers: { [name: string]: JestMatcher }): void,
   /** Add a module that formats application-specific data structures. */
-  addSnapshotSerializer(serializer: (input: Object) => string): void,
+  addSnapshotSerializer(pluginModule: JestPrettyFormatPlugin): void,
   assertions(expectedAssertions: number): void,
   any(value: mixed): JestAsymmetricEqualityType,
   anything(): void,

--- a/definitions/npm/jest_v19.x.x/test_jest-v19.x.x.js
+++ b/definitions/npm/jest_v19.x.x/test_jest-v19.x.x.js
@@ -89,7 +89,14 @@ jest
 
 jest.spyOn({}, 'foo');
 
-expect.addSnapshotSerializer(JSON.stringify);
+expect.addSnapshotSerializer({
+  print: (val, serialize) => `Foo: ${serialize(val.foo)}`,
+  test: val => val && val.hasOwnProperty('foo')
+})
+
+// $ExpectError
+expect.addSnapshotSerializer(JSON.stringify)
+
 expect.assertions(1);
 
 expect.anything();

--- a/definitions/npm/jest_v20.x.x/flow_v0.25.x-v0.38.x/jest_v20.x.x.js
+++ b/definitions/npm/jest_v20.x.x/flow_v0.25.x-v0.38.x/jest_v20.x.x.js
@@ -478,6 +478,52 @@ declare var xit: typeof it;
 /** A disabled individual test */
 declare var xtest: typeof it;
 
+type JestPrettyFormatColors = {
+  comment: { close: string, open: string },
+  content: { close: string, open: string },
+  prop: { close: string, open: string },
+  tag: { close: string, open: string },
+  value: { close: string, open: string },
+};
+
+type JestPrettyFormatIndent = string => string;
+type JestPrettyFormatRefs = Array<any>;
+type JestPrettyFormatPrint = any => string;
+type JestPrettyFormatStringOrNull = string | null;
+
+type JestPrettyFormatOptions = {|
+  callToJSON: boolean,
+  edgeSpacing: string,
+  escapeRegex: boolean,
+  highlight: boolean,
+  indent: number,
+  maxDepth: number,
+  min: boolean,
+  plugins: JestPrettyFormatPlugins,
+  printFunctionName: boolean,
+  spacing: string,
+  theme: {|
+    comment: string,
+    content: string,
+    prop: string,
+    tag: string,
+    value: string,
+  |},
+|};
+
+type JestPrettyFormatPlugin = {
+  print: (
+    val: any,
+    serialize: JestPrettyFormatPrint,
+    indent: JestPrettyFormatIndent,
+    opts: JestPrettyFormatOptions,
+    colors: JestPrettyFormatColors,
+  ) => string,
+  test: any => boolean,
+};
+
+type JestPrettyFormatPlugins = Array<JestPrettyFormatPlugin>;
+
 /** The expect function is used every time you want to test a value */
 declare var expect: {
   /** The object that you want to make assertions against */
@@ -485,7 +531,7 @@ declare var expect: {
   /** Add additional Jasmine matchers to Jest's roster */
   extend(matchers: { [name: string]: JestMatcher }): void,
   /** Add a module that formats application-specific data structures. */
-  addSnapshotSerializer(serializer: (input: Object) => string): void,
+  addSnapshotSerializer(pluginModule: JestPrettyFormatPlugin): void,
   assertions(expectedAssertions: number): void,
   hasAssertions(): void,
   any(value: mixed): JestAsymmetricEqualityType,


### PR DESCRIPTION
The current flow-typed definition will error on any proper usage of this function, since it needs to take in an object shaped as such, not a function `(input: Object): string`.

This PR uses the same types as Jest declares for these functions internally.

This function is [defined within Jest here](https://github.com/facebook/jest/blob/3c94c23786c223c17ee8f051be32cee549a2ff1a/packages/jest-jasmine2/src/jest-expect.js#L31), by assigning the value to the [function `addSerializer`, defined here](https://github.com/facebook/jest/blob/dec54a34ffbf37f859a252d05901e87615accb7b/packages/jest-snapshot/src/plugins.js#L25), which takes in a [`type Plugin`, defined here](https://github.com/facebook/jest/blob/dec54a34ffbf37f859a252d05901e87615accb7b/types/PrettyFormat.js#L43-L52).

You can see [how Jest tests this internally here](https://github.com/facebook/jest/blob/cd678bca8bc31fb1fa5b0387fcd240523b01d319/integration_tests/snapshot-serializers/__tests__/snapshot-test.js#L89-L92).

You can see more [documentation about `expect.addSnapshotSerializer(serializer)` in Jest's docs](https://facebook.github.io/jest/docs/expect.html#expectaddsnapshotserializerserializer).