### PR TITLE
[RxJS 5.0.x] Add bufferCount and bufferTime methods

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.29.0-v0.33.x/rxjs_v5.0.x.js
@@ -130,6 +130,15 @@ declare class rxjs$Observable<+T> {
 
   buffer(bufferBoundaries: rxjs$Observable<any>): rxjs$Observable<Array<T>>;
 
+  bufferCount(bufferSize: number, startBufferEvery?: number): rxjs$Observable<Array<T>>;
+
+  bufferTime(
+    bufferTimeSpan: number,
+    bufferCreationInterval?: number,
+    maxBufferSize?: number,
+    scheduler?: rxjs$SchedulerClass
+  ): rxjs$Observable<Array<T>>;
+
   catch<U>(selector: (err: any, caught: rxjs$Observable<T>) => rxjs$Observable<U>): rxjs$Observable<U>;
 
   concat<U>(...sources: rxjs$Observable<U>[]): rxjs$Observable<T | U>;

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -134,6 +134,15 @@ declare class rxjs$Observable<+T> {
 
   buffer(bufferBoundaries: rxjs$Observable<any>): rxjs$Observable<Array<T>>;
 
+  bufferCount(bufferSize: number, startBufferEvery?: number): rxjs$Observable<Array<T>>;
+
+  bufferTime(
+    bufferTimeSpan: number,
+    bufferCreationInterval?: number,
+    maxBufferSize?: number,
+    scheduler?: rxjs$SchedulerClass
+  ): rxjs$Observable<Array<T>>;
+
   catch<U>(selector: (err: any, caught: rxjs$Observable<T>) => rxjs$Observable<U>): rxjs$Observable<U>;
 
   concat<U>(...sources: rxjs$Observable<U>[]): rxjs$Observable<T | U>;

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -195,3 +195,12 @@ numbers.filter(
   },
   {x: 'bar'}, // thisArg
 );
+
+(numbers.bufferCount(4): Observable<Array<number>>);
+(numbers.bufferTime(500): Observable<Array<number>>);
+
+// $ExpectError
+(numbers.startWith('foo').bufferCount(4): Observable<Array<number>>);
+
+// $ExpectError
+(numbers.startWith('foo').bufferTime(500): Observable<Array<number>>);


### PR DESCRIPTION
Added annotations and tests for `Rx.Observable` methods `bufferCount` and `bufferTime`.