### PR TITLE
Fully support array arguments in classnames

### DIFF
--- a/definitions/npm/classnames_v2.x.x/flow_v0.22.x-v0.24.x/classnames_v2.x.x.js
+++ b/definitions/npm/classnames_v2.x.x/flow_v0.22.x-v0.24.x/classnames_v2.x.x.js
@@ -1,11 +1,12 @@
 type $npm$classnames$Classes =
   | string
   | { [className: string]: * }
-  | Array<string>
   | false
   | void
   | null;
 
 declare module "classnames" {
-  declare function exports(...classes: Array<$npm$classnames$Classes>): string;
+  declare function exports(
+    ...classes: Array<$npm$classnames$Classes | Array<$npm$classnames$Classes>>
+  ): string;
 }

--- a/definitions/npm/classnames_v2.x.x/flow_v0.22.x-v0.24.x/classnames_v2.x.x.js
+++ b/definitions/npm/classnames_v2.x.x/flow_v0.22.x-v0.24.x/classnames_v2.x.x.js
@@ -6,6 +6,6 @@ type $npm$classnames$Classes =
   | void
   | null;
 
-declare module 'classnames' {
+declare module "classnames" {
   declare function exports(...classes: Array<$npm$classnames$Classes>): string;
 }

--- a/definitions/npm/classnames_v2.x.x/flow_v0.25.x-/classnames_v2.x.x.js
+++ b/definitions/npm/classnames_v2.x.x/flow_v0.25.x-/classnames_v2.x.x.js
@@ -1,13 +1,14 @@
 type $npm$classnames$Classes =
   | string
   | { [className: string]: * }
-  | Array<string>
   | false
   | void
   | null;
 
 declare module "classnames" {
-  declare function exports(...classes: Array<$npm$classnames$Classes>): string;
+  declare function exports(
+    ...classes: Array<$npm$classnames$Classes | Array<$npm$classnames$Classes>>
+  ): string;
 }
 
 declare module "classnames/bind" {

--- a/definitions/npm/classnames_v2.x.x/flow_v0.25.x-/classnames_v2.x.x.js
+++ b/definitions/npm/classnames_v2.x.x/flow_v0.25.x-/classnames_v2.x.x.js
@@ -6,14 +6,14 @@ type $npm$classnames$Classes =
   | void
   | null;
 
-declare module 'classnames' {
+declare module "classnames" {
   declare function exports(...classes: Array<$npm$classnames$Classes>): string;
 }
 
-declare module 'classnames/bind' {
-  declare module.exports: $Exports<'classnames'>;
+declare module "classnames/bind" {
+  declare module.exports: $Exports<"classnames">;
 }
 
-declare module 'classnames/dedupe' {
-  declare module.exports: $Exports<'classnames'>;
+declare module "classnames/dedupe" {
+  declare module.exports: $Exports<"classnames">;
 }

--- a/definitions/npm/classnames_v2.x.x/test_classnames_v2.x.x.js
+++ b/definitions/npm/classnames_v2.x.x/test_classnames_v2.x.x.js
@@ -1,20 +1,20 @@
 // @flow
 
-import classnames from 'classnames';
+import classnames from "classnames";
 
 classnames();
-classnames('a');
-classnames('a', 'b');
+classnames("a");
+classnames("a", "b");
 classnames({ a: true });
 classnames({ a: true }, { b: true });
-classnames('a', { b: true });
-classnames('a', { b: 'truthy' });
-classnames('a', { b: null });
-classnames({ a: true }, 'b');
+classnames("a", { b: true });
+classnames("a", { b: "truthy" });
+classnames("a", { b: null });
+classnames({ a: true }, "b");
 classnames({ a: null, b: undefined });
 classnames(undefined);
 classnames(null);
-classnames('a', false);
+classnames("a", false);
 
 // $ExpectError
 classnames(42);

--- a/definitions/npm/classnames_v2.x.x/test_classnames_v2.x.x.js
+++ b/definitions/npm/classnames_v2.x.x/test_classnames_v2.x.x.js
@@ -15,6 +15,9 @@ classnames({ a: null, b: undefined });
 classnames(undefined);
 classnames(null);
 classnames("a", false);
+classnames("a", ["b", null, { c: "truthy", d: null }]);
 
 // $ExpectError
 classnames(42);
+// $ExpectError
+classnames("a", ["b", 42]);


### PR DESCRIPTION
Other than strings, array arguments can contain objects and falsy values. Arrays are just flattened.