### PR TITLE
Update to moment to fix isBetween method

### DIFF
--- a/definitions/npm/moment_v2.3.x/flow_v0.34.x-/moment_v2.3.x.js
+++ b/definitions/npm/moment_v2.3.x/flow_v0.34.x-/moment_v2.3.x.js
@@ -205,7 +205,12 @@ declare class moment$Moment {
   isAfter(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
   isSameOrBefore(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
   isSameOrAfter(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
-  isBetween(date: moment$Moment|string|number|Date|Array<number>): bool;
+  isBetween(
+    fromDate: moment$Moment|string|number|Date|Array<number>,
+    toDate?: ?moment$Moment|string|number|Date|Array<number>,
+    granularity?: ?string,
+    inclusion?: ?string
+  ): bool;
   isDST(): bool;
   isDSTShifted(): bool;
   isLeapYear(): bool;


### PR DESCRIPTION
As of moment 2.13.0 isBetween not supports many more arguments. See documentation here: https://momentjs.com/docs/#/query/is-between/

This PR updates the types for the `moment.isBetween` function to support all supported arguments.

Fixes #891