### PR TITLE
refactor react-i18next typedef for Flow 0.53.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,57 +1,27 @@
 {
   "name": "flow-typed",
-  "version": "2.1.5",
   "description": "A repository of high quality flowtype definitions",
+  "license": "MIT",
+  "homepage": "https://github.com/flowtype/flow-typed#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/flowtype/flow-typed.git"
+  },
+  "bugs": {
+    "url": "https://github.com/flowtype/flow-typed/issues"
+  },
+  "version": "2.1.5",
   "main": "dist/cli.js",
   "bin": "dist/cli.js",
   "scripts": {
-    "clean": "rimraf dist",
     "build": "mkdirp dist && babel ./src --out-dir=./dist",
+    "clean": "rimraf dist",
     "flow": "flow",
     "lint": "eslint .",
     "prepublish": "mkdirp dist && npm run test",
     "test": "npm run clean && npm run build && npm run test-quick",
     "test-quick": "jest && npm run lint",
     "watch": "mkdirp dist && babel --source-maps --watch=./src --out-dir=./dist"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/flowtype/flow-typed.git"
-  },
-  "keywords": [
-    "flow",
-    "flowtype"
-  ],
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/flowtype/flow-typed/issues"
-  },
-  "homepage": "https://github.com/flowtype/flow-typed#readme",
-  "jest": {
-    "name": "flow-typed-cli",
-    "modulePathIgnorePatterns": [
-      "<rootDir>/dist/.*",
-      "<rootDir>/node_modules/.*"
-    ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/.*/__[^/]*-fixtures__/.*"
-    ]
-  },
-  "devDependencies": {
-    "babel-cli": "^6.24.1",
-    "babel-eslint": "^7.2.3",
-    "babel-plugin-syntax-async-functions": "^6.5.0",
-    "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-    "babel-plugin-transform-flow-strip-types": "^6.22.0",
-    "babel-plugin-transform-object-rest-spread": "^6.23.0",
-    "babel-plugin-transform-regenerator": "^6.24.1",
-    "babel-preset-es2015": "^6.24.1",
-    "eslint": "^4.2.0",
-    "eslint-plugin-flowtype": "^2.35.0",
-    "eslint-plugin-prettier": "^2.1.2",
-    "flow-bin": "0.50.0",
-    "jest": "^20.0.4",
-    "prettier": "^1.5.3"
   },
   "dependencies": {
     "babel-polyfill": "^6.23.0",
@@ -70,5 +40,31 @@
     "unzip": "^0.1.11",
     "which": "^1.2.14",
     "yargs": "^4.2.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-eslint": "^7.2.3",
+    "babel-plugin-syntax-async-functions": "^6.5.0",
+    "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+    "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-plugin-transform-regenerator": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1",
+    "eslint": "^4.2.0",
+    "eslint-plugin-flowtype": "^2.35.0",
+    "eslint-plugin-prettier": "^2.1.2",
+    "flow-bin": "0.50.0",
+    "jest": "^20.0.4",
+    "jest-cli": "^20.0.4",
+    "prettier": "^1.5.3"
+  },
+  "keywords": ["flow", "flowtype"],
+  "jest": {
+    "name": "flow-typed-cli",
+    "modulePathIgnorePatterns": [
+      "<rootDir>/dist/.*",
+      "<rootDir>/node_modules/.*"
+    ],
+    "testPathIgnorePatterns": ["<rootDir>/.*/__[^/]*-fixtures__/.*"]
   }
 }

