### PR TITLE
Styled-Components: Fixing withTheme implementation + tests

### DIFF
--- a/definitions/npm/styled-components_v2.x.x/flow_v0.34.x-/styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.34.x-/styled-components_v2.x.x.js
@@ -3,24 +3,37 @@
 type $npm$styledComponents$Interpolation = ((executionContext: Object) => string) | string | number;
 type $npm$styledComponents$NameGenerator = (hash: number) => string;
 
-type $npm$styledComponents$ReactComponentClass<P> = Class<React$Component<*, P, *>>
-type $npm$styledComponents$FunctionalReactComponent<P: {}> = P => React$Element<*>
+type $npm$styledComponents$ReactComponentClass<Props: {}, DefaultProps = *> = Class<React$Component<DefaultProps, Props, *>>
+type $npm$styledComponents$FunctionalReactComponent<Props: {}> = Props => React$Element<*>
+
+type $npm$styledComponents$ReactComponentUnion<Props> =
+  | $npm$styledComponents$ReactComponentClass<Props>
+  | $npm$styledComponents$FunctionalReactComponent<Props>;
+
+type $npm$styledComponents$ReactComponentIntersection<Props> =
+  & $npm$styledComponents$ReactComponentClass<Props>
+  & $npm$styledComponents$FunctionalReactComponent<Props>
+
+type $npm$styledComponents$WithThemeReactComponentClass = <
+  InputProps: { theme: $npm$styledComponents$Theme },
+  InputDefaultProps,
+  OutputProps: $Diff<InputProps, { theme: $npm$styledComponents$Theme }>,
+  OutputDefaultProps: InputDefaultProps & { theme: $npm$styledComponents$Theme },
+>($npm$styledComponents$ReactComponentClass<InputProps, InputDefaultProps>) => $npm$styledComponents$ReactComponentClass<OutputProps, OutputDefaultProps>
+
+type $npm$styledComponents$WithThemeFunctionalReactComponent = <
+  InputProps: { theme: $npm$styledComponents$Theme },
+  OutputProps: $Diff<InputProps, { theme: $npm$styledComponents$Theme }>
+>($npm$styledComponents$FunctionalReactComponent<InputProps>) => $npm$styledComponents$FunctionalReactComponent<OutputProps>
+
+type $npm$styledComponents$WithTheme =
+  & $npm$styledComponents$WithThemeReactComponentClass
+  & $npm$styledComponents$WithThemeFunctionalReactComponent
 
 type $npm$styledComponents$TaggedTemplateLiteral<R> = {
   (Array<string>, $npm$styledComponents$Interpolation): R,
-  attrs: <O: {}, P>(O) => $npm$styledComponents$TaggedTemplateLiteral<
-    & $npm$styledComponents$ReactComponentClass<P>
-    & $npm$styledComponents$FunctionalReactComponent<P>
-    >
-}
-
-type $npm$styledComponents$ReactComponentConstructorUnion<P> =
-  | $npm$styledComponents$ReactComponentClass<P>
-  | $npm$styledComponents$FunctionalReactComponent<P>;
-
-type $npm$styledComponents$ReactComponentConstructorIntersection<P> =
-  & $npm$styledComponents$ReactComponentClass<P>
-  & $npm$styledComponents$FunctionalReactComponent<P>
+  attrs: <O: {}>(O) => $npm$styledComponents$TaggedTemplateLiteral<$npm$styledComponents$ReactComponentIntersection<*>>
+};
 
 type $npm$styledComponents$Theme = {[key: string]: mixed};
 type $npm$styledComponents$ThemeProviderProps = {
@@ -50,8 +63,8 @@ declare module 'styled-components' {
   declare type Interpolation = $npm$styledComponents$Interpolation;
   declare type NameGenerator = $npm$styledComponents$NameGenerator;
   declare type TaggedTemplateLiteral<R> = $npm$styledComponents$TaggedTemplateLiteral<R>;
-  declare type StyledComponent<Component: $npm$styledComponents$ReactComponentConstructorUnion<*>> = TaggedTemplateLiteral<Component>;
-  declare type BaseStyledComponent = StyledComponent<$npm$styledComponents$ReactComponentConstructorIntersection<*>>;
+  declare type StyledComponent<Component: $npm$styledComponents$ReactComponentUnion<*>> = TaggedTemplateLiteral<Component>;
+  declare type BaseStyledComponent = StyledComponent<$npm$styledComponents$ReactComponentIntersection<*>>;
   declare type Theme = $npm$styledComponents$Theme;
   declare type ThemeProviderProps = $npm$styledComponents$ThemeProviderProps;
 
@@ -59,12 +72,12 @@ declare module 'styled-components' {
       injectGlobal: TaggedTemplateLiteral<void>,
       css: TaggedTemplateLiteral<Array<Interpolation>>,
       keyframes: TaggedTemplateLiteral<string>,
-      withTheme: <P, U: $npm$styledComponents$ReactComponentConstructorUnion<P>>(U) => $npm$styledComponents$ReactComponentConstructorIntersection<P & { theme: Theme }>,
+      withTheme: $npm$styledComponents$WithTheme,
       ServerStyleSheet: typeof Npm$StyledComponents$ServerStyleSheet,
       StyleSheetManager: typeof Npm$StyledComponents$StyleSheetManager,
       ThemeProvider: typeof Npm$StyledComponents$ThemeProvider,
 
-      <P, C: $npm$styledComponents$ReactComponentConstructorUnion<P>>(C): TaggedTemplateLiteral<C>,
+      <P, C: $npm$styledComponents$ReactComponentUnion<P>>(C): TaggedTemplateLiteral<C>,
 
       a:                        BaseStyledComponent,
       abbr:                     BaseStyledComponent,
@@ -207,18 +220,18 @@ declare module 'styled-components/native' {
   declare type Interpolation = $npm$styledComponents$Interpolation;
   declare type NameGenerator = $npm$styledComponents$NameGenerator;
   declare type TaggedTemplateLiteral<R> = $npm$styledComponents$TaggedTemplateLiteral<R>;
-  declare type StyledComponent<Component: $npm$styledComponents$ReactComponentConstructorUnion<*>> = TaggedTemplateLiteral<Component>;
-  declare type BaseStyledComponent = StyledComponent<$npm$styledComponents$ReactComponentConstructorIntersection<*>>;
+  declare type StyledComponent<Component: $npm$styledComponents$ReactComponentUnion<*>> = TaggedTemplateLiteral<Component>;
+  declare type BaseStyledComponent = StyledComponent<$npm$styledComponents$ReactComponentIntersection<*>>;
   declare type Theme = $npm$styledComponents$Theme;
   declare type ThemeProviderProps = $npm$styledComponents$ThemeProviderProps;
 
   declare module.exports: {
     css: TaggedTemplateLiteral<Array<Interpolation>>,
     keyframes: TaggedTemplateLiteral<string>,
-    withTheme: <P, U: $npm$styledComponents$ReactComponentConstructorUnion<P>>(U) => $npm$styledComponents$ReactComponentConstructorIntersection<P & { theme: Theme }>,
+    withTheme: $npm$styledComponents$WithTheme,
     ThemeProvider: typeof Npm$StyledComponents$ThemeProvider,
 
-    <P, C: $npm$styledComponents$ReactComponentConstructorUnion<P>>(C): TaggedTemplateLiteral<C>,
+    <P, C: $npm$styledComponents$ReactComponentUnion<P>>(C): TaggedTemplateLiteral<C>,
 
     ActivityIndicator:            BaseStyledComponent,
     ActivityIndicatorIOS:         BaseStyledComponent,

--- a/definitions/npm/styled-components_v2.x.x/flow_v0.34.x-/test_styled-components_native_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.34.x-/test_styled-components_native_v2.x.x.js
@@ -12,9 +12,9 @@ import type {
   TaggedTemplateLiteral as NativeTaggedTemplateLiteral
 } from 'styled-components/native'
 
-type NativeFunctionalReactComponent<P: {}> = P => React$Element<*>
-type NativeReactComponentClass<P> = Class<React$Component<*, P, *>>
-type NativeReactComponentConstructor<P> = & NativeFunctionalReactComponent<P> & NativeReactComponentClass<P>
+type NativeFunctionalReactComponent<Props: {}> = Props => React$Element<*>
+type NativeReactComponentClass<Props, DefaultProps = *> = Class<React$Component<DefaultProps, Props, *>>
+type NativeReactComponentConstructor<Props> = & NativeFunctionalReactComponent<Props> & NativeReactComponentClass<Props>
 
 const Title: NativeReactComponentConstructor<{}> = nativeStyled.Text`
   font-size: 1.5em;
@@ -64,7 +64,7 @@ const nativeTheme: NativeTheme = {
   background: "papayawhip"
 };
 
-const NativeComponent: NativeFunctionalReactComponent<{}> = () => (
+const NeedsThemeNativeComponent: NativeFunctionalReactComponent<{ theme: NativeTheme }> = () => (
   <NativeThemeProvider theme={nativeTheme}>
     <Wrapper>
       <Title>Hello World, this is my first nativeStyled component!</Title>
@@ -72,7 +72,7 @@ const NativeComponent: NativeFunctionalReactComponent<{}> = () => (
   </NativeThemeProvider>
 );
 
-const NativeComponentWithTheme: NativeFunctionalReactComponent<{ theme: NativeTheme }> = nativeWithTheme(NativeComponent);
+const NativeComponentWithTheme: NativeFunctionalReactComponent<{}> = nativeWithTheme(NeedsThemeNativeComponent);
 
 const NativeComponent2: NativeFunctionalReactComponent<{}> = () => (
   <NativeThemeProvider theme={outerNativeTheme => outerNativeTheme}>
@@ -108,30 +108,36 @@ const NativeNumberWrapper = nativeStyled(num)`
 `;
 
 // ---- COMPONENT CLASS TESTS ----
-class NativeNeedsFooReactClass extends React.Component {
+class NativeNeedsThemeReactClass extends React.Component {
+  props: { foo: string, theme: NativeTheme }
+  render() { return <div />; }
+}
+
+class NativeReactClass extends React.Component {
   props: { foo: string }
   render() { return <div />; }
 }
 
-const NativeNeedsFooStyledClass: NativeReactComponentClass<{ foo: string }> = nativeStyled(NativeNeedsFooReactClass)`
+const NativeStyledClass: NativeReactComponentClass<{ foo: string, theme: NativeTheme }> = nativeStyled(NativeNeedsThemeReactClass)`
   color: red;
 `;
 
-const NativeNeedsFoonativeWithTheme1Class: NativeReactComponentClass<{ foo: string, theme: NativeTheme }> = nativeWithTheme(NativeNeedsFooReactClass);
-const NativeNeedsFoonativeWithTheme2Class: NativeReactComponentClass<{ foo: string, theme: NativeTheme }> = nativeWithTheme(NativeNeedsFoonativeWithTheme1Class);
+const NativeNeedsFoo1Class: NativeReactComponentClass<{ foo: string }> = nativeWithTheme(NativeNeedsThemeReactClass);
 
 // $ExpectError
-const NativeNeedsFoonativeWithTheme1ErrorClass: NativeReactComponentClass<{ foo: number }> = nativeWithTheme(NativeNeedsFooReactClass);
+const NativeNeedsFoo0ClassError: NativeReactComponentClass<{ foo: string }> = nativeWithTheme(NativeReactClass);
 // $ExpectError
-const NativeNeedsFoonativeWithTheme2ErrorClass: NativeReactComponentClass<{ foo: string, theme: string }> = nativeWithTheme(NativeNeedsFooReactClass);
+const NativeNeedsFoo1ClassError: NativeReactComponentClass<{ foo: string }> = nativeWithTheme(NativeNeedsFoo1Class);
 // $ExpectError
-const NativeNeedsFoonativeWithTheme3ErrorClass: NativeReactComponentClass<{ foo: string }> = nativeWithTheme(NativeNeedsFooReactClass);
+const NativeNeedsFoo1ErrorClass: NativeReactComponentClass<{ foo: number }> = nativeWithTheme(NativeNeedsThemeReactClass);
 // $ExpectError
-const NativeNeedsFoonativeWithTheme4ErrorClass: NativeReactComponentClass<{ foo: number, theme: NativeTheme }> = nativeWithTheme(NativeNeedsFoonativeWithTheme1Class);
+const NativeNeedsFoo2ErrorClass: NativeReactComponentClass<{ foo: string }, { theme: string }> = nativeWithTheme(NativeNeedsThemeReactClass);
 // $ExpectError
-const NativeNeedsFoonativeWithTheme5ErrorClass: NativeReactComponentClass<{ foo: number }> = nativeWithTheme(NativeNeedsFoonativeWithTheme1Class);
+const NativeNeedsFoo3ErrorClass: NativeReactComponentClass<{ foo: string, theme: NativeTheme }> = nativeWithTheme(NativeNeedsFoo1Class);
 // $ExpectError
-const NativeNeedsFoonativeWithTheme6ErrorClass: NativeReactComponentClass<{ foo: string, theme: string }> = nativeWithTheme(NativeNeedsFoonativeWithTheme1Class);
+const NativeNeedsFoo4ErrorClass: NativeReactComponentClass<{ foo: number }> = nativeWithTheme(NativeNeedsFoo1Class);
+// $ExpectError
+const NativeNeedsFoo5ErrorClass: NativeReactComponentClass<{ foo: string, theme: string }> = nativeWithTheme(NativeNeedsFoo1Class);
 
 // ---- INTERPOLATION TESTS ----
 const nativeInterpolation: Array<NativeInterpolation> = nativeStyled.css`
@@ -156,9 +162,9 @@ const NativeDefaultComponentError: {} => string = nativeStyled.View`
 
 // ---- FUNCTIONAL COMPONENT TESTS ----
 declare var View: {} => React$Element<*>
-const NativeFunctionalComponent: ({ foo: string } => React$Element<*>) = props => <View />
+const NativeFunctionalComponent: NativeFunctionalReactComponent<{ foo: string, theme: NativeTheme }> = props => <View />
 
-const NativeNeedsFoo1: NativeFunctionalReactComponent<{ foo: string }> = nativeStyled(NativeFunctionalComponent)`
+const NativeNeedsFoo1: NativeFunctionalReactComponent<{ foo: string, theme: NativeTheme }> = nativeStyled(NativeFunctionalComponent)`
   background-color: red;
 `;
 // $ExpectError
@@ -166,7 +172,7 @@ const NativeNeedsFoo1Error: NativeFunctionalReactComponent<{ foo: number }> = na
   background-color: red;
 `;
 
-const NativeNeedsFoo2: NativeFunctionalReactComponent<{ foo: string }> = nativeStyled(NativeNeedsFoo1)`
+const NativeNeedsFoo2: NativeFunctionalReactComponent<{ foo: string, theme: NativeTheme }> = nativeStyled(NativeNeedsFoo1)`
   background-color: red;
 `;
 // $ExpectError
@@ -174,19 +180,19 @@ const NativeNeedsFoo2Error: NativeFunctionalReactComponent<{ foo: number }> = na
   background-color: red;
 `;
 
-// ---- FUNCTIONAL COMPONENT TESTS (nativeWithTheme)----
-const NativeNeedsFoonativeWithTheme1Functional: NativeFunctionalReactComponent<{ foo: string, theme: NativeTheme }> = nativeWithTheme(NativeFunctionalComponent);
-const NativeNeedsFoonativeWithTheme2Functional: NativeFunctionalReactComponent<{ foo: string, theme: NativeTheme }> = nativeWithTheme(NativeNeedsFoonativeWithTheme1Functional);
+// ---- FUNCTIONAL COMPONENT TESTS (withTheme)----
+const NativeNeedsFoo1Functional: NativeFunctionalReactComponent<{ foo: string }> = nativeWithTheme(NativeFunctionalComponent);
+const NativeNeedsFoo2Functional: NativeFunctionalReactComponent<{ foo: string }> = nativeWithTheme(NativeNeedsFoo1Functional);
 
 // $ExpectError
-const NativeNeedsFoonativeWithTheme1ErrorFunctional: NativeFunctionalReactComponent<{ foo: number }> = nativeWithTheme(NativeFunctionalComponent);
+const NativeNeedsFoo1ErrorFunctional: NativeFunctionalReactComponent<{ foo: number }> = nativeWithTheme(NativeFunctionalComponent);
 // $ExpectError
-const NativeNeedsFoonativeWithTheme2ErrorFunctional: NativeFunctionalReactComponent<{ foo: string, theme: string }> = nativeWithTheme(NativeFunctionalComponent);
+const NativeNeedsFoo2ErrorFunctional: NativeFunctionalReactComponent<{ foo: string }, { theme: string }> = nativeWithTheme(NativeFunctionalComponent);
 // $ExpectError
-const NativeNeedsFoonativeWithTheme3ErrorFunctional: NativeFunctionalReactComponent<{ foo: string }> = nativeWithTheme(NativeFunctionalComponent);
+const NativeNeedsFoo3ErrorFunctional: NativeFunctionalReactComponent<{ foo: number, theme: NativeTheme }> = nativeWithTheme(NativeFunctionalComponent);
 // $ExpectError
-const NativeNeedsFoonativeWithTheme4ErrorFunctional: NativeFunctionalReactComponent<{ foo: number, theme: NativeTheme }> = nativeWithTheme(NativeNeedsFoonativeWithTheme1Functional);
+const NativeNeedsFoo4ErrorFunctional: NativeFunctionalReactComponent<{ foo: number }> = nativeWithTheme(NativeNeedsFoo1Functional);
 // $ExpectError
-const NativeNeedsFoonativeWithTheme5ErrorFunctional: NativeFunctionalReactComponent<{ foo: number }> = nativeWithTheme(NativeNeedsFoonativeWithTheme1Functional);
+const NativeNeedsFoo5ErrorFunctional: NativeFunctionalReactComponent<{ foo: string }, { theme: string }> = nativeWithTheme(NativeNeedsFoo1Functional);
 // $ExpectError
-const NativeNeedsFoonativeWithTheme6ErrorFunctional: NativeFunctionalReactComponent<{ foo: string, theme: string }> = nativeWithTheme(NativeNeedsFooWithTheme1Functional);
+const NativeNeedsFoo6ErrorFunctional: NativeFunctionalReactComponent<{ foo: number }, { theme: NativeTheme }> = nativeWithTheme(NativeNeedsFoo1Functional);

--- a/definitions/npm/styled-components_v2.x.x/flow_v0.34.x-/test_styled-components_v2.x.x.js
+++ b/definitions/npm/styled-components_v2.x.x/flow_v0.34.x-/test_styled-components_v2.x.x.js
@@ -15,9 +15,9 @@ import type {
   StyledComponent,
 } from 'styled-components'
 
-type FunctionalReactComponent<P: {}> = P => React$Element<*>
-type ReactComponentClass<P> = Class<React$Component<*, P, *>>
-type ReactComponentConstructor<P> = & FunctionalReactComponent<P> & ReactComponentClass<P>
+type FunctionalReactComponent<Props: {}> = Props => React$Element<*>
+type ReactComponentClass<Props, DefaultProps = *> = Class<React$Component<DefaultProps, Props, *>>
+type ReactComponentConstructor<Props> = & FunctionalReactComponent<Props> & ReactComponentClass<Props>
 
 const Title: ReactComponentConstructor<{}> = styled.h1`
   font-size: 1.5em;
@@ -125,30 +125,36 @@ const css2 = sheet.getStyleTags()
 const css3 = sheet.getStyleElement()
 
 // ---- COMPONENT CLASS TESTS ----
-class NeedsFooReactClass extends React.Component {
+class NeedsThemeReactClass extends React.Component {
+  props: { foo: string, theme: Theme }
+  render() { return <div />; }
+}
+
+class ReactClass extends React.Component {
   props: { foo: string }
   render() { return <div />; }
 }
 
-const NeedsFooStyledClass: ReactComponentClass<{ foo: string }> = styled(NeedsFooReactClass)`
+const StyledClass: ReactComponentClass<{ foo: string, theme: Theme }> = styled(NeedsThemeReactClass)`
   color: red;
 `;
 
-const NeedsFooWithTheme1Class: ReactComponentClass<{ foo: string, theme: Theme }> = withTheme(NeedsFooReactClass);
-const NeedsFooWithTheme2Class: ReactComponentClass<{ foo: string, theme: Theme }> = withTheme(NeedsFooWithTheme1Class);
+const NeedsFoo1Class: ReactComponentClass<{ foo: string }> = withTheme(NeedsThemeReactClass);
 
 // $ExpectError
-const NeedsFooWithTheme1ErrorClass: ReactComponentClass<{ foo: number }> = withTheme(NeedsFooReactClass);
+const NeedsFoo0ClassError: ReactComponentClass<{ foo: string }> = withTheme(ReactClass);
 // $ExpectError
-const NeedsFooWithTheme2ErrorClass: ReactComponentClass<{ foo: string, theme: string }> = withTheme(NeedsFooReactClass);
+const NeedsFoo1ClassError: ReactComponentClass<{ foo: string }> = withTheme(NeedsFoo1Class);
 // $ExpectError
-const NeedsFooWithTheme3ErrorClass: ReactComponentClass<{ foo: string }> = withTheme(NeedsFooReactClass);
+const NeedsFoo1ErrorClass: ReactComponentClass<{ foo: number }> = withTheme(NeedsThemeReactClass);
 // $ExpectError
-const NeedsFooWithTheme4ErrorClass: ReactComponentClass<{ foo: number, theme: Theme }> = withTheme(NeedsFooWithTheme1Class);
+const NeedsFoo2ErrorClass: ReactComponentClass<{ foo: string }, { theme: string }> = withTheme(NeedsThemeReactClass);
 // $ExpectError
-const NeedsFooWithTheme5ErrorClass: ReactComponentClass<{ foo: number }> = withTheme(NeedsFooWithTheme1Class);
+const NeedsFoo3ErrorClass: ReactComponentClass<{ foo: string, theme: Theme }> = withTheme(NeedsFoo1Class);
 // $ExpectError
-const NeedsFooWithTheme6ErrorClass: ReactComponentClass<{ foo: string, theme: string }> = withTheme(NeedsFooWithTheme1Class);
+const NeedsFoo4ErrorClass: ReactComponentClass<{ foo: number }> = withTheme(NeedsFoo1Class);
+// $ExpectError
+const NeedsFoo5ErrorClass: ReactComponentClass<{ foo: string, theme: string }> = withTheme(NeedsFoo1Class);
 
 // ---- INTERPOLATION TESTS ----
 const interpolation: Array<Interpolation> = styled.css`
@@ -172,9 +178,9 @@ const defaultComponentError: {} => string = styled.div`
 `;
 
 // ---- FUNCTIONAL COMPONENT TESTS ----
-const FunctionalComponent: ({ foo: string } => React$Element<*>) = props => <div />
+const FunctionalComponent: FunctionalReactComponent<{ foo: string, theme: Theme }> = props => <div />
 
-const NeedsFoo1: FunctionalReactComponent<{ foo: string }> = styled(FunctionalComponent)`
+const NeedsFoo1: FunctionalReactComponent<{ foo: string, theme: Theme }> = styled(FunctionalComponent)`
   background-color: red;
 `;
 // $ExpectError
@@ -182,7 +188,7 @@ const NeedsFoo1Error: FunctionalReactComponent<{ foo: number }> = styled(Functio
   background-color: red;
 `;
 
-const NeedsFoo2: FunctionalReactComponent<{ foo: string }> = styled(NeedsFoo1)`
+const NeedsFoo2: FunctionalReactComponent<{ foo: string, theme: Theme }> = styled(NeedsFoo1)`
   background-color: red;
 `;
 // $ExpectError
@@ -191,18 +197,18 @@ const NeedsFoo2Error: FunctionalReactComponent<{ foo: number }> = styled(NeedsFo
 `;
 
 // ---- FUNCTIONAL COMPONENT TESTS (withTheme)----
-const NeedsFooWithTheme1Functional: FunctionalReactComponent<{ foo: string, theme: Theme }> = withTheme(FunctionalComponent);
-const NeedsFooWithTheme2Functional: FunctionalReactComponent<{ foo: string, theme: Theme }> = withTheme(NeedsFooWithTheme1Functional);
+const NeedsFoo1Functional: FunctionalReactComponent<{ foo: string }> = withTheme(FunctionalComponent);
+const NeedsFoo2Functional: FunctionalReactComponent<{ foo: string }> = withTheme(NeedsFoo1Functional);
 
 // $ExpectError
-const NeedsFooWithTheme1ErrorFunctional: FunctionalReactComponent<{ foo: number }> = withTheme(FunctionalComponent);
+const NeedsFoo1ErrorFunctional: FunctionalReactComponent<{ foo: number }> = withTheme(FunctionalComponent);
 // $ExpectError
-const NeedsFooWithTheme2ErrorFunctional: FunctionalReactComponent<{ foo: string, theme: string }> = withTheme(FunctionalComponent);
+const NeedsFoo2ErrorFunctional: FunctionalReactComponent<{ foo: string }, { theme: string }> = withTheme(FunctionalComponent);
 // $ExpectError
-const NeedsFooWithTheme3ErrorFunctional: FunctionalReactComponent<{ foo: string }> = withTheme(FunctionalComponent);
+const NeedsFoo3ErrorFunctional: FunctionalReactComponent<{ foo: number, theme: Theme }> = withTheme(FunctionalComponent);
 // $ExpectError
-const NeedsFooWithTheme4ErrorFunctional: FunctionalReactComponent<{ foo: number, theme: Theme }> = withTheme(NeedsFooWithTheme1Functional);
+const NeedsFoo4ErrorFunctional: FunctionalReactComponent<{ foo: number }> = withTheme(NeedsFoo1Functional);
 // $ExpectError
-const NeedsFooWithTheme5ErrorFunctional: FunctionalReactComponent<{ foo: number }> = withTheme(NeedsFooWithTheme1Functional);
+const NeedsFoo5ErrorFunctional: FunctionalReactComponent<{ foo: string }, { theme: string }> = withTheme(NeedsFoo1Functional);
 // $ExpectError
-const NeedsFooWithTheme6ErrorFunctional: FunctionalReactComponent<{ foo: string, theme: string }> = withTheme(NeedsFooWithTheme1Functional);
+const NeedsFoo6ErrorFunctional: FunctionalReactComponent<{ foo: number }, { theme: Theme }> = withTheme(NeedsFoo1Functional);


### PR DESCRIPTION
Previously the following would work:
```js
const NeedsFoo3ErrorClass: ReactComponentClass<{ foo: string, theme: Theme }> = withTheme(NeedsFoo1Class);
```
...but ``withTheme`` actually provides the ``{ theme: Theme }`` & the function should not require it as an input. I implemented the inverse.

With these changes, the following works as expected:
```js
const NeedsFoo1Class: ReactComponentClass<{ foo: string }> = withTheme(NeedsThemeReactClass);
```