### PR TITLE
query-string's extract() method will never return null

### DIFF
--- a/definitions/npm/query-string_v5.x.x/flow_v0.32.x-/query-string_v5.x.x.js
+++ b/definitions/npm/query-string_v5.x.x/flow_v0.32.x-/query-string_v5.x.x.js
@@ -11,7 +11,7 @@ declare module "query-string" {
   |};
 
   declare module.exports: {
-    extract(str: string): ?string,
+    extract(str: string): string,
     parse(str: string, opts?: ParseOptions): Object,
     stringify(obj: Object, opts?: StringifyOptions): string
   };


### PR DESCRIPTION
The function looks like this 

```js
exports.extract = function (str) {
	return str.split('?')[1] || '';
};
```

https://github.com/sindresorhus/query-string/blob/master/index.js#L116

It's plainly obvious that this will never return `null` or `undefined`.  