### PR TITLE
[rxjs] Add support for combineLatest with a single argument

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
@@ -354,6 +354,7 @@ declare class rxjs$Observable<+T> {
 
   static combineLatest<A>(
     a: rxjs$Observable<A>,
+    _: void,
   ): rxjs$Observable<[A]>;
 
   static combineLatest<A, B>(

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
@@ -352,6 +352,10 @@ declare class rxjs$Observable<+T> {
     resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H,
   ): rxjs$Observable<H>;
 
+  static combineLatest<A>(
+    a: rxjs$Observable<A>,
+  ): rxjs$Observable<[A]>;
+
   static combineLatest<A, B>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -624,6 +624,11 @@ declare class rxjs$Observable<+T> {
     resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
   ): rxjs$Observable<H>,
 
+  static combineLatest<A>(
+    a: rxjs$Observable<A>,
+    _: void,
+  ): rxjs$Observable<[A]>;
+
   static combineLatest<A, B>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -54,6 +54,10 @@ const combined: Observable<{n: number, s: string}> = Observable.combineLatest(
 
 const combined2: Observable<[number, string]> = Observable.combineLatest(numbers, strings);
 
+const combined3: Observable<[number]> = Observable.combineLatest(
+  numbers
+);
+
 // $ExpectError
 const combinedBad: Observable<{n: number, s: string}> = Observable.combineLatest(
   numbers,

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -65,16 +65,16 @@ const combinedBad: Observable<{n: number, s: string}> = Observable.combineLatest
   (n, s) => ({n, s})
 );
 
-const combined3: Observable<{n: number, s: string}> = Observable.forkJoin(
+const forked: Observable<{n: number, s: string}> = Observable.forkJoin(
   numbers,
   strings,
   (n, s) => ({n, s})
 );
 
-const combined4: Observable<[number, string]> = Observable.forkJoin(numbers, strings);
+const forked2: Observable<[number, string]> = Observable.forkJoin(numbers, strings);
 
 // $ExpectError
-const combinedBad2: Observable<{n: number, s: string}> = Observable.forkJoin(
+const forkedBad: Observable<{n: number, s: string}> = Observable.forkJoin(
   numbers,
   numbers,
   (n, s) => ({n, s})


### PR DESCRIPTION
We are missing a typedef for [`Observable.combineLatest(a)`](
http://reactivex.io/rxjs/test-file/spec-js/observables/combineLatest-spec.js.html#lineNumber448).
While the usage seems odd, it is valid and makes sense when you expect new observables to be added later to the list of arguments.