### PR TITLE
Sets the global git info before running specs in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ addons:
     packages:
       - unzip
       - g++-4.8
+before_install:
+  - git config --global user.name "Travis CI"
+  - git config --global user.email "travis@flowtyped.com"
 script: ./travis.sh
 cache:
   directories:


### PR DESCRIPTION
Closes #1055 

This addresses the first problem in the linked issue. Setting the global git info stops the (pointless and confusing) error message below from appearing:

```
console.error src/lib/git.js:126
  { stderr: '\n*** Please tell me who you are.\n\nRun\n\n  git config --global user.email "you@example.com"\n  git config --global user.name "Your Name"\n\nto set your account\'s default identity.\nOmit --global to set the identity only in this repository.\n\nfatal: empty ident name (for <travis@testing-docker-860d44b1-130f-449f-8d40-65c325a11273.(none)>) not allowed\n',
    stdout: '',
    exitCode: 128 }
console.error src/commands/install.js:463
  !! Failed to install underscore at /tmp/install-cmd-test-dir-839512/flowProj/flow-typed/npm/underscore_v1.x.x.js
console.error src/commands/install.js:464
  ERROR: Error finding latest commit hash for definitions/npm/underscore_v1.x.x/flow_v0.38.x-/underscore_v1.x.x.js: undefined
```