### PR TITLE
add redux-oidc v3 types

### DIFF
--- a/definitions/npm/redux-oidc_v3.x.x/flow_v0.55.x-/redux-oidc_v3.x.x.js
+++ b/definitions/npm/redux-oidc_v3.x.x/flow_v0.55.x-/redux-oidc_v3.x.x.js
@@ -1,0 +1,47 @@
+import type { Reducer, Store } from "redux";
+
+declare module "redux-oidc" {
+  declare type UserManager = {
+    signinRedirect: () => Promise<*>,
+    signoutRedirect: () => Promise<*>
+  };
+  declare type User<P> = {
+    expired: ?boolean,
+    profile: P
+  };
+  declare type UserManagerSettings = {|
+    client_id: string,
+    authority: string,
+    redirect_uri: string,
+    response_type?: string,
+    scope?: string,
+    loadUserInfo?: boolean,
+    silent_redirect_uri?: string,
+    automaticSilentRenew?: boolean,
+    accessTokenExpiringNotificationTime?: number,
+    silentRequestTimeout?: number,
+    filterProtocolClaims?: boolean
+  |};
+  declare type OidcReducerState = {
+    user: ?User<*>
+  };
+  declare type OidcReducer = Reducer<OidcReducerState, *>;
+
+  declare function createUserManager(
+    settings: UserManagerSettings
+  ): UserManager;
+  declare var reducer: OidcReducer;
+
+  declare class CallbackComponent extends React$Component<{
+    userManager: UserManager,
+    successCallback: () => mixed,
+    errorCallback?: () => mixed
+  }> {}
+
+  declare class OidcProvider extends React$Component<{
+    store: Store<*, *>,
+    userManager: UserManager
+  }> {}
+
+  declare function processSilentRenew(): void;
+}

--- a/definitions/npm/redux-oidc_v3.x.x/flow_v0.55.x-/test_redux-oidc.js
+++ b/definitions/npm/redux-oidc_v3.x.x/flow_v0.55.x-/test_redux-oidc.js
@@ -1,0 +1,67 @@
+// @flow
+
+"use strict";
+const React = require("react");
+const reduxOidc = require("redux-oidc");
+// $ExpectError: flow-typed doesn't support pulling in _other_ modules yet?
+const redux = require("redux");
+// This was also attempted, but still no joy.
+// const redux = require('../../redux_v3.x.x/flow_v0.33.x-/redux_v3.x.x.js')
+
+const CallbackComponent = reduxOidc.CallbackComponent;
+const OidcProvider = reduxOidc.OidcProvider;
+
+// createUserManager takes a config.
+const userManagerConfig = {
+  client_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  authority: "https://some-authority.org/oidc",
+  redirect_uri: "http://base/#/callback",
+  response_type: "token id_token",
+  scope: "openid profile email",
+  loadUserInfo: false,
+  automaticSilentRenew: true,
+  silent_redirect_uri: "http://base/oidc-silent-renew.html",
+  accessTokenExpiringNotificationTime: 598
+};
+
+const userManager = reduxOidc.createUserManager(userManagerConfig);
+
+// The UserManager can do redirects for signins/outs.
+userManager.signinRedirect();
+userManager.signoutRedirect();
+
+// The reducer has a user
+const user = reduxOidc.reducer.user;
+
+// $ExpectError: The user could be null/undefined.
+console.log(user.expired);
+
+if (user) {
+  console.log(user.expired);
+}
+
+type Action = {
+  type: "foo"
+};
+type State = {
+  foo: string
+};
+// redux-oidc provides some components.
+const reducer = (state: State, action: Action) => action;
+const store = redux.createStore(redux.combineReducers([reducer]));
+
+const StatelessComponent = () => {
+  return (
+    <div>
+      <CallbackComponent
+        userManager={userManager}
+        successCallback={() => console.log("success!")}
+        errorCallback={() => console.log("error!")}
+      />
+      <OidcProvider store={store} userManager={userManager} />
+    </div>
+  );
+};
+
+// There's a utility function for silent renews.
+reduxOidc.processSilentRenew();

--- a/definitions/npm/redux-oidc_v3.x.x/flow_v0.55.x-/test_redux-oidc.js
+++ b/definitions/npm/redux-oidc_v3.x.x/flow_v0.55.x-/test_redux-oidc.js
@@ -6,6 +6,7 @@ const reduxOidc = require("redux-oidc");
 // $ExpectError: flow-typed doesn't support pulling in _other_ modules yet?
 const redux = require("redux");
 // This was also attempted, but still no joy.
+// See https://github.com/flowtype/flow-typed/issues/1331
 // const redux = require('../../redux_v3.x.x/flow_v0.33.x-/redux_v3.x.x.js')
 
 const CallbackComponent = reduxOidc.CallbackComponent;


### PR DESCRIPTION
This PR adds types for [redux-oidc](https://github.com/maxmantz/redux-oidc) (v3). I converted this from the libdefs in a private repository that uses `redux-oidc`. I'm not positive this is 100% API complete, but it should be very close.