### PR TITLE
Fix definitions for moment isBefore, isAfter etc.

### DIFF
--- a/definitions/npm/moment_v2.3.x/flow_v0.34.x-/moment_v2.3.x.js
+++ b/definitions/npm/moment_v2.3.x/flow_v0.34.x-/moment_v2.3.x.js
@@ -199,11 +199,11 @@ declare class moment$Moment {
   toJSON(): string;
   toISOString(): string;
   toObject(): moment$MomentObject;
-  isBefore(date?: moment$Moment|string|number|Date|Array<number>): bool;
-  isSame(date?: moment$Moment|string|number|Date|Array<number>): bool;
-  isAfter(date?: moment$Moment|string|number|Date|Array<number>): bool;
-  isSameOrBefore(date?: moment$Moment|string|number|Date|Array<number>): bool;
-  isSameOrAfter(date?: moment$Moment|string|number|Date|Array<number>): bool;
+  isBefore(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
+  isSame(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
+  isAfter(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
+  isSameOrBefore(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
+  isSameOrAfter(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
   isBetween(date: moment$Moment|string|number|Date|Array<number>): bool;
   isDST(): bool;
   isDSTShifted(): bool;

--- a/definitions/npm/moment_v2.3.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.3.x/test_moment-v2.js
@@ -30,7 +30,8 @@ moment().isAfter();
 moment().isSameOrBefore();
 moment().isSameOrAfter();
 moment.isDate(new Date());
-
+moment().isBefore(new Date(), 'day');
+moment().isSame(new Date(), 'day');
 
 // CalendarTime
 moment().calendar(null, {


### PR DESCRIPTION
Couldn't find any other pull requests that were addressing this issue with moment v2.3.x