### PR TITLE
Fix the react-redux mapStateToProps annotations (per-instance memoization)

### DIFF
--- a/definitions/npm/react-redux_v5.x.x/flow_v0.30.x-v0.52.x/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.30.x-v0.52.x/react-redux_v5.x.x.js
@@ -14,7 +14,7 @@ declare module "react-redux" {
   declare type MapStateToProps<S, OP: Object, SP: Object> = (
     state: S,
     ownProps: OP
-  ) => SP | MapStateToProps<S, OP, SP>;
+  ) => ((state: S, ownProps: OP) => SP) | SP;
 
   declare type MapDispatchToProps<A, OP: Object, DP: Object> =
     | ((dispatch: Dispatch<A>, ownProps: OP) => DP)

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.30.x-v0.52.x/test_connect.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.30.x-v0.52.x/test_connect.js
@@ -1,34 +1,34 @@
 // @flow
-import React from 'react'
-import { connect } from 'react-redux'
-import type { Connector } from 'react-redux'
+import React from "react";
+import { connect } from "react-redux";
+import type { Connector } from "react-redux";
 
 // copy & paste from redux libedef :(
-type ReduxDispatch<A: { type: $Subtype<string> }> = (action: A) => A
+type ReduxDispatch<A: { type: $Subtype<string> }> = (action: A) => A;
 
-type Action = { type: 'A' } | { type: 'B' }
-type Dispatch = ReduxDispatch<Action>
+type Action = { type: "A" } | { type: "B" };
+type Dispatch = ReduxDispatch<Action>;
 
 type State = {
   c: number,
-  d: string,
-}
+  d: string
+};
 
 type Props1 = {
   a: number,
-  b: string,
-}
+  b: string
+};
 
 const C1 = (props: Props1) =>
   <div>
     {props.a} {props.b}
-  </div>
+  </div>;
 
 type Props2 = {
   a: number,
   b: string,
-  dispatch: Dispatch,
-}
+  dispatch: Dispatch
+};
 
 class C2 extends React.Component<void, Props2, void> {
   render() {
@@ -37,17 +37,17 @@ class C2 extends React.Component<void, Props2, void> {
       <div onClick={this.props.dispatch()}>
         {this.props.a} {this.props.b}
       </div>
-    )
+    );
   }
 }
 
 class C3 extends React.Component<void, Props2, void> {
   render() {
     return (
-      <div onClick={this.props.dispatch({ type: 'A' })}>
+      <div onClick={this.props.dispatch({ type: "A" })}>
         {this.props.a} {this.props.b}
       </div>
-    )
+    );
   }
 }
 
@@ -55,54 +55,54 @@ class C3 extends React.Component<void, Props2, void> {
 // connect()
 //
 
-const CC1 = connect()(C1)
-;<CC1 a={1} b="s" />
+const CC1 = connect()(C1);
+<CC1 a={1} b="s" />;
 // $ExpectError
-;<CC1 /> // missing a, b
+<CC1 />; // missing a, b
 // $ExpectError
-;<CC1 a={1} /> // missing b
+<CC1 a={1} />; // missing b
 // $ExpectError
-;<CC1 a="s" b="s" /> // wrong a type
+<CC1 a="s" b="s" />; // wrong a type
 
-const CC3 = connect()(C3)
-;<CC3 a={1} b="s" />
+const CC3 = connect()(C3);
+<CC3 a={1} b="s" />;
 // $ExpectError
-;<CC3 /> // missing a, b
+<CC3 />; // missing a, b
 // $ExpectError
-;<CC3 a={1} /> // missing b
+<CC3 a={1} />; // missing b
 // $ExpectError
-;<CC3 a="s" b="s" /> // wrong a type
+<CC3 a="s" b="s" />; // wrong a type
 
 //
 // connect(null, null, nul, options)
 //
 
-connect(null, null, null, { pure: true })(C1)
+connect(null, null, null, { pure: true })(C1);
 // $ExpectError
-connect(null, null, null, { pure: 1 })(C1) // wrong type
-connect(null, null, null, { withRef: true })(C1)
+connect(null, null, null, { pure: 1 })(C1); // wrong type
+connect(null, null, null, { withRef: true })(C1);
 // $ExpectError
-connect(null, null, null, { withRef: 1 })(C1) // wrong type
-const CC4 = connect(null, null, null, {})(C1)
-;<CC4 a={1} b="s" />
+connect(null, null, null, { withRef: 1 })(C1); // wrong type
+const CC4 = connect(null, null, null, {})(C1);
+<CC4 a={1} b="s" />;
 // $ExpectError
-;<CC4 /> // missing a, b
+<CC4 />; // missing a, b
 
 //
 // connect(mapStateToProps)
 //
 
-type OwnProps1 = { b: string }
+type OwnProps1 = { b: string };
 // without ownProps
 const connector5: Connector<OwnProps1, Props1> = connect((state: State) => ({
-  a: state.c,
-}))
-const CC5 = connector5(C1)
-;<CC5 b="s" />
+  a: state.c
+}));
+const CC5 = connector5(C1);
+<CC5 b="s" />;
 // $ExpectError
