### PR TITLE
Copy node-fetch definition over from isomorphic-fetch

### DIFF
--- a/definitions/npm/node-fetch_v1.x.x/flow_v0.25.x-/node-fetch_v1.x.x.js
+++ b/definitions/npm/node-fetch_v1.x.x/flow_v0.25.x-/node-fetch_v1.x.x.js
@@ -1,0 +1,4 @@
+
+declare module 'node-fetch' {
+    declare module.exports: (input: string | Request, init?: RequestOptions) => Promise<Response>;
+}

--- a/definitions/npm/node-fetch_v1.x.x/test_node-fetch_v1.js
+++ b/definitions/npm/node-fetch_v1.x.x/test_node-fetch_v1.js
@@ -1,0 +1,58 @@
+import nodeFetch from 'node-fetch';
+
+(nodeFetch('foo'): Promise<Response>);
+(nodeFetch('foo', {}): Promise<Response>);
+
+// $ExpectError url has to be string
+(nodeFetch(123): Promise<any>);
+
+nodeFetch('foo', {
+    method: 'GET'
+});
+
+nodeFetch('foo', {
+    body: 'bar'
+});
+
+// $ExpectError number is not a valid body type
+nodeFetch('foo', {
+    body: 5
+});
+
+// Response tests
+nodeFetch('foo').then(res => {
+    (res.clone(): Response);
+
+    // Response Headers
+    (res.headers: Headers);
+    (res.headers.append('foo', 'bar'): void);
+    // $ExpectError
+    (res.headers.append(5, 'bar'): void);
+    (res.headers.delete('foo'): void);
+    // $ExpectError
+    (res.headers.delete(5): void);
+    (res.headers.entries(): Iterator<*>);
+    (res.headers.get('test'): string);
+    // $ExpectError
+    (res.headers.get(5): string);
+    (res.headers.has('foo'): boolean);
+    // $ExpectError
+    (res.headers.has(5): boolean);
+    (res.headers.keys(): Iterator<string>);
+    // $ExpectError value should be a string
+    (res.headers.set('foo', 5): void);
+    (res.headers.values(): Iterator<*>);
+
+
+    (res.ok: boolean);
+    (res.status: number);
+    (res.statusText: string);
+
+    // Response type
+    (res.type: ResponseType);
+    res.type = 'basic';
+    // $ExpectError foo is not a valid option
+    res.type = 'foo';
+
+    (res.url: string);
+});


### PR DESCRIPTION
Both of these share the same interface so I suspect this is okay.
In fact, isomorphic-fetch defers to node-fetch when it is being used
in a node environment.

Adding this libdef makes it so node-fetch is properly downloaded by flow-typed
when bootstrapping a repository.