### PR TITLE
feat/ramda latest assoc and assoc path mixed source object

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/ramda_v0.x.x.js
@@ -1179,40 +1179,34 @@ declare module ramda {
   declare function assoc<T, S>(
     key: string,
     ...args: Array<void>
-  ): ((
-    val: T,
-    ...rest: Array<void>
-  ) => (src: { [k: string]: S }) => { [k: string]: S | T }) &
-    ((val: T, src: { [k: string]: S }) => { [k: string]: S | T });
+  ): ((val: T, ...rest: Array<void>) => (src: S) => { [k: string]: T }) &
+    ((val: T, src: S) => { [k: string]: T } & S);
   declare function assoc<T, S>(
     key: string,
     val: T,
     ...args: Array<void>
-  ): (src: { [k: string]: S }) => { [k: string]: S | T };
+  ): (src: S) => { [k: string]: T } & S;
   declare function assoc<T, S>(
     key: string,
     val: T,
-    src: { [k: string]: S }
-  ): { [k: string]: S | T };
+    src: S
+  ): { [k: string]: T } & S;
 
   declare function assocPath<T, S>(
     key: Array<string>,
     ...args: Array<void>
-  ): ((
-    val: T,
-    ...rest: Array<void>
-  ) => (src: { [k: string]: S }) => { [k: string]: S | T }) &
-    ((val: T) => (src: { [k: string]: S }) => { [k: string]: S | T });
+  ): ((val: T, ...rest: Array<void>) => (src: S) => { [k: string]: T }) &
+    ((val: T) => (src: S) => { [k: string]: T } & S);
   declare function assocPath<T, S>(
     key: Array<string>,
     val: T,
     ...args: Array<void>
-  ): (src: { [k: string]: S }) => { [k: string]: S | T };
+  ): (src: S) => { [k: string]: T } & S;
   declare function assocPath<T, S>(
     key: Array<string>,
     val: T,
-    src: { [k: string]: S }
-  ): { [k: string]: S | T };
+    src: S
+  ): { [k: string]: T } & S;
 
   declare function clone<T>(src: T): $Shape<T>;
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/ramda_v0.x.x.js
@@ -1,166 +1,312 @@
 /* eslint-disable no-unused-vars, no-redeclare */
 
-type Transformer<A,B> = {
-  '@@transducer/step': <I,R>(r: A, a: *) => R,
-  '@@transducer/init': () => A,
-  '@@transducer/result': (result: *) => B
-}
+type Transformer<A, B> = {
+  "@@transducer/step": <I, R>(r: A, a: *) => R,
+  "@@transducer/init": () => A,
+  "@@transducer/result": (result: *) => B
+};
 
-declare type $npm$ramda$Placeholder = {'@@functional/placeholder': true};
-
+declare type $npm$ramda$Placeholder = { "@@functional/placeholder": true };
 
 declare module ramda {
-  declare type UnaryFn<A,R> = (a: A) => R;
-  declare type BinaryFn<A,B,R> = ((a: A, b: B) => R) & ((a:A) => (b: B) => R);
-  declare type UnarySameTypeFn<T> = UnaryFn<T,T>
-  declare type BinarySameTypeFn<T> = BinaryFn<T,T,T>
-  declare type NestedObject<T> = { [k: string]: T | NestedObject<T> }
-  declare type UnaryPredicateFn<T> = (x:T) => boolean
-  declare type BinaryPredicateFn<T> = (x:T, y:T) => boolean
-  declare type BinaryPredicateFn2<T,S> = (x:T, y:S) => boolean
+  declare type UnaryFn<A, R> = (a: A) => R;
+  declare type BinaryFn<A, B, R> = ((a: A, b: B) => R) &
+    ((a: A) => (b: B) => R);
+  declare type UnarySameTypeFn<T> = UnaryFn<T, T>;
+  declare type BinarySameTypeFn<T> = BinaryFn<T, T, T>;
+  declare type NestedObject<T> = { [k: string]: T | NestedObject<T> };
+  declare type UnaryPredicateFn<T> = (x: T) => boolean;
+  declare type BinaryPredicateFn<T> = (x: T, y: T) => boolean;
+  declare type BinaryPredicateFn2<T, S> = (x: T, y: S) => boolean;
 
   declare interface ObjPredicate {
-    (value: any, key: string): boolean;
+    (value: any, key: string): boolean
   }
 
-  declare type __CurriedFunction1<A, R, AA: A> =
-    & ((...r: [AA]) => R)
-  declare type CurriedFunction1<A, R> = __CurriedFunction1<A, R, *>
+  declare type __CurriedFunction1<A, R, AA: A> = (...r: [AA]) => R;
+  declare type CurriedFunction1<A, R> = __CurriedFunction1<A, R, *>;
 
-  declare type __CurriedFunction2<A, B, R, AA: A, BB: B> =
-    & ((...r: [AA]) => CurriedFunction1<BB, R>)
-    & ((...r: [AA, BB]) => R)
-  declare type CurriedFunction2<A, B, R> = __CurriedFunction2<A, B, R, *, *>
+  declare type __CurriedFunction2<A, B, R, AA: A, BB: B> = ((
+    ...r: [AA]
+  ) => CurriedFunction1<BB, R>) &
+    ((...r: [AA, BB]) => R);
+  declare type CurriedFunction2<A, B, R> = __CurriedFunction2<A, B, R, *, *>;
 
-  declare type __CurriedFunction3<A, B, C, R, AA: A, BB: B, CC: C> =
-    & ((...r: [AA]) => CurriedFunction2<BB, CC, R>)
-    & ((...r: [AA, BB]) => CurriedFunction1<CC, R>)
-    & ((...r: [AA, BB, CC]) => R)
-  declare type CurriedFunction3<A, B, C, R> = __CurriedFunction3<A, B, C, R, *, *, *>
+  declare type __CurriedFunction3<A, B, C, R, AA: A, BB: B, CC: C> = ((
+    ...r: [AA]
+  ) => CurriedFunction2<BB, CC, R>) &
+    ((...r: [AA, BB]) => CurriedFunction1<CC, R>) &
+    ((...r: [AA, BB, CC]) => R);
+  declare type CurriedFunction3<A, B, C, R> = __CurriedFunction3<
+    A,
+    B,
+    C,
+    R,
+    *,
+    *,
+    *
+  >;
 
-  declare type __CurriedFunction4<A, B, C, D, R, AA: A, BB: B, CC: C, DD: D> =
-    & ((...r: [AA]) => CurriedFunction3<BB, CC, DD, R>)
-    & ((...r: [AA, BB]) => CurriedFunction2<CC, DD, R>)
-    & ((...r: [AA, BB, CC]) => CurriedFunction1<DD, R>)
-    & ((...r: [AA, BB, CC, DD]) => R)
-  declare type CurriedFunction4<A, B, C, D, R> = __CurriedFunction4<A, B, C, D, R, *, *, *, *>
+  declare type __CurriedFunction4<
+    A,
+    B,
+    C,
+    D,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D
+  > = ((...r: [AA]) => CurriedFunction3<BB, CC, DD, R>) &
+    ((...r: [AA, BB]) => CurriedFunction2<CC, DD, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction1<DD, R>) &
+    ((...r: [AA, BB, CC, DD]) => R);
+  declare type CurriedFunction4<A, B, C, D, R> = __CurriedFunction4<
+    A,
+    B,
+    C,
+    D,
+    R,
+    *,
+    *,
+    *,
+    *
+  >;
 
-  declare type __CurriedFunction5<A, B, C, D, E, R, AA: A, BB: B, CC: C, DD: D, EE: E> =
-    & ((...r: [AA]) => CurriedFunction4<BB, CC, DD, EE, R>)
-    & ((...r: [AA, BB]) => CurriedFunction3<CC, DD, EE, R>)
-    & ((...r: [AA, BB, CC]) => CurriedFunction2<DD, EE, R>)
-    & ((...r: [AA, BB, CC, DD]) => CurriedFunction1<EE, R>)
-    & ((...r: [AA, BB, CC, DD, EE]) => R)
-  declare type CurriedFunction5<A, B, C, D, E, R> = __CurriedFunction5<A, B, C, D, E, R, *, *, *, *, *>
+  declare type __CurriedFunction5<
+    A,
+    B,
+    C,
+    D,
+    E,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D,
+    EE: E
+  > = ((...r: [AA]) => CurriedFunction4<BB, CC, DD, EE, R>) &
+    ((...r: [AA, BB]) => CurriedFunction3<CC, DD, EE, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction2<DD, EE, R>) &
+    ((...r: [AA, BB, CC, DD]) => CurriedFunction1<EE, R>) &
+    ((...r: [AA, BB, CC, DD, EE]) => R);
+  declare type CurriedFunction5<A, B, C, D, E, R> = __CurriedFunction5<
+    A,
+    B,
+    C,
+    D,
+    E,
+    R,
+    *,
+    *,
+    *,
+    *,
+    *
+  >;
 
-  declare type __CurriedFunction6<A, B, C, D, E, F, R, AA: A, BB: B, CC: C, DD: D, EE: E, FF: F> =
-    & ((...r: [AA]) => CurriedFunction5<BB, CC, DD, EE, FF, R>)
-    & ((...r: [AA, BB]) => CurriedFunction4<CC, DD, EE, FF, R>)
-    & ((...r: [AA, BB, CC]) => CurriedFunction3<DD, EE, FF, R>)
-    & ((...r: [AA, BB, CC, DD]) => CurriedFunction2<EE, FF, R>)
-    & ((...r: [AA, BB, CC, DD, EE]) => CurriedFunction1<FF, R>)
-    & ((...r: [AA, BB, CC, DD, EE, FF]) => R)
-  declare type CurriedFunction6<A, B, C, D, E, F, R> = __CurriedFunction6<A, B, C, D, E, F, R, *, *, *, *, *, *>
+  declare type __CurriedFunction6<
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    R,
+    AA: A,
+    BB: B,
+    CC: C,
+    DD: D,
+    EE: E,
+    FF: F
+  > = ((...r: [AA]) => CurriedFunction5<BB, CC, DD, EE, FF, R>) &
+    ((...r: [AA, BB]) => CurriedFunction4<CC, DD, EE, FF, R>) &
+    ((...r: [AA, BB, CC]) => CurriedFunction3<DD, EE, FF, R>) &
+    ((...r: [AA, BB, CC, DD]) => CurriedFunction2<EE, FF, R>) &
+    ((...r: [AA, BB, CC, DD, EE]) => CurriedFunction1<FF, R>) &
+    ((...r: [AA, BB, CC, DD, EE, FF]) => R);
+  declare type CurriedFunction6<A, B, C, D, E, F, R> = __CurriedFunction6<
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    R,
+    *,
+    *,
+    *,
+    *,
+    *,
+    *
+  >;
 
-  declare type Curry =
-    & (<A, R>((...r: [A]) => R) => CurriedFunction1<A, R>)
-    & (<A, B, R>((...r: [A, B]) => R) => CurriedFunction2<A, B, R>)
-    & (<A, B, C, R>((...r: [A, B, C]) => R) => CurriedFunction3<A, B, C, R>)
-    & (<A, B, C, D, R>((...r: [A, B, C, D]) => R) => CurriedFunction4<A, B, C, D, R>)
-    & (<A, B, C, D, E, R>((...r: [A, B, C, D, E]) => R) => CurriedFunction5<A, B, C, D, E, R>)
-    & (<A, B, C, D, E, F, R>((...r: [A, B, C, D, E, F]) => R) => CurriedFunction6<A, B, C, D, E, F, R>)
+  declare type Curry = (<A, R>((...r: [A]) => R) => CurriedFunction1<A, R>) &
+    (<A, B, R>((...r: [A, B]) => R) => CurriedFunction2<A, B, R>) &
+    (<A, B, C, R>((...r: [A, B, C]) => R) => CurriedFunction3<A, B, C, R>) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R
+    ) => CurriedFunction4<A, B, C, D, R>) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R
+    ) => CurriedFunction5<A, B, C, D, E, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R
+    ) => CurriedFunction6<A, B, C, D, E, F, R>);
 
   declare type Partial = (<A, R>((...r: [A]) => R, args: [A]) => () => R) &
-  (<A, B, R>((...r: [A, B]) => R, args: [A]) => CurriedFunction1<B, R>) &
-  (<A, B, R>((...r: [A, B]) => R, args: [A, B]) => () => R) &
-  (<A, B, C, R>(
-    (...r: [A, B, C]) => R,
-    args: [A]
-  ) => CurriedFunction2<B, C, R>) &
-  (<A, B, C, R>(
-    (...r: [A, B, C]) => R,
-    args: [A, B]
-  ) => CurriedFunction1<C, R>) &
-  (<A, B, C, R>((...r: [A, B, C]) => R, args: [A, B, C]) => () => R) &
-  (<A, B, C, D, R>(
-    (...r: [A, B, C, D]) => R,
-    args: [A]
-  ) => CurriedFunction3<B, C, D, R>) &
-  (<A, B, C, D, R>(
-    (...r: [A, B, C, D]) => R,
-    args: [A, B]
-  ) => CurriedFunction2<C, D, R>) &
-  (<A, B, C, D, R>(
-    (...r: [A, B, C, D]) => R,
-    args: [A, B, C]
-  ) => CurriedFunction1<D, R>) &
-  (<A, B, C, D, R>(
-    (...r: [A, B, C, D]) => R,
-    args: [A, B, C, D]
-  ) => () => R) &
-  (<A, B, C, D, E, R>(
-    (...r: [A, B, C, D, E]) => R,
-    args: [A]
-  ) => CurriedFunction4<B, C, D, E, R>) &
-  (<A, B, C, D, E, R>(
-    (...r: [A, B, C, D, E]) => R,
-    args: [A, B]
-  ) => CurriedFunction3<C, D, E, R>) &
-  (<A, B, C, D, E, R>(
-    (...r: [A, B, C, D, E]) => R,
-    args: [A, B, C]
-  ) => CurriedFunction2<D, E, R>) &
-  (<A, B, C, D, E, R>(
-    (...r: [A, B, C, D, E]) => R,
-    args: [A, B, C, D]
-  ) => CurriedFunction1<E, R>) &
-  (<A, B, C, D, E, R>(
-    (...r: [A, B, C, D, E]) => R,
-    args: [A, B, C, D, E]
-  ) => () => R) &
-  (<A, B, C, D, E, F, R>(
-    (...r: [A, B, C, D, E, F]) => R,
-    args: [A]
-  ) => CurriedFunction5<B, C, D, E, F, R>) &
-  (<A, B, C, D, E, F, R>(
-    (...r: [A, B, C, D, E, F]) => R,
-    args: [A, B]
-  ) => CurriedFunction4<C, D, E, F, R>) &
-  (<A, B, C, D, E, F, R>(
-    (...r: [A, B, C, D, E, F]) => R,
-    args: [A, B, C]
-  ) => CurriedFunction3<D, E, F, R>) &
-  (<A, B, C, D, E, F, R>(
-    (...r: [A, B, C, D, E, F]) => R,
-    args: [A, B, C, D]
-  ) => CurriedFunction2<E, F, R>) &
-  (<A, B, C, D, E, F, R>(
-    (...r: [A, B, C, D, E, F]) => R,
-    args: [A, B, C, D, E]
-  ) => CurriedFunction1<F, R>) &
-  (<A, B, C, D, E, F, R>(
-    (...r: [A, B, C, D, E, F]) => R,
-    args: [A, B, C, D, E, F]
-  ) => () => R);
+    (<A, B, R>((...r: [A, B]) => R, args: [A]) => CurriedFunction1<B, R>) &
+    (<A, B, R>((...r: [A, B]) => R, args: [A, B]) => () => R) &
+    (<A, B, C, R>(
+      (...r: [A, B, C]) => R,
+      args: [A]
+    ) => CurriedFunction2<B, C, R>) &
+    (<A, B, C, R>(
+      (...r: [A, B, C]) => R,
+      args: [A, B]
+    ) => CurriedFunction1<C, R>) &
+    (<A, B, C, R>((...r: [A, B, C]) => R, args: [A, B, C]) => () => R) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R,
+      args: [A]
+    ) => CurriedFunction3<B, C, D, R>) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R,
+      args: [A, B]
+    ) => CurriedFunction2<C, D, R>) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R,
+      args: [A, B, C]
+    ) => CurriedFunction1<D, R>) &
+    (<A, B, C, D, R>(
+      (...r: [A, B, C, D]) => R,
+      args: [A, B, C, D]
+    ) => () => R) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A]
+    ) => CurriedFunction4<B, C, D, E, R>) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B]
+    ) => CurriedFunction3<C, D, E, R>) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B, C]
+    ) => CurriedFunction2<D, E, R>) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B, C, D]
+    ) => CurriedFunction1<E, R>) &
+    (<A, B, C, D, E, R>(
+      (...r: [A, B, C, D, E]) => R,
+      args: [A, B, C, D, E]
+    ) => () => R) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A]
+    ) => CurriedFunction5<B, C, D, E, F, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B]
+    ) => CurriedFunction4<C, D, E, F, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C]
+    ) => CurriedFunction3<D, E, F, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C, D]
+    ) => CurriedFunction2<E, F, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C, D, E]
+    ) => CurriedFunction1<F, R>) &
+    (<A, B, C, D, E, F, R>(
+      (...r: [A, B, C, D, E, F]) => R,
+      args: [A, B, C, D, E, F]
+    ) => () => R);
 
