### PR TITLE
Fixes install overwriting modified stubs

### DIFF
--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -370,7 +370,7 @@ async function installNpmLibDefs({
             flowProjectRoot,
             pkgName,
             pkgVerStr,
-            true /*ovewrite*/,
+            overwrite,
             libdefDir,
           );
         }),


### PR DESCRIPTION
Closes #317 (sorta)

It seems when the install command was build, running `flow-typed install` always overwrote the stubs, whether or not they were modified, and even if `--overwrite` was not used. This patch passes the `overwrite` flag into `createStub` from the `install` command.

I'm curious if there was a reason for this in the original implementation...