### PR TITLE
Added type definitions for react-immutable-pure-component

### DIFF
--- a/definitions/npm/react-immutable-pure-component_v1.x.x/flow_v0.53.x-/react-immutable-pure-component_v1.x.x.js
+++ b/definitions/npm/react-immutable-pure-component_v1.x.x/flow_v0.53.x-/react-immutable-pure-component_v1.x.x.js
@@ -1,0 +1,4 @@
+declare module 'react-immutable-pure-component' {
+  declare export default class ImmutablePureComponent<Props, State = void> extends React$Component<Props, State> {
+  }
+}

--- a/definitions/npm/react-immutable-pure-component_v1.x.x/test_react-immutable-pure-component_v1.x.x.js
+++ b/definitions/npm/react-immutable-pure-component_v1.x.x/test_react-immutable-pure-component_v1.x.x.js
@@ -1,0 +1,40 @@
+// @flow
+import React from "react";
+import ImmutablePureComponent from "react-immutable-pure-component";
+
+type MyProps = {
+  id: string
+};
+
+class Foo extends ImmutablePureComponent<MyProps> {
+  render() {
+    return (
+      <div>
+        {this.props.id}
+      </div>
+    );
+  }
+}
+
+const a = <Foo id={"1"} />;
+
+// $ExpectError
+<Foo />;
+
+// $ExpectError
+<Foo id={1} />;
+
+type MyState = {
+  visible: boolean
+};
+
+class Bar extends ImmutablePureComponent<MyProps, MyState> {
+  componentWillReceiveProps(nextProps: MyProps) {
+    // $ExpectError
+    this.setState({ visible: "true" });
+  }
+
+  render() {
+    return <div />;
+  }
+}


### PR DESCRIPTION
I've been using [react-immutable-pure-component](https://github.com/Monar/react-immutable-pure-component) with flow, which doesn't have an entry in flow-typed. I made a type definition which I've been using successfully on my own project and now I'd like to push it upstream to flow-typed.

react-immutable-pure-component is a simple wrapper for React$Component that adds better support for [immutable.js](https://github.com/facebook/immutable-js/) props. My type definition should just reproduce the flow typing of React$Component, which is the parent class of `ImmutablePureComponent`.
