### PR TITLE
Suppress error with `withTheme` of styled-components

### DIFF
--- a/definitions/npm/styled-components_v2.x.x/flow_v0.25.x-/styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.25.x-/styled-components_v2.x.x.js
@@ -50,7 +50,7 @@ declare module 'styled-components' {
     injectGlobal: (strings: Array<string>, ...interpolations: Array<Interpolation>) => void,
     css: (strings: Array<string>, ...interpolations: Array<Interpolation>) => Array<Interpolation>,
     keyframes: (strings: Array<string>, ...interpolations: Array<Interpolation>) => string,
-    withTheme: (component: Component) => React$Component<*, ThemeProviderProps, *>,
+    withTheme: (component: Component) => ReactClass<*>,
     ServerStyleSheet: typeof Npm$StyledComponents$ServerStyleSheet,
     StyleSheetManager: typeof Npm$StyledComponents$StyleSheetManager,
     ThemeProvider: typeof Npm$StyledComponents$ThemeProvider,
@@ -204,7 +204,7 @@ declare module 'styled-components/native' {
 
   declare module.exports: {
     css: (strings: Array<string>, ...interpolations: Array<Interpolation>) => Array<Interpolation>,
-    withTheme: (component: Component) => React$Component<*, ThemeProviderProps, *>,
+    withTheme: (component: Component) => ReactClass<*>,
     keyframes: (strings: Array<string>, ...interpolations: Array<Interpolation>) => string,
     ThemeProvider: typeof Npm$StyledComponents$ThemeProvider,
 


### PR DESCRIPTION
I was receiving a warning when using the `withTheme` HOC that read, "Expected React component instead of React$Component." So I just replaced React$Component with ReactClass and everything worked ✨

The caveat of this change is that we're no longer providing the prop types provided by the theme. I couldn't find a way around this, so hopefully someone else can.