### PR TITLE
Specify flowbin package.json directory on install

### DIFF
--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -558,5 +558,41 @@ describe("install (command)", () => {
         );
       });
     });
+
+    pit("uses flow-bin defined in another package.json", () => {
+      return fakeProjectEnv(async (FLOWPROJ_DIR) => {
+        // Create some dependencies
+        await Promise.all([
+          writePkgJson(path.join(FLOWPROJ_DIR, "package.json"), {
+            name: "test",
+            dependencies: {
+              "foo": "1.2.3",
+            },
+          }),
+          mkdirp(path.join(FLOWPROJ_DIR, "node_modules", "foo")),
+          writePkgJson(path.join(FLOWPROJ_DIR, "..", "package.json"), {
+            name: "parent",
+            devDependencies: {
+              "flow-bin": "^0.45.0",
+            },
+          }),
+          mkdirp(path.join(FLOWPROJ_DIR, "..", "node_modules", "flow-bin")),
+        ]);
+
+        // Run the install command
+        await run({
+          _: [],
+          overwrite: false,
+          verbose: false,
+          skip: false,
+          packageDir: path.join(FLOWPROJ_DIR, ".."),
+        });
+
+        // Installs libdef
+        expect(await fs.exists(
+          path.join(FLOWPROJ_DIR, "flow-typed", "npm", "foo_v1.x.x.js")
+        )).toEqual(true);
+      });
+    });
   });
 });

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -75,6 +75,7 @@ export type Args = {
   skip: boolean,
   verbose: bool,
   libdefDir?: string,
+  packageDir?: string,
 };
 export function setup(yargs: Yargs) {
   return yargs
@@ -103,11 +104,17 @@ export function setup(yargs: Yargs) {
         type: 'string',
         demand: false,
       },
+      packageDir: {
+        alias: 'p',
+        describe: "The relative path of package.json where flow-bin is installed",
+        type: "string",
+      },
     });
 };
 export async function run(args: Args) {
   const cwd = process.cwd();
-  const flowVersion = await determineFlowVersion(cwd, args.flowVersion);
+  const packageDir = args.packageDir ? path.resolve(args.packageDir) : cwd;
+  const flowVersion = await determineFlowVersion(packageDir, args.flowVersion);
   const libdefDir = args.libdefDir || 'flow-typed';
   const explicitLibDefs = args._.slice(1);
 


### PR DESCRIPTION
Addresses #999 

Adds a flag for `flow-typed install` called `packageDir`, which allows the user to specify the location of the `package.json` that contains an installation of `flow-bin`.

Use: `flow-typed install --packageDir '../../parent_project/`