### PR TITLE
Add number support to Prismic query predicates

### DIFF
--- a/definitions/npm/prismic.io_v3.x.x/flow_v0.25.x-/prismic.io_v3.x.x.js
+++ b/definitions/npm/prismic.io_v3.x.x/flow_v0.25.x-/prismic.io_v3.x.x.js
@@ -262,11 +262,11 @@ declare module 'prismic.io' {
 
   declare class Predicates {
     toQuery(predicate: Object) : string;
-    at(fragment: string, value: string) : PredicateQuery;
-    not(fragment: string, value: string) : PredicateQuery;
+    at(fragment: string, value: number | string) : PredicateQuery;
+    not(fragment: string, value: number | string) : PredicateQuery;
     missing(fragment: string) : PredicateQuery;
     has(fragment: string) : PredicateQuery;
-    any(fragment: string, values: Array<string>) : PredicateQuery;
+    any(fragment: string, values: Array<number | string>) : PredicateQuery;
     in(fragment: string, values: Array<string>) : PredicateQuery;
     fulltext(fragment: string, value: string) : PredicateQuery;
     similar(documentId: string, maxResults: number) : PredicateQuery;

--- a/definitions/npm/prismic.io_v3.x.x/test_prismic.io_v3.x.x.js
+++ b/definitions/npm/prismic.io_v3.x.x/test_prismic.io_v3.x.x.js
@@ -250,11 +250,13 @@ api('http://foo.prismic.com', options).then(_api => {
     .set('foo', 'bar')
     .ref('foo')
     .query(
+      Predicates.at('foo', 1),
       Predicates.at('foo', 'bar'),
+      Predicates.not('foo', 1),
       Predicates.not('foo', 'bar'),
       Predicates.missing('foo'),
       Predicates.has('foo'),
-      Predicates.any('foo', ['bar']),
+      Predicates.any('foo', ['bar', 1]),
       Predicates.in('foo', ['bar']),
       Predicates.fulltext('foo', 'bar'),
       Predicates.similar('foo', 1),
@@ -284,7 +286,7 @@ api('http://foo.prismic.com', options).then(_api => {
     )
     .query(
       // $ExpectError
-      Predicates.at('foo', 1)
+      Predicates.at('foo', null)
     )
     .pageSize(1)
     .fetch('foo')


### PR DESCRIPTION
Certain predicates support more than just strings. [Docs](https://prismic.io/docs/rest-api/query-the-api/predicates-reference#15_0-predicate-reference-in-the-rest-api).