### PR TITLE
Improve joi and joi-browser compile definition

### DIFF
--- a/definitions/npm/joi-browser_v10.x.x/flow_v0.28.x-/joi-browser_v10.x.x.js
+++ b/definitions/npm/joi-browser_v10.x.x/flow_v0.28.x-/joi-browser_v10.x.x.js
@@ -317,7 +317,7 @@ declare module "joi-browser" {
     binary(): npm$joiBrowser$BinarySchema,
     bool(): npm$joiBrowser$BooleanSchema,
     boolean(): npm$joiBrowser$BooleanSchema,
-    compile(schema: Object): npm$joiBrowser$Schema,
+    compile(schema: Object | mixed[]): npm$joiBrowser$Schema,
     date(): npm$joiBrowser$DateSchema,
     func(): npm$joiBrowser$FunctionSchema,
     number(): npm$joiBrowser$NumberSchema,

--- a/definitions/npm/joi_v10.x.x/flow_v0.28.x-/joi_v10.x.x.js
+++ b/definitions/npm/joi_v10.x.x/flow_v0.28.x-/joi_v10.x.x.js
@@ -281,7 +281,7 @@ declare module "joi" {
     binary(): npm$joi$BinarySchema,
     bool(): npm$joi$BooleanSchema,
     boolean(): npm$joi$BooleanSchema,
-    compile(schema: Object): npm$joi$Schema,
+    compile(schema: Object | mixed[]): npm$joi$Schema,
     date(): npm$joi$DateSchema,
     func(): npm$joi$FunctionSchema,
     number(): npm$joi$NumberSchema,


### PR DESCRIPTION
In the Joi docs there's an [example that passes an array to Joi.compile](https://github.com/hapijs/joi/blob/v10.6.0/API.md#compileschema). I've tried it and it works fine
