### PR TITLE
Closes #1313

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -47,7 +47,7 @@ type TestGroup = {
  * directory.
  */
 const basePathRegex = new RegExp(
-  `definitions${path.sep}npm${path.sep}(\@[^${path.sep}]*${path.sep})?[^${path.sep}]*${path.sep}?`,
+  'definitions/npm/(\@[^/]*/)?[^/]*/?',
 );
 async function getTestGroups(
   repoDirPath,

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -46,9 +46,7 @@ type TestGroup = {
  * structs. Each TestGroup represents a Package/PackageVersion/FlowVersion
  * directory.
  */
-const basePathRegex = new RegExp(
-  'definitions/npm/(\@[^/]*/)?[^/]*/?',
-);
+const basePathRegex = new RegExp('definitions/npm/(\@[^/]*/)?[^/]*/?');
 async function getTestGroups(
   repoDirPath,
   onlyChanged: boolean = false,

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -46,7 +46,7 @@ type TestGroup = {
  * structs. Each TestGroup represents a Package/PackageVersion/FlowVersion
  * directory.
  */
-const basePathRegex = new RegExp('definitions/npm/(\@[^/]*/)?[^/]*/?');
+const basePathRegex = new RegExp('definitions/npm/(@[^/]*/)?[^/]*/?');
 async function getTestGroups(
   repoDirPath,
   onlyChanged: boolean = false,


### PR DESCRIPTION
From NodeJS' docs:

> path.sep provides the platform-specific path segment separator:
> - \ on Windows
> - / on POSIX

> Note: On Windows, both the forward slash (/) and backward slash (\) are accepted as path segment separators; however, the path methods only add backward slashes (\).

Backward slashes resulted in breaking flow-typed for Windows. This PR fixes it.