### PR TITLE
Setting error as optional for the chai `throw` function

### DIFF
--- a/definitions/npm/chai_v3.5.x/flow_v0.24.0-/chai_v3.5.x.js
+++ b/definitions/npm/chai_v3.5.x/flow_v0.24.0-/chai_v3.5.x.js
@@ -54,7 +54,7 @@ declare module "chai" {
         keys: (key: string | Array<string>, ...keys: Array<string>) => ExpectChain<T>,
 
         throw: <E>(
-            err: Class<E> | Error | RegExp | string,
+            err?: Class<E> | Error | RegExp | string,
             errMsgMatcher?: RegExp | string,
             msg?: string) => ExpectChain<T>,
 

--- a/definitions/npm/chai_v3.5.x/test_chai_v3.5.x.js
+++ b/definitions/npm/chai_v3.5.x/test_chai_v3.5.x.js
@@ -70,6 +70,7 @@ expect({a: 1, b: 2}).to.have.key("a");
 expect({a: 1, b: 2}).to.have.keys("a", "b");
 expect({a: 1, b: 2}).to.have.keys(["a", "b"]);
 
+expect(() => {}).to.throw();
 expect(() => {}).to.throw(Error);
 expect(() => {}).to.throw(new Error("stuff"));
 expect(() => {}).to.throw("stuff");

--- a/definitions/npm/chai_v4.x.x/flow_v0.48.0-/chai_v4.x.x.js
+++ b/definitions/npm/chai_v4.x.x/flow_v0.48.0-/chai_v4.x.x.js
@@ -54,7 +54,7 @@ declare module "chai" {
         keys: (key: string | Array<string>, ...keys: Array<string>) => ExpectChain<T>,
 
         throw: <E>(
-            err: Class<E> | Error | RegExp | string,
+            err?: Class<E> | Error | RegExp | string,
             errMsgMatcher?: RegExp | string,
             msg?: string) => ExpectChain<T>,
 

--- a/definitions/npm/chai_v4.x.x/test_chai_v4.x.x.js
+++ b/definitions/npm/chai_v4.x.x/test_chai_v4.x.x.js
@@ -70,6 +70,7 @@ expect({a: 1, b: 2}).to.have.key("a");
 expect({a: 1, b: 2}).to.have.keys("a", "b");
 expect({a: 1, b: 2}).to.have.keys(["a", "b"]);
 
+expect(() => { }).to.throw();
 expect(() => {}).to.throw(Error);
 expect(() => {}).to.throw(new Error("stuff"));
 expect(() => {}).to.throw("stuff");


### PR DESCRIPTION
It is possible to call `.throw` without any error http://chaijs.com/api/bdd/#method_throw