### PR TITLE
Set defaultMessages to optional in react-intl typedefs

### DIFF
--- a/definitions/npm/react-intl_v2.x.x/flow_v0.48.x-/react-intl_v2.x.x.js
+++ b/definitions/npm/react-intl_v2.x.x/flow_v0.48.x-/react-intl_v2.x.x.js
@@ -14,8 +14,8 @@ type LocaleData = {
 
 type MessageDescriptor = {
   id: string,
-  defaultMessage: string,
   description?: string,
+  defaultMessage?: string,
 };
 
 type MessageDescriptorMap = { [key: string]: MessageDescriptor };


### PR DESCRIPTION
According to the docs and source code of the react-intl project, the `defaultMessage` in the `messageDescriptorPropTypes` is not required and therefore optional.

https://github.com/yahoo/react-intl/blob/master/src/types.js#L42-L46