### PR TITLE
Fix for styled-components case select

### DIFF
--- a/definitions/npm/styled-components_v1.4.x/flow_v0.25.x-/styled-components_v1.4.x.js
+++ b/definitions/npm/styled-components_v1.4.x/flow_v0.25.x-/styled-components_v1.4.x.js
@@ -11,7 +11,7 @@ type $npm$styledComponents$StyledComponent = (
 
 type $npm$styledComponents$Theme = {[key: string]: mixed};
 type $npm$styledComponents$ThemeProviderProps = {
-  theme: ((outerTheme: $npm$styledComponents$Theme) => void) | $npm$styledComponents$Theme
+  theme: $npm$styledComponents$Theme | ((outerTheme: $npm$styledComponents$Theme) => void)
 };
 type $npm$styledComponents$Component =
   | React$Component<*, *, *>

--- a/definitions/npm/styled-components_v1.4.x/test_styled-components_v1.4.x.js
+++ b/definitions/npm/styled-components_v1.4.x/test_styled-components_v1.4.x.js
@@ -36,6 +36,14 @@ const Component = () => (
 
 const ComponentWithTheme = withTheme(Component)
 
+const Component2 = () => (
+  <ThemeProvider theme={outerTheme => outerTheme}>
+    <Wrapper>
+      <Title>Hello World, this is my first styled component!</Title>
+    </Wrapper>
+  </ThemeProvider>
+)
+
 const OpacityKeyFrame = keyframes`
   0%   { opacity: 0; }
   100% { opacity: 1; }

--- a/definitions/npm/styled-components_v2.x.x/flow_v0.25.x-/styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.25.x-/styled-components_v2.x.x.js
@@ -11,7 +11,7 @@ type $npm$styledComponents$StyledComponent = (
 
 type $npm$styledComponents$Theme = {[key: string]: mixed};
 type $npm$styledComponents$ThemeProviderProps = {
-  theme: ((outerTheme: $npm$styledComponents$Theme) => void) | $npm$styledComponents$Theme
+  theme: $npm$styledComponents$Theme | ((outerTheme: $npm$styledComponents$Theme) => void)
 };
 type $npm$styledComponents$Component =
   | ReactClass<*>

--- a/definitions/npm/styled-components_v2.x.x/test_styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/test_styled-components_v2.x.x.js
@@ -33,6 +33,14 @@ const Component = () => (
 
 const ComponentWithTheme = withTheme(Component)
 
+const Component2 = () => (
+  <ThemeProvider theme={outerTheme => outerTheme}>
+    <Wrapper>
+      <Title>Hello World, this is my first styled component!</Title>
+    </Wrapper>
+  </ThemeProvider>
+)
+
 const OpacityKeyFrame = keyframes`
   0%   { opacity: 0; }
   100% { opacity: 1; }
@@ -79,4 +87,3 @@ class TestReactClass extends React.Component {
 const StyledClass = styled(TestReactClass)`
   color: red;
 `;
-


### PR DESCRIPTION
Without this change you get:

```
 * styled-components_v1.4.x/flow_v0.25.x- (flow-v0.48.0): Unexpected Flow errors(2):
   0-test_styled-components_v1.4.x.js:40
    40:   <ThemeProvider theme={outerTheme => outerTheme}>
                                ^^^^^^^^^^^^^^^^^^^^^^^^ function. Could not decide which case to select
    14:   theme: ((outerTheme: $npm$styledComponents$Theme) => void) | $npm$styledComponents$Theme
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ union type. See lib: styled-components_v1.4.x.js:14
     Case 1 may work:
      14:   theme: ((outerTheme: $npm$styledComponents$Theme) => void) | $npm$styledComponents$Theme
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function type. See lib: styled-components_v1.4.x.js:14
     But if it doesn't, case 2 looks promising too:
      14:   theme: ((outerTheme: $npm$styledComponents$Theme) => void) | $npm$styledComponents$Theme
                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ $npm$styledComponents$Theme. See lib: styled-components_v1.4.x.js:14
     Please provide additional annotation(s) to determine whether case 1 works (or consider merging it with case 2):
      40:   <ThemeProvider theme={outerTheme => outerTheme}>
                                                ^^^^^^^^^^ return
      40:   <ThemeProvider theme={outerTheme => outerTheme}>
                                  ^^^^^^^^^^ parameter `outerTheme`
```