-  declare type Pipe = (<A,B,C,D,E,F,G>(ab: UnaryFn<A,B>, bc: UnaryFn<B,C>, cd: UnaryFn<C,D>, de: UnaryFn<D,E>, ef: UnaryFn<E,F>, fg: UnaryFn<F,G>, ...rest: Array<void>) => UnaryFn<A,G>)
-    & (<A,B,C,D,E,F>(ab: UnaryFn<A,B>, bc: UnaryFn<B,C>, cd: UnaryFn<C,D>, de: UnaryFn<D,E>, ef: UnaryFn<E,F>, ...rest: Array<void>) => UnaryFn<A,F>)
-    & (<A,B,C,D,E>(ab: UnaryFn<A,B>, bc: UnaryFn<B,C>, cd: UnaryFn<C,D>, de: UnaryFn<D,E>, ...rest: Array<void>) => UnaryFn<A,E>)
-    & (<A,B,C,D>(ab: UnaryFn<A,B>, bc: UnaryFn<B,C>, cd: UnaryFn<C,D>, ...rest: Array<void>) => UnaryFn<A,D>)
-    & (<A,B,C>(ab: UnaryFn<A,B>, bc: UnaryFn<B,C>, ...rest: Array<void>) => UnaryFn<A,C>)
-    & (<A,B>(ab: UnaryFn<A,B>, ...rest: Array<void>) => UnaryFn<A,B>)
+  declare type Pipe = (<A, B, C, D, E, F, G>(
+    ab: UnaryFn<A, B>,
+    bc: UnaryFn<B, C>,
+    cd: UnaryFn<C, D>,
+    de: UnaryFn<D, E>,
+    ef: UnaryFn<E, F>,
+    fg: UnaryFn<F, G>,
+    ...rest: Array<void>
+  ) => UnaryFn<A, G>) &
+    (<A, B, C, D, E, F>(
+      ab: UnaryFn<A, B>,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
+      de: UnaryFn<D, E>,
+      ef: UnaryFn<E, F>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, F>) &
+    (<A, B, C, D, E>(
+      ab: UnaryFn<A, B>,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
+      de: UnaryFn<D, E>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, E>) &
+    (<A, B, C, D>(
+      ab: UnaryFn<A, B>,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, D>) &
+    (<A, B, C>(
+      ab: UnaryFn<A, B>,
+      bc: UnaryFn<B, C>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, C>) &
+    (<A, B>(ab: UnaryFn<A, B>, ...rest: Array<void>) => UnaryFn<A, B>);
 
-  declare type Compose = & (<A,B,C,D,E,F,G>(fg: UnaryFn<F,G>, ef: UnaryFn<E,F>, de: UnaryFn<D,E>, cd: UnaryFn<C,D>, bc: UnaryFn<B,C>, ab: UnaryFn<A,B>, ...rest: Array<void>) => UnaryFn<A,G>)
-    & (<A,B,C,D,E,F>(ef: UnaryFn<E,F>, de: UnaryFn<D,E>, cd: UnaryFn<C,D>, bc: UnaryFn<B,C>, ab: UnaryFn<A,B>, ...rest: Array<void>) => UnaryFn<A,F>)
-    & (<A,B,C,D,E>(de: UnaryFn<D,E>, cd: UnaryFn<C,D>, bc: UnaryFn<B,C>, ab: UnaryFn<A,B>, ...rest: Array<void>) => UnaryFn<A,E>)
-    & (<A,B,C,D>(cd: UnaryFn<C,D>, bc: UnaryFn<B,C>, ab: UnaryFn<A,B>, ...rest: Array<void>) => UnaryFn<A,D>)
-    & (<A,B,C>(bc: UnaryFn<B,C>, ab: UnaryFn<A,B>, ...rest: Array<void>) => UnaryFn<A,C>)
-    & (<A,B>(ab: UnaryFn<A,B>, ...rest: Array<void>) => UnaryFn<A,B>)
+  declare type Compose = (<A, B, C, D, E, F, G>(
+    fg: UnaryFn<F, G>,
+    ef: UnaryFn<E, F>,
+    de: UnaryFn<D, E>,
+    cd: UnaryFn<C, D>,
+    bc: UnaryFn<B, C>,
+    ab: UnaryFn<A, B>,
+    ...rest: Array<void>
+  ) => UnaryFn<A, G>) &
+    (<A, B, C, D, E, F>(
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, F>) &
+    (<A, B, C, D, E>(
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, E>) &
+    (<A, B, C, D>(
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, D>) &
+    (<A, B, C>(
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, C>) &
+    (<A, B>(ab: UnaryFn<A, B>, ...rest: Array<void>) => UnaryFn<A, B>);
 
-  declare type Filter =
-    & (<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>, xs:T) => T)
-    & (<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>) => (xs:T) => T)
-
+  declare type Filter = (<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ) => T) &
+    (<K, V, T: Array<V> | { [key: K]: V }>(
+      fn: UnaryPredicateFn<V>
+    ) => (xs: T) => T);
 
   declare class Monad<T> {
     chain: Function
@@ -169,8 +315,8 @@ declare module ramda {
   declare class Semigroup<T> {}
 
   declare class Chain {
-    chain<T,V: Monad<T>|Array<T>>(fn: (a:T) => V, x: V): V;
-    chain<T,V: Monad<T>|Array<T>>(fn: (a:T) => V): (x: V) => V;
+    chain<T, V: Monad<T> | Array<T>>(fn: (a: T) => V, x: V): V,
+    chain<T, V: Monad<T> | Array<T>>(fn: (a: T) => V): (x: V) => V
   }
 
   declare class GenericContructor<T> {
@@ -180,7 +326,6 @@ declare module ramda {
   declare class GenericContructorMulti {
     constructor(...args: Array<any>): GenericContructor<any>
   }
-
 
   /**
   * DONE:
@@ -197,32 +342,40 @@ declare module ramda {
   declare var compose: Compose;
   declare var pipe: Pipe;
   declare var curry: Curry;
-  declare function curryN(length: number, fn: (...args: Array<any>) => any): Function
+  declare function curryN(
+    length: number,
+    fn: (...args: Array<any>) => any
+  ): Function;
 
   // *Math
-  declare var add: CurriedFunction2<number,number,number>;
-  declare var inc: UnaryFn<number,number>;
-  declare var dec: UnaryFn<number,number>;
-  declare var mean: UnaryFn<Array<number>,number>;
-  declare var divide: CurriedFunction2<number,number,number>
-  declare var mathMod: CurriedFunction2<number,number,number>;
-  declare var median: UnaryFn<Array<number>,number>;
-  declare var modulo: CurriedFunction2<number,number,number>;
-  declare var multiply: CurriedFunction2<number,number,number>;
-  declare var negate: UnaryFn<number,number>;
-  declare var product: UnaryFn<Array<number>,number>;
-  declare var subtract: CurriedFunction2<number,number,number>;
-  declare var sum: UnaryFn<Array<number>,number>;
+  declare var add: CurriedFunction2<number, number, number>;
+  declare var inc: UnaryFn<number, number>;
+  declare var dec: UnaryFn<number, number>;
+  declare var mean: UnaryFn<Array<number>, number>;
+  declare var divide: CurriedFunction2<number, number, number>;
+  declare var mathMod: CurriedFunction2<number, number, number>;
+  declare var median: UnaryFn<Array<number>, number>;
+  declare var modulo: CurriedFunction2<number, number, number>;
+  declare var multiply: CurriedFunction2<number, number, number>;
+  declare var negate: UnaryFn<number, number>;
+  declare var product: UnaryFn<Array<number>, number>;
+  declare var subtract: CurriedFunction2<number, number, number>;
+  declare var sum: UnaryFn<Array<number>, number>;
 
   // Filter
   declare var filter: Filter;
   declare var reject: Filter;
 
   // *String
-  declare var match: CurriedFunction2<RegExp,string,Array<string|void>>;
-  declare var replace: CurriedFunction3<RegExp|string,string,string,string>;
-  declare var split: CurriedFunction2<RegExp|string,string,Array<string>>
-  declare var test: CurriedFunction2<RegExp,string,boolean>
+  declare var match: CurriedFunction2<RegExp, string, Array<string | void>>;
+  declare var replace: CurriedFunction3<
+    RegExp | string,
+    string,
+    string,
+    string
+  >;
+  declare var split: CurriedFunction2<RegExp | string, string, Array<string>>;
+  declare var test: CurriedFunction2<RegExp, string, boolean>;
   declare function toLower(a: string): string;
   declare function toString(a: any): string;
   declare function toUpper(a: string): string;
@@ -231,236 +384,575 @@ declare module ramda {
   // *Type
   declare function is<T>(t: T, ...rest: Array<void>): (v: any) => boolean;
   declare function is<T>(t: T, v: any): boolean;
-  declare var propIs: CurriedFunction3<any,string,Object,boolean>;
+  declare var propIs: CurriedFunction3<any, string, Object, boolean>;
   declare function type(x: ?any): string;
   declare function isArrayLike(x: any): boolean;
 
-  declare function isNil(x: void|null): true;
+  declare function isNil(x: void | null): true;
   declare function isNil(x: mixed): false;
 
   // *List
-  declare function adjust<T>(fn:(a: T) => T, ...rest: Array<void>): (index: number, ...rest: Array<void>) => (src: Array<T>) => Array<T>;
-  declare function adjust<T>(fn:(a: T) => T, index: number, ...rest: Array<void>): (src: Array<T>) => Array<T>;
-  declare function adjust<T>(fn:(a: T) => T, index: number, src: Array<T>): Array<T>;
+  declare function adjust<T>(
+    fn: (a: T) => T,
+    ...rest: Array<void>
+  ): (index: number, ...rest: Array<void>) => (src: Array<T>) => Array<T>;
+  declare function adjust<T>(
+    fn: (a: T) => T,
+    index: number,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<T>;
+  declare function adjust<T>(
+    fn: (a: T) => T,
+    index: number,
+    src: Array<T>
+  ): Array<T>;
 
   declare function all<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
-  declare function all<T>(fn: UnaryPredicateFn<T>, ...rest: Array<void>): (xs: Array<T>) => boolean;
+  declare function all<T>(
+    fn: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => boolean;
 
   declare function any<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
-  declare function any<T>(fn: UnaryPredicateFn<T>, ...rest: Array<void>): (xs: Array<T>) => boolean;
+  declare function any<T>(
+    fn: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => boolean;
 
   declare function aperture<T>(n: number, xs: Array<T>): Array<Array<T>>;
-  declare function aperture<T>(n: number, ...rest: Array<void>): (xs: Array<T>) => Array<Array<T>>;
+  declare function aperture<T>(
+    n: number,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => Array<Array<T>>;
 
-  declare function append<E>(x: E, xs: Array<E>): Array<E>
-  declare function append<E>(x: E, ...rest: Array<void>): (xs: Array<E>) => Array<E>
+  declare function append<E>(x: E, xs: Array<E>): Array<E>;
+  declare function append<E>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: Array<E>) => Array<E>;
 
-  declare function prepend<E>(x: E, xs: Array<E>): Array<E>
-  declare function prepend<E>(x: E, ...rest: Array<void>): (xs: Array<E>) => Array<E>
+  declare function prepend<E>(x: E, xs: Array<E>): Array<E>;
+  declare function prepend<E>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: Array<E>) => Array<E>;
 
-  declare function concat<V,T:Array<V>|string>(x: T, y: T): T;
-  declare function concat<V,T:Array<V>|string>(x: T): (y: T) => T;
+  declare function concat<V, T: Array<V> | string>(x: T, y: T): T;
+  declare function concat<V, T: Array<V> | string>(x: T): (y: T) => T;
 
-  declare function contains<E,T:Array<E>|string>(x: E, xs: T): boolean
-  declare function contains<E,T:Array<E>|string>(x: E, ...rest: Array<void>): (xs: T) => boolean
+  declare function contains<E, T: Array<E> | string>(x: E, xs: T): boolean;
+  declare function contains<E, T: Array<E> | string>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: T) => boolean;
 
-  declare function drop<V,T:Array<V>|string>(n: number, ...rest: Array<void>):(xs: T) => T;
-  declare function drop<V,T:Array<V>|string>(n: number, xs: T): T;
+  declare function drop<V, T: Array<V> | string>(
+    n: number,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+  declare function drop<V, T: Array<V> | string>(n: number, xs: T): T;
 
-  declare function dropLast<V,T:Array<V>|string>(n: number, ...rest: Array<void>):(xs: T) => T;
-  declare function dropLast<V,T:Array<V>|string>(n: number, xs: T): T;
+  declare function dropLast<V, T: Array<V> | string>(
+    n: number,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+  declare function dropLast<V, T: Array<V> | string>(n: number, xs: T): T;
 
-  declare function dropLastWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>, ...rest: Array<void>): (xs:T) => T;
-  declare function dropLastWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>, xs:T): T;
+  declare function dropLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+  declare function dropLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): T;
 
-  declare function dropWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>, ...rest: Array<void>): (xs:T) => T;
-  declare function dropWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>, xs:T): T;
+  declare function dropWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+  declare function dropWhile<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T): T;
 
-  declare function dropRepeats<V,T:Array<V>>(xs:T): T;
+  declare function dropRepeats<V, T: Array<V>>(xs: T): T;
 
-  declare function dropRepeatsWith<V,T:Array<V>>(fn: BinaryPredicateFn<V>, ...rest: Array<void>): (xs:T) => T;
-  declare function dropRepeatsWith<V,T:Array<V>>(fn: BinaryPredicateFn<V>, xs:T): T;
+  declare function dropRepeatsWith<V, T: Array<V>>(
+    fn: BinaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+  declare function dropRepeatsWith<V, T: Array<V>>(
+    fn: BinaryPredicateFn<V>,
+    xs: T
+  ): T;
 
-  declare function groupBy<T>(fn: (x: T) => string, xs: Array<T>): {[key: string]: Array<T>}
-  declare function groupBy<T>(fn: (x: T) => string, ...rest: Array<void>): (xs: Array<T>) => {[key: string]: Array<T>}
+  declare function groupBy<T>(
+    fn: (x: T) => string,
+    xs: Array<T>
+  ): { [key: string]: Array<T> };
+  declare function groupBy<T>(
+    fn: (x: T) => string,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => { [key: string]: Array<T> };
 
-  declare function groupWith<T,V:Array<T>|string>(fn: BinaryPredicateFn<T>, xs: V): Array<V>
-  declare function groupWith<T,V:Array<T>|string>(fn: BinaryPredicateFn<T>, ...rest: Array<void>): (xs: V) => Array<V>
+  declare function groupWith<T, V: Array<T> | string>(
+    fn: BinaryPredicateFn<T>,
+    xs: V
+  ): Array<V>;
+  declare function groupWith<T, V: Array<T> | string>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): (xs: V) => Array<V>;
 
-  declare function head<T,V:Array<T>>(xs: V): ?T
-  declare function head<T,V:string>(xs: V): V
+  declare function head<T, V: Array<T>>(xs: V): ?T;
+  declare function head<T, V: string>(xs: V): V;
 
-  declare function into<I,T,A:Array<T>,R:Array<*>|string|Object>(accum: R, xf: (a: A) => I, input: A): R
-  declare function into<I,T,A:Array<T>,R>(accum: Transformer<I,R>, xf: (a: A) => R, input: A): R
+  declare function into<I, T, A: Array<T>, R: Array<*> | string | Object>(
+    accum: R,
+    xf: (a: A) => I,
+    input: A
+  ): R;
+  declare function into<I, T, A: Array<T>, R>(
+    accum: Transformer<I, R>,
+    xf: (a: A) => R,
+    input: A
+  ): R;
 
-  declare function indexOf<E>(x: E, xs: Array<E>): number
-  declare function indexOf<E>(x: E, ...rest: Array<void>): (xs: Array<E>) => number
+  declare function indexOf<E>(x: E, xs: Array<E>): number;
+  declare function indexOf<E>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: Array<E>) => number;
 
-  declare function indexBy<V,T:{[key: string]:*}>(fn: (x: T) => string, ...rest: Array<void>): (xs: Array<T>) => {[key: string]: T}
-  declare function indexBy<V,T:{[key: string]:*}>(fn: (x: T) => string, xs: Array<T>): {[key: string]: T}
+  declare function indexBy<V, T: { [key: string]: * }>(
+    fn: (x: T) => string,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => { [key: string]: T };
+  declare function indexBy<V, T: { [key: string]: * }>(
+    fn: (x: T) => string,
+    xs: Array<T>
+  ): { [key: string]: T };
 
-  declare function insert<T>(index: number, ...rest: Array<void>): (elem: T) => (src: Array<T>) => Array<T>
-  declare function insert<T>(index: number, elem: T, ...rest: Array<void>): (src: Array<T>) => Array<T>
-  declare function insert<T>(index: number, elem: T, src: Array<T>): Array<T>
+  declare function insert<T>(
+    index: number,
+    ...rest: Array<void>
+  ): (elem: T) => (src: Array<T>) => Array<T>;
+  declare function insert<T>(
+    index: number,
+    elem: T,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<T>;
+  declare function insert<T>(index: number, elem: T, src: Array<T>): Array<T>;
 
-  declare function insertAll<T,S>(index: number, ...rest: Array<void>): (elem: Array<S>) => (src: Array<T>) => Array<S|T>
-  declare function insertAll<T,S>(index: number, elems: Array<S>, ...rest: Array<void>): (src: Array<T>) => Array<S|T>
-  declare function insertAll<T,S>(index: number, elems: Array<S>, src: Array<T>): Array<S|T>
+  declare function insertAll<T, S>(
+    index: number,
+    ...rest: Array<void>
+  ): (elem: Array<S>) => (src: Array<T>) => Array<S | T>;
+  declare function insertAll<T, S>(
+    index: number,
+    elems: Array<S>,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<S | T>;
+  declare function insertAll<T, S>(
+    index: number,
+    elems: Array<S>,
+    src: Array<T>
+  ): Array<S | T>;
 
-  declare function join(x: string, xs: Array<any>): string
-  declare function join(x: string, ...rest: Array<void>): (xs: Array<any>) => string
+  declare function join(x: string, xs: Array<any>): string;
+  declare function join(
+    x: string,
+    ...rest: Array<void>
+  ): (xs: Array<any>) => string;
 
-  declare function last<T,V:Array<T>>(xs: V): ?T
-  declare function last<T,V:string>(xs: V): V
+  declare function last<T, V: Array<T>>(xs: V): ?T;
+  declare function last<T, V: string>(xs: V): V;
 
   declare function none<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
-  declare function none<T>(fn: UnaryPredicateFn<T>, ...rest: Array<void>): (xs: Array<T>) => boolean;
+  declare function none<T>(
+    fn: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => boolean;
 
-  declare function nth<V,T:Array<V>>(i: number, xs: T): ?V
-  declare function nth<V,T:Array<V>|string>(i: number, ...rest: Array<void>): ((xs: string) => string)&((xs: T) => ?V)
-  declare function nth<T:string>(i: number, xs: T):  T
+  declare function nth<V, T: Array<V>>(i: number, xs: T): ?V;
+  declare function nth<V, T: Array<V> | string>(
+    i: number,
+    ...rest: Array<void>
+  ): ((xs: string) => string) & ((xs: T) => ?V);
+  declare function nth<T: string>(i: number, xs: T): T;
 
-  declare function find<V,O:{[key:string]:*},T:Array<V>|O>(fn: UnaryPredicateFn<V>, ...rest: Array<void>): (xs:T|O) => ?V|O;
-  declare function find<V,O:{[key:string]:*},T:Array<V>|O>(fn: UnaryPredicateFn<V>, xs:T|O): ?V|O;
-  declare function findLast<V,O:{[key:string]:*},T:Array<V>|O>(fn: UnaryPredicateFn<V>, ...rest: Array<void>): (xs:T|O) => ?V|O;
-  declare function findLast<V,O:{[key:string]:*},T:Array<V>|O>(fn: UnaryPredicateFn<V>, xs:T|O): ?V|O;
+  declare function find<V, O: { [key: string]: * }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T | O) => ?V | O;
+  declare function find<V, O: { [key: string]: * }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+    xs: T | O
+  ): ?V | O;
+  declare function findLast<V, O: { [key: string]: * }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T | O) => ?V | O;
+  declare function findLast<V, O: { [key: string]: * }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+    xs: T | O
+  ): ?V | O;
 
-  declare function findIndex<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>, ...rest: Array<void>): (xs:T) => number
-  declare function findIndex<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>, xs:T): number
-  declare function findLastIndex<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>, ...rest: Array<void>): (xs:T) => number
-  declare function findLastIndex<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>, xs:T): number
+  declare function findIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => number;
+  declare function findIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): number;
+  declare function findLastIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => number;
+  declare function findLastIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): number;
 
-  declare function forEach<T,V>(fn:(x:T) => ?V, xs: Array<T>): Array<T>
-  declare function forEach<T,V>(fn:(x:T) => ?V, ...rest: Array<void>): (xs: Array<T>) => Array<T>
+  declare function forEach<T, V>(fn: (x: T) => ?V, xs: Array<T>): Array<T>;
+  declare function forEach<T, V>(
+    fn: (x: T) => ?V,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => Array<T>;
 
-  declare function lastIndexOf<E>(x: E, xs: Array<E>): number
-  declare function lastIndexOf<E>(x: E, ...rest: Array<void>): (xs: Array<E>) => number
+  declare function lastIndexOf<E>(x: E, xs: Array<E>): number;
+  declare function lastIndexOf<E>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: Array<E>) => number;
 
-  declare function map<T,R>(fn: (x:T) => R, xs: Array<T>): Array<R>;
-  declare function map<T,R,S:{map:Function}>(fn: (x:T) => R, xs: S): S;
-  declare function map<T,R>(fn: (x:T) => R, ...rest: Array<void>): ((xs: {[key: string]: T}) => {[key: string]: R}) & ((xs: Array<T>) => Array<R>)
-  declare function map<T,R,S:{map:Function}>(fn: (x:T) => R, ...rest: Array<void>): ((xs:S) => S) & ((xs: S) => S)
-  declare function map<T,R>(fn: (x:T) => R, xs: {[key: string]: T}): {[key: string]: R}
+  declare function map<T, R>(fn: (x: T) => R, xs: Array<T>): Array<R>;
+  declare function map<T, R, S: { map: Function }>(fn: (x: T) => R, xs: S): S;
+  declare function map<T, R>(
+    fn: (x: T) => R,
+    ...rest: Array<void>
+  ): ((xs: { [key: string]: T }) => { [key: string]: R }) &
+    ((xs: Array<T>) => Array<R>);
+  declare function map<T, R, S: { map: Function }>(
+    fn: (x: T) => R,
+    ...rest: Array<void>
+  ): ((xs: S) => S) & ((xs: S) => S);
+  declare function map<T, R>(
+    fn: (x: T) => R,
+    xs: { [key: string]: T }
+  ): { [key: string]: R };
 
-  declare type AccumIterator<A,B,R> = (acc: R, x: A) => [R,B]
-  declare function mapAccum<A,B,R>(fn: AccumIterator<A,B,R>, acc: R, xs: Array<A>): [R, Array<B>];
-  declare function mapAccum<A,B,R>(fn: AccumIterator<A,B,R>, ...rest: Array<void>): (acc: R, xs: Array<A>) => [R, Array<B>];
+  declare type AccumIterator<A, B, R> = (acc: R, x: A) => [R, B];
+  declare function mapAccum<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    acc: R,
+    xs: Array<A>
+  ): [R, Array<B>];
+  declare function mapAccum<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    ...rest: Array<void>
+  ): (acc: R, xs: Array<A>) => [R, Array<B>];
 
-  declare function mapAccumRight<A,B,R>(fn: AccumIterator<A,B,R>, acc: R, xs: Array<A>): [R, Array<B>];
-  declare function mapAccumRight<A,B,R>(fn: AccumIterator<A,B,R>, ...rest: Array<void>): (acc: R, xs: Array<A>) => [R, Array<B>];
+  declare function mapAccumRight<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    acc: R,
+    xs: Array<A>
+  ): [R, Array<B>];
+  declare function mapAccumRight<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    ...rest: Array<void>
+  ): (acc: R, xs: Array<A>) => [R, Array<B>];
 
-  declare function intersperse<E>(x: E, xs: Array<E>): Array<E>
-  declare function intersperse<E>(x: E, ...rest: Array<void>): (xs: Array<E>) => Array<E>
+  declare function intersperse<E>(x: E, xs: Array<E>): Array<E>;
+  declare function intersperse<E>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: Array<E>) => Array<E>;
 
-  declare function pair<A,B>(a:A, b:B): [A,B]
-  declare function pair<A,B>(a:A, ...rest: Array<void>): (b:B) => [A,B]
+  declare function pair<A, B>(a: A, b: B): [A, B];
+  declare function pair<A, B>(a: A, ...rest: Array<void>): (b: B) => [A, B];
 
-  declare function partition<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>, xs:T): [T,T]
-  declare function partition<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>, ...rest: Array<void>): (xs:T) => [T,T]
+  declare function partition<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): [T, T];
+  declare function partition<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => [T, T];
 
-  declare function pluck<V,K:string|number,T:Array<Array<V>|{[key:string]:V}>>(k: K, xs: T): Array<V>
-  declare function pluck<V,K:string|number,T:Array<Array<V>|{[key:string]:V}>>(k: K,...rest: Array<void>): (xs: T) => Array<V>
+  declare function pluck<
+    V,
+    K: string | number,
+    T: Array<Array<V> | { [key: string]: V }>
+  >(
+    k: K,
+    xs: T
+  ): Array<V>;
+  declare function pluck<
+    V,
+    K: string | number,
+    T: Array<Array<V> | { [key: string]: V }>
+  >(
+    k: K,
+    ...rest: Array<void>
+  ): (xs: T) => Array<V>;
 
-  declare var range: CurriedFunction2<number,number,Array<number>>;
+  declare var range: CurriedFunction2<number, number, Array<number>>;
 
-  declare function remove<T>(from: number, ...rest: Array<void>): ((to: number, ...rest: Array<void>) => (src: Array<T>) => Array<T>) & ((to: number, src: Array<T>) => Array<T>)
-  declare function remove<T>(from: number, to: number, ...rest: Array<void>): (src: Array<T>) => Array<T>
-  declare function remove<T>(from: number, to: number, src: Array<T>): Array<T>
+  declare function remove<T>(
+    from: number,
+    ...rest: Array<void>
+  ): ((to: number, ...rest: Array<void>) => (src: Array<T>) => Array<T>) &
+    ((to: number, src: Array<T>) => Array<T>);
+  declare function remove<T>(
+    from: number,
+    to: number,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<T>;
+  declare function remove<T>(from: number, to: number, src: Array<T>): Array<T>;
 
-  declare function repeat<T>(x: T, times: number): Array<T>
-  declare function repeat<T>(x: T, ...rest: Array<void>): (times: number) => Array<T>
+  declare function repeat<T>(x: T, times: number): Array<T>;
+  declare function repeat<T>(
+    x: T,
+    ...rest: Array<void>
+  ): (times: number) => Array<T>;
 
-  declare function slice<V,T:Array<V>|string>(from: number, ...rest: Array<void>): ((to: number, ...rest: Array<void>) => (src: T) => T) & ((to: number, src: T) => T)
-  declare function slice<V,T:Array<V>|string>(from: number, to: number, ...rest: Array<void>): (src: T) => T
-  declare function slice<V,T:Array<V>|string>(from: number, to: number, src: T): T
+  declare function slice<V, T: Array<V> | string>(
+    from: number,
+    ...rest: Array<void>
+  ): ((to: number, ...rest: Array<void>) => (src: T) => T) &
+    ((to: number, src: T) => T);
+  declare function slice<V, T: Array<V> | string>(
+    from: number,
+    to: number,
+    ...rest: Array<void>
+  ): (src: T) => T;
+  declare function slice<V, T: Array<V> | string>(
+    from: number,
+    to: number,
+    src: T
+  ): T;
 
-  declare function sort<V,T:Array<V>>(fn: (a:V, b:V) => number, xs:T): T
-  declare function sort<V,T:Array<V>>(fn: (a:V, b:V) => number, ...rest: Array<void>): (xs:T) => T
+  declare function sort<V, T: Array<V>>(fn: (a: V, b: V) => number, xs: T): T;
+  declare function sort<V, T: Array<V>>(
+    fn: (a: V, b: V) => number,
+    ...rest: Array<void>
+  ): (xs: T) => T;
 
-  declare function times<T>(fn:(i: number) => T, n: number): Array<T>
-  declare function times<T>(fn:(i: number) => T, ...rest: Array<void>): (n: number) => Array<T>
+  declare function times<T>(fn: (i: number) => T, n: number): Array<T>;
+  declare function times<T>(
+    fn: (i: number) => T,
+    ...rest: Array<void>
+  ): (n: number) => Array<T>;
 
-  declare function take<V,T:Array<V>|string>(n: number, xs: T): T;
-  declare function take<V,T:Array<V>|string>(n: number):(xs: T) => T;
+  declare function take<V, T: Array<V> | string>(n: number, xs: T): T;
+  declare function take<V, T: Array<V> | string>(n: number): (xs: T) => T;
 
-  declare function takeLast<V,T:Array<V>|string>(n: number, xs: T): T;
-  declare function takeLast<V,T:Array<V>|string>(n: number):(xs: T) => T;
+  declare function takeLast<V, T: Array<V> | string>(n: number, xs: T): T;
+  declare function takeLast<V, T: Array<V> | string>(n: number): (xs: T) => T;
 
-  declare function takeLastWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>, xs:T): T;
-  declare function takeLastWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>): (xs:T) => T;
+  declare function takeLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): T;
+  declare function takeLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ): (xs: T) => T;
 
-  declare function takeWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>, xs:T): T;
-  declare function takeWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>): (xs:T) => T;
+  declare function takeWhile<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T): T;
+  declare function takeWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ): (xs: T) => T;
 
-  declare function unfold<T,R>(fn: (seed: T) => [R, T]|boolean, ...rest: Array<void>): (seed: T) => Array<R>
-  declare function unfold<T,R>(fn: (seed: T) => [R, T]|boolean, seed: T): Array<R>
+  declare function unfold<T, R>(
+    fn: (seed: T) => [R, T] | boolean,
+    ...rest: Array<void>
+  ): (seed: T) => Array<R>;
+  declare function unfold<T, R>(
+    fn: (seed: T) => [R, T] | boolean,
+    seed: T
+  ): Array<R>;
 
-  declare function uniqBy<T,V>(fn:(x: T) => V, ...rest: Array<void>): (xs: Array<T>) => Array<T>
-  declare function uniqBy<T,V>(fn:(x: T) => V, xs: Array<T>): Array<T>
+  declare function uniqBy<T, V>(
+    fn: (x: T) => V,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => Array<T>;
+  declare function uniqBy<T, V>(fn: (x: T) => V, xs: Array<T>): Array<T>;
 
-  declare function uniqWith<T>(fn: BinaryPredicateFn<T>, ...rest: Array<void>): (xs: Array<T>) => Array<T>
-  declare function uniqWith<T>(fn: BinaryPredicateFn<T>, xs: Array<T>): Array<T>
+  declare function uniqWith<T>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => Array<T>;
+  declare function uniqWith<T>(
+    fn: BinaryPredicateFn<T>,
+    xs: Array<T>
+  ): Array<T>;
 
-  declare function update<T>(index: number, ...rest: Array<void>): ((elem: T, ...rest: Array<void>) => (src: Array<T>) => Array<T>) & ((elem: T, src: Array<T>) => Array<T>)
-  declare function update<T>(index: number, elem: T, ...rest: Array<void>): (src: Array<T>) => Array<T>
-  declare function update<T>(index: number, elem: T, src: Array<T>): Array<T>
+  declare function update<T>(
+    index: number,
+    ...rest: Array<void>
+  ): ((elem: T, ...rest: Array<void>) => (src: Array<T>) => Array<T>) &
+    ((elem: T, src: Array<T>) => Array<T>);
+  declare function update<T>(
+    index: number,
+    elem: T,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<T>;
+  declare function update<T>(index: number, elem: T, src: Array<T>): Array<T>;
 
   // TODO `without` as a transducer
-  declare function without<T>(xs: Array<T>, src: Array<T>): Array<T>
-  declare function without<T>(xs: Array<T>, ...rest: Array<void>): (src: Array<T>) => Array<T>
+  declare function without<T>(xs: Array<T>, src: Array<T>): Array<T>;
+  declare function without<T>(
+    xs: Array<T>,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<T>;
 
-  declare function xprod<T,S>(xs: Array<T>, ys: Array<S>): Array<[T,S]>
-  declare function xprod<T,S>(xs: Array<T>, ...rest: Array<void>): (ys: Array<S>) => Array<[T,S]>
+  declare function xprod<T, S>(xs: Array<T>, ys: Array<S>): Array<[T, S]>;
+  declare function xprod<T, S>(
+    xs: Array<T>,
+    ...rest: Array<void>
+  ): (ys: Array<S>) => Array<[T, S]>;
 
-  declare function zip<T,S>(xs: Array<T>, ys: Array<S>): Array<[T,S]>
-  declare function zip<T,S>(xs: Array<T>, ...rest: Array<void>): (ys: Array<S>) => Array<[T,S]>
+  declare function zip<T, S>(xs: Array<T>, ys: Array<S>): Array<[T, S]>;
+  declare function zip<T, S>(
+    xs: Array<T>,
+    ...rest: Array<void>
+  ): (ys: Array<S>) => Array<[T, S]>;
 
-  declare function zipObj<T:string,S>(xs: Array<T>, ys: Array<S>): {[key:T]:S}
-  declare function zipObj<T:string,S>(xs: Array<T>, ...rest: Array<void>): (ys: Array<S>) => {[key:T]:S}
+  declare function zipObj<T: string, S>(
+    xs: Array<T>,
+    ys: Array<S>
+  ): { [key: T]: S };
+  declare function zipObj<T: string, S>(
+    xs: Array<T>,
+    ...rest: Array<void>
+  ): (ys: Array<S>) => { [key: T]: S };
 
-  declare type NestedArray<T> = Array<T | NestedArray<T>>
+  declare type NestedArray<T> = Array<T | NestedArray<T>>;
   declare function flatten<T>(xs: NestedArray<T>): Array<T>;
 
-  declare function fromPairs<T,V>(pair: Array<[T,V]>): {[key: string]:V};
+  declare function fromPairs<T, V>(pair: Array<[T, V]>): { [key: string]: V };
 
-  declare function init<T,V:Array<T>|string>(xs: V): V;
+  declare function init<T, V: Array<T> | string>(xs: V): V;
 
   declare function length<T>(xs: Array<T>): number;
 
-  declare function mergeAll(objs: Array<{[key: string]: any}>):{[key: string]: any};
+  declare function mergeAll(
+    objs: Array<{ [key: string]: any }>
+  ): { [key: string]: any };
 
-  declare function reverse<T,V:Array<T>|string>(xs: V): V;
+  declare function reverse<T, V: Array<T> | string>(xs: V): V;
 
-  declare function reduce<A, B>(fn: (acc: A, elem: B) => A, ...rest: Array<void>): ((init: A, xs: Array<B>) => A) & ((init: A, ...rest: Array<void>) => (xs: Array<B>) => A);
-  declare function reduce<A, B>(fn: (acc: A, elem: B) => A, init: A, ...rest: Array<void>): (xs: Array<B>) => A;
-  declare function reduce<A, B>(fn: (acc: A, elem: B) => A, init: A, xs: Array<B>): A;
+  declare function reduce<A, B>(
+    fn: (acc: A, elem: B) => A,
+    ...rest: Array<void>
+  ): ((init: A, xs: Array<B>) => A) &
+    ((init: A, ...rest: Array<void>) => (xs: Array<B>) => A);
+  declare function reduce<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    ...rest: Array<void>
+  ): (xs: Array<B>) => A;
+  declare function reduce<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    xs: Array<B>
+  ): A;
 
-  declare function reduceBy<A, B>(fn: (acc: B, elem: A) => B, ...rest: Array<void>):
-  ((acc: B, ...rest: Array<void>) => ((keyFn:(elem: A) => string, ...rest: Array<void>) => (xs: Array<A>) => {[key: string]: B}) & ((keyFn:(elem: A) => string, xs: Array<A>) => {[key: string]: B}))
-  & ((acc: B, keyFn:(elem: A) => string, ...rest: Array<void>) => (xs: Array<A>) => {[key: string]: B})
-  & ((acc: B, keyFn:(elem: A) => string, xs: Array<A>) => {[key: string]: B})
-  declare function reduceBy<A, B>(fn: (acc: B, elem: A) => B, acc: B, ...rest: Array<void>):
-  ((keyFn:(elem: A) => string, ...rest: Array<void>) => (xs: Array<A>) => {[key: string]: B})
-  & ((keyFn:(elem: A) => string, xs: Array<A>) => {[key: string]: B})
-  declare function reduceBy<A, B>(fn: (acc: B, elem: A) => B, acc: B, keyFn:(elem: A) => string): (xs: Array<A>) => {[key: string]: B};
-  declare function reduceBy<A, B>(fn: (acc: B, elem: A) => B, acc: B, keyFn:(elem: A) => string, xs: Array<A>): {[key: string]: B};
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    ...rest: Array<void>
+  ): ((
+    acc: B,
+    ...rest: Array<void>
+  ) => ((
+    keyFn: (elem: A) => string,
+    ...rest: Array<void>
+  ) => (xs: Array<A>) => { [key: string]: B }) &
+    ((keyFn: (elem: A) => string, xs: Array<A>) => { [key: string]: B })) &
+    ((
+      acc: B,
+      keyFn: (elem: A) => string,
+      ...rest: Array<void>
+    ) => (xs: Array<A>) => { [key: string]: B }) &
+    ((
+      acc: B,
+      keyFn: (elem: A) => string,
+      xs: Array<A>
+    ) => { [key: string]: B });
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    acc: B,
+    ...rest: Array<void>
+  ): ((
+    keyFn: (elem: A) => string,
+    ...rest: Array<void>
+  ) => (xs: Array<A>) => { [key: string]: B }) &
+    ((keyFn: (elem: A) => string, xs: Array<A>) => { [key: string]: B });
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    acc: B,
+    keyFn: (elem: A) => string
+  ): (xs: Array<A>) => { [key: string]: B };
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    acc: B,
+    keyFn: (elem: A) => string,
+    xs: Array<A>
+  ): { [key: string]: B };
 
-  declare function reduceRight<A, B>(fn: (acc: A, elem: B) => A, ...rest: Array<void>): ((init: A, xs: Array<B>) => A) & ((init: A, ...rest: Array<void>) => (xs: Array<B>) => A);
-  declare function reduceRight<A, B>(fn: (acc: A, elem: B) => A, init: A, ...rest: Array<void>): (xs: Array<B>) => A;
-  declare function reduceRight<A, B>(fn: (acc: A, elem: B) => A, init: A, xs: Array<B>): A;
+  declare function reduceRight<A, B>(
+    fn: (acc: A, elem: B) => A,
+    ...rest: Array<void>
+  ): ((init: A, xs: Array<B>) => A) &
+    ((init: A, ...rest: Array<void>) => (xs: Array<B>) => A);
+  declare function reduceRight<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    ...rest: Array<void>
+  ): (xs: Array<B>) => A;
+  declare function reduceRight<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    xs: Array<B>
+  ): A;
 
-  declare function scan<A, B>(fn: (acc: A, elem: B) => A, ...rest: Array<void>): ((init: A, xs: Array<B>) => Array<A>) & ((init: A, ...rest: Array<void>) => (xs: Array<B>) => Array<A>);
-  declare function scan<A, B>(fn: (acc: A, elem: B) => A, init: A, ...rest: Array<void>): (xs: Array<B>) => Array<A>;
-  declare function scan<A, B>(fn: (acc: A, elem: B) => A, init: A, xs: Array<B>): Array<A>;
+  declare function scan<A, B>(
+    fn: (acc: A, elem: B) => A,
+    ...rest: Array<void>
+  ): ((init: A, xs: Array<B>) => Array<A>) &
+    ((init: A, ...rest: Array<void>) => (xs: Array<B>) => Array<A>);
+  declare function scan<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    ...rest: Array<void>
+  ): (xs: Array<B>) => Array<A>;
+  declare function scan<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    xs: Array<B>
+  ): Array<A>;
 
-  declare function splitAt<V,T:Array<V>|string>(i: number, xs: T): [T,T];
-  declare function splitAt<V,T:Array<V>|string>(i: number): (xs: T) => [T,T];
-  declare function splitEvery<V,T:Array<V>|string>(i: number, xs: T): Array<T>;
-  declare function splitEvery<V,T:Array<V>|string>(i: number): (xs: T) => Array<T>;
-  declare function splitWhen<V,T:Array<V>>(fn: UnaryPredicateFn<V>, xs:T): [T,T];
-  declare function splitWhen<V,T:Array<V>>(fn: UnaryPredicateFn<V>): (xs:T) => [T,T];
+  declare function splitAt<V, T: Array<V> | string>(i: number, xs: T): [T, T];
+  declare function splitAt<V, T: Array<V> | string>(
+    i: number
+  ): (xs: T) => [T, T];
+  declare function splitEvery<V, T: Array<V> | string>(
+    i: number,
+    xs: T
+  ): Array<T>;
+  declare function splitEvery<V, T: Array<V> | string>(
+    i: number
+  ): (xs: T) => Array<T>;
+  declare function splitWhen<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): [T, T];
+  declare function splitWhen<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ): (xs: T) => [T, T];
 
-  declare function tail<T,V:Array<T>|string>(xs: V): V;
+  declare function tail<T, V: Array<T> | string>(xs: V): V;
 
   declare function transpose<T>(xs: Array<Array<T>>): Array<Array<T>>;
 
@@ -468,40 +960,103 @@ declare module ramda {
 
   declare function unnest<T>(xs: NestedArray<T>): NestedArray<T>;
 
-  declare function zipWith<T,S,R>(fn: (a: T, b: S) => R, ...rest: Array<void>): ((xs: Array<T>, ys: Array<S>) => Array<R>) & ((xs: Array<T>, ...rest: Array<void> ) => (ys: Array<S>) => Array<R>)
-  declare function zipWith<T,S,R>(fn: (a: T, b: S) => R, xs: Array<T>, ...rest: Array<void>): (ys: Array<S>) => Array<R>;
-  declare function zipWith<T,S,R>(fn: (a: T, b: S) => R, xs: Array<T>, ys: Array<S>): Array<R>;
+  declare function zipWith<T, S, R>(
+    fn: (a: T, b: S) => R,
+    ...rest: Array<void>
+  ): ((xs: Array<T>, ys: Array<S>) => Array<R>) &
+    ((xs: Array<T>, ...rest: Array<void>) => (ys: Array<S>) => Array<R>);
+  declare function zipWith<T, S, R>(
+    fn: (a: T, b: S) => R,
+    xs: Array<T>,
+    ...rest: Array<void>
+  ): (ys: Array<S>) => Array<R>;
+  declare function zipWith<T, S, R>(
+    fn: (a: T, b: S) => R,
+    xs: Array<T>,
+    ys: Array<S>
+  ): Array<R>;
 
   // *Relation
   declare function equals<T>(x: T, ...rest: Array<void>): (y: T) => boolean;
   declare function equals<T>(x: T, y: T): boolean;
 
-  declare function eqBy<A,B>(fn: (x: A) => B, ...rest: Array<void>): ((x: A, y: A) => boolean) & ((x: A, ...rest: Array<void>) => (y: A) => boolean);
-  declare function eqBy<A,B>(fn: (x: A) => B, x: A, ...rest: Array<void>): (y: A) => boolean;
-  declare function eqBy<A,B>(fn: (x: A) => B, x: A, y: A): boolean;
+  declare function eqBy<A, B>(
+    fn: (x: A) => B,
+    ...rest: Array<void>
+  ): ((x: A, y: A) => boolean) &
+    ((x: A, ...rest: Array<void>) => (y: A) => boolean);
+  declare function eqBy<A, B>(
+    fn: (x: A) => B,
+    x: A,
+    ...rest: Array<void>
+  ): (y: A) => boolean;
+  declare function eqBy<A, B>(fn: (x: A) => B, x: A, y: A): boolean;
 
-  declare function propEq(prop: string, ...rest: Array<void>): ((val: *, o: {[k:string]: *}) => boolean) & ((val: *, ...rest: Array<void>) => (o: {[k:string]: *}) => boolean)
-  declare function propEq(prop: string, val: *, ...rest: Array<void>): (o: {[k:string]: *}) => boolean;
-  declare function propEq(prop: string, val: *, o: {[k:string]:*}): boolean;
+  declare function propEq(
+    prop: string,
+    ...rest: Array<void>
+  ): ((val: *, o: { [k: string]: * }) => boolean) &
+    ((val: *, ...rest: Array<void>) => (o: { [k: string]: * }) => boolean);
+  declare function propEq(
+    prop: string,
+    val: *,
+    ...rest: Array<void>
+  ): (o: { [k: string]: * }) => boolean;
+  declare function propEq(prop: string, val: *, o: { [k: string]: * }): boolean;
 
-  declare function pathEq(path: Array<string>, ...rest: Array<void>): ((val: any, o: Object) => boolean) & ((val: any, ...rest: Array<void>) => (o: Object) => boolean);
-  declare function pathEq(path: Array<string>, val: any, ...rest: Array<void>): (o: Object) => boolean;
+  declare function pathEq(
+    path: Array<string>,
+    ...rest: Array<void>
+  ): ((val: any, o: Object) => boolean) &
+    ((val: any, ...rest: Array<void>) => (o: Object) => boolean);
+  declare function pathEq(
+    path: Array<string>,
+    val: any,
+    ...rest: Array<void>
+  ): (o: Object) => boolean;
   declare function pathEq(path: Array<string>, val: any, o: Object): boolean;
 
-  declare function clamp<T:number|string|Date>(min: T, ...rest: Array<void>):
-    ((max: T, ...rest: Array<void>) => (v: T) => T) & ((max: T, v: T) => T);
-  declare function clamp<T:number|string|Date>(min: T, max: T, ...rest: Array<void>): (v: T) => T;
-  declare function clamp<T:number|string|Date>(min: T, max: T, v: T): T;
+  declare function clamp<T: number | string | Date>(
+    min: T,
+    ...rest: Array<void>
+  ): ((max: T, ...rest: Array<void>) => (v: T) => T) & ((max: T, v: T) => T);
+  declare function clamp<T: number | string | Date>(
+    min: T,
+    max: T,
+    ...rest: Array<void>
+  ): (v: T) => T;
+  declare function clamp<T: number | string | Date>(min: T, max: T, v: T): T;
 
-  declare function countBy<T>(fn: (x: T) => string, ...rest: Array<void>): (list: Array<T>) => {[key: string]: number};
-  declare function countBy<T>(fn: (x: T) => string, list: Array<T>): {[key: string]: number};
+  declare function countBy<T>(
+    fn: (x: T) => string,
+    ...rest: Array<void>
+  ): (list: Array<T>) => { [key: string]: number };
+  declare function countBy<T>(
+    fn: (x: T) => string,
+    list: Array<T>
+  ): { [key: string]: number };
 
-  declare function difference<T>(xs1: Array<T>, ...rest: Array<void>): (xs2: Array<T>) => Array<T>;
+  declare function difference<T>(
+    xs1: Array<T>,
+    ...rest: Array<void>
+  ): (xs2: Array<T>) => Array<T>;
   declare function difference<T>(xs1: Array<T>, xs2: Array<T>): Array<T>;
 
-  declare function differenceWith<T>(fn: BinaryPredicateFn<T>, ...rest: Array<void>): ((xs1: Array<T>) => (xs2: Array<T>) => Array<T>) & ((xs1: Array<T>, xs2: Array<T>) => Array<T>);
-  declare function differenceWith<T>(fn: BinaryPredicateFn<T>, xs1: Array<T>, ...rest: Array<void>): (xs2: Array<T>) => Array<T>;
-  declare function differenceWith<T>(fn: BinaryPredicateFn<T>, xs1: Array<T>, xs2: Array<T>): Array<T>;
+  declare function differenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((xs1: Array<T>) => (xs2: Array<T>) => Array<T>) &
+    ((xs1: Array<T>, xs2: Array<T>) => Array<T>);
+  declare function differenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    xs1: Array<T>,
+    ...rest: Array<void>
+  ): (xs2: Array<T>) => Array<T>;
+  declare function differenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    xs1: Array<T>,
+    xs2: Array<T>
+  ): Array<T>;
 
   declare function eqBy<T>(fn: (x: T) => T, x: T, y: T): boolean;
   declare function eqBy<T>(fn: (x: T) => T): (x: T, y: T) => boolean;
@@ -520,9 +1075,21 @@ declare module ramda {
   declare function intersection<T>(x: Array<T>, y: Array<T>): Array<T>;
   declare function intersection<T>(x: Array<T>): (y: Array<T>) => Array<T>;
 
-  declare function intersectionWith<T>(fn: BinaryPredicateFn<T>, ...rest: Array<void>): ((x: Array<T>, y: Array<T>) => Array<T>) & ((x: Array<T>) => (y: Array<T>) => Array<T>);
-  declare function intersectionWith<T>(fn: BinaryPredicateFn<T>, x: Array<T>, ...rest: Array<void>): (y: Array<T>) => Array<T>;
-  declare function intersectionWith<T>(fn: BinaryPredicateFn<T>, x: Array<T>, y: Array<T>): Array<T>;
+  declare function intersectionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((x: Array<T>, y: Array<T>) => Array<T>) &
+    ((x: Array<T>) => (y: Array<T>) => Array<T>);
+  declare function intersectionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    ...rest: Array<void>
+  ): (y: Array<T>) => Array<T>;
+  declare function intersectionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    y: Array<T>
+  ): Array<T>;
 
   declare function lt<T>(x: T, ...rest: Array<void>): (y: T) => boolean;
   declare function lt<T>(x: T, y: T): boolean;
@@ -533,53 +1100,139 @@ declare module ramda {
   declare function max<T>(x: T, ...rest: Array<void>): (y: T) => T;
   declare function max<T>(x: T, y: T): T;
 
-  declare function maxBy<T,V>(fn: (x:T) => V, ...rest: Array<void>): ((x: T, y: T) => T) & ((x: T) => (y: T) => T);
-  declare function maxBy<T,V>(fn: (x:T) => V, x: T, ...rest: Array<void>): (y: T) => T;
-  declare function maxBy<T,V>(fn: (x:T) => V, x: T, y: T): T;
+  declare function maxBy<T, V>(
+    fn: (x: T) => V,
+    ...rest: Array<void>
+  ): ((x: T, y: T) => T) & ((x: T) => (y: T) => T);
+  declare function maxBy<T, V>(
+    fn: (x: T) => V,
+    x: T,
+    ...rest: Array<void>
+  ): (y: T) => T;
+  declare function maxBy<T, V>(fn: (x: T) => V, x: T, y: T): T;
 
   declare function min<T>(x: T, ...rest: Array<void>): (y: T) => T;
   declare function min<T>(x: T, y: T): T;
 
-  declare function minBy<T,V>(fn: (x:T) => V, ...rest: Array<void>): ((x: T, y: T) => T) & ((x: T) => (y: T) => T);
-  declare function minBy<T,V>(fn: (x:T) => V, x: T, ...rest: Array<void>): (y: T) => T;
-  declare function minBy<T,V>(fn: (x:T) => V, x: T, y: T): T;
+  declare function minBy<T, V>(
+    fn: (x: T) => V,
+    ...rest: Array<void>
+  ): ((x: T, y: T) => T) & ((x: T) => (y: T) => T);
+  declare function minBy<T, V>(
+    fn: (x: T) => V,
+    x: T,
+    ...rest: Array<void>
+  ): (y: T) => T;
+  declare function minBy<T, V>(fn: (x: T) => V, x: T, y: T): T;
 
-  declare function sortBy<T,V>(fn: (x:T) => V, ...rest: Array<void>): (x: Array<T>) => Array<T>;
-  declare function sortBy<T,V>(fn: (x:T) => V, x: Array<T>): Array<T>;
+  declare function sortBy<T, V>(
+    fn: (x: T) => V,
+    ...rest: Array<void>
+  ): (x: Array<T>) => Array<T>;
+  declare function sortBy<T, V>(fn: (x: T) => V, x: Array<T>): Array<T>;
 
-  declare function symmetricDifference<T>(x: Array<T>, ...rest: Array<void>): (y: Array<T>) => Array<T>;
+  declare function symmetricDifference<T>(
+    x: Array<T>,
+    ...rest: Array<void>
+  ): (y: Array<T>) => Array<T>;
   declare function symmetricDifference<T>(x: Array<T>, y: Array<T>): Array<T>;
 
-  declare function symmetricDifferenceWith<T>(fn: BinaryPredicateFn<T>, ...rest: Array<void>): ((x: Array<T>, ...rest: Array<void>) => (y: Array<T>) => Array<T>) & ((x: Array<T>, y: Array<T>) => Array<T>);
-  declare function symmetricDifferenceWith<T>(fn: BinaryPredicateFn<T>, x: Array<T>, ...rest: Array<void>): (y: Array<T>) => Array<T>;
-  declare function symmetricDifferenceWith<T>(fn: BinaryPredicateFn<T>, x: Array<T>, y: Array<T>): Array<T>;
+  declare function symmetricDifferenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((x: Array<T>, ...rest: Array<void>) => (y: Array<T>) => Array<T>) &
+    ((x: Array<T>, y: Array<T>) => Array<T>);
+  declare function symmetricDifferenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    ...rest: Array<void>
+  ): (y: Array<T>) => Array<T>;
+  declare function symmetricDifferenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    y: Array<T>
+  ): Array<T>;
 
-  declare function union<T>(x: Array<T>, ...rest: Array<void>): (y: Array<T>) => Array<T>;
+  declare function union<T>(
+    x: Array<T>,
+    ...rest: Array<void>
+  ): (y: Array<T>) => Array<T>;
   declare function union<T>(x: Array<T>, y: Array<T>): Array<T>;
 
-  declare function unionWith<T>(fn: BinaryPredicateFn<T>, ...rest: Array<void>): ((x: Array<T>, ...rest: Array<void>) => (y: Array<T>) => Array<T>) & (x: Array<T>, y: Array<T>) => Array<T>;
-  declare function unionWith<T>(fn: BinaryPredicateFn<T>, x: Array<T>, ...rest: Array<void>): (y: Array<T>) => Array<T>;
-  declare function unionWith<T>(fn: BinaryPredicateFn<T>, x: Array<T>, y: Array<T>): Array<T>;
+  declare function unionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((x: Array<T>, ...rest: Array<void>) => (y: Array<T>) => Array<T>) &
+    ((x: Array<T>, y: Array<T>) => Array<T>);
+  declare function unionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    ...rest: Array<void>
+  ): (y: Array<T>) => Array<T>;
+  declare function unionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    y: Array<T>
+  ): Array<T>;
 
   // *Object
-  declare function assoc<T,S>(key: string, ...args: Array<void>):
-    ((val: T, ...rest: Array<void>) => (src: {[k:string]:S}) => {[k:string]:S|T}) & ((val: T, src: {[k:string]:S}) => {[k:string]:S|T});
-  declare function assoc<T,S>(key: string, val:T, ...args: Array<void>): (src: {[k:string]:S}) => {[k:string]:S|T};
-  declare function assoc<T,S>(key: string, val: T, src: {[k:string]:S}): {[k:string]:S|T};
+  declare function assoc<T, S>(
+    key: string,
+    ...args: Array<void>
+  ): ((
+    val: T,
+    ...rest: Array<void>
+  ) => (src: { [k: string]: S }) => { [k: string]: S | T }) &
+    ((val: T, src: { [k: string]: S }) => { [k: string]: S | T });
+  declare function assoc<T, S>(
+    key: string,
+    val: T,
+    ...args: Array<void>
+  ): (src: { [k: string]: S }) => { [k: string]: S | T };
+  declare function assoc<T, S>(
+    key: string,
+    val: T,
+    src: { [k: string]: S }
+  ): { [k: string]: S | T };
 
-  declare function assocPath<T,S>(key: Array<string>, ...args: Array<void>):
-    ((val: T, ...rest: Array<void>) => (src: {[k:string]:S}) => {[k:string]:S|T})
-    & ((val: T) => (src: {[k:string]:S}) => {[k:string]:S|T});
-  declare function assocPath<T,S>(key: Array<string>, val:T, ...args: Array<void>): (src: {[k:string]:S}) => {[k:string]:S|T};
-  declare function assocPath<T,S>(key: Array<string>, val:T, src: {[k:string]:S}): {[k:string]:S|T};
+  declare function assocPath<T, S>(
+    key: Array<string>,
+    ...args: Array<void>
+  ): ((
+    val: T,
+    ...rest: Array<void>
+  ) => (src: { [k: string]: S }) => { [k: string]: S | T }) &
+    ((val: T) => (src: { [k: string]: S }) => { [k: string]: S | T });
+  declare function assocPath<T, S>(
+    key: Array<string>,
+    val: T,
+    ...args: Array<void>
+  ): (src: { [k: string]: S }) => { [k: string]: S | T };
+  declare function assocPath<T, S>(
+    key: Array<string>,
+    val: T,
+    src: { [k: string]: S }
+  ): { [k: string]: S | T };
 
   declare function clone<T>(src: T): $Shape<T>;
 
-  declare function dissoc<T>(key: string, ...args: Array<void>): (src: {[k:string]:T}) => {[k:string]:T};
-  declare function dissoc<T>(key: string, src: {[k:string]:T}): {[k:string]:T};
+  declare function dissoc<T>(
+    key: string,
+    ...args: Array<void>
+  ): (src: { [k: string]: T }) => { [k: string]: T };
+  declare function dissoc<T>(
+    key: string,
+    src: { [k: string]: T }
+  ): { [k: string]: T };
 
-  declare function dissocPath<T>(key: Array<string>, ...args: Array<void>): (src: {[k:string]:T}) => {[k:string]:T};
-  declare function dissocPath<T>(key: Array<string>, src: {[k:string]:T}): {[k:string]:T};
+  declare function dissocPath<T>(
+    key: Array<string>,
+    ...args: Array<void>
+  ): (src: { [k: string]: T }) => { [k: string]: T };
+  declare function dissocPath<T>(
+    key: Array<string>,
+    src: { [k: string]: T }
+  ): { [k: string]: T };
 
   // TODO: Started failing in v31... (Attempt to fix below)
   // declare type __UnwrapNestedObjectR<T, U, V: NestedObject<(t: T) => U>> = U
@@ -588,20 +1241,26 @@ declare module ramda {
   // declare function evolve<R, T: NestedObject<(x:any) => R>>(fn: T, ...rest: Array<void>): (src: NestedObject<any>) => UnwrapNestedObjectR<T>;
   // declare function evolve<R: NestedObject<(x:any) => R>>(fn: T, src: NestedObject<any>): UnwrapNestedObjectR<T>;
 
-  declare function eqProps(key: string, ...args: Array<void>):
-  ((o1: Object, ...rest: Array<void>) => (o2: Object) => boolean)
-  & ((o1: Object, o2: Object) => boolean);
-  declare function eqProps(key: string, o1: Object, ...args: Array<void>): (o2: Object) => boolean;
+  declare function eqProps(
+    key: string,
+    ...args: Array<void>
+  ): ((o1: Object, ...rest: Array<void>) => (o2: Object) => boolean) &
+    ((o1: Object, o2: Object) => boolean);
+  declare function eqProps(
+    key: string,
+    o1: Object,
+    ...args: Array<void>
+  ): (o2: Object) => boolean;
   declare function eqProps(key: string, o1: Object, o2: Object): boolean;
 
   declare function has(key: string, o: Object): boolean;
-  declare function has(key: string):(o: Object) => boolean;
+  declare function has(key: string): (o: Object) => boolean;
 
   declare function hasIn(key: string, o: Object): boolean;
   declare function hasIn(key: string): (o: Object) => boolean;
 
-  declare function invert(o: Object): {[k: string]: Array<string>};
-  declare function invertObj(o: Object): {[k: string]: string};
+  declare function invert(o: Object): { [k: string]: Array<string> };
+  declare function invertObj(o: Object): { [k: string]: string };
 
   declare function keys(o: Object): Array<string>;
 
@@ -612,95 +1271,254 @@ declare module ramda {
   lensProp
   */
 
-  declare function mapObjIndexed<A,B>(fn: (val: A, key: string, o: Object) => B, o: {[key: string]: A}): {[key: string]: B};
-  declare function mapObjIndexed<A,B>(fn: (val: A, key: string, o: Object) => B, ...args: Array<void>): (o: {[key: string]: A}) => {[key: string]: B};
+  declare function mapObjIndexed<A, B>(
+    fn: (val: A, key: string, o: Object) => B,
+    o: { [key: string]: A }
+  ): { [key: string]: B };
+  declare function mapObjIndexed<A, B>(
+    fn: (val: A, key: string, o: Object) => B,
+    ...args: Array<void>
+  ): (o: { [key: string]: A }) => { [key: string]: B };
 
-  declare function merge<A,B>(o1: A, ...rest: Array<void>): (o2: B) => A & B;
-  declare function merge<A,B>(o1: A, o2: B): A & B;
+  declare function merge<A, B>(o1: A, ...rest: Array<void>): (o2: B) => A & B;
+  declare function merge<A, B>(o1: A, o2: B): A & B;
 
-  declare function mergeAll<T>(os: Array<{[k:string]:T}>): {[k:string]:T};
+  declare function mergeAll<T>(
+    os: Array<{ [k: string]: T }>
+  ): { [k: string]: T };
 
-  declare function mergeWith<T,S,R,A:{[k:string]:T},B:{[k:string]:S}>(fn: (v1: T, v2: S) => R):
-  ((o1: A, ...rest: Array<void>) => (o2: B) => A & B) & ((o1: A, o2: B) => A & B);
-  declare function mergeWith<T,S,R,A:{[k:string]:T},B:{[k:string]:S}>(fn: (v1: T, v2: S) => R, o1: A, o2: B): A & B;
-  declare function mergeWith<T,S,R,A:{[k:string]:T},B:{[k:string]:S}>(fn: (v1: T, v2: S) => R, o1: A, ...rest: Array<void>): (o2: B) => A & B;
+  declare function mergeWith<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (v1: T, v2: S) => R
+  ): ((o1: A, ...rest: Array<void>) => (o2: B) => A & B) &
+    ((o1: A, o2: B) => A & B);
+  declare function mergeWith<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (v1: T, v2: S) => R,
+    o1: A,
+    o2: B
+  ): A & B;
+  declare function mergeWith<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (v1: T, v2: S) => R,
+    o1: A,
+    ...rest: Array<void>
+  ): (o2: B) => A & B;
 
-  declare function mergeWithKey<T,S,R,A:{[k:string]:T},B:{[k:string]:S}>(fn: (key: $Keys<A&B>, v1: T, v2: S) => R):
-  ((o1: A, ...rest: Array<void>) => (o2: B) => A & B) & ((o1: A, o2: B) => A & B);
-  declare function mergeWithKey<T,S,R,A:{[k:string]:T},B:{[k:string]:S}>(fn: (key: $Keys<A&B>, v1: T, v2: S) => R, o1: A, o2: B): A & B;
-  declare function mergeWithKey<T,S,R,A:{[k:string]:T},B:{[k:string]:S}>(fn: (key: $Keys<A&B>, v1: T, v2: S) => R, o1: A, ...rest: Array<void>): (o2: B) => A & B;
+  declare function mergeWithKey<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (key: $Keys<A & B>, v1: T, v2: S) => R
+  ): ((o1: A, ...rest: Array<void>) => (o2: B) => A & B) &
+    ((o1: A, o2: B) => A & B);
+  declare function mergeWithKey<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (key: $Keys<A & B>, v1: T, v2: S) => R,
+    o1: A,
+    o2: B
+  ): A & B;
+  declare function mergeWithKey<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (key: $Keys<A & B>, v1: T, v2: S) => R,
+    o1: A,
+    ...rest: Array<void>
+  ): (o2: B) => A & B;
 
-  declare function objOf<T>(key: string, ...rest: Array<void>): (val: T) => {[key: string]: T};
-  declare function objOf<T>(key: string, val: T): {[key: string]: T};
+  declare function objOf<T>(
+    key: string,
+    ...rest: Array<void>
+  ): (val: T) => { [key: string]: T };
+  declare function objOf<T>(key: string, val: T): { [key: string]: T };
 
-  declare function omit<T:Object>(keys: Array<$Keys<T>>, ...rest: Array<void>): (val: T) => Object;
-  declare function omit<T:Object>(keys: Array<$Keys<T>>, val: T): Object;
+  declare function omit<T: Object>(
+    keys: Array<$Keys<T>>,
+    ...rest: Array<void>
+  ): (val: T) => Object;
+  declare function omit<T: Object>(keys: Array<$Keys<T>>, val: T): Object;
 
   // TODO over
 
-  declare function path<V>(p: Array<mixed>, ...rest: Array<void>): (o: NestedObject<V>) => V;
-  declare function path<V>(p: Array<mixed>, ...rest: Array<void>): (o: null|void) => void;
-  declare function path<V>(p: Array<mixed>, ...rest: Array<void>): (o: mixed) => ?V;
-  declare function path<V,A:NestedObject<V>>(p: Array<mixed>, o: A): V;
-  declare function path<V,A:null|void>(p: Array<mixed>, o: A): void;
-  declare function path<V,A:mixed>(p: Array<mixed>, o: A): ?V;
+  declare function path<V>(
+    p: Array<mixed>,
+    ...rest: Array<void>
+  ): (o: NestedObject<V>) => V;
+  declare function path<V>(
+    p: Array<mixed>,
+    ...rest: Array<void>
+  ): (o: null | void) => void;
+  declare function path<V>(
+    p: Array<mixed>,
+    ...rest: Array<void>
+  ): (o: mixed) => ?V;
+  declare function path<V, A: NestedObject<V>>(p: Array<mixed>, o: A): V;
+  declare function path<V, A: null | void>(p: Array<mixed>, o: A): void;
+  declare function path<V, A: mixed>(p: Array<mixed>, o: A): ?V;
 
-  declare function path<V>(p: Array<string>, ...rest: Array<void>): (o: NestedObject<V>) => V;
-  declare function path<V>(p: Array<string>, ...rest: Array<void>): (o: null|void) => void;
-  declare function path<V>(p: Array<string>, ...rest: Array<void>): (o: mixed) => ?V;
-  declare function path<V,A:NestedObject<V>>(p: Array<string>, o: A): V;
-  declare function path<V,A:null|void>(p: Array<string>, o: A): void;
-  declare function path<V,A:mixed>(p: Array<string>, o: A): ?V;
+  declare function path<V>(
+    p: Array<string>,
+    ...rest: Array<void>
+  ): (o: NestedObject<V>) => V;
+  declare function path<V>(
+    p: Array<string>,
+    ...rest: Array<void>
+  ): (o: null | void) => void;
+  declare function path<V>(
+    p: Array<string>,
+    ...rest: Array<void>
+  ): (o: mixed) => ?V;
+  declare function path<V, A: NestedObject<V>>(p: Array<string>, o: A): V;
+  declare function path<V, A: null | void>(p: Array<string>, o: A): void;
+  declare function path<V, A: mixed>(p: Array<string>, o: A): ?V;
 
-  declare function pathOr<T,V,A:NestedObject<V>>(or: T, ...rest: Array<void>):
-  ((p: Array<string>, ...rest: Array<void>) => (o: ?A) => V|T)
-  & ((p: Array<string>, o: ?A) => V|T);
-  declare function pathOr<T,V,A:NestedObject<V>>(or: T, p: Array<string>, ...rest: Array<void>): (o: ?A) => V|T;
-  declare function pathOr<T,V,A:NestedObject<V>>(or: T, p: Array<string>, o: ?A): V|T;
+  declare function pathOr<T, V, A: NestedObject<V>>(
+    or: T,
+    ...rest: Array<void>
+  ): ((p: Array<string>, ...rest: Array<void>) => (o: ?A) => V | T) &
+    ((p: Array<string>, o: ?A) => V | T);
+  declare function pathOr<T, V, A: NestedObject<V>>(
+    or: T,
+    p: Array<string>,
+    ...rest: Array<void>
+  ): (o: ?A) => V | T;
+  declare function pathOr<T, V, A: NestedObject<V>>(
+    or: T,
+    p: Array<string>,
+    o: ?A
+  ): V | T;
 
-  declare function pick<A>(keys: Array<string>, ...rest: Array<void>): (val: {[key:string]: A}) => {[key:string]: A};
-  declare function pick<A>(keys: Array<string>, val: {[key:string]: A}): {[key:string]: A};
+  declare function pick<A>(
+    keys: Array<string>,
+    ...rest: Array<void>
+  ): (val: { [key: string]: A }) => { [key: string]: A };
+  declare function pick<A>(
+    keys: Array<string>,
+    val: { [key: string]: A }
+  ): { [key: string]: A };
 
-  declare function pickAll<A>(keys: Array<string>, ...rest: Array<void>): (val: {[key:string]: A}) => {[key:string]: ?A};
-  declare function pickAll<A>(keys: Array<string>, val: {[key:string]: A}): {[key:string]: ?A};
+  declare function pickAll<A>(
+    keys: Array<string>,
+    ...rest: Array<void>
+  ): (val: { [key: string]: A }) => { [key: string]: ?A };
+  declare function pickAll<A>(
+    keys: Array<string>,
+    val: { [key: string]: A }
+  ): { [key: string]: ?A };
 
-  declare function pickBy<A>(fn: BinaryPredicateFn2<A,string>, ...rest: Array<void>): (val: {[key:string]: A}) => {[key:string]: A};
-  declare function pickBy<A>(fn: BinaryPredicateFn2<A,string>, val: {[key:string]: A}): {[key:string]: A};
+  declare function pickBy<A>(
+    fn: BinaryPredicateFn2<A, string>,
+    ...rest: Array<void>
+  ): (val: { [key: string]: A }) => { [key: string]: A };
+  declare function pickBy<A>(
+    fn: BinaryPredicateFn2<A, string>,
+    val: { [key: string]: A }
+  ): { [key: string]: A };
 
-  declare function project<T>(keys: Array<string>, ...rest: Array<void>): (val: Array<{[key:string]: T}>) => Array<{[key:string]: T}>;
-  declare function project<T>(keys: Array<string>, val: Array<{[key:string]: T}>): Array<{[key:string]: T}>;
+  declare function project<T>(
+    keys: Array<string>,
+    ...rest: Array<void>
+  ): (val: Array<{ [key: string]: T }>) => Array<{ [key: string]: T }>;
+  declare function project<T>(
+    keys: Array<string>,
+    val: Array<{ [key: string]: T }>
+  ): Array<{ [key: string]: T }>;
 
-  declare function prop<T,O:{[k:string]:T}>(key: $Keys<O>, ...rest: Array<void>): (o: O) => ?T;
-  declare function prop<T,O:{[k:string]:T}>(__: $npm$ramda$Placeholder, o: O): (key: $Keys<O>) => ?T;
-  declare function prop<T,O:{[k:string]:T}>(key: $Keys<O>, o: O): ?T;
+  declare function prop<T, O: { [k: string]: T }>(
+    key: $Keys<O>,
+    ...rest: Array<void>
+  ): (o: O) => ?T;
+  declare function prop<T, O: { [k: string]: T }>(
+    __: $npm$ramda$Placeholder,
+    o: O
+  ): (key: $Keys<O>) => ?T;
+  declare function prop<T, O: { [k: string]: T }>(key: $Keys<O>, o: O): ?T;
 
-  declare function propOr<T,V,A:{[k:string]:V}>(or: T, ...rest: Array<void>):
-  ((p: $Keys<A>, ...rest: Array<void>) => (o: A) => V|T)
-  & ((p: $Keys<A>, o: A) => V|T);
-  declare function propOr<T,V,A:{[k:string]:V}>(or: T, p: $Keys<A>, ...rest: Array<void>): (o: A) => V|T;
-  declare function propOr<T,V,A:{[k:string]:V}>(or: T, p: $Keys<A>, o: A): V|T;
+  declare function propOr<T, V, A: { [k: string]: V }>(
+    or: T,
+    ...rest: Array<void>
+  ): ((p: $Keys<A>, ...rest: Array<void>) => (o: A) => V | T) &
+    ((p: $Keys<A>, o: A) => V | T);
+  declare function propOr<T, V, A: { [k: string]: V }>(
+    or: T,
+    p: $Keys<A>,
+    ...rest: Array<void>
+  ): (o: A) => V | T;
+  declare function propOr<T, V, A: { [k: string]: V }>(
+    or: T,
+    p: $Keys<A>,
+    o: A
+  ): V | T;
 
   declare function keysIn(o: Object): Array<string>;
 
-  declare function props<T,O:{[k:string]:T}>(keys: Array<$Keys<O>>, ...rest: Array<void>): (o: O) => Array<?T>;
-  declare function props<T,O:{[k:string]:T}>(keys: Array<$Keys<O>>, o: O): Array<?T>;
+  declare function props<T, O: { [k: string]: T }>(
+    keys: Array<$Keys<O>>,
+    ...rest: Array<void>
+  ): (o: O) => Array<?T>;
+  declare function props<T, O: { [k: string]: T }>(
+    keys: Array<$Keys<O>>,
+    o: O
+  ): Array<?T>;
 
   // TODO set
 
-  declare function toPairs<T,O:{[k:string]:T}>(o: O): Array<[$Keys<O>, T]>;
+  declare function toPairs<T, O: { [k: string]: T }>(
+    o: O
+  ): Array<[$Keys<O>, T]>;
 
-  declare function toPairsIn<T,O:{[k:string]:T}>(o: O): Array<[string, T]>;
+  declare function toPairsIn<T, O: { [k: string]: T }>(
+    o: O
+  ): Array<[string, T]>;
 
+  declare function values<T, O: { [k: string]: T }>(o: O): Array<T>;
 
-  declare function values<T,O:{[k:string]:T}>(o: O): Array<T>;
+  declare function valuesIn<T, O: { [k: string]: T }>(o: O): Array<T | any>;
 
-  declare function valuesIn<T,O:{[k:string]:T}>(o: O): Array<T|any>;
+  declare function where<T>(
+    predObj: { [key: string]: UnaryPredicateFn<T> },
+    ...rest: Array<void>
+  ): (o: { [k: string]: T }) => boolean;
+  declare function where<T>(
+    predObj: { [key: string]: UnaryPredicateFn<T> },
+    o: { [k: string]: T }
+  ): boolean;
 
-  declare function where<T>(predObj: {[key: string]: UnaryPredicateFn<T>}, ...rest: Array<void>): (o: {[k:string]:T}) => boolean;
-  declare function where<T>(predObj: {[key: string]: UnaryPredicateFn<T>}, o: {[k:string]:T}): boolean;
-
-  declare function whereEq<T,S,O:{[k:string]:T},Q:{[k:string]:S}>(predObj: O, ...rest: Array<void>): (o: $Shape<O&Q>) => boolean;
-  declare function whereEq<T,S,O:{[k:string]:T},Q:{[k:string]:S}>(predObj: O, o: $Shape<O&Q>): boolean;
+  declare function whereEq<T, S, O: { [k: string]: T }, Q: { [k: string]: S }>(
+    predObj: O,
+    ...rest: Array<void>
+  ): (o: $Shape<O & Q>) => boolean;
+  declare function whereEq<T, S, O: { [k: string]: T }, Q: { [k: string]: S }>(
+    predObj: O,
+    o: $Shape<O & Q>
+  ): boolean;
 
   // TODO view
 
@@ -710,61 +1528,120 @@ declare module ramda {
   declare var T: (_: any) => true;
   declare var F: (_: any) => false;
 
-  declare function addIndex<A,B>(iterFn:(fn:(x:A) => B, xs: Array<A>) => Array<B>): (fn: (x: A, idx: number, xs: Array<A>) => B, xs: Array<A>) => Array<B>;
+  declare function addIndex<A, B>(
+    iterFn: (fn: (x: A) => B, xs: Array<A>) => Array<B>
+  ): (fn: (x: A, idx: number, xs: Array<A>) => B, xs: Array<A>) => Array<B>;
 
-  declare function always<T>(x:T): (x: any) => T;
+  declare function always<T>(x: T): (x: any) => T;
 
-  declare function ap<T,V>(fns: Array<(x:T) => V>, ...rest: Array<void>): (xs: Array<T>) => Array<V>;
-  declare function ap<T,V>(fns: Array<(x:T) => V>, xs: Array<T>): Array<V>;
+  declare function ap<T, V>(
+    fns: Array<(x: T) => V>,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => Array<V>;
+  declare function ap<T, V>(fns: Array<(x: T) => V>, xs: Array<T>): Array<V>;
 
-  declare function apply<T,V>(fn: (...args: Array<T>) => V, ...rest: Array<void>): (xs: Array<T>) => V;
-  declare function apply<T,V>(fn: (...args: Array<T>) => V, xs: Array<T>): V;
+  declare function apply<T, V>(
+    fn: (...args: Array<T>) => V,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => V;
+  declare function apply<T, V>(fn: (...args: Array<T>) => V, xs: Array<T>): V;
 
-  declare function applySpec<V, S, A: Array<V>, T: NestedObject<(...args: A) => S>>(spec: T): (...args: A) => NestedObject<S>
+  declare function applySpec<
+    V,
+    S,
+    A: Array<V>,
+    T: NestedObject<(...args: A) => S>
+  >(
+    spec: T
+  ): (...args: A) => NestedObject<S>;
 
-  declare function binary<T>(fn:(...args: Array<any>) => T): (x: any, y: any) => T;
+  declare function binary<T>(
+    fn: (...args: Array<any>) => T
+  ): (x: any, y: any) => T;
 
-  declare function bind<T>(fn: (...args: Array<any>) => any, thisObj: T): (...args: Array<any>) => any;
+  declare function bind<T>(
+    fn: (...args: Array<any>) => any,
+    thisObj: T
+  ): (...args: Array<any>) => any;
 
-  declare function call<T,V>(fn: (...args: Array<V>) => T, ...args: Array<V>): T;
+  declare function call<T, V>(
+    fn: (...args: Array<V>) => T,
+    ...args: Array<V>
+  ): T;
 
-  declare function comparator<T>(fn: BinaryPredicateFn<T>): (x:T, y:T) => number;
+  declare function comparator<T>(
+    fn: BinaryPredicateFn<T>
+  ): (x: T, y: T) => number;
 
   // TODO add tests
-  declare function construct<T>(ctor: Class<GenericContructor<T>>): (x: T) => GenericContructor<T>;
+  declare function construct<T>(
+    ctor: Class<GenericContructor<T>>
+  ): (x: T) => GenericContructor<T>;
 
   // TODO add tests
-  declare function constructN<T>(n: number, ctor: Class<GenericContructorMulti<any>>): (...args: any) => GenericContructorMulti<any>;
+  declare function constructN<T>(
+    n: number,
+    ctor: Class<GenericContructorMulti<any>>
+  ): (...args: any) => GenericContructorMulti<any>;
 
   // TODO make less generic
   declare function converge(after: Function, fns: Array<Function>): Function;
 
   declare function empty<T>(x: T): T;
 
-  declare function flip<A,B,TResult>(fn: (arg0: A, arg1: B) => TResult): CurriedFunction2<B,A,TResult>;
-  declare function flip<A,B,C,TResult>(fn: (arg0: A, arg1: B, arg2: C) => TResult): (( arg0: B, arg1: A, ...rest: Array<void>) => (arg2: C) => TResult) & (( arg0: B, arg1: A, arg2: C) => TResult);
-  declare function flip<A,B,C,D,TResult>(fn: (arg0: A, arg1: B, arg2: C, arg3: D) => TResult): ((arg1: B, arg0: A, ...rest: Array<void>) => (arg2: C, arg3: D) => TResult) & ((arg1: B, arg0: A, arg2: C, arg3: D) => TResult);
-  declare function flip<A,B,C,D,E,TResult>(fn: (arg0: A, arg1: B, arg2: C, arg3: D, arg4:E) => TResult): ((arg1: B, arg0: A, ...rest: Array<void>) => (arg2: C, arg3: D, arg4: E) => TResult) & ((arg1: B, arg0: A, arg2: C, arg3: D, arg4: E) => TResult);
+  declare function flip<A, B, TResult>(
+    fn: (arg0: A, arg1: B) => TResult
+  ): CurriedFunction2<B, A, TResult>;
+  declare function flip<A, B, C, TResult>(
+    fn: (arg0: A, arg1: B, arg2: C) => TResult
+  ): ((arg0: B, arg1: A, ...rest: Array<void>) => (arg2: C) => TResult) &
+    ((arg0: B, arg1: A, arg2: C) => TResult);
+  declare function flip<A, B, C, D, TResult>(
+    fn: (arg0: A, arg1: B, arg2: C, arg3: D) => TResult
+  ): ((
+    arg1: B,
+    arg0: A,
+    ...rest: Array<void>
+  ) => (arg2: C, arg3: D) => TResult) &
+    ((arg1: B, arg0: A, arg2: C, arg3: D) => TResult);
+  declare function flip<A, B, C, D, E, TResult>(
+    fn: (arg0: A, arg1: B, arg2: C, arg3: D, arg4: E) => TResult
+  ): ((
+    arg1: B,
+    arg0: A,
+    ...rest: Array<void>
+  ) => (arg2: C, arg3: D, arg4: E) => TResult) &
+    ((arg1: B, arg0: A, arg2: C, arg3: D, arg4: E) => TResult);
 
-  declare function identity<T>(x:T): T;
+  declare function identity<T>(x: T): T;
 
-  declare function invoker<A,B,C,D,O:{[k:string]: Function}>(arity: number, name: $Enum<O>): CurriedFunction2<A,O,D> & CurriedFunction3<A,B,O,D> & CurriedFunction4<A,B,C,O,D>
+  declare function invoker<A, B, C, D, O: { [k: string]: Function }>(
+    arity: number,
+    name: $Enum<O>
+  ): CurriedFunction2<A, O, D> &
+    CurriedFunction3<A, B, O, D> &
+    CurriedFunction4<A, B, C, O, D>;
 
-  declare function juxt<T,S>(fns: Array<(...args: Array<S>) => T>): (...args: Array<S>) => Array<T>;
+  declare function juxt<T, S>(
+    fns: Array<(...args: Array<S>) => T>
+  ): (...args: Array<S>) => Array<T>;
 
   // TODO lift
 
   // TODO liftN
 
-  declare function memoize<A,B,T:(...args: Array<A>) => B>(fn:T):T;
+  declare function memoize<A, B, T: (...args: Array<A>) => B>(fn: T): T;
 
-  declare function nAry<T>(arity: number, fn:(...args: Array<any>) => T): (...args: Array<any>) => T;
+  declare function nAry<T>(
+    arity: number,
+    fn: (...args: Array<any>) => T
+  ): (...args: Array<any>) => T;
 
   declare function nthArg<T>(n: number): (...args: Array<T>) => T;
 
   declare function of<T>(x: T): Array<T>;
 
-  declare function once<A,B,T:(...args: Array<A>) => B>(fn:T):T;
+  declare function once<A, B, T: (...args: Array<A>) => B>(fn: T): T;
 
   declare var partial: Partial;
   // TODO partialRight
@@ -776,58 +1653,107 @@ declare module ramda {
 
   // TODO tryCatch
 
-  declare function unapply<T,V>(fn: (xs: Array<T>) => V): (...args: Array<T>) => V;
+  declare function unapply<T, V>(
+    fn: (xs: Array<T>) => V
+  ): (...args: Array<T>) => V;
 
-  declare function unary<T>(fn:(...args: Array<any>) => T): (x: any) => T;
+  declare function unary<T>(fn: (...args: Array<any>) => T): (x: any) => T;
 
-  declare var uncurryN:
-    & (<A, B, C>(2, A => B => C) => (A, B) => C)
-    & (<A, B, C, D>(3, A => B => C => D) => (A, B, C) => D)
-    & (<A, B, C, D, E>(4, A => B => C => D => E) => (A, B, C, D) => E)
-    & (<A, B, C, D, E, F>(5, A => B => C => D => E => F) => (A, B, C, D, E) => F)
-    & (<A, B, C, D, E, F, G>(6, A => B => C => D => E => F => G) => (A, B, C, D, E, F) => G)
-    & (<A, B, C, D, E, F, G, H>(7, A => B => C => D => E => F => G => H) => (A, B, C, D, E, F, G) => H)
-    & (<A, B, C, D, E, F, G, H, I>(8, A => B => C => D => E => F => G => H => I) => (A, B, C, D, E, F, G, H) => I)
+  declare var uncurryN: (<A, B, C>(2, (A) => B => C) => (A, B) => C) &
+    (<A, B, C, D>(3, (A) => B => C => D) => (A, B, C) => D) &
+    (<A, B, C, D, E>(4, (A) => B => C => D => E) => (A, B, C, D) => E) &
+    (<A, B, C, D, E, F>(
+      5,
+      (A) => B => C => D => E => F
+    ) => (A, B, C, D, E) => F) &
+    (<A, B, C, D, E, F, G>(
+      6,
+      (A) => B => C => D => E => F => G
+    ) => (A, B, C, D, E, F) => G) &
+    (<A, B, C, D, E, F, G, H>(
+      7,
+      (A) => B => C => D => E => F => G => H
+    ) => (A, B, C, D, E, F, G) => H) &
+    (<A, B, C, D, E, F, G, H, I>(
+      8,
+      (A) => B => C => D => E => F => G => H => I
+    ) => (A, B, C, D, E, F, G, H) => I);
 
   //TODO useWith
 
-  declare function wrap<A,B,C,D,F:(...args: Array<A>) => B>(fn: F, fn2: (fn: F, ...args: Array<C>) => D): (...args: Array<A|C>) => D;
+  declare function wrap<A, B, C, D, F: (...args: Array<A>) => B>(
+    fn: F,
+    fn2: (fn: F, ...args: Array<C>) => D
+  ): (...args: Array<A | C>) => D;
 
   // *Logic
 
-  declare function allPass<T>(fns: Array<(...args: Array<T>) => boolean>): (...args: Array<T>) => boolean;
+  declare function allPass<T>(
+    fns: Array<(...args: Array<T>) => boolean>
+  ): (...args: Array<T>) => boolean;
 
-  declare function and(x: boolean, ...rest: Array<void>): (y: boolean) => boolean;
+  declare function and(
+    x: boolean,
+    ...rest: Array<void>
+  ): (y: boolean) => boolean;
   declare function and(x: boolean, y: boolean): boolean;
 
-  declare function anyPass<T>(fns: Array<(...args: Array<T>) => boolean>): (...args: Array<T>) => boolean;
+  declare function anyPass<T>(
+    fns: Array<(...args: Array<T>) => boolean>
+  ): (...args: Array<T>) => boolean;
 
-  declare function both<T>(x: (...args: Array<T>) => boolean, ...rest: Array<void>): (y: (...args: Array<T>) => boolean) => (...args: Array<T>) => boolean;
-  declare function both<T>(x: (...args: Array<T>) => boolean, y: (...args: Array<T>) => boolean): (...args: Array<T>) => boolean;
+  declare function both<T>(
+    x: (...args: Array<T>) => boolean,
+    ...rest: Array<void>
+  ): (y: (...args: Array<T>) => boolean) => (...args: Array<T>) => boolean;
+  declare function both<T>(
+    x: (...args: Array<T>) => boolean,
+    y: (...args: Array<T>) => boolean
+  ): (...args: Array<T>) => boolean;
 
-  declare function complement<T>(x: (...args: Array<T>) => boolean): (...args: Array<T>) => boolean;
+  declare function complement<T>(
+    x: (...args: Array<T>) => boolean
+  ): (...args: Array<T>) => boolean;
 
-  declare function cond<A,B>(fns: Array<[(...args: Array<A>) => boolean, (...args: Array<A>) => B]>): (...args: Array<A>) => B;
+  declare function cond<A, B>(
+    fns: Array<[(...args: Array<A>) => boolean, (...args: Array<A>) => B]>
+  ): (...args: Array<A>) => B;
 
+  declare function defaultTo<T, V>(
+    d: T,
+    ...rest: Array<void>
+  ): (x: ?V) => V | T;
+  declare function defaultTo<T, V>(d: T, x: ?V): V | T;
 
-  declare function defaultTo<T,V>(d: T, ...rest: Array<void>): (x: ?V) => V|T;
-  declare function defaultTo<T,V>(d: T, x: ?V): V|T;
+  declare function either(
+    x: (...args: Array<any>) => *,
+    ...rest: Array<void>
+  ): (y: (...args: Array<any>) => *) => (...args: Array<any>) => *;
+  declare function either(
+    x: (...args: Array<any>) => *,
+    y: (...args: Array<any>) => *
+  ): (...args: Array<any>) => *;
 
-  declare function either(x: (...args: Array<any>) => *, ...rest: Array<void>): (y: (...args: Array<any>) => *) => (...args: Array<any>) => *;
-  declare function either(x: (...args: Array<any>) => *, y: (...args: Array<any>) => *): (...args: Array<any>) => *;
-
-  declare function ifElse<A,B,C>(cond:(...args: Array<A>) => boolean, ...rest: Array<void>):
-  ((f1: (...args: Array<A>) => B, ...rest: Array<void>) => (f2: (...args: Array<A>) => C) => (...args: Array<A>) => B|C)
-  & ((f1: (...args: Array<A>) => B, f2: (...args: Array<A>) => C) => (...args: Array<A>) => B|C)
-  declare function ifElse<A,B,C>(
-    cond:(...args: Array<any>) => boolean,
+  declare function ifElse<A, B, C>(
+    cond: (...args: Array<A>) => boolean,
+    ...rest: Array<void>
+  ): ((
+    f1: (...args: Array<A>) => B,
+    ...rest: Array<void>
+  ) => (f2: (...args: Array<A>) => C) => (...args: Array<A>) => B | C) &
+    ((
+      f1: (...args: Array<A>) => B,
+      f2: (...args: Array<A>) => C
+    ) => (...args: Array<A>) => B | C);
+  declare function ifElse<A, B, C>(
+    cond: (...args: Array<any>) => boolean,
     f1: (...args: Array<any>) => B,
     f2: (...args: Array<any>) => C
-  ): (...args: Array<A>) => B|C;
+  ): (...args: Array<A>) => B | C;
 
-  declare function isEmpty(x:?Array<any>|Object|string): boolean;
+  declare function isEmpty(x: ?Array<any> | Object | string): boolean;
 
-  declare function not(x:boolean): boolean;
+  declare function not(x: boolean): boolean;
 
   declare function or(x: boolean, y: boolean): boolean;
   declare function or(x: boolean): (y: boolean) => boolean;
@@ -839,27 +1765,67 @@ declare module ramda {
   // ((path: Array<string>, ...rest: Array<void>) => (o: NestedObject<T>) => boolean)
   // & ((path: Array<string>, o: NestedObject<T>) => boolean)
 
-  declare function propSatisfies<T>(cond: (x: T) => boolean, prop: string, o: NestedObject<T>): boolean;
-  declare function propSatisfies<T>(cond: (x: T) => boolean, prop: string, ...rest: Array<void>): (o: NestedObject<T>) => boolean;
-  declare function propSatisfies<T>(cond: (x: T) => boolean, ...rest: Array<void>):
-  ((prop: string, ...rest: Array<void>) => (o: NestedObject<T>) => boolean)
-  & ((prop: string, o: NestedObject<T>) => boolean)
+  declare function propSatisfies<T>(
+    cond: (x: T) => boolean,
+    prop: string,
+    o: NestedObject<T>
+  ): boolean;
+  declare function propSatisfies<T>(
+    cond: (x: T) => boolean,
+    prop: string,
+    ...rest: Array<void>
+  ): (o: NestedObject<T>) => boolean;
+  declare function propSatisfies<T>(
+    cond: (x: T) => boolean,
+    ...rest: Array<void>
+  ): ((prop: string, ...rest: Array<void>) => (o: NestedObject<T>) => boolean) &
+    ((prop: string, o: NestedObject<T>) => boolean);
 
-  declare function unless<T,V,S>(pred: UnaryPredicateFn<T>, ...rest: Array<void>):
-  ((fn: (x: S) => V, ...rest: Array<void>) => (x: T|S) => T|V)
-  & ((fn: (x: S) => V, x: T|S) => T|V);
-  declare function unless<T,V,S>(pred: UnaryPredicateFn<T>, fn: (x: S) => V, ...rest: Array<void>): (x: T|S) => V|T;
-  declare function unless<T,V,S>(pred: UnaryPredicateFn<T>, fn: (x: S) => V, x: T|S): T|V;
+  declare function unless<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((fn: (x: S) => V, ...rest: Array<void>) => (x: T | S) => T | V) &
+    ((fn: (x: S) => V, x: T | S) => T | V);
+  declare function unless<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    ...rest: Array<void>
+  ): (x: T | S) => V | T;
+  declare function unless<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    x: T | S
+  ): T | V;
 
-  declare function until<T>(pred: UnaryPredicateFn<T>, ...rest: Array<void>):
-  ((fn: (x: T) => T, ...rest: Array<void>) => (x: T) => T)
-  & ((fn: (x: T) => T, x: T) => T);
-  declare function until<T>(pred: UnaryPredicateFn<T>, fn: (x: T) => T, ...rest: Array<void>): (x: T) => T;
-  declare function until<T>(pred: UnaryPredicateFn<T>, fn: (x: T) => T, x: T): T;
+  declare function until<T>(
+    pred: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((fn: (x: T) => T, ...rest: Array<void>) => (x: T) => T) &
+    ((fn: (x: T) => T, x: T) => T);
+  declare function until<T>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: T) => T,
+    ...rest: Array<void>
+  ): (x: T) => T;
+  declare function until<T>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: T) => T,
+    x: T
+  ): T;
 
-  declare function when<T,V,S>(pred: UnaryPredicateFn<T>, ...rest: Array<void>):
-  ((fn: (x: S) => V, ...rest: Array<void>) => (x: T|S) => T|V)
-  & ((fn: (x: S) => V, x: T|S) => T|V);
-  declare function when<T,V,S>(pred: UnaryPredicateFn<T>, fn: (x: S) => V, ...rest: Array<void>): (x: T|S) => V|T;
-  declare function when<T,V,S>(pred: UnaryPredicateFn<T>, fn: (x: S) => V, x: T|S): T|V;
+  declare function when<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((fn: (x: S) => V, ...rest: Array<void>) => (x: T | S) => T | V) &
+    ((fn: (x: S) => V, x: T | S) => T | V);
+  declare function when<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    ...rest: Array<void>
+  ): (x: T | S) => V | T;
+  declare function when<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    x: T | S
+  ): T | V;
 }

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_cjs_modules.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_cjs_modules.js
@@ -1,15 +1,29 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-const _ = require('ramda')
-const { compose, match, toLower, trim, zipWith } = _
+const _ = require("ramda");
+const { compose, match, toLower, trim, zipWith } = _;
 
 // $ExpectError
