### PR TITLE
[react-intl] Remove requirement for intl prop

### DIFF
--- a/definitions/npm/react-intl_v2.x.x/flow_v0.53.x-/react-intl_v2.x.x.js
+++ b/definitions/npm/react-intl_v2.x.x/flow_v0.53.x-/react-intl_v2.x.x.js
@@ -130,7 +130,7 @@ declare module "react-intl" {
       intlPropName?: string,
       withRef?: boolean
     }
-  ): React$ComponentType<Props>;
+  ): React$ComponentType<$Diff<Props, { intl: $npm$ReactIntl$IntlShape }>>;
   declare function formatMessage(
     messageDescriptor: $npm$ReactIntl$MessageDescriptor,
     values?: Object


### PR DESCRIPTION
When `injectIntl` HOC is used it injects `intl` property into component.  So there is no reason for resulting component to require consumers to provide it.