### PR TITLE
fix(lodash): Fix type def for `attempt`

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/lodash_v4.x.x.js
@@ -454,7 +454,7 @@ declare module 'lodash' {
     words(string?: string, pattern?: RegExp|string): Array<string>;
 
     // Util
-    attempt(func: Function): any;
+    attempt(func: Function, ...args: Array<any>): any;
     bindAll(object?: ?Object, methodNames: Array<string>): Object;
     bindAll(object?: ?Object, ...methodNames: Array<string>): Object;
     cond(pairs: NestedArray<Function>): Function;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.47.x-/test_lodash-v4.x.x.js
@@ -2,6 +2,14 @@
 import _ from 'lodash';
 
 /**
+ * _.attempt
+ */
+_.attempt(() => void 0)
+_.attempt(x => x)
+_.attempt(x => x, 'first arg')
+_.attempt((x, y, z) => {}, null, {}, [])
+
+/**
  * _.countBy
  */
 _.countBy([6.1, 4.2, 6.3], Math.floor);


### PR DESCRIPTION
- Fixes `unused argument` error when using `_.attempt`

<https://lodash.com/docs/4.17.4#attempt>