-inc()
+inc();
 
-const str: Array<string|void> = compose(match(/2/), toLower, trim)(' 1,2,3 ')
-const str1: Array<string> = _.compose(_.split(','), _.toLower, _.trim)(' 1,2,3 ')
-const str2: string = _.compose(_.replace('3', '4'), _.toLower, _.trim)(' 1,2,3 ')
+const str: Array<string | void> = compose(match(/2/), toLower, trim)(" 1,2,3 ");
+const str1: Array<string> = _.compose(_.split(","), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+const str2: string = _.compose(_.replace("3", "4"), _.toLower, _.trim)(
+  " 1,2,3 "
+);
 
-const zipped: Array<{s: number, y: string}> = _.zipWith((a, b) => ({ s: a, y: b }), [ 1, 2, 3 ], [ '1', '2', '3' ])
-const zipped2: Array<{s: number, y: string}> = zipWith((a, b) => ({ s: a, y: b }), [ 1, 2, 3 ])([ '1', '2', '3' ])
-const zipped3: Array<{s: number, y: string}> = _.zipWith((a, b) => ({ s: a, y: b }))([ 1, 2, 3 ])([ '1', '2', '3' ])
+const zipped: Array<{ s: number, y: string }> = _.zipWith(
+  (a, b) => ({ s: a, y: b }),
+  [1, 2, 3],
+  ["1", "2", "3"]
+);
+const zipped2: Array<{ s: number, y: string }> = zipWith(
+  (a, b) => ({ s: a, y: b }),
+  [1, 2, 3]
+)(["1", "2", "3"]);
+const zipped3: Array<{ s: number, y: string }> = _.zipWith((a, b) => ({
+  s: a,
+  y: b
+}))([1, 2, 3])(["1", "2", "3"]);

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_es_modules.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_es_modules.js
@@ -1,10 +1,14 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, match, toLower, trim } from 'ramda'
+import _, { compose, match, toLower, trim } from "ramda";
 
 //$ExpectError
