### PR TITLE
Fix npm check for packages of type @<parent>/<package>

### DIFF
--- a/cli/src/lib/npm/npmLibDefs.js
+++ b/cli/src/lib/npm/npmLibDefs.js
@@ -82,11 +82,12 @@ async function extractLibDefsFromNpmPkgDir(
   const pkgDirItems = await fs.readdir(pkgDirPath);
 
   if (validating) {
-    await _npmExists(pkgName).then().catch(error => {
+    const fullPkgName = `${scope === null ? '' : scope + '/'}${pkgName}`;
+    await _npmExists(fullPkgName).then().catch(error => {
       // Only fail spen on 404, not on timeout
       if (error.statusCode === 404) {
         const pkgError = `Package does not exist on npm!`;
-        validationError(pkgName, pkgError, validationErrors);
+        validationError(fullPkgName, pkgError, validationErrors);
       }
     });
   }
@@ -367,7 +368,7 @@ function filterLibDefs(
 }
 
 async function _npmExists(pkgName: string): Promise<Function> {
-  const pkgUrl = `https://www.npmjs.org/package/${pkgName}`;
+  const pkgUrl = `https://www.npmjs.com/package/${pkgName}`;
   return got(pkgUrl, {method: 'HEAD'});
 }
 


### PR DESCRIPTION
Addresses spec failures in #937