--- a/definitions/npm/react-i18next_v5.x.x/flow_v0.53.x-/react-i18next_v5.x.x.js
+++ b/definitions/npm/react-i18next_v5.x.x/flow_v0.53.x-/react-i18next_v5.x.x.js
@@ -1,0 +1,46 @@
+declare module "react-i18next" {
+  declare type TFunction = (
+    key?: ?string,
+    data?: ?{ [key: string]: string }
+  ) => string;
+  declare type Locales = string | Array<string>;
+
+  declare type TranslatorProps = {
+    t: TFunction,
+    i18nLoadedAt: ?Date,
+    i18n: Object
+  };
+
+  declare type StatelessComponent<P> = (props: P) => ?React$Element<any>;
+  declare type LegacyTranslator<OP, P> = {
+    (component: StatelessComponent<P>): Class<React$Component<OP, void>>,
+    <St>(
+      component: Class<React$Component<P, St>>
+    ): Class<React$Component<OP, St>>
+  };
+
+  declare type Translator = <P: {}>(
+    component: React$ComponentType<TranslatorProps & P>
+  ) => Class<React$Component<P, *>>;
+
+  declare function translate(locales: Locales): Translator;
+  declare function translate<OP, P>(locales: Locales): LegacyTranslator<OP, P>;
+
+  declare type NamespacesProps = {
+    components: Array<React$ComponentType<*>>,
+    i18n: { loadNamespaces: Function }
+  };
+
+  declare function loadNamespaces(props: NamespacesProps): Promise<void>;
+
+  declare type ProviderProps = { i18n: Object, children: React$Element<*> };
+
+  declare var I18nextProvider: React$ComponentType<ProviderProps>;
+
+  declare type InterpolateProps = {
+    children?: React$Element<any>,
+    className?: string
+  };
+
+  declare var Interpolate: React$ComponentType<InterpolateProps>;
+}

--- a/definitions/npm/react-i18next_v5.x.x/flow_v0.53.x-/test_react-i18next_v5.x.x.js
+++ b/definitions/npm/react-i18next_v5.x.x/flow_v0.53.x-/test_react-i18next_v5.x.x.js
@@ -1,0 +1,117 @@
+// @flow
+
+import * as React from "react";
+import {
+  loadNamespaces,
+  translate,
+  I18nextProvider,
+  Interpolate,
+  type TranslatorProps,
+  type LegacyTranslator,
+  type TFunction
+} from "react-i18next";
+
+const i18n = { loadNamespaces: () => {} };
+
+<I18nextProvider i18n={i18n}>
+  <div />
+</I18nextProvider>;
+
+// $ExpectError - missing children prop
+<I18nextProvider i18n={i18n} />;
+// $ExpectError - missing i18n prop
+<I18nextProvider children={<div />} />;
+
+// passing
+loadNamespaces({ components: [], i18n });
+loadNamespaces({ components: [() => <div />], i18n });
+
+// $ExpectError - too few arguments
+loadNamespaces();
+// $ExpectError - wrong type
+loadNamespaces("");
+// $ExpectError - wrong component type
+loadNamespaces({ components: [{}], i18n });
+
+type Props = { s: string } & TranslatorProps;
+
+// $ExpectError - wrong argument type
+const FlowErrorComp = ({ s, t }: Props) =>
+  <div
+    prop1={t("", "")} // misuse of t()
+    prop2={" " + s}
+  />;
+
+class FlowErrorClassComp extends React.Component<Props> {
+  render() {
+    // $ExpectError - wrong argument type
+    const { s, t } = this.props;
+    return <div prop={t({})} />; // misuse of t()
+  }
+}
+
+// $ExpectError - too few arguments
+translate();
+// $ExpectError - wrong argument type
+translate({});
+
+const StatelessComp = ({ s, t }: Props) =>
+  <div prop1={t("")} prop2={" " + s} />;
+
+const WrappedStatelessComp = translate("")(StatelessComp);
+
+// passing
+<WrappedStatelessComp s="" />;
+
+// $ExpectError - missing prop "s"
+<WrappedStatelessComp />;
+// $ExpectError - wrong type
+<WrappedStatelessComp s={1} />;
+
+class ClassComp extends React.Component<Props> {
+  render() {
+    const { s, t } = this.props;
+    return <div prop={t("")} />;
+  }
+}
+
+const WrappedClassComp = translate("")(ClassComp);
+
+// passing
+<WrappedClassComp s="s" />;
+
+// $ExpectError - missing prop "s"
+<WrappedClassComp />;
+// $ExpectError - wrong type
+<WrappedClassComp s={1} />;
+
+// passing
+<Interpolate />;
+<Interpolate children={<div />} className="string" />;
+
+// $ExpectError - className prop wrong type
+<Interpolate className={null} />;
+// $ExpectError - children prop wrong type
+<Interpolate children={{}} />;
+
+// Works with legacy syntax
+
+type LegacyProps = { s: string };
+type LegacyPropsWithT = LegacyProps & { t: TFunction };
+
+const LegacyStatelessComp = ({ s, t }: LegacyPropsWithT) => {
+  return <div prop1={t("")} prop2={" " + s} />;
+};
+
+const translator: LegacyTranslator<LegacyProps, LegacyPropsWithT> = translate(
+  ""
+);
+const LegacyWrappedClassComp = translator(LegacyStatelessComp);
+
+// passing
+<LegacyWrappedClassComp s="s" />;
+
+// $ExpectError - missing prop "s"
+<LegacyWrappedClassComp />;
+// $ExpectError - wrong type
+<LegacyWrappedClassComp s={1} />;