-inc()
+inc();
 
-const str: Array<string|void> = compose(match(/2/), toLower, trim)(' 1,2,3 ')
-const str1: Array<string> = _.compose(_.split(','), _.toLower, _.trim)(' 1,2,3 ')
-const str2: string = _.compose(_.replace('3', '4'), _.toLower, _.trim)(' 1,2,3 ')
+const str: Array<string | void> = compose(match(/2/), toLower, trim)(" 1,2,3 ");
+const str1: Array<string> = _.compose(_.split(","), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+const str2: string = _.compose(_.replace("3", "4"), _.toLower, _.trim)(
+  " 1,2,3 "
+);

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_functions.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_functions.js
@@ -1,13 +1,13 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, uncurryN, curry } from 'ramda'
+import _, { compose, pipe, uncurryN, curry } from "ramda";
 // Function
-const ns: Array<number> = [ 1, 2, 3, 4, 5 ]
-const ss: Array<string> = [ 'one', 'two', 'three', 'four' ]
-const obj: {[k:string]:number} = { a: 1, c: 2 }
-const objMixed: {[k:string]:mixed} = { a: 1, c: 'd' }
-const os: Array<{[k:string]: *}> = [ { a: 1, c: 'd' }, { b: 2 } ]
-const str: string = 'hello world'
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: * }> = [{ a: 1, c: "d" }, { b: 2 }];
+const str: string = "hello world";
 
 // TODO: "Gap" Functions: Started failing in v31...
 // const g = _.propIs
