### PR TITLE
Reenable Ramda's `sortBy`

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/ramda_v0.x.x.js
@@ -544,9 +544,8 @@ declare module ramda {
   declare function minBy<T,V>(fn: (x:T) => V, x: T, ...rest: Array<void>): (y: T) => T;
   declare function minBy<T,V>(fn: (x:T) => V, x: T, y: T): T;
 
-  // TODO: sortBy: Started failing in v38...
-  // declare function sortBy<T,V>(fn: (x:T) => V, ...rest: Array<void>): (x: Array<T>) => Array<T>;
-  // declare function sortBy<T,V>(fn: (x:T) => V, x: Array<T>): Array<T>;
+  declare function sortBy<T,V>(fn: (x:T) => V, ...rest: Array<void>): (x: Array<T>) => Array<T>;
+  declare function sortBy<T,V>(fn: (x:T) => V, x: Array<T>): Array<T>;
 
   declare function symmetricDifference<T>(x: Array<T>, ...rest: Array<void>): (y: Array<T>) => Array<T>;
   declare function symmetricDifference<T>(x: Array<T>, y: Array<T>): Array<T>;

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_relation.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_relation.js
@@ -1,68 +1,84 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from 'ramda'
+import _, { compose, pipe, curry, filter, find, repeat, zipWith } from "ramda";
 
-const ns: Array<number> = [ 1, 2, 3, 4, 5 ]
-const ss: Array<string> = [ 'one', 'two', 'three', 'four' ]
-const obj: {[k:string]:number} = { a: 1, c: 2 }
-const objMixed: {[k:string]:mixed} = { a: 1, c: 'd' }
-const os: Array<{[k:string]: *}> = [ { a: 1, c: 'd' }, { b: 2 } ]
-const str: string = 'hello world'
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: * }> = [{ a: 1, c: "d" }, { b: 2 }];
+const str: string = "hello world";
 
-const cl:number = _.clamp(1, 10, -1)
-const numbers = [ 1.0, 1.1, 1.2, 2.0, 3.0, 2.2 ]
-const letters = _.split('', 'abcABCaaaBBc')
+const cl: number = _.clamp(1, 10, -1);
+const numbers = [1.0, 1.1, 1.2, 2.0, 3.0, 2.2];
+const letters = _.split("", "abcABCaaaBBc");
 // In ramda docs example it's just `Math.floor`
 // but we don't want the implicit number -> string
-const countB = _.countBy(_.compose(_.toString, Math.floor))(numbers)
-const countB1: {[k:string]:number} = _.countBy(_.toLower)(letters)
-const diff: Array<number> = _.difference([ 1,2,3,4 ], [ 7,6,5,4,3 ])
+const countB = _.countBy(_.compose(_.toString, Math.floor))(numbers);
+const countB1: { [k: string]: number } = _.countBy(_.toLower)(letters);
+const diff: Array<number> = _.difference([1, 2, 3, 4], [7, 6, 5, 4, 3]);
 //$ExpectError
-const diff1: Array<string> = _.difference([ '1', '2' ,'3', '4' ], [ 7, 6, 5, 4, 3 ])
+const diff1: Array<string> = _.difference(
+  ["1", "2", "3", "4"],
+  [7, 6, 5, 4, 3]
+);
 
-const cmp = (x, y) => x.a === y.a
-const l1 = [ { a: 1 }, { a: 2 }, { a: 3 } ]
-const l2 = [ { a: 3 }, { a: 4 } ]
-const diff2 = _.differenceWith(cmp, l1, l2)
+const cmp = (x, y) => x.a === y.a;
+const l1 = [{ a: 1 }, { a: 2 }, { a: 3 }];
+const l2 = [{ a: 3 }, { a: 4 }];
+const diff2 = _.differenceWith(cmp, l1, l2);
 
-const eqb: boolean = _.eqBy(Math.abs, 5, -5)
+const eqb: boolean = _.eqBy(Math.abs, 5, -5);
 
-const es: boolean = _.equals([ 1, 2, 3 ], [ 1, 2, 3 ])
+const es: boolean = _.equals([1, 2, 3], [1, 2, 3]);
 
-const _gt: boolean = _.gt(2, 1)
-const _lt: boolean = _.lt(2, 1)
+const _gt: boolean = _.gt(2, 1);
+const _lt: boolean = _.lt(2, 1);
 
