### PR TITLE
Add node-fetch's non-spec API

### DIFF
--- a/definitions/npm/node-fetch_v1.x.x/flow_v0.25.x-/node-fetch_v1.x.x.js
+++ b/definitions/npm/node-fetch_v1.x.x/flow_v0.25.x-/node-fetch_v1.x.x.js
@@ -1,4 +1,0 @@
-
-declare module 'node-fetch' {
-    declare module.exports: (input: string | Request, init?: RequestOptions) => Promise<Response>;
-}

--- a/definitions/npm/node-fetch_v1.x.x/flow_v0.44.x-/node-fetch_v1.x.x.js
+++ b/definitions/npm/node-fetch_v1.x.x/flow_v0.44.x-/node-fetch_v1.x.x.js
@@ -1,0 +1,101 @@
+declare module 'node-fetch' {
+  declare export class Request mixins Body {
+    constructor(input: string | Request, init?: RequestInit): this;
+    method: string;
+    url: string;
+    headers: Headers;
+    context: RequestContext;
+    referrer: string;
+    redirect: RequestRedirect;
+
+    // node-fetch extensions
+    compress: boolean;
+    agent: http$Agent;
+    counter: number;
+    follow: number;
+    hostname: string;
+    protocol: string;
+    port: number;
+    timeout: number;
+    size: number
+  }
+
+  declare interface RequestInit {
+    method?: string,
+    headers?: HeaderInit | {
+      [index: string]: string
+    },
+    body?: BodyInit,
+    redirect?: RequestRedirect,
+
+    // node-fetch extensions
+    timeout?: number,
+    compress?: boolean,
+    size?: number,
+    agent?: http$Agent,
+    follow?: number
+  }
+
+  declare type RequestContext =
+    'audio' | 'beacon' | 'cspreport' | 'download' | 'embed' |
+    'eventsource' | 'favicon' | 'fetch' | 'font' | 'form' | 'frame' |
+    'hyperlink' | 'iframe' | 'image' | 'imageset' | 'import' |
+    'internal' | 'location' | 'manifest' | 'object' | 'ping' | 'plugin' |
+    'prefetch' | 'script' | 'serviceworker' | 'sharedworker' |
+    'subresource' | 'style' | 'track' | 'video' | 'worker' |
+    'xmlhttprequest' | 'xslt';
+  declare type RequestRedirect = 'follow' | 'error' | 'manual';
+
+  declare export class Headers {
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    get(name: string): string;
+    getAll(name: string): Array<string>;
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+    forEach(callback: (value: string, name: string) => void): void
+  }
+
+  declare export class Body {
+    bodyUsed: boolean;
+    body: stream$Readable;
+    json(): Promise<any>;
+    json<T>(): Promise<T>;
+    text(): Promise<string>;
+    buffer(): Promise<Buffer >
+  }
+
+  declare export class Response mixins Body {
+    constructor(body?: BodyInit, init?: ResponseInit): this;
+    error(): Response;
+    redirect(url: string, status: number): Response;
+    type: ResponseType;
+    url: string;
+    status: number;
+    ok: boolean;
+    size: number;
+    statusText: string;
+    timeout: number;
+    headers: Headers;
+    clone(): Response
+  }
+
+  declare type ResponseType =
+    | 'basic'
+    | 'cors'
+    | 'default'
+    | 'error'
+    | 'opaque'
+    | 'opaqueredirect';
+
+  declare interface ResponseInit {
+    status: number,
+    statusText?: string,
+    headers?: HeaderInit
+  }
+
+  declare type HeaderInit = Headers | Array<string>;
+  declare type BodyInit = string;
+
+  declare export default function fetch(url: string | Request, init?: RequestInit): Promise<Response>
+}

--- a/definitions/npm/node-fetch_v1.x.x/test_node-fetch_v1.js
+++ b/definitions/npm/node-fetch_v1.x.x/test_node-fetch_v1.js
@@ -1,10 +1,13 @@
-import nodeFetch from 'node-fetch';
+// @flow
+
+import nodeFetch, { type Headers, type Response } from 'node-fetch';
+import type { Readable } from 'stream';
 
 (nodeFetch('foo'): Promise<Response>);
 (nodeFetch('foo', {}): Promise<Response>);
 
 // $ExpectError url has to be string
-(nodeFetch(123): Promise<any>);
+(nodeFetch(123): Promise<Response>);
 
 nodeFetch('foo', {
     method: 'GET'
@@ -14,8 +17,8 @@ nodeFetch('foo', {
     body: 'bar'
 });
 
-// $ExpectError number is not a valid body type
 nodeFetch('foo', {
+    // $ExpectError number is not a valid body type
     body: 5
 });
 
@@ -31,16 +34,20 @@ nodeFetch('foo').then(res => {
     (res.headers.delete('foo'): void);
     // $ExpectError
     (res.headers.delete(5): void);
+    // $ExpectError `entries` not found in Headers
     (res.headers.entries(): Iterator<*>);
     (res.headers.get('test'): string);
     // $ExpectError
     (res.headers.get(5): string);
+    (res.headers.getAll('test'): Array<string>);
     (res.headers.has('foo'): boolean);
     // $ExpectError
     (res.headers.has(5): boolean);
+    // $ExpectError `keys` not found in Headers
     (res.headers.keys(): Iterator<string>);
     // $ExpectError value should be a string
     (res.headers.set('foo', 5): void);
+    // $ExpectError `values` not found in Headers
     (res.headers.values(): Iterator<*>);
 
 
@@ -55,4 +62,11 @@ nodeFetch('foo').then(res => {
     res.type = 'foo';
 
     (res.url: string);
+    (res.size: number);
+    (res.timeout: number);
+
+    (res.bodyUsed: boolean);
+    (res.body: Readable);
+    (res.text(): Promise<string>);
+    (res.buffer(): Promise<Buffer>);
 });


### PR DESCRIPTION
`node-fetch@1` implements some non-spec methods, [such as `Body#buffer()`](https://github.com/bitinn/node-fetch/blob/1.x/lib/body.js#L67-L76). Furthermore, methods like `entries()`, `keys()`, and `values()` are **not** available in `node-fetch@1` (but they will be in `node-fetch@2`). This patch fixes these issues, using a new libdef inspired by the TypeScript equivalent. I raised the required `flow` version to `@0.44` since that's the first version to support [`http.Agent`](https://nodejs.org/api/http.html#http_class_http_agent).