### PR TITLE
[ramda] Support placeholder currying

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/ramda_v0.x.x.js
@@ -6,6 +6,8 @@ type Transformer<A,B> = {
   '@@transducer/result': (result: *) => B
 }
 
+declare type $npm$ramda$Placeholder = {'@@functional/placeholder': true};
+
 
 declare module ramda {
   declare type UnaryFn<A,R> = (a: A) => R;
@@ -602,6 +604,7 @@ declare module ramda {
   declare function project<T>(keys: Array<string>, val: Array<{[key:string]: T}>): Array<{[key:string]: T}>;
 
   declare function prop<T,O:{[k:string]:T}>(key: $Keys<O>, ...rest: Array<void>): (o: O) => ?T;
+  declare function prop<T,O:{[k:string]:T}>(__: $npm$ramda$Placeholder, o: O): (key: $Keys<O>) => ?T;
   declare function prop<T,O:{[k:string]:T}>(key: $Keys<O>, o: O): ?T;
 
   declare function propOr<T,V,A:{[k:string]:V}>(or: T, ...rest: Array<void>):
@@ -635,7 +638,7 @@ declare module ramda {
   // TODO view
 
   // *Function
-  declare var __: *;
+  declare var __: $npm$ramda$Placeholder;
 
   declare var T: (_: any) => true;
   declare var F: (_: any) => false;

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_object.js
@@ -126,6 +126,12 @@ const pb:Object = _.pickBy(isUpperCase, ooo)
 const ppp:?number = _.prop('x', { x: 100 })
 //$ExpectError
 const ppp1:?number = _.prop('y', { x: 100 })
+const ppp2:?number = _.prop('x')({ x: 100 })
+//$ExpectError
+const ppp3:?number = _.prop('y')({ x: 100 })
+const ppp4:?number = _.prop(_.__, { x: 100 })('x')
+//$ExpectError
+const ppp5:?number = _.prop(_.__, { x: 100 })('y')
 
 const alice = {
   name: 'ALICE',


### PR DESCRIPTION
Ramda support "placeholder currying" (not sure if there's a better word for it) when the argument order doesn't naturally support the kind of partial application you'd like to do:

```js
ramda.prop('x', {x: 100}); // 100
ramda.prop('x')({x: 100}); // 100
ramda.prop(ramda.__, {x: 100})('x'); // 100
```

This is tricky to type, but not impossible. This PR currently does it for `.prop()`. If this looks good, I'll extend it to other functions. It takes bit of brute forcing to type out all the typedefs, but I'm pretty sure that's the only way to get Flow to understand it.