### PR TITLE
Install with --overwrite removes stub if typedef becomes available

### DIFF
--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -414,6 +414,45 @@ describe("install (command)", () => {
       });
     });
 
+    pit("overwrites stubs when libdef becomes available (with --overwrite)", () => {
+      return fakeProjectEnv(async (FLOWPROJ_DIR) => {
+        // Create some dependencies
+        await Promise.all([
+          writePkgJson(path.join(FLOWPROJ_DIR, "package.json"), {
+            name: "test",
+            devDependencies: {
+              "flow-bin": "^0.43.0",
+            },
+            dependencies: {
+              "foo": "1.2.3",
+            },
+          }),
+          mkdirp(path.join(FLOWPROJ_DIR, "node_modules", "foo")),
+          mkdirp(path.join(FLOWPROJ_DIR, "node_modules", "flow-bin")),
+        ]);
+
+        await fs.writeFile(path.join(FLOWPROJ_DIR, "flow-typed", "npm", "foo_vx.x.x.js"), '');
+
+        // Run the install command
+        await run({
+          _: [],
+          overwrite: true,
+          verbose: false,
+          skip: false,
+        });
+
+        // Replaces the stub with the real typedef
+        expect(await Promise.all([
+          fs.exists(
+            path.join(FLOWPROJ_DIR, "flow-typed", "npm", "foo_vx.x.x.js")
+          ),
+          fs.exists(
+            path.join(FLOWPROJ_DIR, "flow-typed", "npm", "foo_v1.x.x.js")
+          ),
+        ])).toEqual([false, true]);
+      });
+    });
+
     pit("doesn't overwrite tweaked libdefs (without --overwrite)", () => {
       return fakeProjectEnv(async (FLOWPROJ_DIR) => {
         // Create some dependencies

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -442,6 +442,16 @@ async function installNpmLibDef(
       colors.green(`.${path.sep}${terseFilePath}`)
     );
 
+    // Remove any lingering stubs
+    console.log(npmLibDef.name);
+    console.log(scopedDir);
+    const stubName = `${npmLibDef.name}_vx.x.x.js`;
+    const stubPath = path.join(scopedDir, stubName);
+
+    if (overwrite && (await fs.exists(stubPath))) {
+      await fs.unlink(stubPath);
+    }
+
     return true;
   } catch (e) {
     console.error(`  !! Failed to install ${npmLibDef.name} at ${filePath}`);


### PR DESCRIPTION
Addressed #676 

Stops situations where installing a (newly available) libdef will keep the stub around, causing the new definition to be ignored. It does so by removing the stub if the `--overwrite` flag is passed to `install`, or if `update` is used. 