### PR TITLE
Added isValid() method to moment.js duration class

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.28.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.28.x-/moment_v2.x.x.js
@@ -98,6 +98,7 @@ declare class moment$MomentDuration {
   get(unit: string): number;
   toJSON(): string;
   toISOString(): string;
+  isValid(): bool;
 }
 declare class moment$Moment {
   static ISO_8601: string;


### PR DESCRIPTION
In version 2.18.0, durations gained validity: https://gist.github.com/ichernev/78920c5a1e419fb28c6e4546d1b7235c

More info: https://github.com/moment/moment/pull/3611