### PR TITLE
Improve Typing for Ramda Utils (path/either/isNil)

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.34.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.34.x-/ramda_v0.x.x.js
@@ -149,7 +149,9 @@ declare module ramda {
   declare var propIs: CurriedFunction3<any,string,Object,boolean>;
   declare function type(x: ?any): string;
   declare function isArrayLike(x: any): boolean;
-  declare function isNil(x: ?any): boolean;
+
+  declare function isNil(x: void|null): true;
+  declare function isNil(x: mixed): false;
 
   // *List
   declare function adjust<T>(fn:(a: T) => T, ...rest: Array<void>): (index: number, ...rest: Array<void>) => (src: Array<T>) => Array<T>;
@@ -557,8 +559,19 @@ declare module ramda {
 
   // TODO over
 
-  declare function path<V,A:?NestedObject<V>>(p: Array<string>, ...rest: Array<void>): (o: A) => ?V;
-  declare function path<V,A:?NestedObject<V>>(p: Array<string>, o: A): ?V;
+  declare function path<V>(p: Array<mixed>, ...rest: Array<void>): (o: NestedObject<V>) => V;
+  declare function path<V>(p: Array<mixed>, ...rest: Array<void>): (o: null|void) => void;
+  declare function path<V>(p: Array<mixed>, ...rest: Array<void>): (o: mixed) => ?V;
+  declare function path<V,A:NestedObject<V>>(p: Array<mixed>, o: A): V;
+  declare function path<V,A:null|void>(p: Array<mixed>, o: A): void;
+  declare function path<V,A:mixed>(p: Array<mixed>, o: A): ?V;
+
+  declare function path<V>(p: Array<string>, ...rest: Array<void>): (o: NestedObject<V>) => V;
+  declare function path<V>(p: Array<string>, ...rest: Array<void>): (o: null|void) => void;
+  declare function path<V>(p: Array<string>, ...rest: Array<void>): (o: mixed) => ?V;
+  declare function path<V,A:NestedObject<V>>(p: Array<string>, o: A): V;
+  declare function path<V,A:null|void>(p: Array<string>, o: A): void;
+  declare function path<V,A:mixed>(p: Array<string>, o: A): ?V;
 
   declare function pathOr<T,V,A:NestedObject<V>>(or: T, ...rest: Array<void>):
   ((p: Array<string>, ...rest: Array<void>) => (o: ?A) => V|T)
@@ -720,8 +733,8 @@ declare module ramda {
   declare function defaultTo<T,V>(d: T, ...rest: Array<void>): (x: ?V) => V|T;
   declare function defaultTo<T,V>(d: T, x: ?V): V|T;
 
-  declare function either(x: (...args: Array<any>) => boolean, ...rest: Array<void>): (y: (...args: Array<any>) => boolean) => (...args: Array<any>) => boolean;
-  declare function either(x: (...args: Array<any>) => boolean, y: (...args: Array<any>) => boolean): (...args: Array<any>) => boolean;
+  declare function either(x: (...args: Array<any>) => *, ...rest: Array<void>): (y: (...args: Array<any>) => *) => (...args: Array<any>) => *;
+  declare function either(x: (...args: Array<any>) => *, y: (...args: Array<any>) => *): (...args: Array<any>) => *;
 
   declare function ifElse<A,B,C>(cond:(...args: Array<A>) => boolean, ...rest: Array<void>):
   ((f1: (...args: Array<A>) => B, ...rest: Array<void>) => (f2: (...args: Array<A>) => C) => (...args: Array<A>) => B|C)

--- a/definitions/npm/ramda_v0.x.x/flow_v0.34.x-/test_ramda_v0.x.x_misc.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.34.x-/test_ramda_v0.x.x_misc.js
@@ -37,6 +37,8 @@ const str: string = 'hello world'
 //Type
 {
   const x: boolean = _.is(Number, 1)
-  const x1: boolean = _.isNil(1)
+  const x1: false = _.isNil(1)
+  const x1a: true = _.isNil()
+  const x1b: true = _.isNil(null)
   const x2: boolean = _.propIs(1, 'num', { num: 1 })
 }

--- a/definitions/npm/ramda_v0.x.x/flow_v0.34.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.34.x-/test_ramda_v0.x.x_object.js
@@ -110,7 +110,10 @@ const om: Object = _.omit([ 'a', 'd', 'h' ], { a: 1, b: 2, c: 3, d: 4 })
 const om2 = _.omit([ 'a', 'd', 'h' ])
 const omap = om2({ a: 1, b: 2, c: 3, d: 4 })
 
-const path1:?Object|number = _.path([ 'a', 'b' ], { a: { b: 2 } })
+const path1:Object|number = _.path([ 'a', 'b' ], { a: { b: 2 } })
+const path2:Object|number = _.path([ 'a', 1 ], { a: { '1': 2 } })
+const path3:?Object = _.path(['a', 'b'], {c: {b: 2}})
+const path4:void = _.path([ 'a' ], null)
 
 const pathOr: string|Object|number = _.pathOr('N/A', [ 'a', 'b' ], { a: { b: 2 } })
 


### PR DESCRIPTION
Makes `isNil` understandable to flow, `either` reflects reality a bit
better (simple ||, not a boolean cast), and `path` is now more robust and
provides better guarantees on a return value.