-;<CC5 /> // missing b
+<CC5 />; // missing b
 // $ExpectError
-;<CC5 b={1} /> // wrong b type
+<CC5 b={1} />; // wrong b type
 
 // with ownProps
 const connector6: Connector<
@@ -110,14 +110,14 @@ const connector6: Connector<
   Props1
 > = connect((state: State, ownProps: OwnProps1) => ({
   a: state.c,
-  b: ownProps.b + 's',
-}))
-const CC6 = connector6(C1)
-;<CC6 b="s" />
+  b: ownProps.b + "s"
+}));
+const CC6 = connector6(C1);
+<CC6 b="s" />;
 // $ExpectError
-;<CC6 /> // missing b
+<CC6 />; // missing b
 // $ExpectError
-;<CC6 b={1} /> // wrong b type
+<CC6 b={1} />; // wrong b type
 
 //
 // connect(null, mapDispatchToProps)
@@ -125,35 +125,35 @@ const CC6 = connector6(C1)
 
 type OwnProps2 = {
   a: number,
-  b: string,
-}
+  b: string
+};
 // without ownProps
 const connector7: Connector<
   OwnProps2,
   Props2
-> = connect(null, (dispatch: Dispatch) => ({ dispatch }))
-const CC7 = connector7(C3)
-;<CC7 a={1} b="s" />
+> = connect(null, (dispatch: Dispatch) => ({ dispatch }));
+const CC7 = connector7(C3);
+<CC7 a={1} b="s" />;
 // $ExpectError
-;<CC7 a={1} /> // missing b
+<CC7 a={1} />; // missing b
 // $ExpectError
-;<CC7 a="s" b="s" /> // wrong b type
+<CC7 a="s" b="s" />; // wrong b type
 
-type OwnProps3 = { a: number }
+type OwnProps3 = { a: number };
 // with ownProps
 const connector8: Connector<
   OwnProps3,
   Props2
 > = connect(null, (dispatch: Dispatch, ownProps: OwnProps3) => ({
   dispatch,
-  b: ownProps.a + 's',
-}))
-const CC8 = connector8(C3)
-;<CC8 a={1} />
+  b: ownProps.a + "s"
+}));
+const CC8 = connector8(C3);
+<CC8 a={1} />;
 // $ExpectError
-;<CC8 /> // missing a
+<CC8 />; // missing a
 // $ExpectError
-;<CC8 a="s" /> // wrong b type
+<CC8 a="s" />; // wrong b type
 
 //
 // connect(mapStateToProps, mapDispatchToProps)
