### PR TITLE
fix moment.parseZone()

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.28.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.28.x-/moment_v2.x.x.js
@@ -115,8 +115,11 @@ declare class moment$Moment {
   static utc(str: string, str2?: string|Array<string>, str3?: string): moment$Moment;
   static utc(moment: moment$Moment): moment$Moment;
   static utc(date: Date): moment$Moment;
+  static parseZone(): moment$Moment;
   static parseZone(rawDate: string): moment$Moment;
-  parseZone(): moment$Moment;
+  static parseZone(rawDate: string, format: string | Array<string>): moment$Moment;
+  static parseZone(rawDate: string, format: string, strict: boolean): moment$Moment;
+  static parseZone(rawDate: string, format: string, locale: string, strict: boolean): moment$Moment;
   isValid(): bool;
   invalidAt(): 0|1|2|3|4|5|6;
   creationData(): moment$MomentCreationData;


### PR DESCRIPTION
According to https://momentjs.com/docs/#/parsing/parse-zone/, `parseZone` may now accept up to four arguments.
Additionally, I think someone failed to mark `parseZone()` `static`.