@@ -23,264 +23,308 @@ const str: string = 'hello world'
 
 type R = {
   sum: number,
-  nested: { mul: number },
-}
+  nested: { mul: number }
+};
 // TODO: "Gap" Functions: Started failing in v31...
 // const greet: string = _.replace('{name}', _.__, 'Hello, {name}!')('John')
-const truth: boolean = _.T('ddd')
-const lie: boolean = _.F('ddd')
-const mapIndexed = _.addIndex(_.map)
+const truth: boolean = _.T("ddd");
+const lie: boolean = _.F("ddd");
+const mapIndexed = _.addIndex(_.map);
 
-const mi: Array<string> = mapIndexed((val, idx) => idx + '-' + val, [ 'f', 'o', 'o', 'b', 'a', 'r' ])
+const mi: Array<string> = mapIndexed((val, idx) => idx + "-" + val, [
+  "f",
+  "o",
+  "o",
+  "b",
+  "a",
+  "r"
+]);
 
-const t: string = _.always('Tee')()
-const app: Array<number> = _.ap([ _.multiply(2), _.add(3) ], [ 1,2,3 ])
-const app1: Array<string|number> = _.ap([ _.toString, _.add(3) ], [ 1,2,3 ])
+const t: string = _.always("Tee")();
+const app: Array<number> = _.ap([_.multiply(2), _.add(3)], [1, 2, 3]);
+const app1: Array<string | number> = _.ap([_.toString, _.add(3)], [1, 2, 3]);
 
-const nums = [ 1, 2, 3, -99, 42, 6, 7 ]
-const applied: number = _.apply(Math.max, nums)
+const nums = [1, 2, 3, -99, 42, 6, 7];
+const applied: number = _.apply(Math.max, nums);
 const spec = {
   sum: _.add,
-  nested: { mul: _.multiply },
-}
-const getMetrics = _.applySpec(spec)
-const apspec: $Shape<R> = getMetrics(2, 2)
+  nested: { mul: _.multiply }
+};
+const getMetrics = _.applySpec(spec);
+const apspec: $Shape<R> = getMetrics(2, 2);
 
-const cmp: (x: Object, y: Object) => number = _.comparator((a, b) => a.age < b.age)
-const compf: number = _.compose(_.inc, _.negate)(2)
+const cmp: (x: Object, y: Object) => number = _.comparator(
+  (a, b) => a.age < b.age
+);
+const compf: number = _.compose(_.inc, _.negate)(2);
 
