### PR TITLE
Copy typedefs from knex_v0.12.x to knex_v0.13.x

### DIFF
--- a/definitions/npm/knex_v0.13.x/flow_v0.38.x-/knex_v0.13.x.js
+++ b/definitions/npm/knex_v0.13.x/flow_v0.38.x-/knex_v0.13.x.js
@@ -1,0 +1,200 @@
+declare class Knex$Transaction<R> mixins Knex$QueryBuilder<R>, events$EventEmitter, Promise<R> {
+  commit(connection?: any, value?: any): Promise<R>,
+  rollback(): Promise<R>,
+  savepoint(connection?: any): Promise<R>
+}
+
+declare type Knex$QueryBuilderFn<R> = (
+  qb: Knex$QueryBuilder<R>
+) => Knex$QueryBuilder<R> | void;
+
+declare class Knex$QueryBuilder<R> mixins Promise<R> {
+  select(key?: string[]): this,
+  select(...key: string[]): this,
+  timeout(ms: number, options?: { cancel: boolean }): this,
+  column(key: string[]): this,
+  column(...key: string[]): this,
+  with(alias: string, w: string | Knex$QueryBuilderFn<R>): this,
+  withSchema(schema: string): this,
+  returning(column: string): this,
+  returning(...columns: string[]): this,
+  returning(columns: string[]): this,
+  as(name: string): this,
+  transacting(trx: ?Knex$Transaction<R>): this,
+  transaction((trx: Knex$Transaction<R>) => void): this,
+  where(builder: Knex$QueryBuilderFn<R>): this,
+  where(column: string, value: any): this,
+  where(column: string, operator: string, value: any): this,
+  where(object: { [string]: any }): this,
+  whereNot(builder: Knex$QueryBuilderFn<R>): this,
+  whereNot(column: string, value: any): this,
+  whereNot(column: string, operator: string, value: any): this,
+  whereIn(column: string, values: any[]): this,
+  whereNotIn(column: string, values: any[]): this,
+  whereNull(column: string): this,
+  whereNotNull(column: string): this,
+  whereExists(column: string): this,
+  whereNotExists(column: string): this,
+  whereBetween(column: string, range: number[]): this,
+  whereNotBetween(column: string, range: number[]): this,
+  whereRaw(sql: string, bindings?: Knex$RawBindings): this,
+  orWhere(builder: Knex$QueryBuilderFn<R>): this,
+  orWhere(column: string, value: any): this,
+  orWhere(column: string, operator: string, value: any): this,
+  orWhereNot(builder: Knex$QueryBuilderFn<R>): this,
+  orWhereNot(column: string, value: any): this,
+  orWhereNot(column: string, operator: string, value: any): this,
+  orWhereIn(column: string, values: any[]): this,
+  orWhereNotIn(column: string, values: any[]): this,
+  orWhereNull(column: string): this,
+  orWhereNotNull(column: string): this,
+  orWhereExists(column: string): this,
+  orWhereNotExists(column: string): this,
+  orWhereBetween(column: string, range: number[]): this,
+  orWhereNotBetween(column: string, range: number[]): this,
+  orWhereRaw(sql: string, bindings?: Knex$RawBindings): this,
+  innerJoin(table: string, c1: string, operator: string, c2: string): this,
+  innerJoin(table: string, c1: string, c2: string): this,
+  innerJoin(
+    builder: Knex$QueryBuilder<R> | Knex$QueryBuilderFn<R>,
+    c1?: string,
+    c2?: string
+  ): this,
+  innerJoin(table: string, builder: Knex$QueryBuilderFn<R>): this,
+  leftJoin(table: string, c1: string, operator: string, c2: string): this,
+  leftJoin(table: string, c1: string, c2: string): this,
+  leftJoin(builder: Knex$QueryBuilder<R>): this,
+  leftJoin(table: string, builder: Knex$QueryBuilderFn<R>): this,
+  leftOuterJoin(table: string, c1: string, operator: string, c2: string): this,
+  leftOuterJoin(table: string, c1: string, c2: string): this,
+  leftOuterJoin(table: string, builder: Knex$QueryBuilderFn<R>): this,
+  rightJoin(table: string, c1: string, operator: string, c2: string): this,
+  rightJoin(table: string, c1: string, c2: string): this,
+  rightJoin(table: string, builder: Knex$QueryBuilderFn<R>): this,
+  rightOuterJoin(table: string, c1: string, operator: string, c2: string): this,
+  rightOuterJoin(table: string, c1: string, c2: string): this,
+  rightOuterJoin(table: string, builder: Knex$QueryBuilderFn<R>): this,
+  outerJoin(table: string, c1: string, operator: string, c2: string): this,
+  outerJoin(table: string, c1: string, c2: string): this,
+  outerJoin(table: string, builder: Knex$QueryBuilderFn<R>): this,
+  fullOuterJoin(table: string, c1: string, operator: string, c2: string): this,
+  fullOuterJoin(table: string, c1: string, c2: string): this,
+  fullOuterJoin(table: string, builder: Knex$QueryBuilderFn<R>): this,
+  crossJoin(column: string, c1: string, c2: string): this,
+  crossJoin(column: string, c1: string, operator: string, c2: string): this,
+  crossJoin(table: string, builder: Knex$QueryBuilderFn<R>): this,
+  joinRaw(sql: string, bindings?: Knex$RawBindings): this,
+  distinct(): this,
+  groupBy(column: string): this,
+  groupByRaw(sql: string, bindings?: Knex$RawBindings): this,
+  orderBy(column: string, direction?: "desc" | "asc"): this,
+  orderByRaw(sql: string, bindings?: Knex$RawBindings): this,
+  offset(offset: number): this,
+  limit(limit: number): this,
+  having(column: string, operator: string, value: mixed): this,
+  havingIn(column: string, values: Array<mixed>): this,
+  havingNotIn(column: string, values: Array<mixed>): this,
+  havingNull(column: string): this,
+  havingNotNull(column: string): this,
+  havingExists(builder: Knex$QueryBuilderFn<R> | Knex$QueryBuilder<R>): this,
+  havingNotExists(builder: Knex$QueryBuilderFn<R> | Knex$QueryBuilder<R>): this,
+  havingBetween<T>(column: string, range: [T, T]): this,
+  havingNotBetween<T>(column: string, range: [T, T]): this,
+  havingRaw(column: string, operator: string, value: mixed): this,
+  havingRaw(column: string, value: mixed): this,
+  havingRaw(raw: string, bindings?: Knex$RawBindings): this,
+  union(): this,
+  unionAll(): this,
+  count(column?: string): this,
+  countDistinct(column?: string): this,
+  min(column?: string): this,
+  max(column?: string): this,
+  sum(column?: string): this,
+  sumDistinct(column?: string): this,
+  avg(column?: string): this,
+  avgDistinct(column?: string): this,
+  pluck(column: string): this,
+  first(): this,
+  from(table: string): this,
+  from(
+    builder: Knex$QueryBuilderFn<R> | Knex$Knex<R> | Knex$QueryBuilder<R>
+  ): this,
+  into(table: string, options?: Object): this,
+
+  insert(val: Object | Object[]): this,
+  del(): this,
+  delete(): this,
+  update(column: string, value: any): this,
+  update(val: Object): this,
+  returning(columns: string[]): this
+}
+
+declare class Knex$Knex<R> mixins Knex$QueryBuilder<R>, Promise<R>, events$EventEmitter {
+  static (config: Knex$Config): Knex$Knex<R>,
+  static QueryBuilder: typeof Knex$QueryBuilder,
+  $call: (tableName: string) => Knex$QueryBuilder<R>,
+  raw(sqlString: string, bindings?: Knex$RawBindings): any,
+  client: any,
+  destroy(): Promise<void>
+}
+
+declare type Knex$PostgresConfig = {
+  client?: "pg",
+  connection?:
+    | string
+    | {
+        host?: string,
+        user?: string,
+        password?: string,
+        database?: string,
+        charset?: string
+      },
+  searchPath?: string
+};
+
+declare type Knex$RawBindings = Array<mixed> | { [key: string]: mixed };
+
+declare type Knex$MysqlConfig = {
+  client?: "mysql",
+  connection?: {
+    host?: string,
+    user?: string,
+    password?: string,
+    database?: string
+  }
+};
+declare type Knex$SqliteConfig = {
+  client?: "sqlite3",
+  connection?: {
+    filename?: string
+  }
+};
+declare type Knex$Config =
+  | Knex$PostgresConfig
+  | Knex$MysqlConfig
+  | Knex$SqliteConfig;
+
+declare module "knex" {
+  declare type Error = {
+    name: string,
+    length: number,
+    severity: string,
+    code: string,
+    detail: string,
+    hint?: string,
+    position?: any,
+    intenralPosition?: any,
+    internalQuery?: any,
+    where?: any,
+    schema: string,
+    table: string,
+    column?: any,
+    dataType?: any,
+    constraint?: string,
+    file: string,
+    line: string,
+    routine: string
+  };
+  declare type $QueryBuilder<R> = Knex$QueryBuilder<R>;
+  declare var exports: typeof Knex$Knex;
+}

