### PR TITLE
Add Dispatch override for redux

### DIFF
--- a/definitions/npm/redux_v3.x.x/flow_v0.33.x-/redux_v3.x.x.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.33.x-/redux_v3.x.x.js
@@ -4,19 +4,21 @@ declare module 'redux' {
 
     S = State
     A = Action
+    D = Dispatch
 
   */
 
-  declare type Dispatch<A: { type: $Subtype<string> }> = (action: A) => A;
+  declare type DispatchAPI<A> = (action: A) => A;
+  declare type Dispatch<A: { type: $Subtype<string> }> = DispatchAPI<A>;
 
-  declare type MiddlewareAPI<S, A> = {
-    dispatch: Dispatch<A>;
+  declare type MiddlewareAPI<S, A, D = Dispatch<A>> = {
+    dispatch: D;
     getState(): S;
   };
 
-  declare type Store<S, A> = {
+  declare type Store<S, A, D = Dispatch<A>> = {
     // rewrite MiddlewareAPI members in order to get nicer error messages (intersections produce long messages)
-    dispatch: Dispatch<A>;
+    dispatch: D;
     getState(): S;
     subscribe(listener: () => void): () => void;
     replaceReducer(nextReducer: Reducer<S, A>): void
@@ -26,27 +28,27 @@ declare module 'redux' {
 
   declare type CombinedReducer<S, A> = (state: $Shape<S> & {} | void, action: A) => S;
 
-  declare type Middleware<S, A> =
-    (api: MiddlewareAPI<S, A>) =>
-      (next: Dispatch<A>) => Dispatch<A>;
+  declare type Middleware<S, A, D = Dispatch<A>> =
+    (api: MiddlewareAPI<S, A, D>) =>
+      (next: D) => D;
 
-  declare type StoreCreator<S, A> = {
-    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A>): Store<S, A>;
-    (reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A>): Store<S, A>;
+  declare type StoreCreator<S, A, D = Dispatch<A>> = {
+    (reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+    (reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
   };
 
-  declare type StoreEnhancer<S, A> = (next: StoreCreator<S, A>) => StoreCreator<S, A>;
+  declare type StoreEnhancer<S, A, D = Dispatch<A>> = (next: StoreCreator<S, A, D>) => StoreCreator<S, A, D>;
 
-  declare function createStore<S, A>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A>): Store<S, A>;
-  declare function createStore<S, A>(reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A>): Store<S, A>;
+  declare function createStore<S, A, D>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+  declare function createStore<S, A, D>(reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
 
-  declare function applyMiddleware<S, A>(...middlewares: Array<Middleware<S, A>>): StoreEnhancer<S, A>;
+  declare function applyMiddleware<S, A, D>(...middlewares: Array<Middleware<S, A, D>>): StoreEnhancer<S, A, D>;
 
   declare type ActionCreator<A, B> = (...args: Array<B>) => A;
   declare type ActionCreators<K, A> = { [key: K]: ActionCreator<A, any> };
 
-  declare function bindActionCreators<A, C: ActionCreator<A, any>>(actionCreator: C, dispatch: Dispatch<A>): C;
-  declare function bindActionCreators<A, K, C: ActionCreators<K, A>>(actionCreators: C, dispatch: Dispatch<A>): C;
+  declare function bindActionCreators<A, C: ActionCreator<A, any>, D: DispatchAPI<A>>(actionCreator: C, dispatch: D): C;
+  declare function bindActionCreators<A, K, C: ActionCreators<K, A>, D: DispatchAPI<A>>(actionCreators: C, dispatch: D): C;
 
   declare function combineReducers<O: Object, A>(reducers: O): CombinedReducer<$ObjMap<O, <S>(r: Reducer<S, any>) => S>, A>;
 

--- a/definitions/npm/redux_v3.x.x/flow_v0.33.x-/test_custom_dispatch.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.33.x-/test_custom_dispatch.js
@@ -1,0 +1,57 @@
+// @flow
+import type { Store as ReduxStore, DispatchAPI, MiddlewareAPI, StoreEnhancer } from 'redux'
+import { applyMiddleware, bindActionCreators, createStore } from 'redux'
+
+type State = Array<number>;
+type Action = { type: 'A' };
+type Thunk = (dispatch: Dispatch, getState: () => State) => void;
+type Dispatch = DispatchAPI<Action | Thunk>;
+type Store = ReduxStore<State, Action, Dispatch>;
+const reducer = (state: State, action: Action): State => state
+
+//
+// applyMiddleware interaction with createStore
+//
+
+createStore(reducer, [1], applyMiddleware((api: MiddlewareAPI<State, Action, Dispatch>) => {
+  api.dispatch({ type: 'A' });
+  // $ExpectError
+  api.dispatch({ type: 'wrong' }) // wrong action
+
+  api.dispatch((dispatch, getState) => {});
+  // $ExpectError
+  api.dispatch(() => false);
+
+  return next => next
+}));
+
+//
+// bindActionCreators API
+//
+
+declare var dispatch: Dispatch;
+
+const ac1 = bindActionCreators((n: number) => ({ type: 'A' }), dispatch);
+ac1(1);
+// $ExpectError
+bindActionCreators((n: number) => ({ type: 'wrong' }), dispatch); // wrong action
+
+const ac2 = bindActionCreators((n: number) => (dispatch, getState) => {}, dispatch);
+ac2(1);
+// $ExpectError
+bindActionCreators((n: number) => (dispatch, getState) => 'wrong', dispatch); // wrong thunk
+
+//
+// createStore API
+//
+
+declare var myEnhancer: StoreEnhancer<State, Action, Dispatch>;
+const store: Store = createStore(reducer, [1], myEnhancer);
+
+store.dispatch({ type: 'A' });
+// $ExpectError
+store.dispatch({ type: 'wrong' }); // wrong action
+
+store.dispatch((dispatch, getState) => {});
+// $ExpectError
+store.dispatch((dispatch, getState) => false); // wrong action


### PR DESCRIPTION
Redux `Dispatch` is hardwired to accept only `{ type: $Subtype<string> }`. This makes it particularly hard to use redux with redux-thunk or other middlewares without rolling out your own flow annotations.

This PR adds additional parameter `D` which defaults to original `Dispatch<A>` when not provided by consumer, giving backward compatibility for existing consumers and providing flexibility.

The number of examples on how to use custom Dispatch are available at:
https://flow.org/en/docs/frameworks/redux/#toc-typing-redux-thunk-actions

```
// @flow
import type { Store } from 'redux';

type Dispatch = (action: Action | ThunkAction | PromiseAction) => any;
type GetState = () => State;
type ThunkAction = (dispatch: Dispatch, getState: GetState) => any;
type PromiseAction = Promise<Action>;

// store with default dispatch
type DefaultStore = Store<State, Action>;

// store with custom dispatch
type CustomStore = Store<State, Action, Dispatch>;
```

Related #574.