### PR TITLE
Fix Flyd `scanMerge` module def

### DIFF
--- a/definitions/npm/flyd_v0.x.x/flow_v0.34.x-/flyd_v0.x.x.js
+++ b/definitions/npm/flyd_v0.x.x/flow_v0.34.x-/flyd_v0.x.x.js
@@ -101,7 +101,7 @@ declare module 'flyd/module/sampleon' {
 }
 
 declare module 'flyd/module/scanmerge' {
-  declare module.exports: CurriedFunction2<[Stream, ScanFn], *, Stream>;
+  declare module.exports: CurriedFunction2<Array<[Stream, ScanFn]>, *, Stream>;
 }
 
 declare module 'flyd/module/switchlatest' {


### PR DESCRIPTION
The point of `scanMerge` is to combine multiple streams via a `[Stream,
ScanFn]` tuple set.  This def was just wrong.  Again, that's on me. 😄 