### PR TITLE
Express req.query values can be arrays.

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.25.x-v0.27.x/express_v4.x.x.js
@@ -24,7 +24,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   params: {[param: string]: string};
   path: string;
   protocol: 'https' | 'http';
-  query: {[name: string]: string};
+  query: {[name: string]: string | Array<string>};
   route: string;
   secure: boolean;
   signedCookies: {[signedCookie: string]: string};

--- a/definitions/npm/express_v4.x.x/flow_v0.28.x-v0.31.x/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.28.x-v0.31.x/express_v4.x.x.js
@@ -24,7 +24,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   params: {[param: string]: string};
   path: string;
   protocol: 'https' | 'http';
-  query: {[name: string]: string};
+  query: {[name: string]: string | Array<string>};
   route: string;
   secure: boolean;
   signedCookies: {[signedCookie: string]: string};

--- a/definitions/npm/express_v4.x.x/flow_v0.32.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.32.x-/express_v4.x.x.js
@@ -30,7 +30,7 @@ declare class express$Request extends http$IncomingMessage mixins express$Reques
   params: express$RequestParams;
   path: string;
   protocol: 'https' | 'http';
-  query: {[name: string]: string};
+  query: {[name: string]: string | Array<string>};
   route: string;
   secure: boolean;
   signedCookies: {[signedCookie: string]: string};

--- a/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/test_express_v4.x.x.js
@@ -134,6 +134,10 @@ app.use((err: ?Error, req: express$Request, res: express$Response, next: express
     // test req
     req.accepts('accepted/type');
     req.accepts(['json', 'text']);
+    if (typeof req.query.foo === 'string')
+      console.log((req.query.foo: string));
+    else
+      console.log((req.query.foo: Array<string>));
     // test response
     res.redirect('/somewhere');
     // test next


### PR DESCRIPTION
The express v4 libdef has express's `req.query` has being an object with string values, but the values can also be arrays of string. The [express docs](http://expressjs.com/en/api.html#app.set) claim that:
> The simple query parser is based on Node’s native query parser, [querystring](https://nodejs.org/api/querystring.html).
> The extended query parser is based on [qs](https://www.npmjs.com/package/qs).

Both modules support query string array syntax:

```
> querystring.parse('foos=one&foos=two')
{ foos: [ 'one', 'two' ] }
> qs.parse('foos=one&foos=two')
{ foos: [ 'one', 'two' ] }
```

It's unclear to me how to write a good test for this. The one I wrote doesn't seem great, and appears to pass before my change, so I must be doing something wrong. Little help?

Thanks.