### PR TITLE
[ramda] Fix ramda.dissoc() and ramda.dissocPath() types

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/ramda_v0.x.x.js
@@ -506,11 +506,8 @@ declare module ramda {
   declare function dissoc<T>(key: string, ...args: Array<void>): (src: {[k:string]:T}) => {[k:string]:T};
   declare function dissoc<T>(key: string, src: {[k:string]:T}): {[k:string]:T};
 
-  declare function dissocPath<T>(key: Array<string>, ...args: Array<void>):
-    ((val: T, ...rest: Array<void>) => (src: {[k:string]:T}) => {[k:string]:T})
-    & ((val: T) => (src: {[k:string]:T}) => {[k:string]:T});
-  declare function dissocPath<T>(key: Array<string>, val:T, ...args: Array<void>): (src: {[k:string]:T}) => {[k:string]:T};
-  declare function dissocPath<T>(key: Array<string>, val:T, src: {[k:string]:T}): {[k:string]:T};
+  declare function dissocPath<T>(key: Array<string>, ...args: Array<void>): (src: {[k:string]:T}) => {[k:string]:T};
+  declare function dissocPath<T>(key: Array<string>, src: {[k:string]:T}): {[k:string]:T};
 
   // TODO: Started failing in v31... (Attempt to fix below)
   // declare type __UnwrapNestedObjectR<T, U, V: NestedObject<(t: T) => U>> = U

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/ramda_v0.x.x.js
@@ -503,10 +503,8 @@ declare module ramda {
 
   declare function clone<T>(src: T): $Shape<T>;
 
-  declare function dissoc<T>(key: string, ...args: Array<void>):
-    ((val: T, ...rest: Array<void>) => (src: {[k:string]:T}) => {[k:string]:T}) & ((val: T, src: {[k:string]:T}) => {[k:string]:T});
-  declare function dissoc<T>(key: string, val:T, ...args: Array<void>): (src: {[k:string]:T}) => {[k:string]:T};
-  declare function dissoc<T>(key: string, val: T, src: {[k:string]:T}): {[k:string]:T};
+  declare function dissoc<T>(key: string, ...args: Array<void>): (src: {[k:string]:T}) => {[k:string]:T};
+  declare function dissoc<T>(key: string, src: {[k:string]:T}): {[k:string]:T};
 
   declare function dissocPath<T>(key: Array<string>, ...args: Array<void>):
     ((val: T, ...rest: Array<void>) => (src: {[k:string]:T}) => {[k:string]:T})

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_object.js
@@ -49,6 +49,13 @@ const dissocd3: { a: string } = _.dissoc('b', { a: 1, b: 2 })
 //$ExpectError
 const dissocd4: { a: string } = _.dissoc('b')({ a: 1, b: 2 })
 
+const dissocPathd: { a: { b: number } } = _.dissocPath(['a', 'c'], { a: { b: 1, c: 2 } })
+const dissocPathd2: { a: { b: number } } = _.dissocPath(['a', 'c'])({ a: { b: 1, c: 2 } })
+//$ExpectError
+const dissocPathd3: { a: { b: string } } = _.dissocPath(['a', 'c'], { a: { b: 1, c: 2 } })
+//$ExpectError
+const dissocPathd4: { a: { b: string } } = _.dissocPath(['a', 'c'])({ a: { b: 1, c: 2 } })
+
 const o1 = { a: 1, b: 2, c: 3, d: 4 }
 const o2 = { a: 10, b: 20, c: 3, d: 40 }
 const ep: boolean = _.eqProps('a')(o1, o2)

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_object.js
@@ -42,6 +42,13 @@ const id = objectsClone2.id
 //$ExpectError
 const idE = objectsClone4.id
 
+const dissocd: { a: number } = _.dissoc('b', { a: 1, b: 2 })
+const dissocd2: { a: number } = _.dissoc('b')({ a: 1, b: 2 })
+//$ExpectError
+const dissocd3: { a: string } = _.dissoc('b', { a: 1, b: 2 })
+//$ExpectError
+const dissocd4: { a: string } = _.dissoc('b')({ a: 1, b: 2 })
+
 const o1 = { a: 1, b: 2, c: 3, d: 4 }
 const o2 = { a: 10, b: 20, c: 3, d: 40 }
 const ep: boolean = _.eqProps('a')(o1, o2)


### PR DESCRIPTION
Looks like this was just a copy-paste blunder from `assoc()`/`assocPath()`.