### PR TITLE
Update to `react-addons-css-transition-group`

### DIFF
--- a/definitions/npm/react-addons-css-transition-group_v15.x.x/flow_v0.26.x-v0.52.x/react-addons-css-transition-group_v15.x.x.js
+++ b/definitions/npm/react-addons-css-transition-group_v15.x.x/flow_v0.26.x-v0.52.x/react-addons-css-transition-group_v15.x.x.js
@@ -1,10 +1,10 @@
 declare module 'react-addons-css-transition-group' {
   declare type ReactCSSTransitionGroupNames = {
-    enter: string,
+    enter?: string,
     enterActive?: string,
-    leave: string,
+    leave?: string,
     leaveActive?: string,
-    appear: string,
+    appear?: string,
     appearActive?: string
   };
   declare type Props = {

--- a/definitions/npm/react-addons-css-transition-group_v15.x.x/flow_v0.53.x-/react-addons-css-transition-group_v15.x.x.js
+++ b/definitions/npm/react-addons-css-transition-group_v15.x.x/flow_v0.53.x-/react-addons-css-transition-group_v15.x.x.js
@@ -1,10 +1,10 @@
 declare module 'react-addons-css-transition-group' {
   declare type ReactCSSTransitionGroupNames = {
-    enter: string,
+    enter?: string,
     enterActive?: string,
-    leave: string,
+    leave?: string,
     leaveActive?: string,
-    appear: string,
+    appear?: string,
     appearActive?: string
   };
   declare type Props = {

--- a/definitions/npm/react-addons-css-transition-group_v15.x.x/test_react-addons-css-transition-group.js
+++ b/definitions/npm/react-addons-css-transition-group_v15.x.x/test_react-addons-css-transition-group.js
@@ -34,10 +34,8 @@ const customClasses = () => (
 );
 
 
-const customClassesFail = () => (
-
+const customClassesPass = () => (
   <ReactCSSTransitionGroup
-    // $ExpectError
     transitionName={{}}
     transitionEnterTimeout={500}
     transitionLeaveTimeout={300}>


### PR DESCRIPTION
The `enter`, `leave` and `appear` keys of the `ReactCSSTransitionGroupNames` object are actually all totally optional.

See: https://github.com/reactjs/react-transition-group/blob/v1-stable/src/utils/PropTypes.js#L38 (all properties are missing `.isRequired`)