### PR TITLE
Entered arguments for the predicate of findKey

### DIFF
--- a/definitions/npm/underscore_v1.x.x/flow_v0.38.x-/test_underscore.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.38.x-/test_underscore.js
@@ -69,6 +69,8 @@ _.any(['a', true, 0]);
 _.every(['a', true, 0]);
 _.all(['a', true, 0]);
 
+_.findKey({a: {t: 'a'}, b: {t: 'b'}}, obj => obj.t == 'a');
+
 
 // $ExpectError
 _.zip([{x:1}], [{x:2,y:1}])[0][2]

--- a/definitions/npm/underscore_v1.x.x/flow_v0.38.x-/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.38.x-/underscore_v1.x.x.js
@@ -444,7 +444,7 @@ declare module "underscore" {
     invert<K, V>(object: {[keys: K]: V}): {[keys: V]: K};
     // TODO: _.create
     functions(object: Object): Array<string>;
-    findKey(object: Object, predicate: () => boolean, context?: mixed): ?string;
+    findKey(object: Object, predicate: (...args: Array<any>) => boolean, context?: mixed): ?string;
     extend: typeof $underscore$Extend;
     extendOwn: typeof $underscore$Extend;
     pick<K, V>(object: {[keys: K]: V}, predicate?: K): {[keys: K]: V};
@@ -492,7 +492,7 @@ declare module "underscore" {
     invert(): UnderscoreChainedObject<WrappedObj>;
     // TODO: _.create
     functions(): UnderscoreChainedList<string>;
-    findKey(predicate: () => boolean, context?: mixed): UnderscoreChainedValue<?string>;
+    findKey(predicate: (...args: Array<any>) => boolean, context?: mixed): UnderscoreChainedValue<?string>;
     // TODO: Reimplement these when you can get them to return UnderscoreChainedObject
     // extend: ExtendParameterized<{[key: K]: V}>;
     // extendOwn: ExtendParameterized<{[key: K]: V}>>;
@@ -543,7 +543,7 @@ declare module "underscore" {
     // TODO: _.create
     functions(): Array<string>;
     find(predicate: (v: any, k: $Keys<WrappedObj>, obj: WrappedObj) => boolean): ?any;
-    findKey(predicate: () => boolean, context?: mixed): ?string;
+    findKey(predicate: (...args: Array<any>) => boolean, context?: mixed): ?string;
     extend: typeof $underscore$ExtendParameterized;
     extendOwn: typeof $underscore$ExtendParameterized;
     // TODO make these actually remove properties


### PR DESCRIPTION
The `findKey` annotation used to afford no arguments to its predicate. Now it does.

Included a valid test that used to fail, but now passes.

Thanks to @lewisf.