-const fn = compose(_.add)
-const fn1: (n: number) => number = fn(2)
-const add2 = _.compose(_.add(2))
-const four: number = add2(2)
-const str0: Array<string|void> = _.compose(_.match(/2/), _.toLower, _.trim)(' 1,2,3 ')
-const str1: Array<string> = _.compose(_.split(','), _.toLower, _.trim)(' 1,2,3 ')
-const str2: string = _.compose(_.replace('3', '4'), _.toLower, _.trim)(' 1,2,3 ')
+const fn = compose(_.add);
+const fn1: (n: number) => number = fn(2);
+const add2 = _.compose(_.add(2));
+const four: number = add2(2);
+const str0: Array<string | void> = _.compose(_.match(/2/), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+const str1: Array<string> = _.compose(_.split(","), _.toLower, _.trim)(
+  " 1,2,3 "
+);
+const str2: string = _.compose(_.replace("3", "4"), _.toLower, _.trim)(
+  " 1,2,3 "
+);
 
-const fn2:(n: number) => (n: number) => number = pipe(_.add)
-const fn3: (n: number) => number = fn2(2)
-const add2p = _.pipe(_.add(2))
-const b: number = add2(2)
-const fail: string = _.pipe(_.trim)('h')
-const str3: Array<string|void> = _.pipe(_.toLower, _.trim, _.match(/2/))(' 1,2,3 ')
-const str4: Array<string> = _.pipe(_.toLower, _.trim, _.split(','))(' 1,2,3 ')
-const str5: string = _.pipe(_.replace('3', '4'), _.toLower, _.trim)(' 1,2,3 ')
+const fn2: (n: number) => (n: number) => number = pipe(_.add);
+const fn3: (n: number) => number = fn2(2);
+const add2p = _.pipe(_.add(2));
+const b: number = add2(2);
+const fail: string = _.pipe(_.trim)("h");
+const str3: Array<string | void> = _.pipe(_.toLower, _.trim, _.match(/2/))(
+  " 1,2,3 "
+);
+const str4: Array<string> = _.pipe(_.toLower, _.trim, _.split(","))(" 1,2,3 ");
+const str5: string = _.pipe(_.replace("3", "4"), _.toLower, _.trim)(" 1,2,3 ");
 
 // --- Curry ---
-declare var bar1: (string) => 'bar1'
-declare var bar2: (string, number) => 'bar2'
-declare var bar6: (string, number, boolean, null, {}, []) => 'bar6'
+declare var bar1: string => "bar1";
+declare var bar2: (string, number) => "bar2";
+declare var bar6: (string, number, boolean, null, {}, []) => "bar6";
 
-const foo1 = curry(bar1)
-const foo2 = curry(bar2)
-const foo6 = curry(bar6)
+const foo1 = curry(bar1);
+const foo2 = curry(bar2);
+const foo6 = curry(bar6);
 
-const foo1_1: 'bar1' = foo1('')
-const foo2_1: 'bar2' = foo2('', 0)
-const foo2_2: 'bar2' = foo2('')(0)
+const foo1_1: "bar1" = foo1("");
+const foo2_1: "bar2" = foo2("", 0);
+const foo2_2: "bar2" = foo2("")(0);
 
-const foo6_1: 'bar6' = foo6('', 0, true, null, {}, [])
-const foo6_2: 'bar6' = foo6('')(0, true, null, {}, [])
-const foo6_3: 'bar6' = foo6('', 0)(true, null, {}, [])
-const foo6_4: 'bar6' = foo6('', 0, true)(null, {}, [])
-const foo6_5: 'bar6' = foo6('', 0, true, null)({}, [])
-const foo6_6: 'bar6' = foo6('', 0, true, null, {})([])
-const foo6_7: 'bar6' = foo6('')(0)(true, null, {}, [])
-const foo6_8: 'bar6' = foo6('', 0)(true)(null, {}, [])
-const foo6_9: 'bar6' = foo6('', 0, true)(null)({}, [])
-const foo6_10: 'bar6' = foo6('', 0, true, null)({})([])
-const foo6_11: 'bar6' = foo6('')(0, true)(null, {}, [])
-const foo6_12: 'bar6' = foo6('', 0)(true, null)({}, [])
-const foo6_13: 'bar6' = foo6('', 0, true)(null, {})([])
-const foo6_14: 'bar6' = foo6('')(0, true, null)({}, [])
-const foo6_15: 'bar6' = foo6('', 0)(true, null, {})([])
-const foo6_16: 'bar6' = foo6('')(0, true, null, {})([])
-
-// $ExpectError
-const foo6_1_Error1: 'bar6' = foo6(false, 0, true, null, {}, [])
-// $ExpectError
-const foo6_2_Error1: 'bar6' = foo6(false)(0, true, null, {}, [])
-// $ExpectError
-const foo6_3_Error1: 'bar6' = foo6(false, 0)(true, null, {}, [])
-// $ExpectError
-const foo6_4_Error1: 'bar6' = foo6(false, 0, true)(null, {}, [])
-// $ExpectError
-const foo6_5_Error1: 'bar6' = foo6(false, 0, true, null)({}, [])
-// $ExpectError
-const foo6_6_Error1: 'bar6' = foo6(false, 0, true, null, {})([])
-// $ExpectError
-const foo6_7_Error1: 'bar6' = foo6(false)(0)(true, null, {}, [])
-// $ExpectError
-const foo6_8_Error1: 'bar6' = foo6(false, 0)(true)(null, {}, [])
-// $ExpectError
-const foo6_9_Error1: 'bar6' = foo6(false, 0, true)(null)({}, [])
-// $ExpectError
-const foo6_10_Error1: 'bar6' = foo6(false, 0, true, null)({})([])
-// $ExpectError
-const foo6_11_Error1: 'bar6' = foo6(false)(0, true)(null, {}, [])
-// $ExpectError
-const foo6_12_Error1: 'bar6' = foo6(false, 0)(true, null)({}, [])
-// $ExpectError
-const foo6_13_Error1: 'bar6' = foo6(false, 0, true)(null, {})([])
-// $ExpectError
-const foo6_14_Error1: 'bar6' = foo6(false)(0, true, null)({}, [])
-// $ExpectError
-const foo6_15_Error1: 'bar6' = foo6(false, 0)(true, null, {})([])
-// $ExpectError
-const foo6_16_Error1: 'bar6' = foo6(false)(0, true, null, {})([])
+const foo6_1: "bar6" = foo6("", 0, true, null, {}, []);
+const foo6_2: "bar6" = foo6("")(0, true, null, {}, []);
+const foo6_3: "bar6" = foo6("", 0)(true, null, {}, []);
+const foo6_4: "bar6" = foo6("", 0, true)(null, {}, []);
+const foo6_5: "bar6" = foo6("", 0, true, null)({}, []);
+const foo6_6: "bar6" = foo6("", 0, true, null, {})([]);
+const foo6_7: "bar6" = foo6("")(0)(true, null, {}, []);
+const foo6_8: "bar6" = foo6("", 0)(true)(null, {}, []);
+const foo6_9: "bar6" = foo6("", 0, true)(null)({}, []);
+const foo6_10: "bar6" = foo6("", 0, true, null)({})([]);
+const foo6_11: "bar6" = foo6("")(0, true)(null, {}, []);
+const foo6_12: "bar6" = foo6("", 0)(true, null)({}, []);
+const foo6_13: "bar6" = foo6("", 0, true)(null, {})([]);
+const foo6_14: "bar6" = foo6("")(0, true, null)({}, []);
+const foo6_15: "bar6" = foo6("", 0)(true, null, {})([]);
+const foo6_16: "bar6" = foo6("")(0, true, null, {})([]);
 
 // $ExpectError
-const foo6_1_Error2: 'bar6' = foo6('', 0, true, '', {}, [])
+const foo6_1_Error1: "bar6" = foo6(false, 0, true, null, {}, []);
 // $ExpectError
-const foo6_2_Error2: 'bar6' = foo6('')(0, true, '', {}, [])
+const foo6_2_Error1: "bar6" = foo6(false)(0, true, null, {}, []);
 // $ExpectError
-const foo6_3_Error2: 'bar6' = foo6('', 0)(true, '', {}, [])
+const foo6_3_Error1: "bar6" = foo6(false, 0)(true, null, {}, []);
 // $ExpectError
-const foo6_4_Error2: 'bar6' = foo6('', 0, true)('', {}, [])
+const foo6_4_Error1: "bar6" = foo6(false, 0, true)(null, {}, []);
 // $ExpectError
-const foo6_5_Error2: 'bar6' = foo6('', 0, true, '')({}, [])
+const foo6_5_Error1: "bar6" = foo6(false, 0, true, null)({}, []);
 // $ExpectError
-const foo6_6_Error2: 'bar6' = foo6('', 0, true, '', {})([])
+const foo6_6_Error1: "bar6" = foo6(false, 0, true, null, {})([]);
 // $ExpectError
-const foo6_7_Error2: 'bar6' = foo6('')(0)(true, '', {}, [])
+const foo6_7_Error1: "bar6" = foo6(false)(0)(true, null, {}, []);
 // $ExpectError
-const foo6_8_Error2: 'bar6' = foo6('', 0)(true)('', {}, [])
+const foo6_8_Error1: "bar6" = foo6(false, 0)(true)(null, {}, []);
 // $ExpectError
-const foo6_9_Error2: 'bar6' = foo6('', 0, true)('')({}, [])
+const foo6_9_Error1: "bar6" = foo6(false, 0, true)(null)({}, []);
 // $ExpectError
-const foo6_10_Error2: 'bar6' = foo6('', 0, true, '')({})([])
+const foo6_10_Error1: "bar6" = foo6(false, 0, true, null)({})([]);
 // $ExpectError
-const foo6_11_Error2: 'bar6' = foo6('')(0, true)('', {}, [])
+const foo6_11_Error1: "bar6" = foo6(false)(0, true)(null, {}, []);
 // $ExpectError
-const foo6_12_Error2: 'bar6' = foo6('', 0)(true, '')({}, [])
+const foo6_12_Error1: "bar6" = foo6(false, 0)(true, null)({}, []);
 // $ExpectError
-const foo6_13_Error2: 'bar6' = foo6('', 0, true)('', {})([])
+const foo6_13_Error1: "bar6" = foo6(false, 0, true)(null, {})([]);
 // $ExpectError
-const foo6_14_Error2: 'bar6' = foo6('')(0, true, '')({}, [])
+const foo6_14_Error1: "bar6" = foo6(false)(0, true, null)({}, []);
 // $ExpectError
-const foo6_15_Error2: 'bar6' = foo6('', 0)(true, '', {})([])
+const foo6_15_Error1: "bar6" = foo6(false, 0)(true, null, {})([]);
 // $ExpectError
-const foo6_16_Error2: 'bar6' = foo6('')(0, true, '', {})([])
+const foo6_16_Error1: "bar6" = foo6(false)(0, true, null, {})([]);
 
 // $ExpectError
-const foo6_1_Error3: 'bar6' = foo6('', 0, true, null, {}, '')
+const foo6_1_Error2: "bar6" = foo6("", 0, true, "", {}, []);
 // $ExpectError
-const foo6_2_Error3: 'bar6' = foo6('')(0, true, null, {}, '')
+const foo6_2_Error2: "bar6" = foo6("")(0, true, "", {}, []);
 // $ExpectError
-const foo6_3_Error3: 'bar6' = foo6('', 0)(true, null, {}, '')
+const foo6_3_Error2: "bar6" = foo6("", 0)(true, "", {}, []);
 // $ExpectError
-const foo6_4_Error3: 'bar6' = foo6('', 0, true)(null, {}, '')
+const foo6_4_Error2: "bar6" = foo6("", 0, true)("", {}, []);
 // $ExpectError
-const foo6_5_Error3: 'bar6' = foo6('', 0, true, null)({}, '')
+const foo6_5_Error2: "bar6" = foo6("", 0, true, "")({}, []);
 // $ExpectError
-const foo6_6_Error3: 'bar6' = foo6('', 0, true, null, {})('')
+const foo6_6_Error2: "bar6" = foo6("", 0, true, "", {})([]);
 // $ExpectError
-const foo6_7_Error3: 'bar6' = foo6('')(0)(true, null, {}, '')
+const foo6_7_Error2: "bar6" = foo6("")(0)(true, "", {}, []);
 // $ExpectError
-const foo6_8_Error3: 'bar6' = foo6('', 0)(true)(null, {}, '')
+const foo6_8_Error2: "bar6" = foo6("", 0)(true)("", {}, []);
 // $ExpectError
-const foo6_9_Error3: 'bar6' = foo6('', 0, true)(null)({}, '')
+const foo6_9_Error2: "bar6" = foo6("", 0, true)("")({}, []);
 // $ExpectError
-const foo6_10_Error3: 'bar6' = foo6('', 0, true, null)({})('')
+const foo6_10_Error2: "bar6" = foo6("", 0, true, "")({})([]);
 // $ExpectError
-const foo6_11_Error3: 'bar6' = foo6('')(0, true)(null, {}, '')
+const foo6_11_Error2: "bar6" = foo6("")(0, true)("", {}, []);
 // $ExpectError
-const foo6_12_Error3: 'bar6' = foo6('', 0)(true, null)({}, '')
+const foo6_12_Error2: "bar6" = foo6("", 0)(true, "")({}, []);
 // $ExpectError
-const foo6_13_Error3: 'bar6' = foo6('', 0, true)(null, {})('')
+const foo6_13_Error2: "bar6" = foo6("", 0, true)("", {})([]);
 // $ExpectError
-const foo6_14_Error3: 'bar6' = foo6('')(0, true, null)({}, '')
+const foo6_14_Error2: "bar6" = foo6("")(0, true, "")({}, []);
 // $ExpectError
-const foo6_15_Error3: 'bar6' = foo6('', 0)(true, null, {})('')
+const foo6_15_Error2: "bar6" = foo6("", 0)(true, "", {})([]);
 // $ExpectError
-const foo6_16_Error3: 'bar6' = foo6('')(0, true, null, {})('')
+const foo6_16_Error2: "bar6" = foo6("")(0, true, "", {})([]);
 
 // $ExpectError
-const foo6_1_Error4: 'error' = foo6('', 0, true, null, {}, [])
+const foo6_1_Error3: "bar6" = foo6("", 0, true, null, {}, "");
 // $ExpectError
-const foo6_2_Error4: 'error' = foo6('')(0, true, null, {}, [])
+const foo6_2_Error3: "bar6" = foo6("")(0, true, null, {}, "");
 // $ExpectError
-const foo6_3_Error4: 'error' = foo6('', 0)(true, null, {}, [])
+const foo6_3_Error3: "bar6" = foo6("", 0)(true, null, {}, "");
 // $ExpectError
-const foo6_4_Error4: 'error' = foo6('', 0, true)(null, {}, [])
+const foo6_4_Error3: "bar6" = foo6("", 0, true)(null, {}, "");
 // $ExpectError
-const foo6_5_Error4: 'error' = foo6('', 0, true, null)({}, [])
+const foo6_5_Error3: "bar6" = foo6("", 0, true, null)({}, "");
 // $ExpectError
-const foo6_6_Error4: 'error' = foo6('', 0, true, null, {})([])
+const foo6_6_Error3: "bar6" = foo6("", 0, true, null, {})("");
 // $ExpectError
-const foo6_7_Error4: 'error' = foo6('')(0)(true, null, {}, [])
+const foo6_7_Error3: "bar6" = foo6("")(0)(true, null, {}, "");
 // $ExpectError
-const foo6_8_Error4: 'error' = foo6('', 0)(true)(null, {}, [])
+const foo6_8_Error3: "bar6" = foo6("", 0)(true)(null, {}, "");
 // $ExpectError
-const foo6_9_Error4: 'error' = foo6('', 0, true)(null)({}, [])
+const foo6_9_Error3: "bar6" = foo6("", 0, true)(null)({}, "");
 // $ExpectError
-const foo6_10_Error4: 'error' = foo6('', 0, true, null)({})([])
+const foo6_10_Error3: "bar6" = foo6("", 0, true, null)({})("");
 // $ExpectError
-const foo6_11_Error4: 'error' = foo6('')(0, true)(null, {}, [])
+const foo6_11_Error3: "bar6" = foo6("")(0, true)(null, {}, "");
 // $ExpectError
-const foo6_12_Error4: 'error' = foo6('', 0)(true, null)({}, [])
+const foo6_12_Error3: "bar6" = foo6("", 0)(true, null)({}, "");
 // $ExpectError
-const foo6_13_Error4: 'error' = foo6('', 0, true)(null, {})([])
+const foo6_13_Error3: "bar6" = foo6("", 0, true)(null, {})("");
 // $ExpectError
-const foo6_14_Error4: 'error' = foo6('')(0, true, null)({}, [])
+const foo6_14_Error3: "bar6" = foo6("")(0, true, null)({}, "");
 // $ExpectError
-const foo6_15_Error4: 'error' = foo6('', 0)(true, null, {})([])
+const foo6_15_Error3: "bar6" = foo6("", 0)(true, null, {})("");
 // $ExpectError
-const foo6_16_Error4: 'error' = foo6('')(0, true, null, {})([])
+const foo6_16_Error3: "bar6" = foo6("")(0, true, null, {})("");
+
+// $ExpectError
+const foo6_1_Error4: "error" = foo6("", 0, true, null, {}, []);
+// $ExpectError
+const foo6_2_Error4: "error" = foo6("")(0, true, null, {}, []);
+// $ExpectError
+const foo6_3_Error4: "error" = foo6("", 0)(true, null, {}, []);
+// $ExpectError
+const foo6_4_Error4: "error" = foo6("", 0, true)(null, {}, []);
+// $ExpectError
+const foo6_5_Error4: "error" = foo6("", 0, true, null)({}, []);
+// $ExpectError
+const foo6_6_Error4: "error" = foo6("", 0, true, null, {})([]);
+// $ExpectError
+const foo6_7_Error4: "error" = foo6("")(0)(true, null, {}, []);
+// $ExpectError
+const foo6_8_Error4: "error" = foo6("", 0)(true)(null, {}, []);
+// $ExpectError
+const foo6_9_Error4: "error" = foo6("", 0, true)(null)({}, []);
+// $ExpectError
+const foo6_10_Error4: "error" = foo6("", 0, true, null)({})([]);
+// $ExpectError
+const foo6_11_Error4: "error" = foo6("")(0, true)(null, {}, []);
+// $ExpectError
+const foo6_12_Error4: "error" = foo6("", 0)(true, null)({}, []);
+// $ExpectError
+const foo6_13_Error4: "error" = foo6("", 0, true)(null, {})([]);
+// $ExpectError
+const foo6_14_Error4: "error" = foo6("")(0, true, null)({}, []);
+// $ExpectError
+const foo6_15_Error4: "error" = foo6("", 0)(true, null, {})([]);
+// $ExpectError
+const foo6_16_Error4: "error" = foo6("")(0, true, null, {})([]);
 
 // -------------
 
-const currfn1: (y: number) => number = _.curryN(2, (x: number, y: number): number => x + y)(2)
+const currfn1: (y: number) => number = _.curryN(
+  2,
+  (x: number, y: number): number => x + y
+)(2);
 
-const flipped: (x: number, y: boolean, z: string) => number = _.flip((x: boolean, y: number, z: string) => 1)
-const flipped2: (x: number, y: boolean) => (z: string) => number = _.flip((x: boolean, y: number, z: string) => 1)
+const flipped: (x: number, y: boolean, z: string) => number = _.flip(
+  (x: boolean, y: number, z: string) => 1
+);
+const flipped2: (x: number, y: boolean) => (z: string) => number = _.flip(
+  (x: boolean, y: number, z: string) => 1
+);
 const obb = {
   doStuff(x: string, y: number, z: boolean) {
-    return 1
+    return 1;
   },
   doLessStuff(x: string, y: number) {
-    return 'hello'
+    return "hello";
   },
   doEvenLessStuff(x: string) {
-    return true
-  },
-}
-const doStuff: (x: string, y: number, z: boolean, obj: typeof obb) => number = _.invoker(3, 'doStuff')
+    return true;
+  }
+};
+const doStuff: (
+  x: string,
+  y: number,
+  z: boolean,
+  obj: typeof obb
+) => number = _.invoker(3, "doStuff");
 //$ExpectError
-const doLessStuff: (x: string, y: number, z: boolean, obj: typeof obb) => number = _.invoker(3, 'doLStuff')
-const stuffDone: number = doStuff('dd', 1, true, obb)
+const doLessStuff: (
+  x: string,
+  y: number,
+  z: boolean,
+  obj: typeof obb
+) => number = _.invoker(3, "doLStuff");
+const stuffDone: number = doStuff("dd", 1, true, obb);
 
-const range = _.juxt([ _.toString, Math.min, Math.max ])
-const ju: Array<number|string> = range(3, 4, 9, -3)
+const range = _.juxt([_.toString, Math.min, Math.max]);
+const ju: Array<number | string> = range(3, 4, 9, -3);
 
-let count = 0
+let count = 0;
 const factorial = _.memoize(n => {
-  count += 1
-  return _.product(_.range(1, n + 1))
-})
-const mem: number = factorial(5)
+  count += 1;
+  return _.product(_.range(1, n + 1));
+});
+const mem: number = factorial(5);
 
-const narg:string|number = _.nthArg(1)(1, 'b', 'c')
+const narg: string | number = _.nthArg(1)(1, "b", "c");
 
-const oof: Array<Array<number>> = _.of([ 42 ])
+const oof: Array<Array<number>> = _.of([42]);
 
-const unap: string = _.unapply(JSON.stringify)(1, 2, 3)
+const unap: string = _.unapply(JSON.stringify)(1, 2, 3);
 
-const greetName = name => 'Hello ' + name
+const greetName = name => "Hello " + name;
 
-const shoutedGreet: boolean = _.wrap(greetName, (gr, name) => gr(name) === 'Hello Anna')('Anna')
-const shoutedGreet2: string = _.wrap(greetName, (gr, name) => name && 'Hello Anna')(true)
+const shoutedGreet: boolean = _.wrap(
+  greetName,
+  (gr, name) => gr(name) === "Hello Anna"
+)("Anna");
+const shoutedGreet2: string = _.wrap(
+  greetName,
+  (gr, name) => name && "Hello Anna"
+)(true);
 
 // Uncurry
-const needs3: string => string => string => string = a => b => c => a + b + c
+const needs3: string => string => string => string = a => b => c => a + b + c;
 
 //$ExpectError
-const needs3_error1: number = uncurryN(3, needs3)('', '', '')
+const needs3_error1: number = uncurryN(3, needs3)("", "", "");
 
 //$ExpectError
-const needs3_error2: string => string = uncurryN(3, needs3)('', '', '')
+const needs3_error2: string => string = uncurryN(3, needs3)("", "", "");
 
 //$ExpectError
-const needs3_error3: string => string => string = uncurryN(3, needs3)('', '', '')
+const needs3_error3: string => string => string = uncurryN(3, needs3)(
+  "",
+  "",
+  ""
+);
 
-const needs3_no_error: string = uncurryN(3, needs3)('', '', '')
+const needs3_no_error: string = uncurryN(3, needs3)("", "", "");

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_list.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_list.js
@@ -1,235 +1,300 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from 'ramda'
+import _, { compose, pipe, curry, filter, find, repeat, zipWith } from "ramda";
 
