### PR TITLE
Jest toMatch can match on string

### DIFF
--- a/definitions/npm/jest_v20.x.x/flow_v0.33.x-/jest_v20.x.x.js
+++ b/definitions/npm/jest_v20.x.x/flow_v0.33.x-/jest_v20.x.x.js
@@ -245,9 +245,9 @@ type JestExpectType = {
    */
   toHaveProperty(propPath: string, value?: any): void,
   /**
-   * Use .toMatch to check that a string matches a regular expression.
+   * Use .toMatch to check that a string matches a regular expression or string.
    */
-  toMatch(regexp: RegExp): void,
+  toMatch(regexpOrString: RegExp | string): void,
   /**
    * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
    */

--- a/definitions/npm/jest_v20.x.x/test_jest-v20.x.x.js
+++ b/definitions/npm/jest_v20.x.x/test_jest-v20.x.x.js
@@ -20,6 +20,8 @@ expect({foo: 'bar'}).toHaveProperty('foo');
 expect({foo: 'bar'}).toHaveProperty('foo', 'bar');
 expect('foo').toMatchSnapshot('snapshot name');
 expect({foo: 'bar'}).toMatchObject({baz: 'qux'});
+expect('foobar').toMatch(/foo/);
+expect('foobar').toMatch('foo');
 
 mockFn('a')
 expect('someVal').toBeCalled()


### PR DESCRIPTION
Jest's `toMatch` matcher is able [to match on regexp or string](https://facebook.github.io/jest/docs/expect.html#tomatchregexporstring). This change updates the Jest definitions to support this, and adds a couple of tests to enforce it.