### PR TITLE
Fix Buffer usage in node-uuid for flow 0.53

### DIFF
--- a/definitions/npm/node-uuid_v1.4.x/flow_v0.28.x-/node-uuid_v1.4.x.js
+++ b/definitions/npm/node-uuid_v1.4.x/flow_v0.28.x-/node-uuid_v1.4.x.js
@@ -1,24 +1,31 @@
-declare module 'node-uuid' {
+declare module "node-uuid" {
   declare type V1Options = {
-    node: Array<number>;
-    clockseq: number;
-    msecs: number;
-    nsecs: number;
-  }
+    node: Array<number>,
+    clockseq: number,
+    msecs: number,
+    nsecs: number
+  };
 
   declare type V4Options = {
-    random: Array<number>;
-    rng: () => Array<number>;
-  }
+    random: Array<number>,
+    rng: () => Array<number>
+  };
 
   declare type Uuid = {
-    v1: (o?: V1Options | null, b?: (Array<number> | Buffer<number>), of?: number) => string;
-    v4: (o?: V4Options | null, b?: (Array<number> | Buffer<number>), of?: number) => string;
-    parse: (u: string, b?: Array<number>, o?: number) => Array<number>;
-    unparse: (b: Array<number>, o?: number) => string;
-    noConflict: () => Uuid;
-  }
+    v1: (
+      o?: V1Options | null,
+      b?: Array<number> | Buffer,
+      of?: number
+    ) => string,
+    v4: (
+      o?: V4Options | null,
+      b?: Array<number> | Buffer,
+      of?: number
+    ) => string,
+    parse: (u: string, b?: Array<number>, o?: number) => Array<number>,
+    unparse: (b: Array<number>, o?: number) => string,
+    noConflict: () => Uuid
+  };
 
-  declare export default Uuid;
+  declare export default Uuid
 }
-


### PR DESCRIPTION
`Buffer<number>` is invalid for all flow versions, but becomes an error in flow 0.53. Fixes #1170 