### PR TITLE
[enzyme_2.3.x] Not function returns reference to self instead of boolean

### DIFF
--- a/definitions/npm/enzyme_v2.3.x/flow_v0.23.x-v0.27.x/enzyme_v2.3.x.js
+++ b/definitions/npm/enzyme_v2.3.x/flow_v0.23.x-v0.27.x/enzyme_v2.3.x.js
@@ -22,7 +22,7 @@ declare module 'enzyme' {
     hasClass(className: string): boolean;
     is(selector: EnzymeSelector): boolean;
     isEmpty(): boolean;
-    not(selector: EnzymeSelector): boolean;
+    not(selector: EnzymeSelector): this;
     children(selector?: EnzymeSelector): this;
     childAt(index: number): this;
     parents(selector?: EnzymeSelector): this;

--- a/definitions/npm/enzyme_v2.3.x/flow_v0.28.x-/enzyme_v2.3.x.js
+++ b/definitions/npm/enzyme_v2.3.x/flow_v0.28.x-/enzyme_v2.3.x.js
@@ -22,7 +22,7 @@ declare module 'enzyme' {
     hasClass(className: string): boolean;
     is(selector: EnzymeSelector): boolean;
     isEmpty(): boolean;
-    not(selector: EnzymeSelector): boolean;
+    not(selector: EnzymeSelector): this;
     children(selector?: EnzymeSelector): this;
     childAt(index: number): this;
     parents(selector?: EnzymeSelector): this;


### PR DESCRIPTION
According to [this](http://airbnb.io/enzyme/docs/api/ReactWrapper/not.html) (also true for [ShallowWrapper](http://airbnb.io/enzyme/docs/api/ShallowWrapper/not.html)), not should return `this` instead of something of boolean type. I've made the changes in both the newer and older versions of flow.