### PR TITLE
koa: make `port` argument to `app.listen` optional

### DIFF
--- a/definitions/npm/koa_v2.x.x/flow_v0.47.x-/koa_v2.x.x.js
+++ b/definitions/npm/koa_v2.x.x/flow_v0.47.x-/koa_v2.x.x.js
@@ -11,7 +11,7 @@ declare module 'koa' {
   // Currently, import type doesnt work well ?
   // so copy `Server` from flow/lib/node.js#L820
   declare class Server extends net$Server {
-    listen(port: number, hostname?: string, backlog?: number, callback?: Function): Server,
+    listen(port?: number, hostname?: string, backlog?: number, callback?: Function): Server,
     listen(path: string, callback?: Function): Server,
     listen(handle: Object, callback?: Function): Server,
     close(callback?: Function): Server,


### PR DESCRIPTION
For running tests against `koa` apps it's common to not pass in a `port` argument to `listen` as in this example: https://github.com/koajs/examples/blob/master/hello-world/test.js

This will make `koa` let the OS assign a random port. This is important during testing so that concurrent tests don't create port clashes.