### PR TITLE
Fixes test groups not accounting for scoped (@) definitions

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -47,7 +47,7 @@ type TestGroup = {
  * directory.
  */
 const basePathRegex = new RegExp(
-  `definitions${path.sep}npm${path.sep}[^${path.sep}]*${path.sep}?`,
+  `definitions${path.sep}npm${path.sep}(\@[^${path.sep}]*${path.sep})?[^${path.sep}]*${path.sep}?`,
 );
 async function getTestGroups(
   repoDirPath,


### PR DESCRIPTION
Addresses #1083 

The Regex used to create test groups (when running tests with `--onlyChanged`) did not account for scoped module names. This fix allows for definitions of the type:

`definitions/npm/@turf/destination_v4.x.x/...`