### PR TITLE
Add bufferCount() to Observable.

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
@@ -130,6 +130,8 @@ declare class rxjs$Observable<+T> {
 
   buffer(bufferBoundaries: rxjs$Observable<any>): rxjs$Observable<Array<T>>;
 
+  bufferCount(bufferSize: number, startBufferEvery?: number): rxjs$Observable<Array<T>>;
+
   catch<U>(selector: (err: any, caught: rxjs$Observable<T>) => rxjs$Observable<U>): rxjs$Observable<U>;
 
   concat<U>(...sources: rxjs$Observable<U>[]): rxjs$Observable<T | U>;

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -336,6 +336,8 @@ declare class rxjs$Observable<+T> {
 
   buffer(bufferBoundaries: rxjs$Observable<any>): rxjs$Observable<Array<T>>,
 
+  bufferCount(bufferSize: number, startBufferEvery?: number): rxjs$Observable<Array<T>>;
+
   catch<U>(
     selector: (err: any, caught: rxjs$Observable<T>) => rxjs$Observable<U>
   ): rxjs$Observable<U>,


### PR DESCRIPTION
Docs for bufferCount here:
https://github.com/btroncone/learn-rxjs/blob/master/operators/transformation/buffercount.md

Unlike buffer(), it takes one required and one optional argument.  The
return value is the same.