### PR TITLE
Fixed mistake in T16 struct in reselect defs that used , instead of ;

### DIFF
--- a/definitions/npm/reselect_v2.x.x/flow_v0.37.x-/reselect_v2.x.x.js
+++ b/definitions/npm/reselect_v2.x.x/flow_v0.37.x-/reselect_v2.x.x.js
@@ -38,7 +38,7 @@ type SelectorCreator = {
       arg15: T15,
       arg16: T16
     ) => TResult
-  ): Selector<TState, TProps, TResult>,
+  ): Selector<TState, TProps, TResult>;
   <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
     selectors: [
       Selector<TState, TProps, T1>,
@@ -76,7 +76,7 @@ type SelectorCreator = {
       arg15: T15,
       arg16: T16
     ) => TResult
-  ): Selector<TState, TProps, TResult>,
+  ): Selector<TState, TProps, TResult>;
 
   <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
   	selector1: Selector<TState, TProps, T1>,

--- a/definitions/npm/reselect_v3.x.x/flow_v0.37.x-/reselect_v3.x.x.js
+++ b/definitions/npm/reselect_v3.x.x/flow_v0.37.x-/reselect_v3.x.x.js
@@ -39,7 +39,7 @@ declare module 'reselect' {
       arg15: T15,
       arg16: T16
     ) => TResult
-  ): Selector<TState, TProps, TResult>,
+  ): Selector<TState, TProps, TResult>;
   <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
     selectors: [
       Selector<TState, TProps, T1>,
@@ -77,7 +77,7 @@ declare module 'reselect' {
       arg15: T15,
       arg16: T16
     ) => TResult
-  ): Selector<TState, TProps, TResult>,
+  ): Selector<TState, TProps, TResult>;
 
     <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
       selector1: Selector<TState, TProps, T1>,


### PR DESCRIPTION
Realized I made this mistake in my change yesterday, doesn't seem to affect anything (works fine both ways locally and passes all tests) but it looks inconsistent.