### PR TITLE
koa_v2.x.x.js: make Context middleware params customizable

### DIFF
--- a/definitions/npm/koa_v2.x.x/flow_v0.47.x-/koa_v2.x.x.js
+++ b/definitions/npm/koa_v2.x.x/flow_v0.47.x-/koa_v2.x.x.js
@@ -283,7 +283,7 @@ declare module 'koa' {
     ips: $PropertyType<Request, 'ips'>,
     ip: $PropertyType<Request, 'ip'>,
 
-    [key: string]: mixed, // props added by middlewares.
+    [key: string]: any, // props added by middlewares.
   }
 
   declare type Middleware =


### PR DESCRIPTION
`any` type can be cast to any strict type, therefore allowing covariant customization of Context. Useful when writing custom middleware.

With this change developer can customize Context as per below:

```
type CustomContext = Context & {
  reqId: string
};

app.use(requestId);
app.use(logRequests);

async function logRequests(ctx: CustomContext, next: *) {
   log('got request', ctx.reqId, ctx.request.url);
   await next();
}
```

When type is mixed it will conflict with the above customization.