### PR TITLE
[knex_v0.12.x] Add a new definition for knex.where()

### DIFF
--- a/definitions/npm/knex_v0.12.x/flow_v0.38.x-/knex_v0.12.x.js
+++ b/definitions/npm/knex_v0.12.x/flow_v0.38.x-/knex_v0.12.x.js
@@ -24,6 +24,7 @@ declare class Knex$QueryBuilder mixins Promise {
   where(builder: Knex$QueryBuilderFn): this,
   where(column: string, value: any): this,
   where(column: string, operator: string, value: any): this,
+  where(mixed: { [string]: any }): this,
   whereNot(builder: Knex$QueryBuilderFn): this,
   whereNot(column: string, value: any): this,
   whereNot(column: string, operator: string, value: any): this,

--- a/definitions/npm/knex_v0.12.x/test_knex-v0.12.js
+++ b/definitions/npm/knex_v0.12.x/test_knex-v0.12.js
@@ -11,6 +11,7 @@ knex
   .withSchema('a')
   .from('bar')
   .where('foo', 2)
+  .where({ mixed: 'hi' })
   .orWhere('bar', 'foo')
   .whereNot('asd', 1)
   .whereIn('batz', [1, 2]);


### PR DESCRIPTION
# Reference

According to the [official documentation](http://knexjs.org/#Builder-wheres):

**where** — .where(mixed)
Object Syntax:

```js
knex('users').where({
  first_name: 'Test',
  last_name:  'User'
}).select('id')
```
```
Outputs:
select `id` from `users` where `first_name` = 'Test' and `last_name` = 'User'
```


# Important note

I may be doing something wrong that would cause the [tests to never fail](https://github.com/flowtype/flow-typed/issues/1093). Could someone run the tests with these changes in their environment to make sure they are not breaking anything?