### PR TITLE
enzyme add missing constructor definition

### DIFF
--- a/definitions/npm/enzyme_v2.3.x/flow_v0.53.x-/enzyme_v2.3.x.js
+++ b/definitions/npm/enzyme_v2.3.x/flow_v0.53.x-/enzyme_v2.3.x.js
@@ -83,7 +83,7 @@ declare module "enzyme" {
   }
 
   declare export class ShallowWrapper extends Wrapper {
-    constructor(nodes: NodeOrNodes, root: any, options?: ?Object): ReactWrapper;
+    constructor(nodes: NodeOrNodes, root: any, options?: ?Object): ShallowWrapper;
     equals(node: React.Node): boolean,
     shallow(options?: { context?: Object }): ShallowWrapper
   }

--- a/definitions/npm/enzyme_v2.3.x/flow_v0.53.x-/enzyme_v2.3.x.js
+++ b/definitions/npm/enzyme_v2.3.x/flow_v0.53.x-/enzyme_v2.3.x.js
@@ -83,6 +83,7 @@ declare module "enzyme" {
   }
 
   declare export class ShallowWrapper extends Wrapper {
+    constructor(nodes: NodeOrNodes, root: any, options?: ?Object): ReactWrapper;
     equals(node: React.Node): boolean,
     shallow(options?: { context?: Object }): ShallowWrapper
   }


### PR DESCRIPTION
Here is the corresponding constructor definition: https://github.com/airbnb/enzyme/blob/35df18a0835cc7892b155172a500c87c127f153a/packages/enzyme/src/ShallowWrapper.js#L111

```jsx
/**
 * @class ShallowWrapper
 */
class ShallowWrapper {
  constructor(nodes, root, options = {}) {
```
