### PR TITLE
Fixed marked_v03.x constructor error when using Flow 0.53.1.

### DIFF
--- a/definitions/npm/marked_v0.3.x/flow_v0.28.x-/marked_v0.3.x.js
+++ b/definitions/npm/marked_v0.3.x/flow_v0.28.x-/marked_v0.3.x.js
@@ -3,7 +3,6 @@ type marked$AlignFlag = 'left' | 'right' | 'center'
 type marked$NodeCallback<T> = (e: ?Error, d: ?T) => void
 
 class marked$Renderer {
-  constructor: (o?: marked$MarkedOptions) => marked$Renderer
   options: marked$MarkedOptions;
   code: (c: string, l: string) => string;
   blockquote: (q: string) => string;
@@ -25,6 +24,9 @@ class marked$Renderer {
   link: (h: string, ti: string, te: string) => string;
   image: (h: string, ti: string, te: string) => string;
   text: (t: string) => string;
+  constructor(o?: marked$MarkedOptions): marked$Renderer {
+    return this;
+  }
 }
 
 type marked$HighlightFunction =
@@ -95,15 +97,16 @@ class marked$Lexer {
   static lexer: (t: string, o?: marked$MarkedOptions) => marked$Tokens;
   static rules: { [key: string]: marked$Rule };
   rules: { [key: string]: marked$Rule };
-  constructor: (o?: marked$MarkedOptions) => marked$Lexer;
   lex: marked$lex;
   tokens: marked$Tokens;
   options: marked$MarkedOptions;
+  constructor(o?: marked$MarkedOptions): marked$Lexer {
+    return this;
+  }
 }
 
 class marked$Parser {
   static parse: (t: marked$Tokens, o?: marked$MarkedOptions) => string;
-  constructor: (o?: marked$MarkedOptions) => marked$Parser;
   parse: (t: marked$Tokens) => string;
   next: () => marked$Token;
   peek: () => marked$Token;
@@ -113,12 +116,14 @@ class marked$Parser {
   token: ?marked$Token;
   options: marked$MarkedOptions;
   renderer: marked$Renderer;
+  constructor(o?: marked$MarkedOptions): marked$Parser {
+    return this;
+  }
 }
 
 class marked$InlineLexer {
   static rules: Array<marked$Rule>;
   static output: (s: string, l: Array<marked$Link>, o?: marked$MarkedOptions) => string;
-  constructor: (l: Array<marked$Link>, o?: marked$MarkedOptions) => marked$InlineLexer;
   output: (s: string) => string;
   outputmarked$Link: (c: Array<string>, l: marked$Link) => string;
   smartypants: (t: string) => string;
@@ -127,6 +132,9 @@ class marked$InlineLexer {
   links: Array<marked$Link>;
   rules: Array<marked$Rule>;
   renderer: marked$Renderer;
+  constructor(l: Array<marked$Link>, o?: marked$MarkedOptions): marked$InlineLexer {
+    return this;
+  }
 }
 
 type marked$Marked = {


### PR DESCRIPTION
Fixed an issue with the `marked_v03.x` definitions when running against Flow 0.53.1.

The constructors in these definitions were defined as properties. Here's the error:
```
Classes may not have properties named 'constructor'
```

Changed the constructors to 'methods' that return `this`.