### PR TITLE
Add lib defs for mongoose@4.x.x

### DIFF
--- a/definitions/npm/mongoose_v4.x.x/flow_v0.50.x-/mongoose_v4.x.x.js
+++ b/definitions/npm/mongoose_v4.x.x/flow_v0.50.x-/mongoose_v4.x.x.js
@@ -1,0 +1,483 @@
+import mongoose from "mongoose";
+
+type MongoId =
+  | typeof mongoose.Types.ObjectId
+  | {
+      toString(): string
+    };
+
+type MongoOrScalarId = MongoId | string | number;
+
+type SchemaFields = {
+  [fieldName: string]: any
+};
+
+type ToObjectOpts<Doc> = {
+  getters?: boolean,
+  virtuals?: boolean,
+  minimize?: boolean,
+  transform?: (doc: Doc, ret: Object, options: Object) => any,
+  depopulate?: boolean,
+  versionKey?: boolean,
+  retainKeyOrder?: boolean
+};
+
+type SchemaOpts<Doc> = {
+  autoIndex?: boolean,
+  bufferCommands?: boolean,
+  capped?: boolean,
+  collection?: string,
+  emitIndexErrors?: boolean,
+  id?: boolean,
+  _id?: boolean,
+  minimize?: boolean,
+  read?: string,
+  safe?: boolean,
+  shardKey?: boolean,
+  strict?: boolean,
+  toJSON?: ToObjectOpts<Doc>,
+  toObject?: ToObjectOpts<Doc>,
+  typeKey?: string,
+  useNestedStrict?: boolean,
+  validateBeforeSave?: boolean,
+  versionKey?: string,
+  timestamps?: boolean
+};
+
+type IndexFields = {
+  [fieldName: string]: 1 | -1 | true | false | string
+};
+
+type IndexOpts = {|
+  background?: boolean,
+  unique?: boolean,
+  sparse?: boolean,
+  partialFilterExpression?: Object,
+  name?: string,
+  default_language?: string,
+  weights?: Object
+|};
+
+type Mongoose$Types = {|
+  ObjectId: {
+    $call: (id: string | MongoId) => MongoId
+  },
+  Mixed: Object,
+  Embedded: Object,
+  Document: Object,
+  DocumentArray: Object,
+  Subdocument: Object,
+  Array: Object,
+  Buffer: Object,
+  Decimal128: Object
+|};
+
+type Mongoose$SchemaMethods = {
+  [name: string]: Function
+};
+
+type Mongoose$SchemaStatics = {
+  [name: string]: Function
+};
+
+type VirtualType = Object;
+
+type Mongoose$SchemaHookTypes =
+  | "save"
+  | "validate"
+  | "find"
+  | "update"
+  | "remove"
+  | "findOneAndRemove"
+  | "init";
+
+type Mongoose$SchemaPlugin<Doc, O> = (
+  schema: Mongoose$Schema<Doc>,
+  opts: O
+) => void;
+
+declare class Mongoose$Schema<Doc: Object> {
+  static Types: Mongoose$Types,
+  constructor(
+    fields: SchemaFields,
+    opts?: SchemaOpts<Doc>
+  ): Mongoose$Schema<Doc>,
+  index(fields: IndexFields, opts?: IndexOpts): void,
+  methods: Mongoose$SchemaMethods,
+  statics: Mongoose$SchemaStatics,
+  virtual(fieldName: string): Mongoose$SchemaVirtualField,
+  pre(
+    hookType: Mongoose$SchemaHookTypes,
+    serialCb: (next: Function) => any
+  ): void,
+  pre(
+    hookType: Mongoose$SchemaHookTypes,
+    true,
+    parallelCb: (next: Function, done: Function) => any
+  ): void,
+  // post(hookType: Mongoose$SchemaHookTypes, parallelCb: (doc: Doc) => any): void;
+  post(
+    hookType: Mongoose$SchemaHookTypes,
+    serialCb: (doc: Doc, next: Function) => any
+  ): void,
+  // post(hookType: Mongoose$SchemaHookTypes, serialCb: (error: Error, doc: Doc, next: Function) => any): void;
+  plugin<O>(plugin: Mongoose$SchemaPlugin<Doc, O>, opts: O): void,
+  add(fields: SchemaFields, prefix?: string): void,
+  loadClass(cls: Class<Doc>): void,
+  paths: {
+    [name: string]: Mongoose$SchemaField<this>
+  },
+  clone(): Mongoose$Schema<Doc>,
+  eachPath(fn: (path: string, fieldOpts: Object) => void): this,
+  get(optionKey: string): any,
+  set(optionKey: string, value: any): void,
+  indexes(): ?Array<[string, IndexOpts]>,
+  path(path: string): Object,
+  path(path: string, schemaType: Object): void,
+  pathType(path: string): string,
+  remove(path: string | string[]): void,
+  requiredPaths(invalidate?: boolean): string[],
+  method(method: string, fn: Function): this,
+  method(methods: { [method: string]: Function }): this,
+  static (method: string, fn: Function): this,
+  static (methods: { [method: string]: Function }): this,
+  virtual(name: string, opts?: Object): VirtualType,
+  virtualpath(name: string): ?VirtualType,
+  indexTypes(): string[],
+  reserved: string[],
+  obj: SchemaOpts<Doc>
+}
+
+type Mongoose$SchemaField<Schema> = {
+  path?: string,
+  instance: string,
+  caster?: ?Mongoose$SchemaField<Schema>,
+  options?: ?{
+    description: ?string
+  },
+  enumValues?: ?(string[]),
+  schema?: Schema
+};
+
+declare class Mongoose$SchemaVirtualField {
+  get(() => any): this,
+  set((value: any) => any): this
+}
+
+type MongooseProjection = Object | string;
+
+type UpdateResult = {
+  nMatched: number,
+  nUpserted: number,
+  nModified: number,
+  ok?: boolean
+};
+
+declare class Mongoose$Document {
+  static find(
+    criteria?: Object,
+    projection?: MongooseProjection,
+    options?: Object
+  ): Mongoose$Query<Array<this>, this>,
+  static findOne(
+    criteria?: Object,
+    projection?: MongooseProjection
+  ): Mongoose$Query<?this, this>,
+  static findById(
+    id: MongoOrScalarId,
+    projection?: MongooseProjection,
+    options?: Object
+  ): Mongoose$Query<?this, this>,
+  static findOneAndRemove(
+    criteria: ?Object,
+    options?: Object
+  ): Mongoose$Query<?this, this>,
+  static findOneAndUpdate(
+    criteria: ?Object,
+    data: Object,
+    options?: Object
+  ): Mongoose$Query<?this, this>,
+  static findByIdAndRemove(
+    id: MongoOrScalarId,
+    options?: Object
+  ): Mongoose$Query<?this, this>,
+  static findByIdAndUpdate(
+    id: MongoOrScalarId,
+    data: Object,
+    options?: Object
+  ): Mongoose$Query<?this, this>,
+  static count(criteria: Object): Promise<number>,
+  static remove(criteria: Object): Promise<mixed>,
+  static update(
+    criteria: Object,
+    update: Object,
+    options?: Object
+  ): Promise<UpdateResult> & { exec(): Promise<UpdateResult> },
+  static updateOne(
+    criteria: Object,
+    update: Object,
+    options?: Object
+  ): Promise<UpdateResult> & { exec(): Promise<UpdateResult> },
+  static updateMany(
+    criteria: Object,
+    update: Object,
+    options?: Object
+  ): Promise<UpdateResult> & { exec(): Promise<UpdateResult> },
+  static create(doc: $Shape<this> | Array<$Shape<this>>): Promise<this>,
+  static where(criteria?: Object): Mongoose$Query<this, this>,
+  static aggregate(pipeline: Object[]): Promise<any>,
+  static bulkWrite(ops: Object[]): Promise<any>,
+  static deleteMany(criteria: Object): Promise<any>,
+  static deleteOne(criteria: Object): Promise<any>,
+  static distinct(field: string, criteria?: Object): Promise<any>,
+  static ensureIndexes(opts?: Object): Promise<any>,
+  static hydrate(data: Object): Mongoose$Document,
+  static insertMany(docs: Object | Object[], opts?: Object): Promise<any>,
+  static mapReduce(o: Object): Promise<any>,
+  static collection: Mongoose$Collection,
+  static db: any,
+  static modelName: string,
+  static schema: Mongoose$Schema<this>,
+
+  constructor(data?: $Shape<this>): this,
+  id: string | number,
+  _id: MongoOrScalarId,
+  __v?: number,
+  save(): Promise<this>,
+  update(update: Object, options?: Object): Promise<UpdateResult>,
+  set(data: $Shape<this>): this,
+  set(path: string, val: any, type?: any, options?: Object): this,
+  isSelected(fieldName: string): boolean,
+  validate(opts?: Object): Promise<*>,
+  validateSync(pathsToValidate: string | string[]): Error | void,
+  errors: Object,
+  isNew: boolean,
+  schema: Mongoose$Schema<this>,
+
+  $ignore(path: string): void,
+  $isDefault(path: string): boolean,
+  depopulate(path: string): this,
+  equals(doc: Mongoose$Document): boolean,
+  get(path: string, type?: Object): any,
+
+  inspect(): Object,
+  invalidate(
+    path: string,
+    errorMsg: string | Error,
+    value?: any,
+    kind?: string
+  ): ValidationError,
+  isDirectModified(path: string): boolean,
+  isDirectSelected(path: string): boolean,
+  isInit(path: string): boolean,
+  isModified(path?: string): boolean,
+  isSelected(path: string): boolean,
+  markModified(path: string): void,
+  modifiedPaths(): string[],
+
+  populate(path?: string | Object, cb?: (err: Error, doc: this) => void): void,
+  execPopulate(): Promise<this>,
+  populated(path: string): ?MongoOrScalarId,
+  toJSON(options: ToObjectOpts<this>): Object,
+  toObject(options: ToObjectOpts<this>): Object,
+  toString(): string,
+  unmarkModified(path: string): void,
+
+  increment(): void,
+  remove(): Promise<this>
+}
+
+type ValidationError = Object;
+
+// Try to replace `Mongoose$Query<Result, Doc>` on `this` in Flow above v0.53
+// For better dropdown suggesting used `Mongoose$Query<Result, Doc>`
+//   Fast check: `User.find().limit(5).` does not suggest if used `this`
+declare class Mongoose$Query<Result, Doc> extends Promise<Result> {
+  exec(): Promise<Result>,
+  where(criteria: Object): Mongoose$Query<Result, Doc>,
+  sort(fields: Object | string): Mongoose$Query<Result, Doc>,
+  limit(n: number): Mongoose$Query<Result, Doc>,
+  skip(n: number): Mongoose$Query<Result, Doc>,
+  select(fields: MongooseProjection): Mongoose$Query<Result, Doc>,
+  setOptions(opts: Object): Mongoose$Query<Result, Doc>,
+  update(data: Object): Mongoose$Query<any, Doc>,
+  update(
+    criteria: Object,
+    data: Object,
+    opts?: {
+      safe?: boolean,
+      upsert?: boolean,
+      multi?: boolean,
+      runValidators?: boolean,
+      setDefaultsOnInsert?: boolean,
+      strict?: boolean,
+      overwrite?: boolean
+    }
+  ): Mongoose$Query<any, Doc>,
+  updateMany(
+    criteria: Object,
+    data: Object,
+    opts?: Object
+  ): Mongoose$Query<any, Doc>,
+  updateOne(
+    criteria: Object,
+    data: Object,
+    opts?: Object
+  ): Mongoose$Query<any, Doc>,
+  remove(criteria?: Object): Mongoose$Query<?Doc, Doc>,
+  count(criteria?: Object): Promise<number>,
+  schema: Mongoose$Schema<Doc>,
+  $where(fn: Function): Mongoose$Query<Result, Doc>,
+  batchSize(n: number): Mongoose$Query<Result, Doc>,
+  collation(value: Object): Mongoose$Query<Result, Doc>,
+  comment(val: string): Mongoose$Query<Result, Doc>,
+  cursor(opts: Object): Mongoose$QueryCursor<Doc>,
+  deleteMany(criteria?: Object): Mongoose$Query<any, Doc>,
+  deleteOne(criteria?: Object): Mongoose$Query<any, Doc>,
+  distinct(field: string, criteria?: Object): Mongoose$Query<Result, Doc>,
+  find(criteria: Object): Mongoose$Query<Result, Doc>,
+  findOne(criteria?: Object, projection?: Object): Mongoose$Query<?Doc, Doc>,
+  findOneAndRemove(
+    criteria: Object,
+    opts?: { sort?: Object, maxTimeMS?: number, passRawResult?: boolean }
+  ): Mongoose$Query<?Doc, Doc>,
+  findOneAndUpdate(
+    criteria: Object,
+    data: Object,
+    opts?: {
+      new?: boolean,
+      upsert?: boolean,
+      fields?: Object | string,
+      maxTimeMS?: number,
+      runValidators?: boolean,
+      setDefaultsOnInsert?: boolean,
+      passRawResult?: boolean,
+      runSettersOnQuery?: boolean
+    }
+  ): Mongoose$Query<?Doc, Doc>,
+  getQuery(): Object,
+  getUpdate(): Object,
+  hint(index: Object): Mongoose$Query<Result, Doc>,
+  lean(passPlainObject: boolean): Mongoose$Query<Result, Doc>,
+  maxScan(n: number): Mongoose$Query<Result, Doc>,
+  populate(path: string): Mongoose$Query<Result, Doc>,
+  populate(obj: {
+    path: string,
+    select?: string,
+    match?: Object,
+    options?: Object
+  }): Mongoose$Query<Result, Doc>,
+  read(
+    pref:
+      | "primary"
+      | "secondary"
+      | "primaryPreferred"
+      | "secondaryPreferred"
+      | "nearest",
+    tags?: Object[]
+  ): Mongoose$Query<Result, Doc>,
+  selected(): boolean,
+  selectedExclusively(): boolean,
+  selectedInclusively(): boolean,
+  setOptions(options: Object): Mongoose$Query<Result, Doc>,
+  slice(
+    path: string,
+    val: number | [number, number]
+  ): Mongoose$Query<Result, Doc>,
+  snapshot(bool: boolean): Mongoose$Query<Result, Doc>,
+  stream(opts?: Object): Mongoose$QueryStream,
+  tailable(bool: boolean, opts?: Object): Mongoose$Query<Result, Doc>,
+  toConstructor(): Class<Mongoose$Query<Result, Doc>>
+}
+
+declare class Mongoose$QueryCursor<Doc> {
+  on(type: "data" | "end", cb: Function): void,
+  next(cb: (err: Error, doc: Doc) => void): void
+}
+
+declare class Mongoose$QueryStream {
+  destroy(): void,
+  pause(): void,
+  pipe(): void,
+  resume(): void,
+  paused: boolean,
+  readable: boolean,
+  on(event: "data" | "error" | "close", cb: Function): void
+}
+
+declare class Mongoose$Collection {
+  constructor(name: string, conn: Mongoose$Connection, opts?: Object): this,
+  ensureIndex(): any,
+  find(): any,
+  findAndModify(): any,
+  findOne(): any,
+  getIndexes(): any,
+  inser(): any,
+  mapReduce(): any,
+  save(): any,
+  update(): any,
+  collectionName: string,
+  conn: Mongoose$Connection,
+  name: string
+}
+
+type ConnectionConnectOpts = {
+  promiseLibrary?: any,
+  autoReconnect?: boolean,
+  reconnectTries?: number,
+  reconnectInterval?: number,
+  useMongoClient?: boolean,
+  config?: {
+    autoIndex?: boolean
+  }
+};
+type ConnectionEventTypes = "error" | "open" | "disconnected" | string;
+type CreateMongooseModel = <Doc>(
+  name: string,
+  schema: Mongoose$Schema<Doc>,
+  collection?: Mongoose$Collection
+) => Class<Doc>;
+
+declare class Mongoose$Connection {
+  constructor(): this,
+  close(): Promise<any>,
+  connect(uri: string, opts?: ConnectionConnectOpts): void,
+  openUri(uri: string, opts?: ConnectionConnectOpts): void,
+  model: CreateMongooseModel,
+  collection(name: string): Mongoose$Collection,
+  modelNames(): string[],
+  config: Object,
+  db: any,
+  collections: Mongoose$Collection[],
+  readyState: number,
+
+  // EventEmitter
+  addListener(event: ConnectionEventTypes, listener: Function): this,
+  emit(event: ConnectionEventTypes, ...args: Array<any>): boolean,
+  eventNames(): Array<ConnectionEventTypes>,
+  listeners(event: ConnectionEventTypes): Array<Function>,
+  listenerCount(event: ConnectionEventTypes): number,
+  on(event: ConnectionEventTypes, listener: Function): this,
+  once(event: ConnectionEventTypes, listener: Function): this,
+  prependListener(event: ConnectionEventTypes, listener: Function): this,
+  prependOnceListener(event: ConnectionEventTypes, listener: Function): this,
+  removeAllListeners(event?: ConnectionEventTypes): this,
+  removeListener(event: ConnectionEventTypes, listener: Function): this,
+  setMaxListeners(n: number): this,
+  getMaxListeners(): number
+}
+
+declare module "mongoose" {
+  declare export type MongooseConnection = Mongoose$Connection;
+  declare export type MongoId = MongoId;
+  declare export type MongoOrScalarId = MongoOrScalarId;
+
+  declare module.exports: {
+    Schema: typeof Mongoose$Schema,
+    Types: Mongoose$Types,
+    Promise: any,
+    model: CreateMongooseModel,
+    createConnection(): Mongoose$Connection,
+    set: (key: string, value: string | Function | boolean) => void
+  };
+}

