### PR TITLE
Adding another export for the no-important module of Aphrodite.

### DIFF
--- a/definitions/npm/aphrodite_v0.5.x/flow_v0.28.x-/aphrodite_v0.5.x.js
+++ b/definitions/npm/aphrodite_v0.5.x/flow_v0.28.x-/aphrodite_v0.5.x.js
@@ -34,4 +34,8 @@ declare module 'aphrodite' {
     suppressStyleInjection: () => void;
     clearBufferAndResumeStyleInjection: () => void;
   };
+
+  declare module 'aphrodite/no-important' {
+    declare module.exports: $Exports<'aphrodite'>;
+  };
 };


### PR DESCRIPTION
Aphrodite exports a no-important module (https://github.com/Khan/aphrodite/blob/master/no-important.js) that looks identical to Aphrodite from type-information perspective but changes the behavior (https://github.com/Khan/aphrodite/blob/master/src/no-important.js). Exporting at similarly to Aphrodite.