### PR TITLE
next links can take a URLObject

### DIFF
--- a/definitions/npm/next_v2.x.x/flow_v0.37.x-/next_v2.x.x.js
+++ b/definitions/npm/next_v2.x.x/flow_v0.37.x-/next_v2.x.x.js
@@ -42,7 +42,7 @@ declare module "next/link" {
 
   declare export type State = {
     href: string | URLObject,
-    as: string | URLObject
+    as?: string | URLObject
   };
   declare export default Class<Component<void, State, *>>
 }

--- a/definitions/npm/next_v2.x.x/flow_v0.37.x-/next_v2.x.x.js
+++ b/definitions/npm/next_v2.x.x/flow_v0.37.x-/next_v2.x.x.js
@@ -24,10 +24,27 @@ declare module "next/head" {
 }
 
 declare module "next/link" {
-  import type {Component} from 'react';
+  import type { Component } from "react";
 
-  declare export type State = { href: string };
-  declare export default Class<Component<void, State, *>>;
+  declare export type URLObject = {
+    +href?: string,
+    +protocol?: string,
+    +slashes?: boolean,
+    +auth?: string,
+    +hostname?: string,
+    +port?: string | number,
+    +host?: string,
+    +pathname?: string,
+    +search?: string,
+    +query?: Object,
+    +hash?: string
+  };
+
+  declare export type State = {
+    href: string | URLObject,
+    as: string | URLObject
+  };
+  declare export default Class<Component<void, State, *>>
 }
 
 declare module "next/prefetch" {


### PR DESCRIPTION
Note: this is the same URLObject as the [`format` call in node accepts](https://github.com/facebook/flow/blob/68dd89ecdf1ddcdca7fe04ca24ad7c0731e4c7e7/lib/node.js#L1450).