### PR TITLE
Update express$Application.enable() return type

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
@@ -151,7 +151,7 @@ declare class express$Application extends express$Router mixins events$EventEmit
   listen(handle: Object, callback?: (err?: ?Error) => mixed): Server;
   disable(name: string): void;
   disabled(name: string): boolean;
-  enable(name: string): void;
+  enable(name: string): express$Application;
   enabled(name: string): boolean;
   engine(name: string, callback: Function): void;
   /**

--- a/definitions/npm/express_v4.x.x/flow_v0.28.x-v0.31.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.28.x-v0.31.x/express_v4.x.x.js
@@ -151,7 +151,7 @@ declare class express$Application extends express$Router mixins events$EventEmit
   listen(handle: Object, callback?: (err?: ?Error) => mixed): Server;
   disable(name: string): void;
   disabled(name: string): boolean;
-  enable(name: string): void;
+  enable(name: string): express$Application;
   enabled(name: string): boolean;
   engine(name: string, callback: Function): void;
   /**

--- a/definitions/npm/express_v4.x.x/flow_v0.32.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.32.x-/express_v4.x.x.js
@@ -157,7 +157,7 @@ declare class express$Application extends express$Router mixins events$EventEmit
   listen(handle: Object, callback?: (err?: ?Error) => mixed): Server;
   disable(name: string): void;
   disabled(name: string): boolean;
-  enable(name: string): void;
+  enable(name: string): express$Application;
   enabled(name: string): boolean;
   engine(name: string, callback: Function): void;
   /**

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -105,6 +105,8 @@ app.enable(100);
 // $ExpectError
 const f: number = app.enabled('100');
 
+const g: express$Application = app.enable('foo');
+
 app.render('view', { title: 'News Feed' }, (err: ?Error, html: ?string): void => {
     if (err) return console.log(err);
     console.log(html);


### PR DESCRIPTION
After checking the API documentation for the Express library, I updated the return type for the .enable() method on express$Application to allow chaining without error.