@@ -162,28 +162,43 @@ const CC8 = connector8(C3)
 const connector9: Connector<OwnProps1, Props2> = connect(
   (state: State) => ({ a: state.c }),
   (dispatch: Dispatch) => ({ dispatch })
-)
-const CC9 = connector9(C3)
-;<CC9 b="s" />
+);
+const CC9 = connector9(C3);
+<CC9 b="s" />;
 // $ExpectError
-;<CC9 /> // missing b
+<CC9 />; // missing b
 // $ExpectError
-;<CC9 b={1} /> // wrong b type
+<CC9 b={1} />; // wrong b type
+
+//
+// connect(() => mapStateToProps)
+//
+
+const connector10: Connector<
+  OwnProps1,
+  Props2
+> = connect(() => (state: State) => ({ a: state.c }));
+const CC10 = connector10(C3);
+<CC10 b="s" />;
+// $ExpectError
+<CC10 />; // missing b
+// $ExpectError
+<CC10 b={1} />; // wrong b type
 
 //
 // connect(mapStateToProps, mapDispatchToProps, MergeProps)
 //
 
-const connector10: Connector<{}, Props2> = connect(
+const connector11: Connector<{}, Props2> = connect(
   (state: State) => ({ a: state.c }),
   (dispatch: Dispatch) => ({ dispatch }),
   (stateProps, dispatchProps) =>
-    Object.assign({}, stateProps, dispatchProps, { b: 's' })
-)
-const CC10 = connector10(C3)
-;<CC10 />
+    Object.assign({}, stateProps, dispatchProps, { b: "s" })
+);
+const CC11 = connector11(C3);
+<CC11 />;
 
 //
 // ConnectedComponent
 //
-;(CC1.WrappedComponent: C1)
+(CC1.WrappedComponent: C1);

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.53.x-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.53.x-/react-redux_v5.x.x.js
@@ -17,7 +17,7 @@ declare module "react-redux" {
   declare type MapStateToProps<S, OP: Object, SP: Object> = (
     state: S,
     ownProps: OP
-  ) => SP | MapStateToProps<S, OP, SP>;
+  ) => ((state: S, ownProps: OP) => SP) | SP;
 
   declare type MapDispatchToProps<A, OP: Object, DP: Object> =
     | ((dispatch: Dispatch<A>, ownProps: OP) => DP)

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.53.x-/test_connect.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.53.x-/test_connect.js
@@ -171,17 +171,31 @@ const CC9 = connector9(C3);
 <CC9 b={1} />; // wrong b type
 
 //
+// connect(() => mapStateToProps)
+//
+const connector10: Connector<
+  OwnProps1,
+  Props2
+> = connect(() => (state: State) => ({ a: state.c }));
+const CC10 = connector10(C3);
+<CC10 b="s" />;
+// $ExpectError
+<CC10 />; // missing b
+// $ExpectError
+<CC10 b={1} />; // wrong b type
+
+//
 // connect(mapStateToProps, mapDispatchToProps, MergeProps)
 //
 
-const connector10: Connector<{}, Props2> = connect(
+const connector11: Connector<{}, Props2> = connect(
   (state: State) => ({ a: state.c }),
   (dispatch: Dispatch) => ({ dispatch }),
   (stateProps, dispatchProps) =>
     Object.assign({}, stateProps, dispatchProps, { b: "s" })
 );
-const CC10 = connector10(C3);
-<CC10 />;
+const CC11 = connector11(C3);
+<CC11 />;
 
 //
 // ConnectedComponent


### PR DESCRIPTION
[![Sponsored by Immowelt](https://img.shields.io/badge/sponsored%20by-immowelt-yellow.svg?colorB=ffb200)](https://stackshare.io/immowelt-group/)

This commit fixes an issue with the typings of React-Redux's mapStateToProps function which was reported in #979. The official docs state that the mapStateToProps fn can in fact return another mapStateToProps fn to get a per-instance based memoization.

See the 'Note' on the mapStateToProps documentation block.
https://github.com/reactjs/react-redux/blob/master/docs/api.md\#arguments

/cc @marudor 
resolves #979