### PR TITLE
Adjust flyd module `dropRepeats`

### DIFF
--- a/definitions/npm/flyd_v0.x.x/flow_v0.34.x-/flyd_v0.x.x.js
+++ b/definitions/npm/flyd_v0.x.x/flow_v0.34.x-/flyd_v0.x.x.js
@@ -46,7 +46,10 @@ declare module 'flyd/module/diff' {
 }
 
 declare module 'flyd/module/droprepeats' {
-  declare module.exports: (s: Stream) => Stream;
+  declare module.exports: {
+    dropRepeats: (s: Stream) => Stream,
+    dropRepeatsWith: CurriedFunction2<(*) => boolean, Stream, Stream>,
+  };
 }
 
 declare module 'flyd/module/every' {


### PR DESCRIPTION
I goofed with the initial definition (#951) - this sub-module has two exports and
no default.