### PR TITLE
Ability to Ignore Categories of Dependencies when Installing TypeDefs

### DIFF
--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -129,11 +129,11 @@ describe("install (command)", () => {
           cwd: ROOT_DIR,
           flowVersion: parseFlowDirString('flow_v0.40.0', 'testContext'),
           explicitLibDefs: [],
-          ignoreDeps: [],
+          libdefDir: 'flow-typed',
           verbose: false,
           overwrite: false,
           skip: false,
-          libdefDir: 'flow-typed',
+          ignoreDeps: [],
         });
         expect(result).toBe(1);
         expect(_mock(console.error).mock.calls).toEqual([[
@@ -431,7 +431,6 @@ describe("install (command)", () => {
           overwrite: false,
           verbose: false,
           skip: false,
-          ignoreDeps: [],
         });
 
         // Installs a stub for someUntypedDep
@@ -464,7 +463,6 @@ describe("install (command)", () => {
           overwrite: false,
           verbose: false,
           skip: true,
-          ignoreDeps: [],
         });
 
         // Installs a stub for someUntypedDep
@@ -499,7 +497,6 @@ describe("install (command)", () => {
           overwrite: true,
           verbose: false,
           skip: false,
-          ignoreDeps: [],
         });
 
         // Replaces the stub with the real typedef
@@ -537,7 +534,6 @@ describe("install (command)", () => {
           overwrite: false,
           verbose: false,
           skip: false,
-          ignoreDeps: [],
         });
 
         const libdefFilePath = path.join(
@@ -558,7 +554,6 @@ describe("install (command)", () => {
           overwrite: false,
           verbose: false,
           skip: false,
-          ignoreDeps: [],
         });
 
         // Verify that the tweaked libdef file wasn't overwritten
@@ -591,7 +586,6 @@ describe("install (command)", () => {
           overwrite: false,
           verbose: false,
           skip: false,
-          ignoreDeps: [],
         });
 
         const libdefFilePath = path.join(
@@ -611,7 +605,6 @@ describe("install (command)", () => {
           overwrite: true,
           skip: false,
           verbose: false,
-          ignoreDeps: [],
         });
 
         // Verify that the tweaked libdef file wasn't overwritten
@@ -648,7 +641,6 @@ describe("install (command)", () => {
           verbose: false,
           skip: false,
           packageDir: path.join(FLOWPROJ_DIR, ".."),
-          ignoreDeps: [],
         });
 
         // Installs libdef

--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -129,10 +129,11 @@ describe("install (command)", () => {
           cwd: ROOT_DIR,
           flowVersion: parseFlowDirString('flow_v0.40.0', 'testContext'),
           explicitLibDefs: [],
-          libdefDir: 'flow-typed',
+          ignoreDeps: [],
           verbose: false,
           overwrite: false,
           skip: false,
+          libdefDir: 'flow-typed',
         });
         expect(result).toBe(1);
         expect(_mock(console.error).mock.calls).toEqual([[
@@ -155,6 +156,7 @@ describe("install (command)", () => {
           verbose: false,
           overwrite: false,
           skip: false,
+          ignoreDeps: [],
         });
         expect(result).toBe(1);
         expect(_mock(console.error).mock.calls).toEqual([[
@@ -179,6 +181,7 @@ describe("install (command)", () => {
           verbose: false,
           overwrite: false,
           skip: false,
+          ignoreDeps: [],
         });
         expect(result).toBe(1);
         expect(_mock(console.error).mock.calls).toEqual([[
@@ -332,6 +335,7 @@ describe("install (command)", () => {
           overwrite: false,
           verbose: false,
           skip: false,
+          ignoreDeps: [],
         });
 
         // Installs libdefs
@@ -376,6 +380,7 @@ describe("install (command)", () => {
           overwrite: false,
           verbose: false,
           skip: false,
+          ignoreDeps: [],
         });
 
         // Installs a stub for someUntypedDep
@@ -408,6 +413,7 @@ describe("install (command)", () => {
           overwrite: false,
           verbose: false,
           skip: true,
+          ignoreDeps: [],
         });
 
         // Installs a stub for someUntypedDep
@@ -442,6 +448,7 @@ describe("install (command)", () => {
           overwrite: true,
           verbose: false,
           skip: false,
+          ignoreDeps: [],
         });
 
         // Replaces the stub with the real typedef
@@ -479,6 +486,7 @@ describe("install (command)", () => {
           overwrite: false,
           verbose: false,
           skip: false,
+          ignoreDeps: [],
         });
 
         const libdefFilePath = path.join(
@@ -499,6 +507,7 @@ describe("install (command)", () => {
           overwrite: false,
           verbose: false,
           skip: false,
+          ignoreDeps: [],
         });
 
         // Verify that the tweaked libdef file wasn't overwritten
@@ -531,6 +540,7 @@ describe("install (command)", () => {
           overwrite: false,
           verbose: false,
           skip: false,
+          ignoreDeps: [],
         });
 
         const libdefFilePath = path.join(
@@ -550,6 +560,7 @@ describe("install (command)", () => {
           overwrite: true,
           skip: false,
           verbose: false,
+          ignoreDeps: [],
         });
 
         // Verify that the tweaked libdef file wasn't overwritten
@@ -586,6 +597,7 @@ describe("install (command)", () => {
           verbose: false,
           skip: false,
           packageDir: path.join(FLOWPROJ_DIR, ".."),
+          ignoreDeps: [],
         });
 
         // Installs libdef

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -76,7 +76,7 @@ export type Args = {
   verbose: bool,
   libdefDir?: string,
   packageDir?: string,
-  ignoreDeps: Array<string>,
+  ignoreDeps?: Array<string>,
 };
 export function setup(yargs: Yargs) {
   return yargs
@@ -110,6 +110,11 @@ export function setup(yargs: Yargs) {
         describe: "The relative path of package.json where flow-bin is installed",
         type: "string",
       },
+      ignoreDeps: {
+        alias: 'i',
+        describe: "Dependency categories to ignore when installing definitions",
+        type: "array",
+      },
     });
 };
 export async function run(args: Args) {
@@ -118,6 +123,7 @@ export async function run(args: Args) {
   const flowVersion = await determineFlowVersion(packageDir, args.flowVersion);
   const libdefDir = args.libdefDir || 'flow-typed';
   const explicitLibDefs = args._.slice(1);
+  const ignoreDeps = args.ignoreDeps || [];
 
   const coreLibDefResult = await installCoreLibDefs();
   if (coreLibDefResult !== 0) {
@@ -132,7 +138,7 @@ export async function run(args: Args) {
     verbose: args.verbose,
     overwrite: args.overwrite,
     skip: args.skip,
-    ignoreDeps: args.ignoreDeps,
+    ignoreDeps: ignoreDeps,
   });
   if (npmLibDefResult !== 0) {
     return npmLibDefResult;

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -76,6 +76,7 @@ export type Args = {
   verbose: bool,
   libdefDir?: string,
   packageDir?: string,
+  ignoreDeps: Array<string>,
 };
 export function setup(yargs: Yargs) {
   return yargs
@@ -131,6 +132,7 @@ export async function run(args: Args) {
     verbose: args.verbose,
     overwrite: args.overwrite,
     skip: args.skip,
+    ignoreDeps: args.ignoreDeps,
   });
   if (npmLibDefResult !== 0) {
     return npmLibDefResult;
@@ -179,6 +181,7 @@ type installNpmLibDefsArgs = {|
   verbose: boolean,
   overwrite: boolean,
   skip: boolean,
+  ignoreDeps: Array<string>,
 |};
 async function installNpmLibDefs({
   cwd,
@@ -188,6 +191,7 @@ async function installNpmLibDefs({
   verbose,
   overwrite,
   skip,
+  ignoreDeps,
 }: installNpmLibDefsArgs): Promise<number> {
   const flowProjectRoot = await findFlowRoot(cwd);
   if (flowProjectRoot === null) {
@@ -221,7 +225,7 @@ async function installNpmLibDefs({
     console.log(`• Searching for ${libdefsToSearchFor.size} libdefs...`);
   } else {
     const pkgJsonData = await getPackageJsonData(cwd);
-    const pkgJsonDeps = getPackageJsonDependencies(pkgJsonData);
+    const pkgJsonDeps = getPackageJsonDependencies(pkgJsonData, ignoreDeps);
     for (const pkgName in pkgJsonDeps) {
       libdefsToSearchFor.set(pkgName, pkgJsonDeps[pkgName]);
     }

--- a/cli/src/lib/npm/npmProjectUtils.js
+++ b/cli/src/lib/npm/npmProjectUtils.js
@@ -41,6 +41,8 @@ type PkgJson = {|
   }
 |};
 
+//Issues #379, 453, 528, 599
+
 const PKG_JSON_DEP_FIELDS = [
   'dependencies',
   'devDependencies',
@@ -86,9 +88,14 @@ export async function findPackageJsonPath(pathStr: string): Promise<string> {
 
 // TODO: Write tests for this
 export function getPackageJsonDependencies(
-  pkgJson: PkgJson
+  pkgJson: PkgJson,
+  ignoreDeps: Array<string>,
 ): {[depName: string]: string} {
-  return PKG_JSON_DEP_FIELDS.reduce((deps, section) => {
+  const depFields = PKG_JSON_DEP_FIELDS.filter((field) => {
+    return ignoreDeps.indexOf(field.slice(0, -12)) === -1;
+  });
+
+  return depFields.reduce((deps, section) => {
     const contentSection = pkgJson.content[section];
     if (contentSection) {
       Object.keys(contentSection).forEach(pkgName => {

--- a/cli/src/lib/npm/npmProjectUtils.js
+++ b/cli/src/lib/npm/npmProjectUtils.js
@@ -41,8 +41,6 @@ type PkgJson = {|
   }
 |};
 
-//Issues #379, 453, 528, 599
-
 const PKG_JSON_DEP_FIELDS = [
   'dependencies',
   'devDependencies',

--- a/cli/src/lib/stubUtils.js
+++ b/cli/src/lib/stubUtils.js
@@ -225,7 +225,7 @@ export async function createStub(
     try {
       const pkgJsonPathStr = await findPackageJsonPath(projectRoot);
       const pkgJsonData = await getPackageJsonData(pkgJsonPathStr);
-      const rootDependencies = await getPackageJsonDependencies(pkgJsonData);
+      const rootDependencies = await getPackageJsonDependencies(pkgJsonData, []);
       version = rootDependencies[packageName] || null;
     } catch (e) { }
   }


### PR DESCRIPTION
Fixes #379 
Fixes #453 
Fixes #528 
Fixes #599

This has been requested so many time, I think it's about time we address it.

Pass the `--ignoreDeps` flag with a list of dependency categories to ignore to `flow-typed install`. Permitted values are `dev`, `bundle`, `peer` and `optional`. For instance, running what's below will only install regular and `optional` dependencies:

```
flow-typed install --ignoreDeps dev bundle peer
```

Still didn't want to mess with the `.flowconfig` file, though seeing as this is the 4th flag I've created, it may be time to talk about integrating with the config file.