### PR TITLE
redux-actions: Add support for nested reducers

### DIFF
--- a/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
+++ b/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
@@ -80,8 +80,12 @@ declare module 'redux-actions' {
     defaultState: State
   ): Reducer<State, Action>;
 
+  declare type ReducerDefinition<State, Action> = {
+    [key: string]: (Reducer<State, Action> | ReducerDefinition<State, Action>) | ReducerMap<State, Action>,
+  };
+
   declare function handleActions<State, Action>(
-    reducers: { [key: string]: Reducer<State, Action> | ReducerMap<State, Action> },
+    reducers: ReducerDefinition<State, Action>,
     defaultState?: State
   ): Reducer<State, Action>;
 


### PR DESCRIPTION
redux-actions supports nested reducers in `handleActions`, just like `createActions` supports nested actions