### PR TITLE
Add libdef for react-i18next v6.x.x for flow v0.53.x- (#1279)

### DIFF
--- a/definitions/npm/react-i18next_v6.x.x/flow_v0.53.x-/react-i18next_v6.x.x.js
+++ b/definitions/npm/react-i18next_v6.x.x/flow_v0.53.x-/react-i18next_v6.x.x.js
@@ -1,0 +1,91 @@
+declare module "react-i18next" {
+  declare type TFunction = (key?: ?string, data?: ?Object) => string;
+  declare type Locales = string | Array<string>;
+
+  declare type TranslatorProps = {
+    t: TFunction,
+    i18nLoadedAt: Date,
+    i18n: Object
+  };
+
+  declare type Translator<OP, P> = (
+    component: React$ComponentType<P>
+  ) => Class<React$Component<OP, *>>;
+
+  declare type TranslateOptions = $Shape<{
+    wait: boolean,
+    nsMode: "default" | "fallback",
+    bindi18n: false | string,
+    bindStore: false | string,
+    withRef: boolean,
+    translateFuncName: string,
+    i18n: Object
+  }>;
+
+  declare function translate<OP, P>(
+    locales: Locales,
+    options?: TranslateOptions
+  ): Translator<OP, P>;
+
+  declare type I18nProps = {
+    i18n?: Object,
+    ns?: string | Array<string>,
+    children: (t: TFunction, { i18n: Object, t: TFunction }) => React$Node,
+    initialI18nStore?: Object,
+    initialLanguage?: string
+  };
+  declare var I18n: React$ComponentType<I18nProps>;
+
+  declare type InterpolateProps = {
+    className?: string,
+    dangerouslySetInnerHTMLPartElement?: string,
+    i18n?: Object,
+    i18nKey?: string,
+    options?: Object,
+    parent?: string,
+    style?: Object,
+    t?: TFunction,
+    useDangerouslySetInnerHTML?: boolean
+  };
+  declare var Interpolate: React$ComponentType<InterpolateProps>;
+
+  declare type TransProps = {
+    count?: number,
+    parent?: string,
+    i18n?: Object,
+    i18nKey?: string,
+    t?: TFunction
+  };
+  declare var Trans: React$ComponentType<TransProps>;
+
+  declare type ProviderProps = { i18n: Object, children: React$Element<*> };
+  declare var I18nextProvider: React$ComponentType<ProviderProps>;
+
+  declare type NamespacesProps = {
+    components: Array<React$ComponentType<*>>,
+    i18n: { loadNamespaces: Function }
+  };
+  declare function loadNamespaces(props: NamespacesProps): Promise<void>;
+
+  declare var reactI18nextModule: {
+    type: "3rdParty",
+    init: (instance: Object) => void
+  };
+
+  declare var defaultOptions: {
+    wait: false,
+    withRef: false,
+    bindI18n: "languageChanged loaded",
+    bindStore: "added removed",
+    translateFuncName: "t",
+    nsMode: "default"
+  };
+
+  declare function setDefaults(options: TranslateOptions): void;
+
+  declare function getDefaults(): TranslateOptions;
+
+  declare function getI18n(): Object;
+
+  declare function setI18n(instance: Object): void;
+}

--- a/definitions/npm/react-i18next_v6.x.x/test_react-i18next_v6.x.x.js
+++ b/definitions/npm/react-i18next_v6.x.x/test_react-i18next_v6.x.x.js
@@ -1,0 +1,175 @@
+// @flow
+
+import * as React from "react";
+import {
+  loadNamespaces,
+  translate,
+  I18nextProvider,
+  I18n,
+  Interpolate,
+  Trans,
+  setDefaults,
+  reactI18nextModule,
+  defaultOptions,
+  getDefaults,
+  getI18n,
+  setI18n
+} from "react-i18next";
+import type { TFunction, Translator } from "react-i18next";
+
+const i18n = { loadNamespaces: () => {} };
+
+<I18nextProvider i18n={i18n} children={<div />} />;
+
+// $ExpectError - missing children prop
+<I18nextProvider i18n={i18n} />;
+// $ExpectError - missing i18n prop
+<I18nextProvider children={<div />} />;
+
+// passing
+loadNamespaces({ components: [], i18n });
+loadNamespaces({ components: [() => <div />], i18n });
+
+// $ExpectError - too few arguments
+loadNamespaces();
+// $ExpectError - wrong type
+loadNamespaces("");
+// $ExpectError - wrong component type
+loadNamespaces({ components: [{}], i18n });
+
+type OwnProps = { s: string };
+type Props = OwnProps & { t: TFunction };
+
+const Comp = ({ s, t }: Props) => <div prop1={t("")} prop2={" " + s} />;
+
+class ClassComp extends React.Component<Props> {
+  render() {
+    const { s, t } = this.props;
+    return <div prop={t("")} />;
+  }
+}
+
+// $ExpectError - wrong argument type
+const FlowErrorComp = ({ s, t }: Props) =>
+  <div
+    prop1={t("", "")} // misuse of t()
+    prop2={" " + s}
+  />;
+
+class FlowErrorClassComp extends React.Component<Props> {
+  render() {
+    // $ExpectError - wrong argument type
+    const { s, t } = this.props;
+    return <div prop={t({})} />; // misuse of t()
+  }
+}
+
+// $ExpectError - too few arguments
+translate();
+// $ExpectError - wrong argument type
+translate({});
+
+const translator: Translator<OwnProps, Props> = translate("");
+const WrappedStatelessComp = translator(Comp);
+
+// passing
+<WrappedStatelessComp s="" />;
+
+// $ExpectError - missing prop "s"
+<WrappedStatelessComp />;
+// $ExpectError - wrong type
+<WrappedStatelessComp s={1} />;
+
+const WrappedClassComp = translator(ClassComp);
+
+// passing
+<WrappedClassComp s="" />;
+
+// $ExpectError - missing prop "s"
+<WrappedClassComp />;
+// $ExpectError - wrong type
+<WrappedClassComp s={1} />;
+
+// passing
+<I18n>
+  {(t: TFunction) =>
+    <span>
+      {t("title")}
+    </span>}
+</I18n>;
+<I18n ns="translations">
+  {(t: TFunction, { i18n }: { i18n: Object }) =>
+    <div>
+      <span>
+        {t("title")}
+      </span>
+      <button onClick={() => i18n.changeLanguage("de")}>de</button>
+      <button onClick={() => i18n.changeLanguage("en")}>en</button>
+    </div>}
+</I18n>;
+// $ExpectError - no children passed to I18n component
+<I18n ns="translations" />;
+
+// passing
+<Interpolate />;
+<Interpolate i18nKey="translation.key" keyValue={5} />;
+<Interpolate
+  className="string"
+  dangerouslySetInnerHTMLPartElement="span"
+  i18n={i18n}
+  i18nKey="translation.key"
+  options={{}}
+  parent="div"
+  style={{}}
+  t={key => ""}
+  useDangerouslySetInnerHTML={true}
+/>;
+
+// $ExpectError - i18nKey prop wrong type
+<Interpolate i18nKey={1} />;
+
+// passing
+<Trans i18nKey="translation.key" />;
+<Trans i18nKey="translation.key" count={5} />;
+<Trans i18nKey="translation.key" count={5} parent="div" i18n={i18n} />;
+
+// $ExpectError - i18nKey prop wrong type
+<Trans i18nKey={5} />;
+
+// passing
+reactI18nextModule.init(i18n);
+reactI18nextModule.type;
+// $ExpectError - no field property on reactI18nextModule
+reactI18nextModule.field;
+
+// passing
+defaultOptions.wait;
+defaultOptions.withRef;
+defaultOptions.bindI18n;
+defaultOptions.bindStore;
+defaultOptions.translateFuncName;
+defaultOptions.nsMode;
+// $ExpectError - no field property on defaultOptions
+defaultOptions.field;
+
+// passing
+setDefaults({ wait: true });
+// $ExpectError - setDefaults must be called with an object
+setDefaults("option");
+// $ExpectError - other is not a valid option
+setDefaults({ other: true });
+
+// passing
+getDefaults();
+// $ExpectError - no arguments should be passed to getDefaults
+getDefaults("string");
+
+// passing
+getI18n();
+// $ExpectError - no arguments should be passed to getI18n
+getI18n("string");
+
+// passing
+setI18n(i18n);
+// $ExpectError - setI18n must be called with an object
+setI18n("option");

--- a/definitions/package-lock.json
+++ b/definitions/package-lock.json
@@ -1112,6 +1112,14 @@
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
           "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -1120,14 +1128,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {


### PR DESCRIPTION
Copied over the v2.x.x libdef, added the additional exports that have been added to match the latest release of react-i18next, and made modifications to be 0.53.x- compatible.