### PR TITLE
[ramda] .prop() return type should be a non-maybe type

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/ramda_v0.x.x.js
@@ -601,8 +601,8 @@ declare module ramda {
   declare function project<T>(keys: Array<string>, ...rest: Array<void>): (val: Array<{[key:string]: T}>) => Array<{[key:string]: T}>;
   declare function project<T>(keys: Array<string>, val: Array<{[key:string]: T}>): Array<{[key:string]: T}>;
 
-  declare function prop<T,O:{[k:string]:T}>(key: $Keys<O>, ...rest: Array<void>): (o: O) => ?T;
-  declare function prop<T,O:{[k:string]:T}>(key: $Keys<O>, o: O): ?T;
+  declare function prop<T,O:{[k:string]:T}>(key: $Keys<O>, ...rest: Array<void>): (o: O) => T;
+  declare function prop<T,O:{[k:string]:T}>(key: $Keys<O>, o: O): T;
 
   declare function propOr<T,V,A:{[k:string]:V}>(or: T, ...rest: Array<void>):
   ((p: $Keys<A>, ...rest: Array<void>) => (o: A) => V|T)

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_object.js
@@ -123,9 +123,11 @@ const ooo = { a: 1, b: 2, A: 3, B: 4 }
 const isUpperCase = (val, key) => key.toUpperCase() === key
 const pb:Object = _.pickBy(isUpperCase, ooo)
 
-const ppp:?number = _.prop('x', { x: 100 })
+const ppp:number = _.prop('x', { x: 100 })
 //$ExpectError
-const ppp1:?number = _.prop('y', { x: 100 })
+const ppp1:number = _.prop('y', { x: 100 })
+const indexerPropObject: { [string]: number } = { x: 100 }
+const ppp2:number = _.prop('y', indexerPropObject)
 
 const alice = {
   name: 'ALICE',


### PR DESCRIPTION
Currently, the return value of of Ramda's `.prop()` (after currying) is `?T`, where `T` is the type of the values of the object it's getting a property from. I propose that, while sound, this keeps Flow from catching mistakes it could otherwise catch, and that it would be better to type it as `T`.

There are two cases here: the case where the object (type `O`) is defined with an indexer property, and the case without.

Without an indexer property, the keys of `O` are known. Thus, `Ramda.prop('foo', {bar: 1})` is an error, because `'foo'` does not match the type `$Keys<{bar: number}>`. Without an indexer property, then, `Ramda.prop()` can never fail to return a `T`. Returning `?T`, then, requires handling a `null`/`undefined` return value which can never occur at runtime.

With an indexer property, Flow doesn't know the keys of `O`. Thus, `Ramda.prop('foo', (o: {[string]: number}))` could return `undefined` if `'foo'` is not in that `o` at runtime. But [Flow has already decided that property access for objects with indexer properties is unsafe](https://flow.org/en/docs/types/objects/#toc-objects-as-maps), and it's the programmer's responsibility to ensure a value exists at the key.

Therefore, I think it makes the most sense for Ramda's `.prop()` to follow the same pattern as normal property access and return `T` instead of `?T`.

(This change should apply to more versions than the one given, but I'll add them later if I get a thumbs up for this change.)