### PR TITLE
Fix regression in moment_v2.3.x

### DIFF
--- a/definitions/npm/moment_v2.3.x/flow_v0.34.x-/moment_v2.3.x.js
+++ b/definitions/npm/moment_v2.3.x/flow_v0.34.x-/moment_v2.3.x.js
@@ -1,26 +1,26 @@
 type moment$MomentOptions = {
-  y?: number|string,
-  year?: number|string,
-  years?: number|string,
-  M?: number|string,
-  month?: number|string,
-  months?: number|string,
-  d?: number|string,
-  day?: number|string,
-  days?: number|string,
-  date?: number|string,
-  h?: number|string,
-  hour?: number|string,
-  hours?: number|string,
-  m?: number|string,
-  minute?: number|string,
-  minutes?: number|string,
-  s?: number|string,
-  second?: number|string,
-  seconds?: number|string,
-  ms?: number|string,
-  millisecond?: number|string,
-  milliseconds?: number|string,
+  y?: number | string,
+  year?: number | string,
+  years?: number | string,
+  M?: number | string,
+  month?: number | string,
+  months?: number | string,
+  d?: number | string,
+  day?: number | string,
+  days?: number | string,
+  date?: number | string,
+  h?: number | string,
+  hour?: number | string,
+  hours?: number | string,
+  m?: number | string,
+  minute?: number | string,
+  minutes?: number | string,
+  s?: number | string,
+  second?: number | string,
+  seconds?: number | string,
+  ms?: number | string,
+  millisecond?: number | string,
+  milliseconds?: number | string
 };
 
 type moment$MomentObject = {
@@ -30,18 +30,18 @@ type moment$MomentObject = {
   hours: number,
   minutes: number,
   seconds: number,
-  milliseconds: number,
+  milliseconds: number
 };
 
 type moment$MomentCreationData = {
   input: string,
   format: string,
   locale: Object,
-  isUTC: bool,
-  strict: bool,
+  isUTC: boolean,
+  strict: boolean
 };
 
-type moment$CalendarFormat = string | (moment: moment$Moment) => string;
+type moment$CalendarFormat = string | ((moment: moment$Moment) => string);
 
 type moment$CalendarFormats = {
   sameDay?: moment$CalendarFormat,
@@ -49,197 +49,272 @@ type moment$CalendarFormats = {
   nextWeek?: moment$CalendarFormat,
   lastDay?: moment$CalendarFormat,
   lastWeek?: moment$CalendarFormat,
-  sameElse?: moment$CalendarFormat,
+  sameElse?: moment$CalendarFormat
 };
 
 declare class moment$LocaleData {
-  months(moment: moment$Moment): string;
-  monthsShort(moment: moment$Moment): string;
-  monthsParse(month: string): number;
-  weekdays(moment: moment$Moment): string;
-  weekdaysShort(moment: moment$Moment): string;
-  weekdaysMin(moment: moment$Moment): string;
-  weekdaysParse(weekDay: string): number;
-  longDateFormat(dateFormat: string): string;
-  isPM(date: string): bool;
-  meridiem(hours: number, minutes: number, isLower: bool): string;
-  calendar(key: 'sameDay'|'nextDay'|'lastDay'|'nextWeek'|'prevWeek'|'sameElse', moment: moment$Moment): string;
-  relativeTime(number: number, withoutSuffix: bool, key: 's'|'m'|'mm'|'h'|'hh'|'d'|'dd'|'M'|'MM'|'y'|'yy', isFuture: bool): string;
-  pastFuture(diff: any, relTime: string): string;
-  ordinal(number: number): string;
-  preparse(str: string): any;
-  postformat(str: string): any;
-  week(moment: moment$Moment): string;
-  invalidDate(): string;
-  firstDayOfWeek(): number;
-  firstDayOfYear(): number;
+  months(moment: moment$Moment): string,
+  monthsShort(moment: moment$Moment): string,
+  monthsParse(month: string): number,
+  weekdays(moment: moment$Moment): string,
+  weekdaysShort(moment: moment$Moment): string,
+  weekdaysMin(moment: moment$Moment): string,
+  weekdaysParse(weekDay: string): number,
+  longDateFormat(dateFormat: string): string,
+  isPM(date: string): boolean,
+  meridiem(hours: number, minutes: number, isLower: boolean): string,
+  calendar(
+    key:
+      | "sameDay"
+      | "nextDay"
+      | "lastDay"
+      | "nextWeek"
+      | "prevWeek"
+      | "sameElse",
+    moment: moment$Moment
+  ): string,
+  relativeTime(
+    number: number,
+    withoutSuffix: boolean,
+    key: "s" | "m" | "mm" | "h" | "hh" | "d" | "dd" | "M" | "MM" | "y" | "yy",
+    isFuture: boolean
+  ): string,
+  pastFuture(diff: any, relTime: string): string,
+  ordinal(number: number): string,
+  preparse(str: string): any,
+  postformat(str: string): any,
+  week(moment: moment$Moment): string,
+  invalidDate(): string,
+  firstDayOfWeek(): number,
+  firstDayOfYear(): number
 }
 declare class moment$MomentDuration {
-  humanize(suffix?: bool): string;
-  milliseconds(): number;
-  asMilliseconds(): number;
-  seconds(): number;
-  asSeconds(): number;
-  minutes(): number;
-  asMinutes(): number;
-  hours(): number;
-  asHours(): number;
-  days(): number;
-  asDays(): number;
-  months(): number;
-  asMonths(): number;
-  years(): number;
-  asYears(): number;
-  add(value: number|moment$MomentDuration|Object, unit?: string): this;
-  subtract(value: number|moment$MomentDuration|Object, unit?: string): this;
-  as(unit: string): number;
-  get(unit: string): number;
-  toJSON(): string;
-  toISOString(): string;
-  isValid(): bool;
+  humanize(suffix?: boolean): string,
+  milliseconds(): number,
+  asMilliseconds(): number,
+  seconds(): number,
+  asSeconds(): number,
+  minutes(): number,
+  asMinutes(): number,
+  hours(): number,
+  asHours(): number,
+  days(): number,
+  asDays(): number,
+  months(): number,
+  asMonths(): number,
+  years(): number,
+  asYears(): number,
+  add(value: number | moment$MomentDuration | Object, unit?: string): this,
+  subtract(value: number | moment$MomentDuration | Object, unit?: string): this,
+  as(unit: string): number,
+  get(unit: string): number,
+  toJSON(): string,
+  toISOString(): string,
+  isValid(): boolean
 }
 declare class moment$Moment {
-  static ISO_8601: string;
-  static (string?: string, format?: string|Array<string>, strict?: bool): moment$Moment;
-  static (string?: string, format?: string|Array<string>, locale?: string, strict?: bool): moment$Moment;
-  static (initDate: ?Object|number|Date|Array<number>|moment$Moment|string): moment$Moment;
-  static unix(seconds: number): moment$Moment;
-  static utc(): moment$Moment;
-  static utc(number: number|Array<number>): moment$Moment;
-  static utc(str: string, str2?: string|Array<string>, str3?: string): moment$Moment;
-  static utc(moment: moment$Moment): moment$Moment;
-  static utc(date: Date): moment$Moment;
-  static parseZone(): moment$Moment;
-  static parseZone(rawDate: string): moment$Moment;
-  static parseZone(rawDate: string, format: string | Array<string>): moment$Moment;
-  static parseZone(rawDate: string, format: string, strict: boolean): moment$Moment;
-  static parseZone(rawDate: string, format: string, locale: string, strict: boolean): moment$Moment;
-  isValid(): bool;
-  invalidAt(): 0|1|2|3|4|5|6;
-  creationData(): moment$MomentCreationData;
-  millisecond(number: number): this;
-  milliseconds(number: number): this;
-  millisecond(): number;
-  milliseconds(): number;
-  second(number: number): this;
-  seconds(number: number): this;
-  second(): number;
-  seconds(): number;
-  minute(number: number): this;
-  minutes(number: number): this;
-  minute(): number;
-  minutes(): number;
-  hour(number: number): this;
-  hours(number: number): this;
-  hour(): number;
-  hours(): number;
-  date(number: number): this;
-  dates(number: number): this;
-  date(): number;
-  dates(): number;
-  day(day: number|string): this;
-  days(day: number|string): this;
-  day(): number;
-  days(): number;
-  weekday(number: number): this;
-  weekday(): number;
-  isoWeekday(number: number): this;
-  isoWeekday(): number;
-  dayOfYear(number: number): this;
-  dayOfYear(): number;
-  week(number: number): this;
-  weeks(number: number): this;
-  week(): number;
-  weeks(): number;
-  isoWeek(number: number): this;
-  isoWeeks(number: number): this;
-  isoWeek(): number;
-  isoWeeks(): number;
-  month(number: number): this;
-  months(number: number): this;
-  month(): number;
-  months(): number;
-  quarter(number: number): this;
-  quarter(): number;
-  year(number: number): this;
-  years(number: number): this;
-  year(): number;
-  years(): number;
-  weekYear(number: number): this;
-  weekYear(): number;
-  isoWeekYear(number: number): this;
-  isoWeekYear(): number;
-  weeksInYear(): number;
-  isoWeeksInYear(): number;
-  get(string: string): number;
-  set(unit: string, value: number): this;
-  set(options: { [unit: string]: number }): this;
-  static max(...dates: Array<moment$Moment>): moment$Moment;
-  static max(dates: Array<moment$Moment>): moment$Moment;
-  static min(...dates: Array<moment$Moment>): moment$Moment;
-  static min(dates: Array<moment$Moment>): moment$Moment;
-  add(value: number|moment$MomentDuration|moment$Moment|Object, unit?: string): this;
-  subtract(value: number|moment$MomentDuration|moment$Moment|string|Object, unit?: string): this;
-  startOf(unit: string): this;
-  endOf(unit: string): this;
-  local(): this;
-  utc(): this;
-  utcOffset(offset: number|string): this;
-  utcOffset(): number;
-  format(format?: string): string;
-  fromNow(removeSuffix?: bool): string;
-  from(value: moment$Moment|string|number|Date|Array<number>, removePrefix?: bool): string;
-  toNow(removePrefix?: bool): string;
-  to(value: moment$Moment|string|number|Date|Array<number>, removePrefix?: bool): string;
-  calendar(refTime?: any, formats?: moment$CalendarFormats): string;
-  diff(date: moment$Moment|string|number|Date|Array<number>, format?: string, floating?: bool): number;
-  valueOf(): number;
-  unix(): number;
-  daysInMonth(): number;
-  toDate(): Date;
-  toArray(): Array<number>;
-  toJSON(): string;
-  toISOString(): string;
-  toObject(): moment$MomentObject;
-  isBefore(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
-  isSame(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
-  isAfter(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
-  isSameOrBefore(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
-  isSameOrAfter(date?: moment$Moment|string|number|Date|Array<number>, units?: ?string): bool;
+  static ISO_8601: string,
+  static (
+    string?: string,
+    format?: string | Array<string>,
+    strict?: boolean
+  ): moment$Moment,
+  static (
+    string?: string,
+    format?: string | Array<string>,
+    locale?: string,
+    strict?: boolean
+  ): moment$Moment,
+  static (
+    initDate: ?Object | number | Date | Array<number> | moment$Moment | string
+  ): moment$Moment,
+  static unix(seconds: number): moment$Moment,
+  static utc(): moment$Moment,
+  static utc(number: number | Array<number>): moment$Moment,
+  static utc(
+    str: string,
+    str2?: string | Array<string>,
+    str3?: string
+  ): moment$Moment,
+  static utc(moment: moment$Moment): moment$Moment,
+  static utc(date: Date): moment$Moment,
+  static parseZone(): moment$Moment,
+  static parseZone(rawDate: string): moment$Moment,
+  static parseZone(
+    rawDate: string,
+    format: string | Array<string>
+  ): moment$Moment,
+  static parseZone(
+    rawDate: string,
+    format: string,
+    strict: boolean
+  ): moment$Moment,
+  static parseZone(
+    rawDate: string,
+    format: string,
+    locale: string,
+    strict: boolean
+  ): moment$Moment,
+  isValid(): boolean,
+  invalidAt(): 0 | 1 | 2 | 3 | 4 | 5 | 6,
+  creationData(): moment$MomentCreationData,
+  millisecond(number: number): this,
+  milliseconds(number: number): this,
+  millisecond(): number,
+  milliseconds(): number,
+  second(number: number): this,
+  seconds(number: number): this,
+  second(): number,
+  seconds(): number,
+  minute(number: number): this,
+  minutes(number: number): this,
+  minute(): number,
+  minutes(): number,
+  hour(number: number): this,
+  hours(number: number): this,
+  hour(): number,
+  hours(): number,
+  date(number: number): this,
+  dates(number: number): this,
+  date(): number,
+  dates(): number,
+  day(day: number | string): this,
+  days(day: number | string): this,
+  day(): number,
+  days(): number,
+  weekday(number: number): this,
+  weekday(): number,
+  isoWeekday(number: number): this,
+  isoWeekday(): number,
+  dayOfYear(number: number): this,
+  dayOfYear(): number,
+  week(number: number): this,
+  weeks(number: number): this,
+  week(): number,
+  weeks(): number,
+  isoWeek(number: number): this,
+  isoWeeks(number: number): this,
+  isoWeek(): number,
+  isoWeeks(): number,
+  month(number: number): this,
+  months(number: number): this,
+  month(): number,
+  months(): number,
+  quarter(number: number): this,
+  quarter(): number,
+  year(number: number): this,
+  years(number: number): this,
+  year(): number,
+  years(): number,
+  weekYear(number: number): this,
+  weekYear(): number,
+  isoWeekYear(number: number): this,
+  isoWeekYear(): number,
+  weeksInYear(): number,
+  isoWeeksInYear(): number,
+  get(string: string): number,
+  set(unit: string, value: number): this,
+  set(options: { [unit: string]: number }): this,
+  static max(...dates: Array<moment$Moment>): moment$Moment,
+  static max(dates: Array<moment$Moment>): moment$Moment,
+  static min(...dates: Array<moment$Moment>): moment$Moment,
+  static min(dates: Array<moment$Moment>): moment$Moment,
+  add(
+    value: number | moment$MomentDuration | moment$Moment | Object,
+    unit?: string
+  ): this,
+  subtract(
+    value: number | moment$MomentDuration | moment$Moment | string | Object,
+    unit?: string
+  ): this,
+  startOf(unit: string): this,
+  endOf(unit: string): this,
+  local(): this,
+  utc(): this,
+  utcOffset(offset: number | string): this,
+  utcOffset(): number,
+  format(format?: string): string,
+  fromNow(removeSuffix?: boolean): string,
+  from(
+    value: moment$Moment | string | number | Date | Array<number>,
+    removePrefix?: boolean
+  ): string,
+  toNow(removePrefix?: boolean): string,
+  to(
+    value: moment$Moment | string | number | Date | Array<number>,
+    removePrefix?: boolean
+  ): string,
+  calendar(refTime?: any, formats?: moment$CalendarFormats): string,
+  diff(
+    date: moment$Moment | string | number | Date | Array<number>,
+    format?: string,
+    floating?: boolean
+  ): number,
+  valueOf(): number,
+  unix(): number,
+  daysInMonth(): number,
+  toDate(): Date,
+  toArray(): Array<number>,
+  toJSON(): string,
+  toISOString(): string,
+  toObject(): moment$MomentObject,
+  isBefore(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean,
+  isSame(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean,
+  isAfter(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean,
+  isSameOrBefore(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean,
+  isSameOrAfter(
+    date?: moment$Moment | string | number | Date | Array<number>,
+    units?: ?string
+  ): boolean,
   isBetween(
-    fromDate: moment$Moment|string|number|Date|Array<number>,
-    toDate?: ?moment$Moment|string|number|Date|Array<number>,
+    fromDate: moment$Moment | string | number | Date | Array<number>,
+    toDate?: ?moment$Moment | string | number | Date | Array<number>,
     granularity?: ?string,
     inclusion?: ?string
-  ): bool;
-  isDST(): bool;
-  isDSTShifted(): bool;
-  isLeapYear(): bool;
-  clone(): moment$Moment;
-  static isMoment(obj: any): bool;
-  static isDate(obj: any): bool;
-  static locale(locale: string, localeData?: Object): string;
-  static updateLocale(locale: string, localeData?: ?Object): void;
-  static locale(locales: Array<string>): string;
-  locale(locale: string, customization?: Object|null): moment$Moment;
-  locale(): string;
-  static months(): Array<string>;
-  static monthsShort(): Array<string>;
-  static weekdays(): Array<string>;
-  static weekdaysShort(): Array<string>;
-  static weekdaysMin(): Array<string>;
-  static months(): string;
-  static monthsShort(): string;
-  static weekdays(): string;
-  static weekdaysShort(): string;
-  static weekdaysMin(): string;
-  static localeData(key?: string): moment$LocaleData;
-  static duration(value: number|Object|string, unit?: string): moment$MomentDuration;
-  static isDuration(obj: any): bool;
-  static normalizeUnits(unit: string): string;
-  static invalid(object: any): moment$Moment;
+  ): boolean,
+  isDST(): boolean,
+  isDSTShifted(): boolean,
+  isLeapYear(): boolean,
+  clone(): moment$Moment,
+  static isMoment(obj: any): boolean,
+  static isDate(obj: any): boolean,
+  static locale(locale: string, localeData?: Object): string,
+  static updateLocale(locale: string, localeData?: ?Object): void,
+  static locale(locales: Array<string>): string,
+  locale(locale: string, customization?: Object | null): moment$Moment,
+  locale(): string,
+  static months(): Array<string>,
+  static monthsShort(): Array<string>,
+  static weekdays(): Array<string>,
+  static weekdaysShort(): Array<string>,
+  static weekdaysMin(): Array<string>,
+  static months(): string,
+  static monthsShort(): string,
+  static weekdays(): string,
+  static weekdaysShort(): string,
+  static weekdaysMin(): string,
+  static localeData(key?: string): moment$LocaleData,
+  static duration(
+    value: number | Object | string,
+    unit?: string
+  ): moment$MomentDuration,
+  static isDuration(obj: any): boolean,
+  static normalizeUnits(unit: string): string,
+  static invalid(object: any): moment$Moment
 }
 
-declare module 'moment' {
+declare module "moment" {
   declare module.exports: Class<moment$Moment>;
 }

--- a/definitions/npm/moment_v2.3.x/flow_v0.34.x-/moment_v2.3.x.js
+++ b/definitions/npm/moment_v2.3.x/flow_v0.34.x-/moment_v2.3.x.js
@@ -231,7 +231,11 @@ declare class moment$Moment {
   endOf(unit: string): this,
   local(): this,
   utc(): this,
-  utcOffset(offset: number | string): this,
+  utcOffset(
+    offset: number | string,
+    keepLocalTime?: boolean,
+    keepMinutes?: boolean
+  ): this,
   utcOffset(): number,
   format(format?: string): string,
   fromNow(removeSuffix?: boolean): string,

--- a/definitions/npm/moment_v2.3.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.3.x/test_moment-v2.js
@@ -62,3 +62,8 @@ n = m.utcOffset(-1.5).utcOffset();
 n = m.utcOffset(-90).utcOffset();
 n = m.utcOffset("-01:30").utcOffset();
 n = m.utcOffset("+00:10").utcOffset();
+
+// Optional 2nd and 3rd arguments
+n = m.utcOffset(0, true).utcOffset();
+n = m.utcOffset(0, false).utcOffset();
+n = m.utcOffset(0, true, true).utcOffset();


### PR DESCRIPTION
This regression got introduced with #1242, when a seemingly older version of moment_v2.x.x was forked into moment_v2.3.x.  This definition was previously fixed by me in #890 (for moment_v2.x.x back then), and this now re-introduces the same fix for the forked v2.3.x version, which requires the same method signature for `.utcOffset()`.

When committing the changes, a local precommit hook reformatted my code, so I suppose that's the preferred format.  Anyway, that's why this PR consists of 2 commits:

1. 523f2d3c8c388cce2d5b9bb520e5eb4ad2d46445 with purely the auto-reformatting change
2. 9f4c78fe4030818898bfdf271cc2323c269d1d99 with the actual change that fixes the regression
