### PR TITLE
react-router: type the values of Match.params as ?string

### DIFF
--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-/react-router-dom_v4.x.x.js
@@ -77,7 +77,7 @@ declare module 'react-router-dom' {
   }
 
   declare export type Match = {
-    params: Object,
+    params: { [key: string]: ?string },
     isExact: boolean,
     path: string,
     url: string,

--- a/definitions/npm/react-router_v4.x.x/flow_v0.38.x-/react-router_v4.x.x.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.38.x-/react-router_v4.x.x.js
@@ -37,7 +37,7 @@ declare module 'react-router' {
   }
 
   declare export type Match = {
-    params: Object,
+    params: { [key: string]: ?string },
     isExact: boolean,
     path: string,
     url: string,


### PR DESCRIPTION
Currently react-router’s `Match` type uses `Object` for its `params` attribute. `params` is [explained in the docs](https://reacttraining.com/react-router/web/api/match) as

> params - (object) Key/value pairs parsed from the URL corresponding to the dynamic segments of the path

It seems to me that, since we’re talking about substrings of the url, the type of the values of any params key will always be `string` if that param exists. Does anyone see a reason not to type `Match` like this instead?
```
  declare export type Match = {
    params: { [key: string]: ?string },
    isExact: boolean,
    path: string,
    url: string,
  }
```