### PR TITLE
Add storybook-router

### DIFF
--- a/definitions/npm/storybook-router_v0.2.x/flow_v0.40.x-/storybook-router_v0.2.x.js
+++ b/definitions/npm/storybook-router_v0.2.x/flow_v0.40.x-/storybook-router_v0.2.x.js
@@ -1,0 +1,27 @@
+import type { LocationShape, GetUserConfirmation } from 'react-router';
+
+type Renderable = React$Element<*>;
+type RenderFunction = () => Renderable;
+type StoryDecorator = (story: RenderFunction) => Renderable;
+
+declare module 'storybook-router' {
+  declare type Links = {
+    [key: string]: (kind: string, story: string) => Function,
+  };
+
+  declare type RouterProps = {
+    // v3
+    initialEntry?: Array<string>,
+    autoRoute?: boolean,
+    // v4
+    initialEntries?: Array<LocationShape | string>,
+    initialIndex?: number,
+    getUserConfirmation?: GetUserConfirmation,
+    keyLength?: number,
+    children?: React$Element<*>,
+  };
+
+  declare module.exports: {
+    (links?: Links, routerProps?: RouterProps): StoryDecorator,
+  };
+}

--- a/definitions/npm/storybook-router_v0.2.x/test_storybook-router_v0.2.x.js
+++ b/definitions/npm/storybook-router_v0.2.x/test_storybook-router_v0.2.x.js
@@ -1,0 +1,54 @@
+// @flow
+
+import StoryRouter from 'storybook-router';
+// $ExpectError
+import { linkTo } from '@storybook/addon-links';
+
+StoryRouter();
+
+StoryRouter({}, { autoRoute: false });
+
+StoryRouter(
+  { '/about': linkTo('Linked stories', 'about') },
+  { initialEntry: ['/'], autoRoute: false }
+);
+
+StoryRouter({
+  '/about': linkTo('Linked stories with automatic route definition', 'about'),
+});
+
+StoryRouter(
+  {
+    '/': linkTo('Linked stories with automatic route definition', 'home'),
+  },
+  { initialEntry: ['/about'] }
+);
+
+StoryRouter(
+  {},
+  { getUserConfirmation: (message, cb) => cb(window.confirm(message)) }
+);
+
+// $ExpectError
+StoryRouter(false);
+
+// $ExpectError
+StoryRouter('string');
+
+// $ExpectError
+StoryRouter({}, false);
+
+// $ExpectError
+StoryRouter({}, { autoRoute: 'string' });
+
+// $ExpectError
+StoryRouter({}, { initialEntry: 'string' });
+
+// $ExpectError
+StoryRouter({}, { initialEntries: 'string' });
+
+// $ExpectError
+StoryRouter({}, { keyLength: 'string' });
+
+// $ExpectError
+StoryRouter({}, { children: 'string' });


### PR DESCRIPTION
Hi,

https://github.com/gvaldambrini/storybook-router

Is importing types from other lib declarations supposed to work? 
`import type { LocationShape, GetUserConfirmation } from 'react-router';`
Does not seem to do the validation job, but default to `any`.