-const _gte: boolean = _.gte(2, 1)
-const _lte: boolean = _.lte(2, 1)
+const _gte: boolean = _.gte(2, 1);
+const _lte: boolean = _.lte(2, 1);
 
-const _max: number = _.max(2, 1)
-const _min: number = _.min(2, 1)
+const _max: number = _.max(2, 1);
+const _min: number = _.min(2, 1);
 
-const _maxBy: number = _.maxBy(Math.abs)(2, 1)
-const _minBy: number = _.minBy(Math.abs, 2, 1)
+const _maxBy: number = _.maxBy(Math.abs)(2, 1);
+const _minBy: number = _.minBy(Math.abs, 2, 1);
 
-const _identical: boolean = _.identical(2, 1)
+const _identical: boolean = _.identical(2, 1);
 
-const inters: Array<number> = _.intersection(ns, ns)
+const inters: Array<number> = _.intersection(ns, ns);
 
-const interBy:Array<number> = _.intersectionWith(_.eqBy(Math.abs), ns, ns)
+const interBy: Array<number> = _.intersectionWith(_.eqBy(Math.abs), ns, ns);
 
-const pathEqObj: boolean = _.pathEq([ 'hello' ], 1, obj)
-const pathEqObj2: boolean = _.pathEq([ 'hello' ])(1)(obj)
+const pathEqObj: boolean = _.pathEq(["hello"], 1, obj);
+const pathEqObj2: boolean = _.pathEq(["hello"])(1)(obj);
 
-const propEqObj: boolean = _.propEq('hello', 1, obj)
-const propEqObj2: boolean = _.propEq('hello')(1)(obj)
+const propEqObj: boolean = _.propEq("hello", 1, obj);
+const propEqObj2: boolean = _.propEq("hello")(1)(obj);
 
-// TODO: sortBy: Started failing in v38...
-// const sortByFirstItem = _.sortBy(_.nth(0))
-// const pairs = [ [ -1, 1 ], [ -2, 2 ], [ -3, 3 ] ]
-// const sorted: Array<[number,number]> = sortByFirstItem(pairs)
+const sortByFirstItem = _.sortBy(([first]) => first);
+const pairs = [[-1, 1], [-2, 2], [-3, 3]];
+const sorted: Array<[number, number]> = sortByFirstItem(pairs);
 
-const eqA = _.eqBy(_.prop('a'))
-const ls1: Array<{[k:string]:number}> = [ { a: 1 }, { a: 2 }, { a: 3 }, { a: 4 } ]
-const ls2: Array<{[k:string]:number}> = [ { a: 3 }, { b: 4 }, { a: 5 }, { a: 6 } ]
-const symW: Array<{[k:string]:number}> = _.symmetricDifferenceWith(eqA, ls1, ls2)
-const sym: Array<number> = _.symmetricDifference([ 1,2,3,4 ], [ 7,6,5,4,3 ])
+const eqA = _.eqBy(_.prop("a"));
+const ls1: Array<{ [k: string]: number }> = [
+  { a: 1 },
+  { a: 2 },
+  { a: 3 },
+  { a: 4 }
+];
+const ls2: Array<{ [k: string]: number }> = [
+  { a: 3 },
+  { b: 4 },
+  { a: 5 },
+  { a: 6 }
+];
+const symW: Array<{ [k: string]: number }> = _.symmetricDifferenceWith(
+  eqA,
+  ls1,
+  ls2
+);
+const sym: Array<number> = _.symmetricDifference([1, 2, 3, 4], [7, 6, 5, 4, 3]);
 
-const un: Array<number> = _.union([ 1, 2, 3 ])([ 2, 3, 4 ])
-const un1: Array<{[k:string]:number}> = _.unionWith(eqA, ls1, ls2)
+const un: Array<number> = _.union([1, 2, 3])([2, 3, 4]);
+const un1: Array<{ [k: string]: number }> = _.unionWith(eqA, ls1, ls2);


### PR DESCRIPTION
`sortBy` was disabled due to failing tests after v0.38. This was because 
flow started to correctly infer a type error in the test.

The test was using the `nth` function which expects an Array but the
output of the `sortBy` test was expecting a Tuple. Flow does not
consider Tuples and Array equal and threw a type check error even though
this is completely valid at runtime.

Since Flow favors soundness, this is a valid type error. The fix is
re-enabling `sortBy` and fixing the test to not use `nth`.
