### PR TITLE
knex: allow postgres connection string

### DIFF
--- a/definitions/npm/knex_v0.12.x/flow_v0.38.x-/knex_v0.12.x.js
+++ b/definitions/npm/knex_v0.12.x/flow_v0.38.x-/knex_v0.12.x.js
@@ -132,13 +132,15 @@ declare class Knex$Knex mixins Knex$QueryBuilder, Promise, events$EventEmitter {
 
 declare type Knex$PostgresConfig = {
   client?: 'pg',
-  connection?: {
-    host?: string,
-    user?: string,
-    password?: string,
-    database?: string,
-    charset?: string
-  },
+  connection?: 
+    | string 
+    | {
+      host?: string,
+      user?: string,
+      password?: string,
+      database?: string,
+      charset?: string
+    },
   searchPath?: string
 };
 


### PR DESCRIPTION
From the docs: http://knexjs.org/

The connection options are passed directly to the appropriate database client to create the connection, and may be either an object, or a connection string:

var pg = require('knex')({
  client: 'pg',
  connection: process.env.PG_CONNECTION_STRING,
  searchPath: 'knex,public'
});