### PR DESCRIPTION
Updates the react-i18next typedef to use the new Flow 0.53.0 HOC conventions. Unfortunately this is a very breaking change from the previous version of the plugin, which required passing in BaseProps and BaseProps + HOCProps to the Translator generic. I kept the old version of the Translator type and renamed it LegacyTranslator, so it should be fairly easy to grep through a codebase to get the new typedef working without having to rewrite all the translator types at once.

## Failing Tests

A couple simple tests (lines [69](https://github.com/flowtype/flow-typed/pull/1169/files#diff-5b1784a877f735590fee201dae4ad6e0R69) and [86](https://github.com/flowtype/flow-typed/pull/1169/files#diff-5b1784a877f735590fee201dae4ad6e0R86)) are currently failing, but I was unable to resolve them. I'm really not sure what the issue is since this [simplified example](https://flow.org/try/#0PTAEAEDMBsHsHcBQiCWBbADrATgF1AFSgCGAzqAEoCmxAxvpNrGqAOTY32sDcyuAnhiqgAkgDsAVlXpUAJgAUmGcgF5QAb1CRYsAFygxAVzQAjKtgA0oE8Wz6jp86AC+ySIbH0UsMaBSTpXEVYDAAeYOV9dWcAPgAKRFBQAGFmLDEqMVx9ajpcADpUzB9M3AAVQSpQ8SkZBSVyADJQCNIYi0QAShzOAqL00oqhcIaYjUTQDlxDbF93T1xvXwB1bGIMIWx+kqy4jAb9Vs7xpKSpmd9Q7YysjXz7-ZDSZy0dFXUAFgAmF5tsd++L2AMV4SWcvFciFo0DI5AAsvxrqVQFQAB64TKyci5eiFNI7XChdQTYj2YxmSwTExkxzYRAvZo1QJyVpjaLIWg+Uj4BEAUTEAAtiJ45Ejbmp-LUgko4gixbhOrxEKE+YLhbRRfibvhiO9WABGVi-d4-UDA7hAA) seems to work. **I would greatly appreciate some help here.**

## Caveat

You can avoid https://github.com/facebook/flow/issues/4692 by importing the `TranslatorProps` type and using it in your component files:

```js
import { translate, type TranslatorProps } from 'react-i18next'

type Props = {
  foo: string
} & TranslatorProps

const FooComp = (props: Props) => <div />

export default translate('locale')(FooComp)
```

Ideally, you would still be able to use the old method of defining only the props you use, but this will fail to typecheck since it's missing the other props from the HOC:

```js
import { translate, type TFunction } from 'react-i18next'

// THIS FAILS TO TYPECHECK
type Props = {
  foo: string,
  t: TFunction,
}

const FooComp = (props: Props) => <div />

export default translate('locale')(FooComp)
```