### PR TITLE
fix translate in react-i18next_v6.x.x

### DIFF
--- a/definitions/npm/react-i18next_v6.x.x/flow_v0.53.x-/react-i18next_v6.x.x.js
+++ b/definitions/npm/react-i18next_v6.x.x/flow_v0.53.x-/react-i18next_v6.x.x.js
@@ -23,7 +23,7 @@ declare module "react-i18next" {
   }>;
 
   declare function translate<OP, P>(
-    locales: Locales,
+    locales?: Locales,
     options?: TranslateOptions
   ): Translator<OP, P>;
 

--- a/definitions/npm/react-i18next_v6.x.x/test_react-i18next_v6.x.x.js
+++ b/definitions/npm/react-i18next_v6.x.x/test_react-i18next_v6.x.x.js
@@ -64,7 +64,7 @@ class FlowErrorClassComp extends React.Component<Props> {
   }
 }
 
-// $ExpectError - too few arguments
+// passing
 translate();
 // $ExpectError - wrong argument type
 translate({});


### PR DESCRIPTION
`translate` can have no parameters. 
As discussed in https://github.com/flowtype/flow-typed/pull/1298#issuecomment-335154361

@TLadd please review