### PR TITLE
A valid package.json with no dependencies should not fail.

### DIFF
--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -160,7 +160,7 @@ describe('install (command)', () => {
       },
     );
 
-    it('errors if 0 dependencies are found in package.json', () => {
+    it('warns if 0 dependencies are found in package.json', () => {
       return testProject(async ROOT_DIR => {
         await Promise.all([
           touchFile(path.join(ROOT_DIR, '.flowconfig')),
@@ -178,7 +178,7 @@ describe('install (command)', () => {
           skip: false,
           ignoreDeps: [],
         });
-        expect(result).toBe(1);
+        expect(result).toBe(0);
         expect(_mock(console.error).mock.calls).toEqual([
           ["No dependencies were found in this project's package.json!"],
         ]);

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -206,7 +206,7 @@ async function installNpmLibDefs({
       console.error(
         "No dependencies were found in this project's package.json!",
       );
-      return 1;
+      return 0;
     }
 
     if (verbose) {


### PR DESCRIPTION
Just prints to `console.error`

Fixes #995 