### PR TITLE
A react-router_v4.x.x fix for the Flow version 0.53

### DIFF
--- a/definitions/npm/react-router_v4.x.x/flow_v0.30.x-v0.52.x/test_react-router.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.30.x-v0.52.x/test_react-router.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React from "react";
 import {
   StaticRouter,
   MemoryRouter,
@@ -10,23 +10,25 @@ import {
   Switch,
   withRouter,
   matchPath
-} from 'react-router';
-import type { Location, Match, ContextRouter } from 'react-router';
+} from "react-router";
+import type { Location, Match, ContextRouter } from "react-router";
 
 // Location
 var locationOK: Location = {
-  pathname: '/path',
-  search: '?search',
-  hash: '#hash',
+  pathname: "/path",
+  search: "?search",
+  hash: "#hash",
   state: null,
-  key: 'key'
+  key: "key"
 };
 
 // $ExpectError
 var locationError: Location = {};
 
 // StaticRouter
-<StaticRouter context={{}}><div /></StaticRouter>;
+<StaticRouter context={{}}>
+  <div />
+</StaticRouter>;
 <StaticRouter location="/" context={{}} basename="/foo/">
   <div />
 </StaticRouter>;
@@ -35,9 +37,11 @@ var locationError: Location = {};
 <StaticRouter />;
 
 // MemoryRouter
-<MemoryRouter><div /></MemoryRouter>;
+<MemoryRouter>
+  <div />
+</MemoryRouter>;
 <MemoryRouter
