### PR TITLE
Fix uuid definition

### DIFF
--- a/definitions/npm/uuid_v3.x.x/flow_v0.32.x-/uuid_v3.x.x.js
+++ b/definitions/npm/uuid_v3.x.x/flow_v0.32.x-/uuid_v3.x.x.js
@@ -1,12 +1,21 @@
 declare module 'uuid' {
-  declare function v1(options?: {|
-    node?: number[],
-    clockseq?: number,
-    msecs?: number | Date,
-    nsecs?: number,
-  |}, buffer?: number[] | Buffer, offset?: number): string;
-  declare function v4(options?: {|
-    random?: number[],
-    rng?: () => number[] | Buffer,
-  |}, buffer?: number[] | Buffer, offset?: number): string;
+  declare class uuid {
+    static (options?: {|
+      random?: number[],
+      rng?: () => number[] | Buffer,
+    |}, buffer?: number[] | Buffer, offset?: number): string;
+
+    static v1(options?: {|
+      node?: number[],
+      clockseq?: number,
+      msecs?: number | Date,
+      nsecs?: number,
+    |}, buffer?: number[] | Buffer, offset?: number): string;
+
+    static v4(options?: {|
+      random?: number[],
+      rng?: () => number[] | Buffer,
+    |}, buffer?: number[] | Buffer, offset?: number): string;
+  }
+  declare module.exports: Class<uuid>
 }

--- a/definitions/npm/uuid_v3.x.x/test_uuid_v3.x.x.js
+++ b/definitions/npm/uuid_v3.x.x/test_uuid_v3.x.x.js
@@ -3,6 +3,7 @@ import uuid from 'uuid';
 
 (uuid.v1(): string);
 (uuid.v4(): string);
+(uuid(): string);
 
 uuid.v1({
   node: [0x01, 0x23, 0x45, 0x67, 0x89, 0xab],


### PR DESCRIPTION
The current definition leaves off the default export which, while deprecated is
valid still. https://github.com/kelektiv/node-uuid#deprecated-api

This is currently used in react-native, so using this definition breaks flow
types in RN >= 0.48.
https://github.com/facebook/react-native/blob/7d4a5b67d497ecc9a07447a95f73d8e2ee84573d/Libraries/Blob/Blob.js#L93