-const ns: Array<number> = [ 1, 2, 3, 4, 5 ]
-const ss: Array<string> = [ 'one', 'two', 'three', 'four' ]
-const obj: {[k:string]:number} = { a: 1, c: 2 }
-const objMixed: {[k:string]:mixed} = { a: 1, c: 'd' }
-const os: Array<{[k:string]: number|string}> = [ { a: 1, c: 'd' }, { b: 2 } ]
-const str: string = 'hello world'
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: number | string }> = [
+  { a: 1, c: "d" },
+  { b: 2 }
+];
+const str: string = "hello world";
 
 // List
 {
-  const xs: Array<number> = _.adjust(x => x + 1, 2, ns)
-  const xs1: Array<number> = _.adjust(x => x + 1, 2)(ns)
+  const xs: Array<number> = _.adjust(x => x + 1, 2, ns);
+  const xs1: Array<number> = _.adjust(x => x + 1, 2)(ns);
   //$ExpectError
-  const xs3: Array<string> = _.adjust(x => x + 1)(2)(ns)
+  const xs3: Array<string> = _.adjust(x => x + 1)(2)(ns);
 
-  const as: boolean = _.all(x => x > 1, ns)
-  const asf: (s: Array<string>) => boolean = _.any(x => x.length > 1)
-  const as1: boolean = asf(ss)
+  const as: boolean = _.all(x => x > 1, ns);
+  const asf: (s: Array<string>) => boolean = _.any(x => x.length > 1);
+  const as1: boolean = asf(ss);
 
-  const aps: Array<Array<number>> = _.aperture(2, ns)
-  const aps2: Array<Array<string>> = _.aperture(2)(ss)
+  const aps: Array<Array<number>> = _.aperture(2, ns);
+  const aps2: Array<Array<string>> = _.aperture(2)(ss);
 
-  const newXs: Array<string> = _.append('one', ss)
-  const newXs1: Array<number> = _.prepend(1)(ns)
+  const newXs: Array<string> = _.append("one", ss);
+  const newXs1: Array<number> = _.prepend(1)(ns);
 
-  const concatxs1: Array<number> = _.concat([ 4, 5, 6 ], [ 1, 2, 3 ])
-  const concatxs2: string = _.concat('ABC', 'DEF')
+  const concatxs1: Array<number> = _.concat([4, 5, 6], [1, 2, 3]);
+  const concatxs2: string = _.concat("ABC", "DEF");
 
-  const cont1: boolean = _.contains('s', ss)
+  const cont1: boolean = _.contains("s", ss);
 
-  const dropxs: Array<string> = _.drop(4, ss)
-  const dropxs1: string = _.drop(3)(str)
-  const dropxs2: Array<string> = _.dropLast(4, ss)
-  const dropxs3: string = _.dropLast(3)(str)
-  const dropxs4: Array<number> = _.dropLastWhile(x => x <= 3, ns)
-  const dropxs5: Array<string> = _.dropRepeats(ss)
-  const dropxs6: Array<number> = _.dropRepeatsWith(_.eqBy(Math.abs), ns)
-  const dropxs7: Array<number> = _.dropWhile(x => x === 1, ns)
+  const dropxs: Array<string> = _.drop(4, ss);
+  const dropxs1: string = _.drop(3)(str);
+  const dropxs2: Array<string> = _.dropLast(4, ss);
+  const dropxs3: string = _.dropLast(3)(str);
+  const dropxs4: Array<number> = _.dropLastWhile(x => x <= 3, ns);
+  const dropxs5: Array<string> = _.dropRepeats(ss);
+  const dropxs6: Array<number> = _.dropRepeatsWith(_.eqBy(Math.abs), ns);
+  const dropxs7: Array<number> = _.dropWhile(x => x === 1, ns);
 
-  const findxs:?{[k:string]:number|string} = _.find(_.propEq('a', 2), os)
-  const findxs1:?{[k:string]:number|string} = _.find(_.propEq('a', 4))(os)
-  const findxs2:?{[k:string]:number|string} = _.findLast(_.propEq('a', 2), os)
-  const findxs3:?{[k:string]:number|string} = _.findLast(_.propEq('a', 4))(os)
-  const findxs4: number = _.findIndex(_.propEq('a', 2), os)
-  const findxs5:number = _.findIndex(_.propEq('a', 4))(os)
-  const findxs6:number = _.findLastIndex(_.propEq('a', 2), os)
-  const findxs7:number = _.findLastIndex(_.propEq('a', 4))(os)
+  const findxs: ?{ [k: string]: number | string } = _.find(
+    _.propEq("a", 2),
+    os
+  );
+  const findxs1: ?{ [k: string]: number | string } = _.find(_.propEq("a", 4))(
+    os
+  );
+  const findxs2: ?{ [k: string]: number | string } = _.findLast(
+    _.propEq("a", 2),
+    os
+  );
+  const findxs3: ?{ [k: string]: number | string } = _.findLast(
+    _.propEq("a", 4)
+  )(os);
+  const findxs4: number = _.findIndex(_.propEq("a", 2), os);
+  const findxs5: number = _.findIndex(_.propEq("a", 4))(os);
+  const findxs6: number = _.findLastIndex(_.propEq("a", 2), os);
+  const findxs7: number = _.findLastIndex(_.propEq("a", 4))(os);
 
-  const s: Array<number> = filter(x => x > 1, [ 1, 2 ])
-  const s1: Array<string> = _.filter(x => x === '2', [ '2', '3' ])
-  const s3: {[key: string]: string} = _.filter(x => x === '2', { a:'2', b:'3' })
-  const s4 = _.find(x => x === '2', [ '1', '2' ])
+  const s: Array<number> = filter(x => x > 1, [1, 2]);
+  const s1: Array<string> = _.filter(x => x === "2", ["2", "3"]);
+  const s3: { [key: string]: string } = _.filter(x => x === "2", {
+    a: "2",
+    b: "3"
+  });
+  const s4 = _.find(x => x === "2", ["1", "2"]);
   //$ExpectError
-  const s5: ?{[key: string]: string} = _.find(x => x === '2', { a: 1, b: 2 })
-  const s6: number = _.findIndex(x => x === '2', [ '1', '2' ])
-  const s7: number = _.findIndex(x => x === '2', { a:'1', b:'2' })
-  const forEachxs = _.forEach(x => console.log(x), ns)
+  const s5: ?{ [key: string]: string } = _.find(x => x === "2", { a: 1, b: 2 });
+  const s6: number = _.findIndex(x => x === "2", ["1", "2"]);
+  const s7: number = _.findIndex(x => x === "2", { a: "1", b: "2" });
+  const forEachxs = _.forEach(x => console.log(x), ns);
 
-  const groupedBy: {[k: string]: Array<number>} = _.groupBy(x => x > 1 ? 'more' : 'less' , ns)
+  const groupedBy: { [k: string]: Array<number> } = _.groupBy(
+    x => (x > 1 ? "more" : "less"),
+    ns
+  );
   //$ExpectError
-  const groupedBy1: {[k: string]: Array<string>} = _.groupBy(x => x > 1 ? 'more' : 'less')(ns)
+  const groupedBy1: { [k: string]: Array<string> } = _.groupBy(
+    x => (x > 1 ? "more" : "less")
+  )(ns);
 
-  const groupedWith: Array<Array<number>> = _.groupWith(x => x > 1, ns)
-  const groupedWith1: Array<Array<string>> = _.groupWith(x => x === 'one')(ss)
+  const groupedWith: Array<Array<number>> = _.groupWith(x => x > 1, ns);
+  const groupedWith1: Array<Array<string>> = _.groupWith(x => x === "one")(ss);
 
-  const xOfXs: ?number = _.head(ns)
-  const xOfXs2: ?number = _.head(ns)
-  const xOfStr: string = _.head(str)
+  const xOfXs: ?number = _.head(ns);
+  const xOfXs2: ?number = _.head(ns);
+  const xOfStr: string = _.head(str);
 
-  const transducer = _.compose(_.map(_.add(1)), _.take(2))
+  const transducer = _.compose(_.map(_.add(1)), _.take(2));
 
-  const txs: Array<number> = _.into([], transducer, ns)
+  const txs: Array<number> = _.into([], transducer, ns);
   //$ExpectError
-  const txs1: string = _.into([], transducer, ns)
+  const txs1: string = _.into([], transducer, ns);
   //$ExpectError
-  const txs2: string = _.into([], transducer, ss)
+  const txs2: string = _.into([], transducer, ss);
 
-  const ind: number = _.indexOf(1, ns)
-  const ind1: number = _.indexOf(str)(ss)
+  const ind: number = _.indexOf(1, ns);
+  const ind1: number = _.indexOf(str)(ss);
 
-  const ind2:{[key: string]:{[k: string]: number|string}} = _.indexBy(x => 's', os)
-  const ind3:{[key: string]:{[k: string]: number|string}} = _.indexBy(x => 's')(os)
+  const ind2: { [key: string]: { [k: string]: number | string } } = _.indexBy(
+    x => "s",
+    os
+  );
+  const ind3: { [key: string]: { [k: string]: number | string } } = _.indexBy(
+    x => "s"
+  )(os);
 
-  const insxs: Array<number> = _.insert(1, 2, ns)
-  const insxs2: Array<string> = _.insert(1, '2', ss)
+  const insxs: Array<number> = _.insert(1, 2, ns);
+  const insxs2: Array<string> = _.insert(1, "2", ss);
 
-  const insxs3: Array<number> = _.insertAll(1, [ 2, 3 ], ns)
+  const insxs3: Array<number> = _.insertAll(1, [2, 3], ns);
   // this is disgusting — don't do this :)
   // Technically it's a tuple with arbitrary size
-  const insxs4: Array<number|boolean|string> = _.insertAll(1, [ '2', false ], ns)
-  const insxs5: Array<string|number> = _.insertAll(1, [ 2 ], ss)
+  const insxs4: Array<number | boolean | string> = _.insertAll(
+    1,
+    ["2", false],
+    ns
+  );
+  const insxs5: Array<string | number> = _.insertAll(1, [2], ss);
 
-  const joinxs: string = _.join('|', ns)
+  const joinxs: string = _.join("|", ns);
 
-  const lastxs: ?number = _.last(ns)
-  const laststr: string = _.last(str)
+  const lastxs: ?number = _.last(ns);
+  const laststr: string = _.last(str);
 
-  const lasti: number = _.lastIndexOf(3, [ -1,3,3,0,1,2,3,4 ])
+  const lasti: number = _.lastIndexOf(3, [-1, 3, 3, 0, 1, 2, 3, 4]);
 
-  const mapxs: Array<number>= _.map(x => x + 1, ns)
+  const mapxs: Array<number> = _.map(x => x + 1, ns);
 
   const functor = {
     x: 1,
     map(f) {
-      return f(this.x)
-    },
-  }
+      return f(this.x);
+    }
+  };
 
   // Doesn't typecheck (yet) but at least doesn't break
-  const mapFxs = _.map(_.toString, functor)
+  const mapFxs = _.map(_.toString, functor);
 
-  const double = x => x * 2
-  const dxs: Array<number> = _.map(double, [ 1, 2, 3 ])
-  const dos: $Shape<typeof obj> = _.map(double, obj)
+  const double = x => x * 2;
+  const dxs: Array<number> = _.map(double, [1, 2, 3]);
+  const dos: $Shape<typeof obj> = _.map(double, obj);
 
-  const appender = (a, b) => [ a + b, a + b ]
-  const mapacc:[number, Array<number>] = _.mapAccum(appender, 0, ns)
-  const mapacc1:[number, Array<number>] = _.mapAccumRight(appender, 0, ns)
+  const appender = (a, b) => [a + b, a + b];
+  const mapacc: [number, Array<number>] = _.mapAccum(appender, 0, ns);
+  const mapacc1: [number, Array<number>] = _.mapAccumRight(appender, 0, ns);
 
-  const nxs: boolean = _.none(x => x > 1, ns)
+  const nxs: boolean = _.none(x => x > 1, ns);
 
-  const nthxs: ?string = _.nth(2, [ 'curry' ])
-  const nthxs1: ?string = _.nth(2)([ 'curry' ])
+  const nthxs: ?string = _.nth(2, ["curry"]);
+  const nthxs1: ?string = _.nth(2)(["curry"]);
   //$ExpectError
-  const nthxs2: string = _.nth(2, [ 1, 2, 3 ])
+  const nthxs2: string = _.nth(2, [1, 2, 3]);
 
+  const xxs: Array<number> = _.append(1, [1, 2, 3]);
+  const xxxs: Array<number> = _.intersperse(1, [1, 2, 3]);
 
-  const xxs: Array<number> = _.append(1, [ 1, 2, 3 ])
-  const xxxs: Array<number> = _.intersperse(1, [ 1, 2, 3 ])
+  const pairxs: [number, string] = _.pair(2, "str");
 
-  const pairxs:[number,string] = _.pair(2, 'str')
+  const partxs: [Array<string>, Array<string>] = _.partition(_.contains("s"), [
+    "sss",
+    "ttt",
+    "foo",
+    "bars"
+  ]);
+  const partxs1: [
+    { [k: string]: string },
+    { [k: string]: string }
+  ] = _.partition(_.contains("s"), { a: "sss", b: "ttt", foo: "bars" });
 
-  const partxs:[Array<string>,Array<string>] = _.partition(_.contains('s'), [ 'sss', 'ttt', 'foo', 'bars' ])
-  const partxs1: [{[k:string]:string}, {[k:string]:string}] = _.partition(_.contains('s'), { a: 'sss', b: 'ttt', foo: 'bars' })
+  const pl: Array<number | string> = _.pluck("a")([{ a: "1" }, { a: 2 }]);
+  const pl1: Array<number> = _.pluck(0)([[1, 2], [3, 4]]);
 
-  const pl:Array<number|string> = _.pluck('a')([ { a: '1' }, { a: 2 } ])
-  const pl1:Array<number> = _.pluck(0)([ [ 1, 2 ], [ 3, 4 ] ])
+  const rxs: Array<number> = _.range(1, 10);
 
-  const rxs: Array<number> = _.range(1, 10)
+  const remxs: Array<string> = _.remove(0, 2, ss);
+  const remxs1: Array<string> = _.remove(0, 2)(ss);
+  const remxs2: Array<string> = _.remove(0)(2)(ss);
+  const remxs3: Array<string> = _.remove(0)(2, ss);
 
-  const remxs: Array<string> = _.remove(0, 2, ss)
-  const remxs1: Array<string> = _.remove(0, 2)(ss)
-  const remxs2: Array<string> = _.remove(0)(2)(ss)
-  const remxs3: Array<string> = _.remove(0)(2, ss)
+  const ys4: Array<string> = _.repeat("1", 10);
+  const ys5: Array<number> = _.repeat(1, 10);
 
-  const ys4: Array<string> = _.repeat('1', 10)
-  const ys5: Array<number> = _.repeat(1, 10)
+  const redxs: number = _.reduce(_.add, 10, ns);
+  const redxs1: string = _.reduce(_.concat, "", ss);
+  const redxs2: Array<string> = _.reduce(_.concat, [])(_.map(x => [x], ss));
+  const redxs3: number = _.reduceRight(_.add, 10, ns);
+  const redxs4: string = _.reduceRight(_.concat, "", ss);
+  const redxs5: Array<string> = _.reduceRight(_.concat, [])(
+    _.map(x => [x], ss)
+  );
+  const redxs6: Array<number> = _.scan(_.add)(10)(ns);
+  const redxs7: Array<number> = _.scan(_.add, 10)(ns);
+  const redxs8: Array<number> = _.scan(_.add)(10, ns);
+  const redxs9: Array<number> = _.scan(_.add, 10, ns);
+  const redxs10: Array<string> = _.scan(_.concat)("")(ss);
+  const redxs11: Array<string> = _.scan(_.concat, "")(ss);
+  const redxs12: Array<string> = _.scan(_.concat)("", ss);
+  const redxs13: Array<string> = _.scan(_.concat, "", ss);
 
-  const redxs: number = _.reduce(_.add, 10, ns)
-  const redxs1: string = _.reduce(_.concat, '', ss)
-  const redxs2: Array<string> = _.reduce(_.concat, [])(_.map(x => [ x ], ss))
-  const redxs3: number = _.reduceRight(_.add, 10, ns)
-  const redxs4: string = _.reduceRight(_.concat, '', ss)
-  const redxs5: Array<string> = _.reduceRight(_.concat, [])(_.map(x => [ x ], ss))
-  const redxs6: Array<number> = _.scan(_.add)(10)(ns)
-  const redxs7: Array<number> = _.scan(_.add, 10)(ns)
-  const redxs8: Array<number> = _.scan(_.add)(10, ns)
-  const redxs9: Array<number> = _.scan(_.add, 10, ns)
-  const redxs10: Array<string> = _.scan(_.concat)('')(ss)
-  const redxs11: Array<string> = _.scan(_.concat, '')(ss)
-  const redxs12: Array<string> = _.scan(_.concat)('', ss)
-  const redxs13: Array<string> = _.scan(_.concat, '', ss)
-
-  const reduceToNamesBy = _.reduceBy((acc, student) => acc.concat(student.name), [])
-  const namesByGrade = reduceToNamesBy((student) => {
-    const score = student.score
-    return score < 65 ? 'F' : score < 70 ? 'D' : score < 80 ? 'C' : score < 90 ? 'B' : 'A'
-  })
+  const reduceToNamesBy = _.reduceBy(
+    (acc, student) => acc.concat(student.name),
+    []
+  );
+  const namesByGrade = reduceToNamesBy(student => {
+    const score = student.score;
+    return score < 65
+      ? "F"
+      : score < 70 ? "D" : score < 80 ? "C" : score < 90 ? "B" : "A";
+  });
   const students = [
-    { name: 'Lucy', score: 92 },
-    { name: 'Drew', score: 85 },
-    { name: 'Bart', score: 62 },
-  ]
-  const names1: {[k: string]: Array<string>} = namesByGrade(students)
+    { name: "Lucy", score: 92 },
+    { name: "Drew", score: 85 },
+    { name: "Bart", score: 62 }
+  ];
+  const names1: { [k: string]: Array<string> } = namesByGrade(students);
 
-  const spl: Array<string> = _.split(/\./, 'a.b.c.xyz.d')
+  const spl: Array<string> = _.split(/\./, "a.b.c.xyz.d");
 
-  const spl1: [Array<number>,Array<number>] = _.splitAt(1, [ 1, 2, 3 ])
-  const spl2: [string, string] = _.splitAt(5, 'hello world')
-  const spl3: [string, string]= _.splitAt(-1, 'foobar')
-  const spl4: Array<Array<number>> = _.splitEvery(3, [ 1, 2, 3, 4, 5, 6, 7 ])
-  const spl5: Array<string> = _.splitEvery(3, 'foobarbaz')
-  const spl6: [Array<number>,Array<number>] = _.splitWhen(_.equals(2))([ 1, 2, 3, 1, 2, 3 ])
+  const spl1: [Array<number>, Array<number>] = _.splitAt(1, [1, 2, 3]);
+  const spl2: [string, string] = _.splitAt(5, "hello world");
+  const spl3: [string, string] = _.splitAt(-1, "foobar");
+  const spl4: Array<Array<number>> = _.splitEvery(3, [1, 2, 3, 4, 5, 6, 7]);
+  const spl5: Array<string> = _.splitEvery(3, "foobarbaz");
+  const spl6: [Array<number>, Array<number>] = _.splitWhen(_.equals(2))([
+    1,
+    2,
+    3,
+    1,
+    2,
+    3
+  ]);
 
-  const slixs: Array<string> = _.slice(0, 2, ss)
-  const slixs1: Array<string> = _.slice(0, 2)(ss)
-  const slixs2: Array<string> = _.slice(0)(2)(ss)
-  const slixs3: Array<string> = _.slice(0)(2, ss)
+  const slixs: Array<string> = _.slice(0, 2, ss);
+  const slixs1: Array<string> = _.slice(0, 2)(ss);
+  const slixs2: Array<string> = _.slice(0)(2)(ss);
+  const slixs3: Array<string> = _.slice(0)(2, ss);
 
-  const diff = function (a, b) { return a - b }
-  const sortxs: Array<number> = _.sort(diff, [ 4,2,7,5 ])
+  const diff = function(a, b) {
+    return a - b;
+  };
+  const sortxs: Array<number> = _.sort(diff, [4, 2, 7, 5]);
 
-  const timesxs: Array<number> = _.times(_.identity, 5)
+  const timesxs: Array<number> = _.times(_.identity, 5);
 
-  const unf: (x: string) => Array<string> = _.unfold((x: string) => x.length > 10 || [ x, x + '0' ])
-  const unf1: Array<number> = _.unfold(x => x > 10 || [ x, x + 1 ], 0)
-  const f = n => n > 50 ? false : [ -n, n + 10 ]
-  const unf11: Array<number> = _.unfold(f, 10)
-
-  //$ExpectError
-  const unf2 = _.unfold(x => x.length > 10 || [ x, x + '0' ], 2)
-
-  const unby: Array<number> = _.uniqBy(Math.abs)([ -1, -5, 2, 10, 1, 2 ])
-
-  const strEq = _.eqBy(String)
-  const strEq2 = _.eqBy(String, 1, 2)
-  const unw = _.uniqWith(strEq)([ 1, '1', 2, 1 ])
-  const unw1 = _.uniqWith(strEq)([ {}, {} ])
-  const unw2 = _.uniqWith(strEq)([ 1, '1', 1 ])
-  const unw3 = _.uniqWith(strEq)([ '1', 1, 1 ])
-
-  //$ExpectError
-  const ys6: {[key: string]: string} = _.fromPairs([ [ 'h', 2 ] ])
-
-  const withoutxs: Array<number> = _.without([ 1, 2 ], ns)
-  const withoutxs1: Array<string> = _.without([ 'a' ], ss)
-
-  const xprodxs: Array<[ number, string ]> = _.xprod([ 1, 2 ], [ 'a', 'b', 'c' ])
-  const xprodxs1: Array<[ boolean, string ]> = _.xprod([ true, false ])([ 'a', 'b' ])
-
-  const zipxs: Array<[ number, string ]> = _.zip([ 1, 2, 3 ], [ 'a', 'b', 'c' ])
+  const unf: (x: string) => Array<string> = _.unfold(
+    (x: string) => x.length > 10 || [x, x + "0"]
+  );
+  const unf1: Array<number> = _.unfold(x => x > 10 || [x, x + 1], 0);
+  const f = n => (n > 50 ? false : [-n, n + 10]);
+  const unf11: Array<number> = _.unfold(f, 10);
 
   //$ExpectError
-  const zipxs1: Array<[ number, string ]> = _.zip([ true, false ])([ 'a', 'b' ])
+  const unf2 = _.unfold(x => x.length > 10 || [x, x + "0"], 2);
 
-  const zipos: {[k:string]:number} = _.zipObj([ 'a', 'b', 'c' ], [ 1, 2, 3 ])
+  const unby: Array<number> = _.uniqBy(Math.abs)([-1, -5, 2, 10, 1, 2]);
 
-  const ys9: {[k:string]: number} = _.zipObj([ 'me', 'you' ], [ 1, 2 ])
-  const zipped: Array<{s: number, y: string}> = zipWith((a, b) => ({ s: a, y: b }), [ 1, 2, 3 ], [ '1', '2', '3' ])
-  const zipped2: Array<{s: number, y: string}> = _.zipWith((a, b) => ({ s: a, y: b }), [ 1, 2, 3 ])([ '1', '2', '3' ])
-  const zipped3: Array<{s: number, y: string}> = _.zipWith((a, b) => ({ s: a, y: b }))([ 1, 2, 3 ])([ '1', '2', '3' ])
+  const strEq = _.eqBy(String);
+  const strEq2 = _.eqBy(String, 1, 2);
+  const unw = _.uniqWith(strEq)([1, "1", 2, 1]);
+  const unw1 = _.uniqWith(strEq)([{}, {}]);
+  const unw2 = _.uniqWith(strEq)([1, "1", 1]);
+  const unw3 = _.uniqWith(strEq)(["1", 1, 1]);
+
+  //$ExpectError
+  const ys6: { [key: string]: string } = _.fromPairs([["h", 2]]);
+
+  const withoutxs: Array<number> = _.without([1, 2], ns);
+  const withoutxs1: Array<string> = _.without(["a"], ss);
+
+  const xprodxs: Array<[number, string]> = _.xprod([1, 2], ["a", "b", "c"]);
+  const xprodxs1: Array<[boolean, string]> = _.xprod([true, false])(["a", "b"]);
+
+  const zipxs: Array<[number, string]> = _.zip([1, 2, 3], ["a", "b", "c"]);
+
+  //$ExpectError
+  const zipxs1: Array<[number, string]> = _.zip([true, false])(["a", "b"]);
+
+  const zipos: { [k: string]: number } = _.zipObj(["a", "b", "c"], [1, 2, 3]);
+
+  const ys9: { [k: string]: number } = _.zipObj(["me", "you"], [1, 2]);
+  const zipped: Array<{ s: number, y: string }> = zipWith(
+    (a, b) => ({ s: a, y: b }),
+    [1, 2, 3],
+    ["1", "2", "3"]
+  );
+  const zipped2: Array<{ s: number, y: string }> = _.zipWith(
+    (a, b) => ({ s: a, y: b }),
+    [1, 2, 3]
+  )(["1", "2", "3"]);
+  const zipped3: Array<{ s: number, y: string }> = _.zipWith((a, b) => ({
+    s: a,
+    y: b
+  }))([1, 2, 3])(["1", "2", "3"]);
 }

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_logic.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_logic.js
@@ -1,78 +1,73 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from 'ramda'
+import _, { compose, pipe, curry, filter, find, repeat, zipWith } from "ramda";
 
-const ns: Array<number> = [ 1, 2, 3, 4, 5 ]
-const ss: Array<string> = [ 'one', 'two', 'three', 'four' ]
-const obj: {[k:string]:number} = { a: 1, c: 2 }
-const objMixed: {[k:string]:mixed} = { a: 1, c: 'd' }
-const os: Array<{[k:string]: *}> = [ { a: 1, c: 'd' }, { b: 2 } ]
-const str: string = 'hello world'
-
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: * }> = [{ a: 1, c: "d" }, { b: 2 }];
+const str: string = "hello world";
 
 //Logic
-const isQueen = _.propEq('rank', 'Q')
-const isSpade = _.propEq('suit', '♠︎')
-const isQueenOfSpades = _.allPass([ isQueen, isSpade ])
+const isQueen = _.propEq("rank", "Q");
+const isSpade = _.propEq("suit", "♠︎");
+const isQueenOfSpades = _.allPass([isQueen, isSpade]);
 
 //$ExpectError
-const allp: boolean = isQueenOfSpades(1)
-const allp1: boolean = isQueenOfSpades({ rank: 'Q', suit: '♣︎' })
+const allp: boolean = isQueenOfSpades(1);
+const allp1: boolean = isQueenOfSpades({ rank: "Q", suit: "♣︎" });
 
