### PR TITLE
Added isValid() method to moment.js duration class

### DIFF
--- a/definitions/npm/moment_v2.3.x/flow_v0.34.x-/moment_v2.3.x.js
+++ b/definitions/npm/moment_v2.3.x/flow_v0.34.x-/moment_v2.3.x.js
@@ -96,6 +96,7 @@ declare class moment$MomentDuration {
   get(unit: string): number;
   toJSON(): string;
   toISOString(): string;
+  isValid(): bool;
 }
 declare class moment$Moment {
   static ISO_8601: string;


### PR DESCRIPTION
I previously submitted a similar PR for 2.x.x: #1142
But seems it got lost when the 2.3.x defs were added.
See [this discussion](https://github.com/flowtype/flow-typed/pull/1242#issuecomment-331136528)