--- a/definitions/npm/mongoose_v4.x.x/flow_v0.50.x-/mongoose_v4.x.x.js
+++ b/definitions/npm/mongoose_v4.x.x/flow_v0.50.x-/mongoose_v4.x.x.js
@@ -240,6 +240,7 @@ declare class Mongoose$Document {
   static db: any,
   static modelName: string,
   static schema: Mongoose$Schema<this>,
+  static on(type: string, cb: Function): void,
 
   constructor(data?: $Shape<this>): this,
   id: string | number,
@@ -360,7 +361,7 @@ declare class Mongoose$Query<Result, Doc> extends Promise<Result> {
   getQuery(): Object,
   getUpdate(): Object,
   hint(index: Object): Mongoose$Query<Result, Doc>,
-  lean(passPlainObject: boolean): Mongoose$Query<Result, Doc>,
+  lean(passPlainObject?: boolean): Mongoose$Query<any, Doc>,
   maxScan(n: number): Mongoose$Query<Result, Doc>,
   populate(path: string): Mongoose$Query<Result, Doc>,
   populate(obj: {
@@ -393,7 +394,7 @@ declare class Mongoose$Query<Result, Doc> extends Promise<Result> {
 }
 
 declare class Mongoose$QueryCursor<Doc> {
-  on(type: "data" | "end", cb: Function): void,
+  on(type: "data" | "end" | string, cb: Function): void,
   next(cb: (err: Error, doc: Doc) => void): void
 }
 

--- a/definitions/npm/mongoose_v4.x.x/flow_v0.50.x-/mongoose_v4.x.x.js
+++ b/definitions/npm/mongoose_v4.x.x/flow_v0.50.x-/mongoose_v4.x.x.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 import mongoose from "mongoose";
 
 type MongoId =
@@ -91,12 +93,12 @@ type Mongoose$SchemaHookTypes =
   | "findOneAndRemove"
   | "init";
 
-type Mongoose$SchemaPlugin<Doc, O> = (
-  schema: Mongoose$Schema<Doc>,
-  opts: O
+type Mongoose$SchemaPlugin<Opts> = (
+  schema: Mongoose$Schema<any>,
+  opts: Opts
 ) => void;
 
-declare class Mongoose$Schema<Doc: Object> {
+declare class Mongoose$Schema<Doc> {
   static Types: Mongoose$Types,
   constructor(
     fields: SchemaFields,
@@ -121,7 +123,7 @@ declare class Mongoose$Schema<Doc: Object> {
     serialCb: (doc: Doc, next: Function) => any
   ): void,
   // post(hookType: Mongoose$SchemaHookTypes, serialCb: (error: Error, doc: Doc, next: Function) => any): void;
-  plugin<O>(plugin: Mongoose$SchemaPlugin<Doc, O>, opts: O): void,
+  plugin<Opts>(plugin: Mongoose$SchemaPlugin<Opts>, opts: Opts): void,
   add(fields: SchemaFields, prefix?: string): void,
   loadClass(cls: Class<Doc>): void,
   paths: {
@@ -432,18 +434,17 @@ type ConnectionConnectOpts = {
   }
 };
 type ConnectionEventTypes = "error" | "open" | "disconnected" | string;
-type CreateMongooseModel = <Doc>(
-  name: string,
-  schema: Mongoose$Schema<Doc>,
-  collection?: Mongoose$Collection
-) => Class<Doc>;
 
 declare class Mongoose$Connection {
   constructor(): this,
   close(): Promise<any>,
   connect(uri: string, opts?: ConnectionConnectOpts): void,
   openUri(uri: string, opts?: ConnectionConnectOpts): void,
-  model: CreateMongooseModel,
+  model<Doc>(
+    name: string,
+    schema: Mongoose$Schema<Doc>,
+    collection?: Mongoose$Collection
+  ): Class<Doc>,
   collection(name: string): Mongoose$Collection,
   modelNames(): string[],
   config: Object,
@@ -476,7 +477,7 @@ declare module "mongoose" {
     Schema: typeof Mongoose$Schema,
     Types: Mongoose$Types,
     Promise: any,
-    model: CreateMongooseModel,
+    model: $PropertyType<Mongoose$Connection, "model">,
     createConnection(): Mongoose$Connection,
     set: (key: string, value: string | Function | boolean) => void
   };

--- a/definitions/npm/mongoose_v4.x.x/test_mongoose-v4.js
+++ b/definitions/npm/mongoose_v4.x.x/test_mongoose-v4.js
@@ -1,0 +1,107 @@
+// @flow
+
+import mongoose, { Schema } from "mongoose";
+
+export const AdminSchema = new Schema(
+  {
+    _id: String,
+    email: {
+      type: String,
+      set: (v: string) => v.toLowerCase().trim(),
+      required: true
+    },
+    token: {
+      type: String,
+      required: true
+    },
+    name: String
+  },
+  {
+    timestamps: true,
+    collection: "admin"
+  }
+);
+
+AdminSchema.index({ email: 1 }, { background: true });
+
+AdminSchema.pre("save", function(next) {
+  this._id = this.email;
+  next();
+});
+
+export class AdminDoc /*:: extends Mongoose$Document */ {
+  email: string;
+  token: string;
+  name: ?string;
+
+  // internal properties
+  _plainPassword: ?string;
+
+  static test(ok: number): string {
+    return ok.toString();
+  }
+
+  // NOT SUPPORTED in flow-typed tests
+  // But will work with your code if you add in your .flowconfig
+  //   [options]
+  //   unsafe.enable_getters_and_setters=true
+  //
+  // get password(): ?string {
+  //   return this._plainPassword;
+  // }
+  //
+  // set password(password: string): void {
+  //   this._plainPassword = password;
+  //   this.token = this.encryptPassword(password);
+  // }
+  //
+  // get fullname(): string {
+  //   const fullname = [];
+  //   if (this.lastname) fullname.push(this.lastname);
+  //   if (this.name) fullname.push(this.name);
+  //   if (this.middlename) fullname.push(this.middlename);
+  //   return fullname.join(' ');
+  // }
+
+  encryptPassword(password: string): string {
+    return "bcrypt.hashSync(password, 13)";
+  }
+
+  checkPassword(password: string): boolean {
+    return !!"bcrypt.compareSync(password, this.token)";
+  }
+}
+
+AdminSchema.loadClass(AdminDoc);
+
+AdminSchema.post("save", (doc, next) => {
+  doc.name = "Abc";
+  // $ExpectError
+  doc.name = 123;
+  next();
+});
+
+export const Admin = mongoose.model("Admin", AdminSchema);
+
+Admin.findById().then(d => {
+  if (d) {
+    // $ExpectError
+    d.checkPassword(123);
+  }
+});
+
+Admin.test(123);
+// $ExpectError
+Admin.test("123");
+
+const a = Admin.findOne({}).exec().then(ddd => {
+  if (ddd) {
+    ddd.checkPassword("123");
+    // $ExpectError
+    ddd.checkPassword(123);
+  }
+});
+
+const a1 = new Admin({ email: "123", token: "www" });
+// $ExpectError
+const a2 = new Admin({ email: 123, token: "www" });


### PR DESCRIPTION
This libdef covers almost all regular use cases for mongoose models.
Fill free to extend or fix unregular methods and props.

**PLEASE do not add callbacks args (for `.save()`, `.find()` and other methods). 
Promises all the things!!!**


Related #1140
Related https://github.com/entria/flow-typed-wip/issues/1