### PR TITLE
isomorphic-fetch: Enable passing URL objects as first argument

### DIFF
--- a/definitions/npm/isomorphic-fetch_v2.x.x/flow_v0.25.x-/isomorphic-fetch_v2.x.x.js
+++ b/definitions/npm/isomorphic-fetch_v2.x.x/flow_v0.25.x-/isomorphic-fetch_v2.x.x.js
@@ -1,4 +1,4 @@
 
 declare module 'isomorphic-fetch' {
-    declare module.exports: (input: string | Request, init?: RequestOptions) => Promise<Response>;
+    declare module.exports: (input: string | Request | URL, init?: RequestOptions) => Promise<Response>;
 }


### PR DESCRIPTION
The fetch spec allows passing a `URL`-type object as the first argument to `fetch`, and this feature was added to the `fetch` polyfill (and therefore also `isomorphic-fetch`) in January. 