-const a: boolean = _.and(true, true)
-const a_: (a: boolean) => boolean = _.and(true)
+const a: boolean = _.and(true, true);
+const a_: (a: boolean) => boolean = _.and(true);
 
-const gte = _.anyPass([ _.gt, _.equals ])
-const ge: boolean = gte(3, 2)
-
-//$ExpectError
-const gt10 = x => x > 10
-//$ExpectError
-const even = x => x % 2 === 0
-const f = _.both(gt10, even)
-
-const b: boolean = f('')
-const b_: boolean = f(100)
+const gte = _.anyPass([_.gt, _.equals]);
+const ge: boolean = gte(3, 2);
 
 //$ExpectError
-const isEven = n => n % 2 === 0
-const isOdd = _.complement(isEven)
+const gt10 = x => x > 10;
+//$ExpectError
+const even = x => x % 2 === 0;
+const f = _.both(gt10, even);
 
-const c: boolean = isOdd('')
-const c_: boolean = isOdd(2)
+const b: boolean = f("");
+const b_: boolean = f(100);
+
+//$ExpectError
+const isEven = n => n % 2 === 0;
+const isOdd = _.complement(isEven);
+
+const c: boolean = isOdd("");
+const c_: boolean = isOdd(2);
 
 const fn = _.cond([
-  [ _.equals(0),   _.always('water freezes at 0°C') ],
-  [ _.equals(100), _.always(1) ],
-  [ _.T,           temp => 'nothing special happens at ' + temp + '°C' ],
-])
-const cond_: number|string = fn(0)
+  [_.equals(0), _.always("water freezes at 0°C")],
+  [_.equals(100), _.always(1)],
+  [_.T, temp => "nothing special happens at " + temp + "°C"]
+]);
+const cond_: number | string = fn(0);
 
 // This is abit awkward — if a non-null value of type
 // differrent to number is passed flow will infer a union type
 // for all of them
-const defaultTo42 = _.defaultTo(42)
-const def: number = defaultTo42(null)
-const def1: number = defaultTo42(undefined)
+const defaultTo42 = _.defaultTo(42);
+const def: number = defaultTo42(null);
+const def1: number = defaultTo42(undefined);
 
-const feither = _.either(gt10, even)
-const feitherR: boolean = f(101)
+const feither = _.either(gt10, even);
+const feitherR: boolean = f(101);
 
-const incCount = _.ifElse(
-  _.is(Number),
-  _.inc,
-  _.toString
-)
-const ie: number|string = incCount({})
-const ie2: number|string = incCount(1)
+const incCount = _.ifElse(_.is(Number), _.inc, _.toString);
+const ie: number | string = incCount({});
+const ie2: number | string = incCount(1);
 
-const em: boolean = _.isEmpty([ 1, 2, 3 ])
+const em: boolean = _.isEmpty([1, 2, 3]);
 
-const n: boolean = _.not(true)
+const n: boolean = _.not(true);
 //$ExpectError
-const n1: boolean = _.not(1)
+const n1: boolean = _.not(1);
 
-const oor: boolean = _.or(true, true)
+const oor: boolean = _.or(true, true);
 
 // type refinement is important here
 // which might be awkward for some
@@ -86,17 +81,17 @@ const oor: boolean = _.or(true, true)
 // const psatPart2 = _.pathSatisfies(y => typeof y === 'number' && y > 0, [ 'x', 'y' ])
 // const psat3: boolean = psatPart2({ x: { y: 2 }, z: true })
 
-const propSat: boolean = _.propSatisfies(x => x > 0, 'x', { x: 1, y: 2 })
-const coerceArray = _.unless(_.isArrayLike, _.of)
-const coer: Array<number|Array<number>>|number = coerceArray([ 1, 2, 3 ])
-const coer1: Array<number|Array<number>>|number = coerceArray(1)
+const propSat: boolean = _.propSatisfies(x => x > 0, "x", { x: 1, y: 2 });
+const coerceArray = _.unless(_.isArrayLike, _.of);
+const coer: Array<number | Array<number>> | number = coerceArray([1, 2, 3]);
+const coer1: Array<number | Array<number>> | number = coerceArray(1);
 
-const coerceString = _.unless(_.is(String), _.toString)
-const coer2: string|Array<number> = coerceString([ 1, 2, 3 ])
-const coer3: string|Array<number> = coerceString('s')
+const coerceString = _.unless(_.is(String), _.toString);
+const coer2: string | Array<number> = coerceString([1, 2, 3]);
+const coer3: string | Array<number> = coerceString("s");
 
-const unlPrt = _.unless(_.is(Number), _.T)
-const unl: number|boolean|Array<number> = unlPrt([ 1, 2, 3 ])
-const unl2: number|boolean|Array<number> = unlPrt(1)
+const unlPrt = _.unless(_.is(Number), _.T);
+const unl: number | boolean | Array<number> = unlPrt([1, 2, 3]);
+const unl2: number | boolean | Array<number> = unlPrt(1);
 
-const un: number = _.until(_.gt(100), _.multiply(2))(1)
+const un: number = _.until(_.gt(100), _.multiply(2))(1);

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_misc.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_misc.js
@@ -1,44 +1,43 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from 'ramda'
+import _, { compose, pipe, curry, filter, find, repeat, zipWith } from "ramda";
 
-const ns: Array<number> = [ 1, 2, 3, 4, 5 ]
-const ss: Array<string> = [ 'one', 'two', 'three', 'four' ]
-const obj: {[k:string]:number} = { a: 1, c: 2 }
-const objMixed: {[k:string]:mixed} = { a: 1, c: 'd' }
-const os: Array<{[k:string]: *}> = [ { a: 1, c: 'd' }, { b: 2 } ]
-const str: string = 'hello world'
-
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: * }> = [{ a: 1, c: "d" }, { b: 2 }];
+const str: string = "hello world";
 
 // Math
 {
-  const partDiv: (a: number) => number = _.divide(6)
-  const div: number = _.divide(6, 2)
+  const partDiv: (a: number) => number = _.divide(6);
+  const div: number = _.divide(6, 2);
   //$ExpectError
-  const div2: number = _.divide(6, true)
+  const div2: number = _.divide(6, true);
 }
 
 // String
 {
-  const ss: Array<string|void> = _.match(/h/, 'b')
-  const ss3: string = _.replace(',', '|', 'b,d,d')
-  const ss2: Array<string> = _.split(',', 'b,d,d')
-  const ss1: boolean = _.test(/h/, 'b')
-  const s: string = _.trim('s')
-  const x: string = _.head('one')
-  const sss: string = _.concat('H','E')
-  const sss1: string = _.concat('H')('E')
-  const ssss: string = _.drop(1,'EF')
-  const ssss1: string = _.drop(1)('E')
-  const ssss2: string = _.dropLast(1,'EF')
-  const ys: string = _.nth(2, 'curry')
-  const ys1: string = _.nth(2)('curry')
+  const ss: Array<string | void> = _.match(/h/, "b");
+  const ss3: string = _.replace(",", "|", "b,d,d");
+  const ss2: Array<string> = _.split(",", "b,d,d");
+  const ss1: boolean = _.test(/h/, "b");
+  const s: string = _.trim("s");
+  const x: string = _.head("one");
+  const sss: string = _.concat("H", "E");
+  const sss1: string = _.concat("H")("E");
+  const ssss: string = _.drop(1, "EF");
+  const ssss1: string = _.drop(1)("E");
+  const ssss2: string = _.dropLast(1, "EF");
+  const ys: string = _.nth(2, "curry");
+  const ys1: string = _.nth(2)("curry");
 }
 //Type
 {
-  const x: boolean = _.is(Number, 1)
-  const x1: false = _.isNil(1)
-  const x1a: true = _.isNil()
-  const x1b: true = _.isNil(null)
-  const x2: boolean = _.propIs(1, 'num', { num: 1 })
+  const x: boolean = _.is(Number, 1);
+  const x1: false = _.isNil(1);
+  const x1a: true = _.isNil();
+  const x1b: true = _.isNil(null);
+  const x2: boolean = _.propIs(1, "num", { num: 1 });
 }

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_object.js
@@ -1,23 +1,34 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from 'ramda'
+import _, { compose, pipe, curry, filter, find, repeat, zipWith } from "ramda";
 
-const ns: Array<number> = [ 1, 2, 3, 4, 5 ]
-const ss: Array<string> = [ 'one', 'two', 'three', 'four' ]
-const obj: {[k:string]:number} = { a: 1, c: 2 }
-const objMixed: {[k:string]:mixed} = { a: 1, c: 'd' }
-const os: Array<{[k:string]: *}> = [ { a: 1, c: 'd' }, { b: 2 } ]
-const str: string = 'hello world'
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: * }> = [{ a: 1, c: "d" }, { b: 2 }];
+const str: string = "hello world";
 
 // Object
-const a:{[k:string]:number|string} = _.assoc('c', 's', { a: 1, b: 2 })
+const a: { [k: string]: number | string } = _.assoc("c", "s", { a: 1, b: 2 });
 //$ExpectError
-const a1:{[k:string]:number|boolean} = _.assoc('c', 's', { a: 1, b: 2 })
+const a1: { [k: string]: number | boolean } = _.assoc("c", "s", { a: 1, b: 2 });
 
-const apath: {[k:string]:number|string|Object} = _.assocPath([ 'a', 'b', 'c' ], 's', { a: { b: { c: 0 } } })
+const apath: { [k: string]: number | string | Object } = _.assocPath(
+  ["a", "b", "c"],
+  "s",
+  { a: { b: { c: 0 } } }
+);
 
-const tomato  = { firstName: '  Tomato ', data: { elapsed: 100, remaining: 1400 }, id: 123 }
-const tomato1  = { firstName: '  Tomato ', data: { elapsed: 100, remaining: 1400 } }
+const tomato = {
+  firstName: "  Tomato ",
+  data: { elapsed: 100, remaining: 1400 },
+  id: 123
+};
+const tomato1 = {
+  firstName: "  Tomato ",
+  data: { elapsed: 100, remaining: 1400 }
+};
 
 // TODO: Started failing in v31...
 // const transformations = {
@@ -30,161 +41,187 @@ const tomato1  = { firstName: '  Tomato ', data: { elapsed: 100, remaining: 1400
 // }
 // const evolved:{firstName: string, data: {elapsed: number, remaining: number}, id: number} = _.evolve(transformations, tomato)
 
-const objects = [ {}, {}, {} ]
-const objectsClone: Array<Object> = _.clone(objects)
-const objectsClone1: number = _.clone(1)
-const objectsClone2: typeof tomato = _.clone(tomato)
+const objects = [{}, {}, {}];
+const objectsClone: Array<Object> = _.clone(objects);
+const objectsClone1: number = _.clone(1);
+const objectsClone2: typeof tomato = _.clone(tomato);
 //$ExpectError
-const objectsClone3: $Shape<typeof tomato1> = _.clone(tomato)
-const objectsClone4: $Shape<typeof tomato1> = _.clone(tomato1)
+const objectsClone3: $Shape<typeof tomato1> = _.clone(tomato);
+const objectsClone4: $Shape<typeof tomato1> = _.clone(tomato1);
 
-const id = objectsClone2.id
+const id = objectsClone2.id;
 //$ExpectError
-const idE = objectsClone4.id
+const idE = objectsClone4.id;
 
-const dissocd: { a: number } = _.dissoc('b', { a: 1, b: 2 })
-const dissocd2: { a: number } = _.dissoc('b')({ a: 1, b: 2 })
+const dissocd: { a: number } = _.dissoc("b", { a: 1, b: 2 });
+const dissocd2: { a: number } = _.dissoc("b")({ a: 1, b: 2 });
 //$ExpectError
-const dissocd3: { a: string } = _.dissoc('b', { a: 1, b: 2 })
+const dissocd3: { a: string } = _.dissoc("b", { a: 1, b: 2 });
 //$ExpectError
-const dissocd4: { a: string } = _.dissoc('b')({ a: 1, b: 2 })
+const dissocd4: { a: string } = _.dissoc("b")({ a: 1, b: 2 });
 
-const dissocPathd: { a: { b: number } } = _.dissocPath(['a', 'c'], { a: { b: 1, c: 2 } })
-const dissocPathd2: { a: { b: number } } = _.dissocPath(['a', 'c'])({ a: { b: 1, c: 2 } })
+const dissocPathd: { a: { b: number } } = _.dissocPath(["a", "c"], {
+  a: { b: 1, c: 2 }
+});
+const dissocPathd2: { a: { b: number } } = _.dissocPath(["a", "c"])({
+  a: { b: 1, c: 2 }
+});
 //$ExpectError
-const dissocPathd3: { a: { b: string } } = _.dissocPath(['a', 'c'], { a: { b: 1, c: 2 } })
+const dissocPathd3: { a: { b: string } } = _.dissocPath(["a", "c"], {
+  a: { b: 1, c: 2 }
+});
 //$ExpectError
-const dissocPathd4: { a: { b: string } } = _.dissocPath(['a', 'c'])({ a: { b: 1, c: 2 } })
+const dissocPathd4: { a: { b: string } } = _.dissocPath(["a", "c"])({
+  a: { b: 1, c: 2 }
+});
 
-const o1 = { a: 1, b: 2, c: 3, d: 4 }
-const o2 = { a: 10, b: 20, c: 3, d: 40 }
-const ep: boolean = _.eqProps('a')(o1, o2)
-const ep2: boolean = _.eqProps('c', o1)(o2)
+const o1 = { a: 1, b: 2, c: 3, d: 4 };
+const o2 = { a: 10, b: 20, c: 3, d: 40 };
+const ep: boolean = _.eqProps("a")(o1, o2);
+const ep2: boolean = _.eqProps("c", o1)(o2);
 
-const hasid = _.has('id')
-const has: boolean = hasid(tomato)
+const hasid = _.has("id");
+const has: boolean = hasid(tomato);
 
 function Rectangle(width, height) {
-  this.width = width
-  this.height = height
+  this.width = width;
+  this.height = height;
 }
-Rectangle.prototype.area = function () {
-  return this.width * this.height
-}
+Rectangle.prototype.area = function() {
+  return this.width * this.height;
+};
 
-const square = new Rectangle(2, 2)
-const hasIn: boolean = _.hasIn('width', square)
-const hasIn1: boolean = _.hasIn('area', square)
+const square = new Rectangle(2, 2);
+const hasIn: boolean = _.hasIn("width", square);
+const hasIn1: boolean = _.hasIn("area", square);
 
 const raceResultsByFirstName = {
-  first: 'alice',
-  second: 'jake',
-  third: 'alice',
-}
-const inverted: {[k: string]: Array<string>} = _.invert(raceResultsByFirstName)
-const inverted1: {[k: string]: string} = _.invertObj(raceResultsByFirstName)
+  first: "alice",
+  second: "jake",
+  third: "alice"
+};
+const inverted: { [k: string]: Array<string> } = _.invert(
+  raceResultsByFirstName
+);
+const inverted1: { [k: string]: string } = _.invertObj(raceResultsByFirstName);
 
-const ks: Array<string> = _.keys(raceResultsByFirstName)
-const ksi: Array<string> = _.keysIn(square)
+const ks: Array<string> = _.keys(raceResultsByFirstName);
+const ksi: Array<string> = _.keysIn(square);
 
-const values = { x: 1, y: 2, z: 3 }
-const prependKeyAndDouble = (num, key, obj) => key + (num * 2)
+const values = { x: 1, y: 2, z: 3 };
+const prependKeyAndDouble = (num, key, obj) => key + num * 2;
 
-const obI: {[k:string]: string} = _.mapObjIndexed(prependKeyAndDouble, values)
+const obI: { [k: string]: string } = _.mapObjIndexed(
+  prependKeyAndDouble,
+  values
+);
 //$ExpectError
-const obI2: {[k:string]: number} = _.mapObjIndexed(prependKeyAndDouble, values)
+const obI2: { [k: string]: number } = _.mapObjIndexed(
+  prependKeyAndDouble,
+  values
+);
 
-const ob1 = { a: 1 }
-const ob2 = { b: 3 }
-const ob3 = _.merge(ob1, ob2)
+const ob1 = { a: 1 };
+const ob2 = { b: 3 };
+const ob3 = _.merge(ob1, ob2);
 //$ExpectError
-const propX = ob3.x
-const propA = ob3.a
+const propX = ob3.x;
+const propA = ob3.a;
 
-const mwith = _.mergeWith((a, b) => Array.isArray(a) && _.concat,
-{ a: true, values: [ 10, 20 ] },
-{ b: true, values: [ 15, 35 ] },
-)
-const propB: boolean = mwith.b
+const mwith = _.mergeWith(
+  (a, b) => Array.isArray(a) && _.concat,
+  { a: true, values: [10, 20] },
+  { b: true, values: [15, 35] }
+);
+const propB: boolean = mwith.b;
 
-const mwithK = _.mergeWithKey((k, a, b) => Array.isArray(a) && k === 'd' && _.concat,
-{ a: true, values: [ 10, 20 ] },
-{ b: true, values: [ 15, 35 ] },
-)
-const propB1: boolean = mwithK.b
+const mwithK = _.mergeWithKey(
+  (k, a, b) => Array.isArray(a) && k === "d" && _.concat,
+  { a: true, values: [10, 20] },
+  { b: true, values: [15, 35] }
+);
+const propB1: boolean = mwithK.b;
 
-const objA = _.objOf('a', false)
+const objA = _.objOf("a", false);
 //$ExpectError
-const propAA: number = objA.a
+const propAA: number = objA.a;
 
 //$ExpectError
-const om: Object = _.omit([ 'a', 'd', 'h' ], { a: 1, b: 2, c: 3, d: 4 })
+const om: Object = _.omit(["a", "d", "h"], { a: 1, b: 2, c: 3, d: 4 });
 
 //$ExpectError
-const om2 = _.omit([ 'a', 'd', 'h' ])
-const omap = om2({ a: 1, b: 2, c: 3, d: 4 })
+const om2 = _.omit(["a", "d", "h"]);
+const omap = om2({ a: 1, b: 2, c: 3, d: 4 });
 
-const path1:Object|number = _.path([ 'a', 'b' ], { a: { b: 2 } })
-const path2:Object|number = _.path([ 'a', 1 ], { a: { '1': 2 } })
-const path3:?Object = _.path(['a', 'b'], {c: {b: 2}})
-const path4:void = _.path([ 'a' ], null)
+const path1: Object | number = _.path(["a", "b"], { a: { b: 2 } });
+const path2: Object | number = _.path(["a", 1], { a: { "1": 2 } });
+const path3: ?Object = _.path(["a", "b"], { c: { b: 2 } });
+const path4: void = _.path(["a"], null);
 
-const pathOr: string|Object|number = _.pathOr('N/A', [ 'a', 'b' ], { a: { b: 2 } })
+const pathOr: string | Object | number = _.pathOr("N/A", ["a", "b"], {
+  a: { b: 2 }
+});
 
-const pck: Object = _.pick([ 'a', 'd' ], { a: 1, b: 2, c: 3, d: 4 })
+const pck: Object = _.pick(["a", "d"], { a: 1, b: 2, c: 3, d: 4 });
 
-const ooo = { a: 1, b: 2, A: 3, B: 4 }
-const isUpperCase = (val, key) => key.toUpperCase() === key
-const pb:Object = _.pickBy(isUpperCase, ooo)
+const ooo = { a: 1, b: 2, A: 3, B: 4 };
+const isUpperCase = (val, key) => key.toUpperCase() === key;
+const pb: Object = _.pickBy(isUpperCase, ooo);
 
-const ppp:?number = _.prop('x', { x: 100 })
+const ppp: ?number = _.prop("x", { x: 100 });
 //$ExpectError
-const ppp1:?number = _.prop('y', { x: 100 })
-const ppp2:?number = _.prop('x')({ x: 100 })
+const ppp1: ?number = _.prop("y", { x: 100 });
+const ppp2: ?number = _.prop("x")({ x: 100 });
 //$ExpectError
-const ppp3:?number = _.prop('y')({ x: 100 })
-const ppp4:?number = _.prop(_.__, { x: 100 })('x')
+const ppp3: ?number = _.prop("y")({ x: 100 });
+const ppp4: ?number = _.prop(_.__, { x: 100 })("x");
 //$ExpectError
-const ppp5:?number = _.prop(_.__, { x: 100 })('y')
+const ppp5: ?number = _.prop(_.__, { x: 100 })("y");
 
 const alice = {
-  name: 'ALICE',
-  age: 101,
-}
+  name: "ALICE",
+  age: 101
+};
 
 //$ExpectError
-const favoriteWithDefault = _.propOr('Ramda', 'favoriteLibrary')
-const fav = favoriteWithDefault(alice)
+const favoriteWithDefault = _.propOr("Ramda", "favoriteLibrary");
+const fav = favoriteWithDefault(alice);
 
-const nameWithDefault = _.propOr('Ramda', 'name')
-const nm: number|string = nameWithDefault(alice)
+const nameWithDefault = _.propOr("Ramda", "name");
+const nm: number | string = nameWithDefault(alice);
 
-const pss: Array<?number|boolean> = _.props([ 'x', 'y' ], { x: true, y: 2 })
+const pss: Array<?number | boolean> = _.props(["x", "y"], { x: true, y: 2 });
 //$ExpectError
-const pssE: Array<?number|boolean> = _.props([ 'd', 'y' ], { x: true, y: 2 })
+const pssE: Array<?number | boolean> = _.props(["d", "y"], { x: true, y: 2 });
 
-const top: Array<['a'|'b'|'c', number]> = _.toPairs({ a: 1, b: 2, c: 3 })
+const top: Array<["a" | "b" | "c", number]> = _.toPairs({ a: 1, b: 2, c: 3 });
 
 //$ExpectError
-const topE: Array<['a'|'b'|'c'|'z', number]> = _.toPairs({ a: 1, b: 2, c: 3 })
+const topE: Array<["a" | "b" | "c" | "z", number]> = _.toPairs({
+  a: 1,
+  b: 2,
+  c: 3
+});
 
-const F = function () { this.x = 'X' }
-F.prototype.y = 'Y'
-const f = new F()
-const topin = _.toPairsIn(f)
+const F = function() {
+  this.x = "X";
+};
+F.prototype.y = "Y";
+const f = new F();
+const topin = _.toPairsIn(f);
 
-const val = _.values({ a: 1, b: 2, c: true })
-const val1: number|boolean = val[0]
+const val = _.values({ a: 1, b: 2, c: true });
+const val1: number | boolean = val[0];
 
 const pred = _.where({
-  a: _.equals('foo'),
-  b: _.complement(_.equals('bar')),
+  a: _.equals("foo"),
+  b: _.complement(_.equals("bar")),
   x: _.gt(10),
-  y: _.lt(20),
-})
+  y: _.lt(20)
+});
 
-const w: boolean = pred({ a: 'foo', b: 'xxx', x: 11, y: 19 })
+const w: boolean = pred({ a: "foo", b: "xxx", x: 11, y: 19 });
 
-const pred1 = _.whereEq({ a: 1, b: 2 })
+const pred1 = _.whereEq({ a: 1, b: 2 });
 
-const win: boolean = pred1({ a: 1, d: 1 })
+const win: boolean = pred1({ a: 1, d: 1 });

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-/test_ramda_v0.x.x_object.js
@@ -11,8 +11,11 @@ const str: string = "hello world";
 
 // Object
 const a: { [k: string]: number | string } = _.assoc("c", "s", { a: 1, b: 2 });
-//$ExpectError
-const a1: { [k: string]: number | boolean } = _.assoc("c", "s", { a: 1, b: 2 });
+const mixedA: { x: { [string]: number }, y: Array<string> } = _.assoc(
+  "x",
+  { x1: 11 },
+  { y: ["y1"] }
+);
 
 const apath: { [k: string]: number | string | Object } = _.assocPath(
   ["a", "b", "c"],


### PR DESCRIPTION
**Note**
I see that some definitions have not been formatted by `prettier` yet and ran that over the latest ramda definitions in the first commit with the command:
`node_modules/.bin/prettier --write npm/ramda_v0.x.x/flow_v0.39.x-/*`

**Description**
This change allows for mixed types in the source object and using `assoc` and `assocPath` to update such a source without flow errors.