--- a/definitions/npm/knex_v0.13.x/test_knex-v0.13.js
+++ b/definitions/npm/knex_v0.13.x/test_knex-v0.13.js
@@ -1,0 +1,116 @@
+import Knex from "knex";
+
+const knex = Knex({});
+// $ExpectError - invalid Client
+Knex({
+  client: "foo"
+});
+
+knex
+  .select("foo")
+  .withSchema("a")
+  .from("bar")
+  .where("foo", 2)
+  .where({ mixed: "hi" })
+  .orWhere("bar", "foo")
+  .whereNot("asd", 1)
+  .whereIn("batz", [1, 2]);
+knex.select(knex.raw(""));
+
+knex.innerJoin("bar", function() {
+  return this;
+});
+knex.leftJoin("bar", function() {
+  return this;
+});
+knex.rightJoin("bar", function() {
+  return this;
+});
+knex.rightOuterJoin("bar", function() {
+  return this;
+});
+knex.fullOuterJoin("bar", function() {
+  return this;
+});
+knex.crossJoin("bar", function() {
+  return this;
+});
+
+knex("foo").insert({
+  a: 1
+});
+knex("bar").del();
+// $ExpectError
+knex.from();
+
+knex.destroy();
+
+/**
+ * Promise interface
+ */
+knex
+  .select("foo")
+  .from("bar")
+  .then(function(result) {})
+  .then(function(result) {}, function(err) {})
+  .catch(function(err) {});
+
+knex
+  .transaction(function(trx) {
+    trx
+      .insert({ a: 1 })
+      .into("foo")
+      .transacting(trx)
+      .then(trx.commit)
+      .catch(trx.rollback);
+  })
+  .then(function(result) {})
+  .catch(function(err) {});
+
+/**
+ * knex is also an event emitter,
+ * See : http://knexjs.org/#Interfaces-Events
+ */
+knex.on("start", () => {});
+
+/* Having tests */
+knex("foo").having("count", ">", 100);
+knex("foo").havingIn("count", [1, 2, 3]);
+// $ExpectError
+knex("foo").havingIn("count", "string");
+knex("foo").havingNotIn("count", [1, 2, 3]);
+knex("foo").havingNull("count");
+// $ExpectError
+knex("foo").havingNull(null);
+knex("foo").havingExists(function() {
+  this.select("*");
+});
+knex("foo").havingExists(knex.raw(""));
+knex("foo").havingBetween("count", [1, 5]);
+// $ExpectError
+knex("foo").havingBetween("count", [1, 2, 3]);
+knex("foo").havingRaw("count > 10");
+
+/**
+ * Bindings with *raw methods
+ */
+
+knex.raw("", ["a", 1]);
+knex.raw("", { name: "foo" });
+knex("foo").havingRaw("");
+knex("foo").havingRaw("", ["a"]);
+knex("foo").whereRaw("");
+knex("foo").whereRaw("", ["a"]);
+knex("foo").joinRaw("");
+knex("foo").joinRaw("", ["a"]);
+
+// $ExpectError
+knex("foo").raw();
+// $ExpectError
+knex("foo").raw("", "");
+// $ExpectError
+knex("foo").havingRaw();
+// $ExpectError
+knex("foo").whereRaw();
+// $ExpectError
+knex("foo").joinRaw();


### PR DESCRIPTION
This is another one of these: https://github.com/flowtype/flow-typed/issues/374

Unfortunately it seems that package version directories cannot contain a semver range, so I've resubmitted the existing v0.12.x definitions.
