### PR TITLE
Export connector function types.

### DIFF
--- a/definitions/npm/react-dnd_v2.x.x/flow_v0.23.x-/react-dnd_v2.x.x.js
+++ b/definitions/npm/react-dnd_v2.x.x/flow_v0.23.x-/react-dnd_v2.x.x.js
@@ -207,6 +207,9 @@ declare module 'react-dnd' {
     DragSource: DragSource,
     DropTarget: DropTarget,
     DragLayer: DragLayer,
-    DragDropContext: DragDropContext
+    DragDropContext: DragDropContext,
+    ConnectDragSource: ConnectDragSource,
+    ConnectDragPreview: ConnectDragPreview,
+    ConnectDropTarget: ConnectDropTarget
   }
 }


### PR DESCRIPTION
Exports the `Connect*` (e.g. `ConnectDropTarget`) function types so they can be properly typed as props injected to a React component. Example usage:

```js
class SortableItem extends PureComponent {
  props: {
    /* ... other props... */
    connectDragSource: ConnectDragSource<*>,
    connectDragPreview: ConnectDragPreview<*>,
    connectDropTarget: ConnectDropTarget<*>,
  }
```