-  initialEntries={['/one', '/two', { pathname: '/three' }]}
+  initialEntries={["/one", "/two", { pathname: "/three" }]}
   initialIndex={1}
   getUserConfirmation={(
     message: string,
@@ -49,18 +53,22 @@ var locationError: Location = {};
 </MemoryRouter>;
 
 // $ExpectError
-<MemoryRouter initialEntries={''} />;
+<MemoryRouter initialEntries={""} />;
 
 // Router
 var history: History;
-<Router history={history}><div /></Router>;
+<Router history={history}>
+  <div />
+</Router>;
 
 // $ExpectError
-<Router><div /></Router>;
+<Router>
+  <div />
+</Router>;
 
 // Prompt
 <Prompt message="ok?" when={true} />;
-<Prompt message={location => 'ok?'} />;
+<Prompt message={location => "ok?"} />;
 <Prompt message={location => true} />;
 
 // $ExpectError
@@ -70,9 +78,9 @@ var history: History;
 <Redirect to="/foo" push />;
 <Redirect
   to={{
-    pathname: '/login',
-    search: '?utm=foo',
-    state: { referrer: '/current' }
+    pathname: "/login",
+    search: "?utm=foo",
+    state: { referrer: "/current" }
   }}
 />;
 
@@ -82,10 +90,16 @@ var history: History;
 // Route
 var User = () => <div />;
 <Route path="/user/:username" component={User} exact={true} strict={true} />;
-<Route path="/home" render={({ match }) => <div>Home {match.path}</div>} />;
+<Route
+  path="/home"
+  render={({ match }) =>
+    <div>
+      Home {match.path}
+    </div>}
+/>;
 <Route
   path="/"
-  children={({ match }) => <div className={match ? 'active' : ''} />}
+  children={({ match }) => <div className={match ? "active" : ""} />}
 />;
 
 // $ExpectError
@@ -102,9 +116,10 @@ type FooProps = {
   location: Location,
   name: string
 };
-const Foo = ({ location, name }: FooProps) => (
-  <div>{location.pathname} {name}</div>
-);
+const Foo = ({ location, name }: FooProps) =>
+  <div>
+    {location.pathname} {name}
+  </div>;
 const FooWithRouter = withRouter(Foo);
 <FooWithRouter name="name" />;
 
@@ -115,7 +130,7 @@ const BarWithRouter = withRouter(Bar);
 <BarWithRouter name="name" />;
 
 // $ExpectError
-withRouter('nope');
+withRouter("nope");
 
 // const FooWithRouterError = withRouter(Foo);
 // <FooWithRouterError name={3} />;
@@ -132,7 +147,7 @@ type WithRouterProps = ContextRouter & {
 // $ExpectError
 const IncorrectHistoryUsage = ({ history, name }: Foo2Props) => {
   // Wrong arguments here, error will bubble up to the component declaration
-  history.push(['bla']);
+  history.push(["bla"]);
   return (
     <div>
       {name}
@@ -141,15 +156,15 @@ const IncorrectHistoryUsage = ({ history, name }: Foo2Props) => {
 };
 
 // matchPath
-const match: null | Match = matchPath('/the/pathname', '/the/:dynamicId', {
+const match: null | Match = matchPath("/the/pathname", "/the/:dynamicId", {
   exact: true,
   strict: false
 });
-const match2: null | Match = matchPath('/the/pathname', '/the/:dynamicId');
+const match2: null | Match = matchPath("/the/pathname", "/the/:dynamicId");
 
 // $ExpectError
-matchPath('/the/pathname');
+matchPath("/the/pathname");
 // $ExpectError
 matchPath();
 // $ExpectError
-const matchError: string = matchPath('/the/pathname', 'the/:dynamicId');
+const matchError: string = matchPath("/the/pathname", "the/:dynamicId");

--- a/definitions/npm/react-router_v4.x.x/flow_v0.53.x/react-router_v4.x.x.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.53.x/react-router_v4.x.x.js
@@ -1,5 +1,6 @@
 // flow-typed signature: b701192ca557cf27adf1b295517299fd
-// flow-typed version: b43dff3e0e/react-router_v4.x.x/flow_>=v0.52.x
+// flow-typed version: b43dff3e0e/react-router_v4.x.x/flow_>=v0.53.x
+import * as React from "react";
 
 declare module "react-router" {
   // NOTE: many of these are re-exported by react-router-dom and
@@ -22,10 +23,10 @@ declare module "react-router" {
 
   declare export type HistoryAction = "PUSH" | "REPLACE" | "POP";
 
-  declare export type RouterHistory = {|
-    +length: number,
-    +location: Location,
-    +action: HistoryAction,
+  declare export type RouterHistory = {
+    length: number,
+    location: Location,
+    action: HistoryAction,
     listen(
       callback: (location: Location, action: HistoryAction) => void
     ): () => void,
@@ -34,88 +35,88 @@ declare module "react-router" {
     go(n: number): void,
     goBack(): void,
     goForward(): void,
-    +canGo?: (n: number) => boolean,
+    canGo?: (n: number) => boolean,
     block(
       callback: (location: Location, action: HistoryAction) => boolean
     ): void,
     // createMemoryHistory
-    +index?: number,
-    +entries?: Array<Location>
-  |};
+    index?: number,
+    entries?: Array<Location>
+  };
 
-  declare export type Match = {|
-    +params: { [key: string]: ?string },
-    +isExact: boolean,
-    +path: string,
-    +url: string
-  |};
+  declare export type Match = {
+    params: { [key: string]: ?string },
+    isExact: boolean,
+    path: string,
+    url: string
+  };
 
-  declare export type ContextRouter = {|
-    +history: RouterHistory,
-    +location: Location,
-    +match: Match
-  |};
+  declare export type ContextRouter = {
+    history: RouterHistory,
+    location: Location,
+    match: Match
+  };
 
   declare export type GetUserConfirmation = (
     message: string,
     callback: (confirmed: boolean) => void
   ) => void;
 
-  declare type StaticRouterContext = {|
-    +url?: string
-  |};
+  declare type StaticRouterContext = {
+    url?: string
+  };
 
   declare type StaticRouterProps = {
-    +basename?: string,
-    +location?: string | Location,
-    +context: StaticRouterContext,
-    +children?: React$Element<*>
+    basename?: string,
+    location?: string | Location,
+    context: StaticRouterContext,
+    children?: React$Element<*>
   };
   declare export class StaticRouter extends React$Component<
     StaticRouterProps
   > {}
 
   declare type MemoryRouterProps = {
-    +initialEntries?: Array<LocationShape | string>,
-    +initialIndex?: number,
-    +getUserConfirmation?: GetUserConfirmation,
-    +keyLength?: number,
-    +children?: React$Element<*>
+    initialEntries?: Array<LocationShape | string>,
+    initialIndex?: number,
+    getUserConfirmation?: GetUserConfirmation,
+    keyLength?: number,
+    children?: React$Element<*>
   };
   declare export class MemoryRouter extends React$Component<
     MemoryRouterProps
   > {}
 
   declare type RouterProps = {
-    +history: RouterHistory,
-    +children?: React$Element<*>
+    history: RouterHistory,
+    children?: React$Element<*>
   };
   declare export class Router extends React$Component<RouterProps> {}
 
   declare type PromptProps = {
-    +message: string | ((location: Location) => string | true),
-    +when?: boolean
+    message: string | ((location: Location) => string | true),
+    when?: boolean
   };
   declare export class Prompt extends React$Component<PromptProps> {}
 
   declare type RedirectProps = {
-    +to: string | LocationShape,
-    +push?: boolean
+    to: string | LocationShape,
+    push?: boolean
   };
   declare export class Redirect extends React$Component<RedirectProps> {}
 
   declare type RouteProps = {
-    +component?: React$Element<*>,
-    +render?: (router: ContextRouter) => React$Element<*>,
-    +children?: (router: ContextRouter) => React$Element<*>,
-    +path?: string,
-    +exact?: boolean,
-    +strict?: boolean
+    component?: React$ComponentType<*>,
+    render?: (router: ContextRouter) => React$Element<*>,
+    children?: (router: ContextRouter) => React$Element<*>,
+    path?: string,
+    exact?: boolean,
+    strict?: boolean
   };
   declare export class Route extends React$Component<RouteProps> {}
 
   declare type SwithcProps = {
-    +children?: Array<React$Element<*>>
+    children?: Array<React$Element<*>>
   };
   declare export class Switch extends React$Component<SwithcProps> {}
 

--- a/definitions/npm/react-router_v4.x.x/flow_v0.53.x/react-router_v4.x.x.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.53.x/react-router_v4.x.x.js
@@ -1,0 +1,135 @@
+// flow-typed signature: b701192ca557cf27adf1b295517299fd
+// flow-typed version: b43dff3e0e/react-router_v4.x.x/flow_>=v0.52.x
+
+declare module "react-router" {
+  // NOTE: many of these are re-exported by react-router-dom and
+  // react-router-native, so when making changes, please be sure to update those
+  // as well.
+  declare export type Location = {
+    pathname: string,
+    search: string,
+    hash: string,
+    state?: any,
+    key?: string
+  };
+
+  declare export type LocationShape = {
+    pathname?: string,
+    search?: string,
+    hash?: string,
+    state?: any
+  };
+
+  declare export type HistoryAction = "PUSH" | "REPLACE" | "POP";
+
+  declare export type RouterHistory = {|
+    +length: number,
+    +location: Location,
+    +action: HistoryAction,
+    listen(
+      callback: (location: Location, action: HistoryAction) => void
+    ): () => void,
+    push(path: string | LocationShape, state?: any): void,
+    replace(path: string | LocationShape, state?: any): void,
+    go(n: number): void,
+    goBack(): void,
+    goForward(): void,
+    +canGo?: (n: number) => boolean,
+    block(
+      callback: (location: Location, action: HistoryAction) => boolean
+    ): void,
+    // createMemoryHistory
+    +index?: number,
+    +entries?: Array<Location>
+  |};
+
+  declare export type Match = {|
+    +params: { [key: string]: ?string },
+    +isExact: boolean,
+    +path: string,
+    +url: string
+  |};
+
+  declare export type ContextRouter = {|
+    +history: RouterHistory,
+    +location: Location,
+    +match: Match
+  |};
+
+  declare export type GetUserConfirmation = (
+    message: string,
+    callback: (confirmed: boolean) => void
+  ) => void;
+
+  declare type StaticRouterContext = {|
+    +url?: string
+  |};
+
+  declare type StaticRouterProps = {
+    +basename?: string,
+    +location?: string | Location,
+    +context: StaticRouterContext,
+    +children?: React$Element<*>
+  };
+  declare export class StaticRouter extends React$Component<
+    StaticRouterProps
+  > {}
+
+  declare type MemoryRouterProps = {
+    +initialEntries?: Array<LocationShape | string>,
+    +initialIndex?: number,
+    +getUserConfirmation?: GetUserConfirmation,
+    +keyLength?: number,
+    +children?: React$Element<*>
+  };
+  declare export class MemoryRouter extends React$Component<
+    MemoryRouterProps
+  > {}
+
+  declare type RouterProps = {
+    +history: RouterHistory,
+    +children?: React$Element<*>
+  };
+  declare export class Router extends React$Component<RouterProps> {}
+
+  declare type PromptProps = {
+    +message: string | ((location: Location) => string | true),
+    +when?: boolean
+  };
+  declare export class Prompt extends React$Component<PromptProps> {}
+
+  declare type RedirectProps = {
+    +to: string | LocationShape,
+    +push?: boolean
+  };
+  declare export class Redirect extends React$Component<RedirectProps> {}
+
+  declare type RouteProps = {
+    +component?: React$Element<*>,
+    +render?: (router: ContextRouter) => React$Element<*>,
+    +children?: (router: ContextRouter) => React$Element<*>,
+    +path?: string,
+    +exact?: boolean,
+    +strict?: boolean
+  };
+  declare export class Route extends React$Component<RouteProps> {}
+
+  declare type SwithcProps = {
+    +children?: Array<React$Element<*>>
+  };
+  declare export class Switch extends React$Component<SwithcProps> {}
+
+  declare export function withRouter<P>(
+    Component: React$ComponentType<ContextRouter & P>
+  ): React$ComponentType<P>;
+
+  declare type MatchPathOptions = {
+    exact?: boolean,
+    strict?: boolean
+  };
+  declare export function matchPath(
+    pathname: string,
+    path: string,
+    options?: MatchPathOptions
+  ): null | Match;
+}

--- a/definitions/npm/react-router_v4.x.x/flow_v0.53.x/test_react-router.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.53.x/test_react-router.js
@@ -1,0 +1,166 @@
+// @flow
+import React from "react";
+import {
+  StaticRouter,
+  MemoryRouter,
+  Router,
+  Prompt,
+  Redirect,
+  Route,
+  Switch,
+  withRouter,
+  matchPath
+} from "react-router";
+import type { Location, Match, ContextRouter } from "react-router";
+
+// Location
+var locationOK: Location = {
+  pathname: "/path",
+  search: "?search",
+  hash: "#hash",
+  state: null,
+  key: "key"
+};
+
+// $ExpectError
+var locationError: Location = {};
+
+// StaticRouter
+<StaticRouter context={{}}>
+  <div />
+</StaticRouter>;
+<StaticRouter location="/" context={{}} basename="/foo/">
+  <div />
+</StaticRouter>;
+
+// $ExpectError
+<StaticRouter />;
+
+// MemoryRouter
+<MemoryRouter>
+  <div />
+</MemoryRouter>;
+<MemoryRouter
+  initialEntries={["/one", "/two", { pathname: "/three" }]}
+  initialIndex={1}
+  getUserConfirmation={(
+    message: string,
+    callback: (confirmed: boolean) => void
+  ): void => {}}
+  keyLength={3}
+>
+  <div />
+</MemoryRouter>;
+
+// $ExpectError
+<MemoryRouter initialEntries={""} />;
+
+// Router - fails as history is void in Flow 0.53
+// var history: History;
+// <Router history={history}><div /></Router>;
+
+// $ExpectError
+<Router>
+  <div />
+</Router>;
+
+// Prompt
+<Prompt message="ok?" when={true} />;
+<Prompt message={location => "ok?"} />;
+<Prompt message={location => true} />;
+
+// $ExpectError
+<Prompt />;
+
+// Redirect
+<Redirect to="/foo" push />;
+<Redirect
+  to={{
+    pathname: "/login",
+    search: "?utm=foo",
+    state: { referrer: "/current" }
+  }}
+/>;
+
+// $ExpectError
+<Redirect />;
+
+// Route
+var User = () => <div />;
+<Route path="/user/:username" component={User} exact={true} strict={true} />;
+<Route
+  path="/home"
+  render={({ match }) =>
+    <div>
+      Home {match.path}
+    </div>}
+/>;
+<Route
+  path="/"
+  children={({ match }) => <div className={match ? "active" : ""} />}
+/>;
+
+// $ExpectError
+<Route path="/user/:username" component={<User />} />;
+
+// Switch
+<Switch>
+  <Route />
+  <Route />
+</Switch>;
+
+// withRouter
+type FooProps = ContextRouter & {
+  location: Location,
+  name: string
+};
+const Foo = ({ location, name }: FooProps) =>
+  <div>
+    {location.pathname} {name}
+  </div>;
+const FooWithRouter = withRouter(Foo);
+<FooWithRouter name="name" />;
+
+class Bar extends React.Component<FooProps> {}
+const BarWithRouter = withRouter(Bar);
+<BarWithRouter name="name" />;
+
+// $ExpectError
+withRouter("nope");
+
+// const FooWithRouterError = withRouter(Foo);
+// <FooWithRouterError name={3} />;
+
+// $ExpectError
+const BarWithRouterError = withRouter(Bar);
+<BarWithRouterError name={3} />;
+
+// Test ContextRouter as props
+type WithRouterProps = ContextRouter & {
+  name: string
+};
+
+// $ExpectError
+const IncorrectHistoryUsage = ({ history, name }: Foo2Props) => {
+  // Wrong arguments here, error will bubble up to the component declaration
+  history.push(["bla"]);
+  return (
+    <div>
+      {name}
+    </div>
+  );
+};
+
+// matchPath
+const match: null | Match = matchPath("/the/pathname", "/the/:dynamicId", {
+  exact: true,
+  strict: false
+});
+const match2: null | Match = matchPath("/the/pathname", "/the/:dynamicId");
+
+// $ExpectError
+matchPath("/the/pathname");
+// $ExpectError
+matchPath();
+// $ExpectError
+const matchError: string = matchPath("/the/pathname", "the/:dynamicId");


### PR DESCRIPTION
Added separate definitions that work with Flow v 0.53 for the basic `react-router` package