### PR TITLE
Add typings for storage in firebase_v4.x.x

### DIFF
--- a/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/firebase_v4.x.x.js
+++ b/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/firebase_v4.x.x.js
@@ -1,7 +1,7 @@
 /* @flow */
 /** ** firebase ****/
 
-declare interface FirebaseConfig {
+declare interface $npm$firebase$Config {
   apiKey: string,
   authDomain?: string,
   databaseURL?: string,
@@ -10,149 +10,151 @@ declare interface FirebaseConfig {
   messagingSenderId?: string
 }
 
-declare interface AuthError {
+declare interface $npm$firebase$auth$Error {
   code:
-    | 'auth/app-deleted'
-    | 'auth/app-not-authorized'
-    | 'auth/argument-error'
-    | 'auth/invalid-api-key'
-    | 'auth/invalid-user-token'
-    | 'auth/network-request-failed'
-    | 'auth/operation-not-allowed'
-    | 'auth/requires-recent-login'
-    | 'auth/too-many-requests'
-    | 'auth/unauthorized-domain'
-    | 'auth/user-disabled'
-    | 'auth/user-token-expired'
-    | 'auth/web-storage-unsupported'
-    | 'auth/invalid-email'
-    | 'auth/account-exists-with-different-credential'
-    | 'auth/invalid-credential'
-    | 'auth/user-not-found'
-    | 'auth/wrong-password'
-    | 'auth/invalid-verification-code'
-    | 'auth/invalid-verification-id'
-    | 'auth/expired-action-code'
-    | 'auth/invalid-action-code'
-    | 'auth/invalid-verification-code'
-    | 'auth/missing-verification-code'
-    | 'auth/captcha-check-failed'
-    | 'auth/invalid-phone-number'
-    | 'auth/missing-phone-number'
-    | 'auth/quota-exceeded'
-    | 'auth/credential-already-in-use'
-    | 'auth/email-already-in-use'
-    | 'auth/provider-already-linked'
-    | 'auth/auth-domain-config-required'
-    | 'auth/cancelled-popup-request'
-    | 'auth/popup-blocked'
-    | 'auth/operation-not-supported-in-this-environment'
-    | 'auth/popup-closed-by-user'
-    | 'auth/unauthorized-domain'
-    | 'auth/no-such-provider',
+    | "auth/app-deleted"
+    | "auth/app-not-authorized"
+    | "auth/argument-error"
+    | "auth/invalid-api-key"
+    | "auth/invalid-user-token"
+    | "auth/network-request-failed"
+    | "auth/operation-not-allowed"
+    | "auth/requires-recent-login"
+    | "auth/too-many-requests"
+    | "auth/unauthorized-domain"
+    | "auth/user-disabled"
+    | "auth/user-token-expired"
+    | "auth/web-storage-unsupported"
+    | "auth/invalid-email"
+    | "auth/account-exists-with-different-credential"
+    | "auth/invalid-credential"
+    | "auth/user-not-found"
+    | "auth/wrong-password"
+    | "auth/invalid-verification-code"
+    | "auth/invalid-verification-id"
+    | "auth/expired-action-code"
+    | "auth/invalid-action-code"
+    | "auth/invalid-verification-code"
+    | "auth/missing-verification-code"
+    | "auth/captcha-check-failed"
+    | "auth/invalid-phone-number"
+    | "auth/missing-phone-number"
+    | "auth/quota-exceeded"
+    | "auth/credential-already-in-use"
+    | "auth/email-already-in-use"
+    | "auth/provider-already-linked"
+    | "auth/auth-domain-config-required"
+    | "auth/cancelled-popup-request"
+    | "auth/popup-blocked"
+    | "auth/operation-not-supported-in-this-environment"
+    | "auth/popup-closed-by-user"
+    | "auth/unauthorized-domain"
+    | "auth/no-such-provider",
   message: string
 }
 
-declare interface FirebaseError {
-  code: $PropertyType<AuthError, 'code'> | 'app/no-app',
+declare interface $npm$firebase$Error {
+  code: $PropertyType<$npm$firebase$auth$Error, "code"> | "app/no-app",
   message: string,
   name: string,
   stack: ?string
 }
 
 /** *** app *****/
-declare class App {
+declare class $npm$firebase$App {
   name: string,
-  +options: FirebaseConfig,
-  auth(): Auth,
-  database(): Database,
+  +options: $npm$firebase$Config,
+  auth(): $npm$firebase$auth$Auth,
+  database(): $npm$firebase$database$Database,
   delete(): Promise<void>
 }
 
 /** **** auth *******/
-declare interface ActionCodeInfo {
+declare interface $npm$firebase$auth$ActionCodeInfo {
   data: { email: string }
 }
 
-declare interface ApplicationVerifier {
+declare interface $npm$firebase$auth$ApplicationVerifier {
   type: string,
   verify(): Promise<string>
 }
 
-declare class Auth {
-  app: App,
-  currentUser: FirebaseUser,
+declare class $npm$firebase$auth$Auth {
+  app: $npm$firebase$App,
+  currentUser: $npm$firebase$auth$User,
   applyActionCode(code: string): Promise<void>,
-  checkActionCode(code: string): Promise<ActionCodeInfo>,
+  checkActionCode(code: string): Promise<$npm$firebase$auth$ActionCodeInfo>,
   confirmPasswordReset(code: string, newPassword: string): Promise<void>,
   createCustomToken(uid: string, developerClaims?: {}): string,
   createUserWithEmailAndPassword(
     email: string,
     password: string
-  ): Promise<FirebaseUser>,
+  ): Promise<$npm$firebase$auth$User>,
   fetchProvidersForEmail(email: string): Promise<Array<string>>,
   onAuthStateChanged(
-    nextOrObserver: (?FirebaseUser) => void,
-    error?: (error: AuthError) => void,
+    nextOrObserver: (?$npm$firebase$auth$User) => void,
+    error?: (error: $npm$firebase$auth$Error) => void,
     completed?: () => void
   ): () => void,
   onIdTokenChanged(
-    nextOrObserver: Object | ((user?: FirebaseUser) => void),
-    error?: (error: AuthError) => void,
+    nextOrObserver: Object | ((user?: $npm$firebase$auth$User) => void),
+    error?: (error: $npm$firebase$auth$Error) => void,
     completed?: () => void
   ): () => void,
   sendPasswordResetEmail(email: string): Promise<void>,
   signInAndRetrieveDataWithCredential(
-    credential: AuthCredential
-  ): Promise<FirebaseUserCredential>,
-  signInAnonymously(): Promise<FirebaseUser>,
-  signInWithCredential(credential: AuthCredential): Promise<FirebaseUser>,
-  signInWithCustomToken(token: string): Promise<FirebaseUser>,
+    credential: $npm$firebase$auth$AuthCredential
+  ): Promise<$npm$firebase$auth$UserCredential>,
+  signInAnonymously(): Promise<$npm$firebase$auth$User>,
+  signInWithCredential(
+    credential: $npm$firebase$auth$AuthCredential
+  ): Promise<$npm$firebase$auth$User>,
+  signInWithCustomToken(token: string): Promise<$npm$firebase$auth$User>,
   signInWithEmailAndPassword(
     email: string,
     password: string
-  ): Promise<FirebaseUser>,
+  ): Promise<$npm$firebase$auth$User>,
   signInWithPhoneNumber(
     phoneNumber: string,
-    applicationVerifier: ApplicationVerifier
-  ): Promise<ConfirmationResult>,
+    applicationVerifier: $npm$firebase$auth$ApplicationVerifier
+  ): Promise<$npm$firebase$auth$ConfirmationResult>,
   signOut(): Promise<void>,
   verifyIdToken(idToken: string): Promise<Object>,
   verifyPasswordResetCode(code: string): Promise<string>
 }
 
-declare interface AuthCredential {
+declare interface $npm$firebase$auth$AuthCredential {
   providerId: string
 }
 
-declare class AuthProvider {
+declare class $npm$firebase$auth$AuthProvider {
   providerId: string
 }
 
-declare interface ConfirmationResult {
+declare interface $npm$firebase$auth$ConfirmationResult {
   verificationId: string,
-  confirm(verificationCode: string): Promise<FirebaseUserCredential>
+  confirm(verificationCode: string): Promise<$npm$firebase$auth$UserCredential>
 }
 
-declare type FirebaseUserProfile = {
+declare type $npm$firebase$auth$UserProfile = {
   displayName?: string,
   photoURL?: string
-}
+};
 
-declare interface FirebaseAdditionalUserInfo {
+declare interface $npm$firebase$auth$AdditionalUserInfo {
   providerId: string,
-  profile?: FirebaseUserProfile,
+  profile?: $npm$firebase$auth$UserProfile,
   username?: string
 }
 
-declare interface FirebaseUserCredential {
-  user: FirebaseUser,
-  credential?: AuthCredential,
+declare interface $npm$firebase$auth$UserCredential {
+  user: $npm$firebase$auth$User,
+  credential?: $npm$firebase$auth$AuthCredential,
   operationType?: string,
-  additionalUserInfo?: FirebaseAdditionalUserInfo
+  additionalUserInfo?: $npm$firebase$auth$AdditionalUserInfo
 }
 
-declare class FirebaseUserInfo {
+declare class $npm$firebase$auth$UserInfo {
   displayName: ?string,
   email: ?string,
   photoURL: ?string,
@@ -160,14 +162,14 @@ declare class FirebaseUserInfo {
   uid: string
 }
 
-declare class FirebaseUser extends FirebaseUserInfo {
+declare class $npm$firebase$auth$User extends $npm$firebase$auth$UserInfo {
   displayName: ?string,
   email: ?string,
   emailVerified: boolean,
   isAnonymous: boolean,
   phoneNumber: ?string,
   photoUrl: ?string,
-  providerData: Array<FirebaseUserInfo>,
+  providerData: Array<$npm$firebase$auth$UserInfo>,
   providerId: string,
   refreshToken: string,
   uid: string,
@@ -175,296 +177,345 @@ declare class FirebaseUser extends FirebaseUserInfo {
   getIdToken(forceRefresh?: boolean): Promise<string>,
   getToken(forceRefresh?: boolean): Promise<string>,
   linkAndRetrieveDataWithCredential(
-    credential: AuthCredential
-  ): Promise<FirebaseUserCredential>,
-  linkWithCredential(credential: AuthCredential): Promise<FirebaseUser>,
+    credential: $npm$firebase$auth$AuthCredential
+  ): Promise<$npm$firebase$auth$UserCredential>,
+  linkWithCredential(
+    credential: $npm$firebase$auth$AuthCredential
+  ): Promise<$npm$firebase$auth$User>,
   linkWithPhoneNumber(
     phoneNumber: string,
-    applicationVerifier: ApplicationVerifier
-  ): Promise<ConfirmationResult>,
-  linkWithPopup(provider: OAuthProvider): Promise<FirebaseUserCredential>,
+    applicationVerifier: $npm$firebase$auth$ApplicationVerifier
+  ): Promise<$npm$firebase$auth$ConfirmationResult>,
+  linkWithPopup(
+    provider: $npm$firebase$auth$OAuthProvider
+  ): Promise<$npm$firebase$auth$UserCredential>,
   reauthenticateAndRetrieveDataWithCredential(
-    credential: AuthCredential
+    credential: $npm$firebase$auth$AuthCredential
   ): Promise<void>,
-  reauthenticateWithCredential(credential: AuthCredential): Promise<void>,
+  reauthenticateWithCredential(
+    credential: $npm$firebase$auth$AuthCredential
+  ): Promise<void>,
   reauthenticateWithPhoneNumber(
     phoneNumber: string,
-    applicationVerifier: ApplicationVerifier
-  ): Promise<ConfirmationResult>,
+    applicationVerifier: $npm$firebase$auth$ApplicationVerifier
+  ): Promise<$npm$firebase$auth$ConfirmationResult>,
   reload(): Promise<void>,
   sendEmailVerification(): Promise<void>,
   toJSON(): Object,
-  unlink(providerId: string): Promise<FirebaseUser>,
+  unlink(providerId: string): Promise<$npm$firebase$auth$User>,
   updateEmail(newEmail: string): Promise<void>,
   updatePassword(newPassword: string): Promise<void>,
-  updatePhoneNumber(phoneCredential: AuthCredential): Promise<void>,
-  updateProfile(profile: FirebaseUserProfile): Promise<
-    void
-  >
+  updatePhoneNumber(
+    phoneCredential: $npm$firebase$auth$AuthCredential
+  ): Promise<void>,
+  updateProfile(profile: $npm$firebase$auth$UserProfile): Promise<void>
 }
 
-declare class EmailAuthProvider extends AuthProvider {
+declare class $npm$firebase$auth$EmailAuthProvider extends $npm$firebase$auth$AuthProvider {
   PROVIDER_ID: string,
   providerId: string,
-  credential(email: string, password: string): AuthCredential
+  credential(email: string, password: string): $npm$firebase$auth$AuthCredential
 }
 
-declare class FacebookAuthProvider extends AuthProvider {
+declare class $npm$firebase$auth$FacebookAuthProvider extends $npm$firebase$auth$AuthProvider {
   PROVIDER_ID: string,
-  credential(token: string): AuthCredential,
-  addScope(scope: string): FacebookAuthProvider,
-  setCustomParameters(customOAuthParameters: Object): FacebookAuthProvider
+  credential(token: string): $npm$firebase$auth$AuthCredential,
+  addScope(scope: string): $npm$firebase$auth$FacebookAuthProvider,
+  setCustomParameters(
+    customOAuthParameters: Object
+  ): $npm$firebase$auth$FacebookAuthProvider
 }
 
-declare class GithubAuthProvider extends AuthProvider {
+declare class $npm$firebase$auth$GithubAuthProvider extends $npm$firebase$auth$AuthProvider {
   PROVIDER_ID: string,
-  credential(token: string): AuthCredential,
-  addScope(scope: string): GithubAuthProvider,
-  setCustomParameters(customOAuthParameters: Object): GithubAuthProvider
+  credential(token: string): $npm$firebase$auth$AuthCredential,
+  addScope(scope: string): $npm$firebase$auth$GithubAuthProvider,
+  setCustomParameters(
+    customOAuthParameters: Object
+  ): $npm$firebase$auth$GithubAuthProvider
 }
 
-declare class GoogleAuthProvider extends AuthProvider {
+declare class $npm$firebase$auth$GoogleAuthProvider extends $npm$firebase$auth$AuthProvider {
   PROVIDER_ID: string,
-  credential(idToken?: string, accessToken?: string): AuthCredential,
-  addScope(scope: string): GoogleAuthProvider,
-  setCustomParameters(customOAuthParameters: Object): GoogleAuthProvider
+  credential(
+    idToken?: string,
+    accessToken?: string
+  ): $npm$firebase$auth$AuthCredential,
+  addScope(scope: string): $npm$firebase$auth$GoogleAuthProvider,
+  setCustomParameters(
+    customOAuthParameters: Object
+  ): $npm$firebase$auth$GoogleAuthProvider
 }
 
-declare class PhoneAuthProvider extends AuthProvider {
+declare class $npm$firebase$auth$PhoneAuthProvider extends $npm$firebase$auth$AuthProvider {
   PROVIDER_ID: string,
-  constructor(auth?: Auth): PhoneAuthProvider,
-  credential(verificationId: string, verificationCode: string): AuthCredential,
+  constructor(
+    auth?: $npm$firebase$auth$Auth
+  ): $npm$firebase$auth$PhoneAuthProvider,
+  credential(
+    verificationId: string,
+    verificationCode: string
+  ): $npm$firebase$auth$AuthCredential,
   verifyPhoneNumber(
     phoneNumber: string,
-    applicationVerifier: ApplicationVerifier
+    applicationVerifier: $npm$firebase$auth$ApplicationVerifier
   ): Promise<string>
 }
 
-declare class TwitterAuthProvider extends AuthProvider {
+declare class $npm$firebase$auth$TwitterAuthProvider extends $npm$firebase$auth$AuthProvider {
   PROVIDER_ID: string,
-  credential(token: string, secret: string): AuthCredential,
+  credential(token: string, secret: string): $npm$firebase$auth$AuthCredential,
   setCustomParameters(customOAuthParameters: Object): this
 }
 
-declare type OAuthProvider =
-  | FacebookAuthProvider
-  | GithubAuthProvider
-  | GoogleAuthProvider
-  | TwitterAuthProvider
+declare type $npm$firebase$auth$OAuthProvider =
+  | $npm$firebase$auth$FacebookAuthProvider
+  | $npm$firebase$auth$GithubAuthProvider
+  | $npm$firebase$auth$GoogleAuthProvider
+  | $npm$firebase$auth$TwitterAuthProvider;
 
 /** **** database ******/
-declare type FirebaseValue = any
-declare type OnCompleteCallback = (error: ?Object) => void
-declare type QueryEventType =
-  | 'value'
-  | 'child_added'
-  | 'child_changed'
-  | 'child_removed'
-  | 'child_moved'
-declare type Priority = string | number | null
+declare type $npm$firebase$database$Value = any;
+declare type $npm$firebase$database$OnCompleteCallback = (
+  error: ?Object
+) => void;
+declare type $npm$firebase$database$QueryEventType =
+  | "value"
+  | "child_added"
+  | "child_changed"
+  | "child_removed"
+  | "child_moved";
+declare type $npm$firebase$database$Priority = string | number | null;
 
-declare class Database {
-  app: App,
+declare class $npm$firebase$database$Database {
+  app: $npm$firebase$App,
   goOffline(): void,
   goOnline(): void,
-  ref(path?: string): Reference,
-  refFromURL(url: string): Reference
+  ref(path?: string): $npm$firebase$database$Reference,
+  refFromURL(url: string): $npm$firebase$database$Reference
 }
 
-declare class DataSnapshot {
+declare class $npm$firebase$database$DataSnapshot {
   key: ?string,
-  ref: Reference,
-  child(path?: string): DataSnapshot,
+  ref: $npm$firebase$database$Reference,
+  child(path?: string): $npm$firebase$database$DataSnapshot,
   exists(): boolean,
-  exportVal(): FirebaseValue,
-  forEach(action: (DataSnapshot) => boolean): boolean,
-  getPriority(): Priority,
+  exportVal(): $npm$firebase$database$Value,
+  forEach(action: ($npm$firebase$database$DataSnapshot) => boolean): boolean,
+  getPriority(): $npm$firebase$database$Priority,
   hasChild(path: string): boolean,
   hasChildren(): boolean,
   numChildren(): number,
   toJSON(): Object,
-  val(): FirebaseValue
+  val(): $npm$firebase$database$Value
 }
 
-declare class OnDisconnect {
-  cancel(onComplete: OnCompleteCallback): Promise<void>,
-  remove(onComplete: OnCompleteCallback): Promise<void>,
-  set(value: FirebaseValue, onComplete?: OnCompleteCallback): Promise<void>,
+declare class $npm$firebase$database$OnDisconnect {
+  cancel(onComplete: $npm$firebase$database$OnCompleteCallback): Promise<void>,
+  remove(onComplete: $npm$firebase$database$OnCompleteCallback): Promise<void>,
+  set(
+    value: $npm$firebase$database$Value,
+    onComplete?: $npm$firebase$database$OnCompleteCallback
+  ): Promise<void>,
   setWithPriority(
-    value: FirebaseValue,
+    value: $npm$firebase$database$Value,
     priority: number | string | null,
-    onComplete?: OnCompleteCallback
+    onComplete?: $npm$firebase$database$OnCompleteCallback
   ): Promise<void>,
   update(
-    values: { +[path: string]: FirebaseValue },
-    onComplete?: OnCompleteCallback
+    values: { +[path: string]: $npm$firebase$database$Value },
+    onComplete?: $npm$firebase$database$OnCompleteCallback
   ): Promise<void>
 }
 
-declare type FirebaseDatabaseCallback = (DataSnapshot, ?string) => void
+declare type $npm$firebase$database$Callback = (
+  $npm$firebase$database$DataSnapshot,
+  ?string
+) => void;
 
-declare class Query {
-  ref: Reference,
-  endAt(value: number | string | boolean | null, key?: string): Query,
-  equalTo(value: number | string | boolean | null, key?: string): Query,
-  isEqual(other: Query): boolean,
-  limitToFirst(limit: number): Query,
-  limitToLast(limit: number): Query,
+declare class $npm$firebase$database$Query {
+  ref: $npm$firebase$database$Reference,
+  endAt(
+    value: number | string | boolean | null,
+    key?: string
+  ): $npm$firebase$database$Query,
+  equalTo(
+    value: number | string | boolean | null,
+    key?: string
+  ): $npm$firebase$database$Query,
+  isEqual(other: $npm$firebase$database$Query): boolean,
+  limitToFirst(limit: number): $npm$firebase$database$Query,
+  limitToLast(limit: number): $npm$firebase$database$Query,
   off(
-    eventType?: QueryEventType,
-    callback?: FirebaseDatabaseCallback,
+    eventType?: $npm$firebase$database$QueryEventType,
+    callback?: $npm$firebase$database$Callback,
     context?: Object
   ): void,
   on(
-    eventType: QueryEventType,
-    callback: FirebaseDatabaseCallback,
+    eventType: $npm$firebase$database$QueryEventType,
+    callback: $npm$firebase$database$Callback,
     cancelCallbackOrContext?: (error: Object) => void | Object,
-    context?: FirebaseDatabaseCallback
-  ): FirebaseDatabaseCallback,
+    context?: $npm$firebase$database$Callback
+  ): $npm$firebase$database$Callback,
   once(
-    eventType: QueryEventType,
-    successCallback?: FirebaseDatabaseCallback,
+    eventType: $npm$firebase$database$QueryEventType,
+    successCallback?: $npm$firebase$database$Callback,
     failureCallbackOrContext?: (error: Object) => void | Object,
     context?: Object
-  ): Promise<DataSnapshot>,
-  orderByChild(path: string): Query,
-  orderByKey(): Query,
-  orderByPriority(): Query,
-  orderByValue(): Query,
-  startAt(value: number | string | boolean | null, key?: string): Query,
+  ): Promise<$npm$firebase$database$DataSnapshot>,
+  orderByChild(path: string): $npm$firebase$database$Query,
+  orderByKey(): $npm$firebase$database$Query,
+  orderByPriority(): $npm$firebase$database$Query,
+  orderByValue(): $npm$firebase$database$Query,
+  startAt(
+    value: number | string | boolean | null,
+    key?: string
+  ): $npm$firebase$database$Query,
   toJSON(): Object,
   toString(): string
 }
 
-declare class Reference extends Query {
+declare class $npm$firebase$database$Reference extends $npm$firebase$database$Query {
   key: ?string,
-  parent?: Reference,
-  root: Reference,
-  child(path: string): Reference,
-  onDisconnect(): OnDisconnect,
+  parent?: $npm$firebase$database$Reference,
+  root: $npm$firebase$database$Reference,
+  child(path: string): $npm$firebase$database$Reference,
+  onDisconnect(): $npm$firebase$database$OnDisconnect,
   push(
-    value?: FirebaseValue,
-    onComplete?: OnCompleteCallback
-  ): ThenableReference & Promise<void>,
-  remove(onComplete?: OnCompleteCallback): Promise<void>,
-  set(value: FirebaseValue, onComplete?: OnCompleteCallback): Promise<void>,
+    value?: $npm$firebase$database$Value,
+    onComplete?: $npm$firebase$database$OnCompleteCallback
+  ): $npm$firebase$database$ThenableReference & Promise<void>,
+  remove(onComplete?: $npm$firebase$database$OnCompleteCallback): Promise<void>,
+  set(
+    value: $npm$firebase$database$Value,
+    onComplete?: $npm$firebase$database$OnCompleteCallback
+  ): Promise<void>,
   setPriority(
-    priority: Priority,
-    onComplete?: OnCompleteCallback
+    priority: $npm$firebase$database$Priority,
+    onComplete?: $npm$firebase$database$OnCompleteCallback
   ): Promise<void>,
   setWithPriority(
-    newVal: FirebaseValue,
-    newPriority: Priority,
-    onComplete?: OnCompleteCallback
+    newVal: $npm$firebase$database$Value,
+    newPriority: $npm$firebase$database$Priority,
+    onComplete?: $npm$firebase$database$OnCompleteCallback
   ): Promise<void>,
   transaction(
-    transactionUpdate: (data: FirebaseValue) => FirebaseValue,
+    transactionUpdate: (
+      data: $npm$firebase$database$Value
+    ) => $npm$firebase$database$Value,
     onComplete?: (
       error: null | Object,
       committed: boolean,
-      snapshot: DataSnapshot
+      snapshot: $npm$firebase$database$DataSnapshot
     ) => void,
     applyLocally?: boolean
-  ): Promise<{ committed: boolean, snapshot: DataSnapshot | null }>,
+  ): Promise<{
+    committed: boolean,
+    snapshot: $npm$firebase$database$DataSnapshot | null
+  }>,
   update(
-    values: { [path: string]: FirebaseValue },
-    onComplete?: OnCompleteCallback
+    values: { [path: string]: $npm$firebase$database$Value },
+    onComplete?: $npm$firebase$database$OnCompleteCallback
   ): Promise<void>
 }
 
-declare class ServerValue {
+declare class $npm$firebase$database$ServerValue {
   static TIMESTAMP: {}
 }
 
-declare class ThenableReference extends Reference {}
+declare class $npm$firebase$database$ThenableReference extends $npm$firebase$database$Reference {}
 
 // Exporting the types
-declare module 'firebase' {
+declare module "firebase" {
   declare module.exports: {
-    +apps: Array<App>,
-    initializeApp(options: FirebaseConfig, name?: string): App,
+    +apps: Array<$npm$firebase$App>,
+    initializeApp(
+      options: $npm$firebase$Config,
+      name?: string
+    ): $npm$firebase$App,
     SDK_VERSION: string,
-    FirebaseError: FirebaseError,
-    FirebaseConfig: FirebaseConfig,
-    FirebaseUser: typeof FirebaseUser,
-    FirebaseUserInfo: typeof FirebaseUserInfo,
+    FirebaseError: $npm$firebase$Error,
+    FirebaseConfig: $npm$firebase$Config,
+    FirebaseUser: typeof $npm$firebase$auth$User,
+    FirebaseUserInfo: typeof $npm$firebase$auth$UserInfo,
     app: {
-      (name?: string): typeof App,
-      App: typeof App
+      (name?: string): typeof $npm$firebase$App,
+      App: typeof $npm$firebase$App
     },
     auth: {
-      (app?: App): Auth,
-      FirebaseAdditionalUserInfo: FirebaseAdditionalUserInfo,
-      FirebaseUserCredential: FirebaseUserCredential,
-      ActionCodeInfo: ActionCodeInfo,
-      ApplicationVerifier: ApplicationVerifier,
-      Auth: typeof Auth,
-      AuthCredential: AuthCredential,
-      AuthProvider: AuthProvider,
-      ConfirmationResult: ConfirmationResult,
-      EmailAuthProvider: typeof EmailAuthProvider,
-      Error: AuthError,
-      FacebookAuthProvider: typeof FacebookAuthProvider,
-      GithubAuthProvider: typeof GithubAuthProvider,
-      GoogleAuthProvider: typeof GoogleAuthProvider,
-      PhoneAuthProvider: typeof PhoneAuthProvider,
-      TwitterAuthProvider: typeof TwitterAuthProvider
+      (app?: $npm$firebase$App): $npm$firebase$auth$Auth,
+      FirebaseAdditionalUserInfo: $npm$firebase$auth$AdditionalUserInfo,
+      FirebaseUserCredential: $npm$firebase$auth$UserCredential,
+      ActionCodeInfo: $npm$firebase$auth$ActionCodeInfo,
+      ApplicationVerifier: $npm$firebase$auth$ApplicationVerifier,
+      Auth: typeof $npm$firebase$auth$Auth,
+      AuthCredential: $npm$firebase$auth$AuthCredential,
+      AuthProvider: $npm$firebase$auth$AuthProvider,
+      ConfirmationResult: $npm$firebase$auth$ConfirmationResult,
+      EmailAuthProvider: typeof $npm$firebase$auth$EmailAuthProvider,
+      Error: $npm$firebase$auth$Error,
+      FacebookAuthProvider: typeof $npm$firebase$auth$FacebookAuthProvider,
+      GithubAuthProvider: typeof $npm$firebase$auth$GithubAuthProvider,
+      GoogleAuthProvider: typeof $npm$firebase$auth$GoogleAuthProvider,
+      PhoneAuthProvider: typeof $npm$firebase$auth$PhoneAuthProvider,
+      TwitterAuthProvider: typeof $npm$firebase$auth$TwitterAuthProvider
     },
     database: {
-      (app?: App): Database,
+      (app?: $npm$firebase$App): $npm$firebase$database$Database,
       enableLogging(
         logger?: boolean | ((msg: string) => void),
         persistent?: boolean
       ): void,
-      DataSnapshot: typeof DataSnapshot,
-      Database: typeof Database,
-      OnDisconnect: typeof OnDisconnect,
-      Query: typeof Query,
-      Reference: typeof Reference,
-      ServerValue: typeof ServerValue,
-      ThenableReference: typeof ThenableReference
+      DataSnapshot: typeof $npm$firebase$database$DataSnapshot,
+      Database: typeof $npm$firebase$database$Database,
+      OnDisconnect: typeof $npm$firebase$database$OnDisconnect,
+      Query: typeof $npm$firebase$database$Query,
+      Reference: typeof $npm$firebase$database$Reference,
+      ServerValue: typeof $npm$firebase$database$ServerValue,
+      ThenableReference: typeof $npm$firebase$database$ThenableReference
     }
-  }
+  };
 }
-declare module 'firebase/app' {
+declare module "firebase/app" {
   declare module.exports: {
-    (name?: string): App,
-    App: typeof App
-  }
+    (name?: string): $npm$firebase$App,
+    App: typeof $npm$firebase$App
+  };
 }
-declare module 'firebase/auth' {
+declare module "firebase/auth" {
   declare module.exports: {
-    (app?: App): Auth,
-    FirebaseAdditionalUserInfo: FirebaseAdditionalUserInfo,
-    FirebaseUserCredential: FirebaseUserCredential,
-    ActionCodeInfo: ActionCodeInfo,
-    ApplicationVerifier: ApplicationVerifier,
-    Auth: typeof Auth,
-    AuthCredential: AuthCredential,
-    AuthProvider: AuthProvider,
-    ConfirmationResult: ConfirmationResult,
-    EmailAuthProvider: typeof EmailAuthProvider,
-    Error: AuthError,
-    FacebookAuthProvider: typeof FacebookAuthProvider,
-    GithubAuthProvider: typeof GithubAuthProvider,
-    GoogleAuthProvider: typeof GoogleAuthProvider,
-    PhoneAuthProvider: typeof PhoneAuthProvider,
-    TwitterAuthProvider: typeof TwitterAuthProvider
-  }
+    (app?: $npm$firebase$App): $npm$firebase$auth$Auth,
+    FirebaseAdditionalUserInfo: $npm$firebase$auth$AdditionalUserInfo,
+    FirebaseUserCredential: $npm$firebase$auth$UserCredential,
+    ActionCodeInfo: $npm$firebase$auth$ActionCodeInfo,
+    ApplicationVerifier: $npm$firebase$auth$ApplicationVerifier,
+    Auth: typeof $npm$firebase$auth$Auth,
+    AuthCredential: $npm$firebase$auth$AuthCredential,
+    AuthProvider: $npm$firebase$auth$AuthProvider,
+    ConfirmationResult: $npm$firebase$auth$ConfirmationResult,
+    EmailAuthProvider: typeof $npm$firebase$auth$EmailAuthProvider,
+    Error: $npm$firebase$auth$Error,
+    FacebookAuthProvider: typeof $npm$firebase$auth$FacebookAuthProvider,
+    GithubAuthProvider: typeof $npm$firebase$auth$GithubAuthProvider,
+    GoogleAuthProvider: typeof $npm$firebase$auth$GoogleAuthProvider,
+    PhoneAuthProvider: typeof $npm$firebase$auth$PhoneAuthProvider,
+    TwitterAuthProvider: typeof $npm$firebase$auth$TwitterAuthProvider
+  };
 }
-declare module 'firebase/database' {
+
+declare module "firebase/database" {
   declare module.exports: {
-    (app?: App): Database,
+    (app?: $npm$firebase$App): $npm$firebase$database$Database,
     enableLogging(
       logger?: boolean | ((msg: string) => void),
       persistent?: boolean
     ): void,
-    DataSnapshot: typeof DataSnapshot,
-    Database: typeof Database,
-    OnDisconnect: typeof OnDisconnect,
-    Query: typeof Query,
-    Reference: typeof Reference,
-    ServerValue: typeof ServerValue,
-    ThenableReference: typeof ThenableReference
-  }
+    DataSnapshot: typeof $npm$firebase$database$DataSnapshot,
+    Database: typeof $npm$firebase$database$Database,
+    OnDisconnect: typeof $npm$firebase$database$OnDisconnect,
+    Query: typeof $npm$firebase$database$Query,
+    Reference: typeof $npm$firebase$database$Reference,
+    ServerValue: typeof $npm$firebase$database$ServerValue,
+    ThenableReference: typeof $npm$firebase$database$ThenableReference
+  };
 }

--- a/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/firebase_v4.x.x.js
+++ b/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/firebase_v4.x.x.js
@@ -66,6 +66,7 @@ declare class $npm$firebase$App {
   +options: $npm$firebase$Config,
   auth(): $npm$firebase$auth$Auth,
   database(): $npm$firebase$database$Database,
+  storage(): $npm$firebase$storage$Storage,
   delete(): Promise<void>
 }
 
@@ -425,6 +426,128 @@ declare class $npm$firebase$database$ServerValue {
 
 declare class $npm$firebase$database$ThenableReference extends $npm$firebase$database$Reference {}
 
+/** **** storage ******/
+declare type $npm$firebase$storage$StringFormat =
+  | "raw"
+  | "base64"
+  | "base64url"
+  | "data_url";
+declare type $npm$firebase$storage$TaskEvent = "state_changed";
+declare type $npm$firebase$storage$TaskState =
+  | "running"
+  | "paused"
+  | "success"
+  | "canceled"
+  | "error";
+
+declare class $npm$firebase$storage$Storage {
+  app: $npm$firebase$App,
+  maxOperationRetryTime: number,
+  maxUploadRetryTime: number,
+  ref(path?: string): $npm$firebase$storage$Reference,
+  refFromURL(url: string): $npm$firebase$storage$Reference,
+  setMaxOperationRetryTime(time: number): void,
+  setMaxUploadRetryTime(time: number): void
+}
+
+declare class $npm$firebase$storage$FullMetadata extends $npm$firebase$storage$UploadMetadata {
+  bucket: string,
+  downloadURLs: Array<string>,
+  fullPath: string,
+  generation: string,
+  metageneration: string,
+  name: string,
+  size: number,
+  timeCreated: string,
+  updated: string
+}
+
+declare class $npm$firebase$storage$Reference {
+  bucket: string,
+  fullPath: string,
+  name: string,
+  parent?: $npm$firebase$storage$Reference,
+  root: $npm$firebase$storage$Reference,
+  storage: $npm$firebase$storage$Storage,
+  child(path: string): $npm$firebase$storage$Reference,
+  delete(): Promise<void>,
+  getDownloadURL(): Promise<string>,
+  getMetadata(): Promise<$npm$firebase$storage$FullMetadata>,
+  put(
+    data: Blob | Uint8Array | ArrayBuffer,
+    metadata?: $npm$firebase$storage$UploadMetadata
+  ): $npm$firebase$storage$UploadTask,
+  putString(
+    data: string,
+    format: $npm$firebase$storage$StringFormat,
+    metadata?: $npm$firebase$storage$UploadMetadata
+  ): $npm$firebase$storage$UploadTask,
+  toString(): string,
+  updateMetadata(
+    metadata: $npm$firebase$storage$SettableMetadata
+  ): Promise<$npm$firebase$storage$FullMetadata>
+}
+
+declare class $npm$firebase$storage$SettableMetadata {
+  cacheControl?: string,
+  contentDisposition?: string,
+  contentEncoding?: string,
+  contentLanguage?: string,
+  contentType?: string,
+  customMetadata?: { [key: string]: string | void }
+}
+
+declare class $npm$firebase$storage$UploadMetadata extends $npm$firebase$storage$SettableMetadata {
+  md5Hash?: string
+}
+
+declare interface $npm$firebase$storage$Observer {
+  next: (snapshot: $npm$firebase$storage$UploadTaskSnapshot) => void,
+  error?: (error: Error) => void,
+  complete?: () => void
+}
+
+declare type $npm$firebase$storage$Unsubscribe = () => void;
+
+declare type $npm$firebase$storage$Subscribe = (
+  observerOrNext:
+    | $npm$firebase$storage$Observer
+    | ((snapshot: $npm$firebase$storage$UploadTaskSnapshot) => void),
+  onError?: (error: Error) => void,
+  onComplete?: () => void
+) => $npm$firebase$storage$Unsubscribe;
+
+declare class $npm$firebase$storage$UploadTask extends Promise<
+  $npm$firebase$storage$UploadTaskSnapshot
+> {
+  snapshot: $npm$firebase$storage$UploadTaskSnapshot,
+  cancel(): boolean,
+  on(
+    event: $npm$firebase$storage$TaskEvent,
+    ...rest: Array<void>
+  ): $npm$firebase$storage$Subscribe,
+  on(
+    event: $npm$firebase$storage$TaskEvent,
+    observerOrNext:
+      | $npm$firebase$storage$Observer
+      | ((snapshot: $npm$firebase$storage$UploadTaskSnapshot) => void),
+    onError?: (error: Error) => void,
+    onComplete?: () => void
+  ): $npm$firebase$storage$Unsubscribe,
+  pause(): boolean,
+  resume(): boolean
+}
+
+declare class $npm$firebase$storage$UploadTaskSnapshot {
+  bytesTransferred: number,
+  downloadURL?: string,
+  metadata: $npm$firebase$storage$FullMetadata,
+  ref: $npm$firebase$storage$Reference,
+  state: $npm$firebase$storage$TaskState,
+  task: $npm$firebase$storage$UploadTask,
+  totalBytes: number
+}
+
 // Exporting the types
 declare module "firebase" {
   declare module.exports: {
@@ -473,6 +596,16 @@ declare module "firebase" {
       Reference: typeof $npm$firebase$database$Reference,
       ServerValue: typeof $npm$firebase$database$ServerValue,
       ThenableReference: typeof $npm$firebase$database$ThenableReference
+    },
+    storage: {
+      (app?: $npm$firebase$App): $npm$firebase$storage$Storage,
+      Storage: typeof $npm$firebase$storage$Storage,
+      FullMetadata: typeof $npm$firebase$storage$FullMetadata,
+      Reference: typeof $npm$firebase$storage$Reference,
+      SettableMetadata: typeof $npm$firebase$storage$SettableMetadata,
+      UploadMetadata: typeof $npm$firebase$storage$UploadMetadata,
+      UploadTask: typeof $npm$firebase$storage$UploadTask,
+      UploadTaskSnapshot: typeof $npm$firebase$storage$UploadTaskSnapshot
     }
   };
 }
@@ -502,7 +635,6 @@ declare module "firebase/auth" {
     TwitterAuthProvider: typeof $npm$firebase$auth$TwitterAuthProvider
   };
 }
-
 declare module "firebase/database" {
   declare module.exports: {
     (app?: $npm$firebase$App): $npm$firebase$database$Database,
@@ -517,5 +649,17 @@ declare module "firebase/database" {
     Reference: typeof $npm$firebase$database$Reference,
     ServerValue: typeof $npm$firebase$database$ServerValue,
     ThenableReference: typeof $npm$firebase$database$ThenableReference
+  };
+}
+declare module "firebase/storage" {
+  declare module.exports: {
+    (app?: $npm$firebase$App): $npm$firebase$storage$Storage,
+    Storage: typeof $npm$firebase$storage$Storage,
+    FullMetadata: typeof $npm$firebase$storage$FullMetadata,
+    Reference: typeof $npm$firebase$storage$Reference,
+    SettableMetadata: typeof $npm$firebase$storage$SettableMetadata,
+    UploadMetadata: typeof $npm$firebase$storage$UploadMetadata,
+    UploadTask: typeof $npm$firebase$storage$UploadTask,
+    UploadTaskSnapshot: typeof $npm$firebase$storage$UploadTaskSnapshot
   };
 }

--- a/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/test_firebase.js
+++ b/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/test_firebase.js
@@ -72,9 +72,9 @@ firebase.auth()
 
 // #8
 const provider2 = new firebase.auth.EmailAuthProvider();
-// $ExpectError
 firebase.auth()
   .currentUser
+  // $ExpectError
   .linkWithPopup(provider2)
   .then(result => {
     (result.credential);

--- a/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/test_firebase.js
+++ b/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/test_firebase.js
@@ -1,120 +1,186 @@
 // @flow
 
-import * as firebase from 'firebase';
-import app from 'firebase/app';
-import auth from 'firebase/auth';
-import database from 'firebase/database';
+import * as firebase from "firebase";
+import app from "firebase/app";
+import auth from "firebase/auth";
+import database from "firebase/database";
 
 // #1
 const a1: firebase.app.App = firebase.initializeApp({
-  apiKey: 'apiKey',
-  databaseURL: 'databaseURL',
-  projectId: '42',
+  apiKey: "apiKey",
+  databaseURL: "databaseURL",
+  projectId: "42"
 });
 
 // #2
 // $ExpectError
 const a2: firebase.app.App = firebase.initializeApp({
-  storageBucker: 'storageBucket',
-  projectId: '42',
+  storageBucker: "storageBucket",
+  projectId: "42"
 });
 
 // #3
-const a3: app.App = app('DEFAULT');
+const a3: app.App = app("DEFAULT");
 
 // #4
-firebase.auth()
-  .createUserWithEmailAndPassword('email', 'password')
+firebase
+  .auth()
+  .createUserWithEmailAndPassword("email", "password")
   .then()
-  .catch()
+  .catch();
 
 // #5
-firebase.auth()
-  .onAuthStateChanged(user => {
-    if (user) {
-      (user.displayName);
-      (user.email);
-      (user.emailVerified);
-      (user.photoURL);
-      (user.isAnonymous);
-      (user.uid);
-      (user.providerData);
-      // $ExpectError
-      (user.foobar);
-    }
-  });
+firebase.auth().onAuthStateChanged(user => {
+  if (user) {
+    user.displayName;
+    user.email;
+    user.emailVerified;
+    user.photoURL;
+    user.isAnonymous;
+    user.uid;
+    user.providerData;
+    // $ExpectError
+    user.foobar;
+  }
+});
 
 // #6
-firebase.auth()
-  .currentUser
-  .linkAndRetrieveDataWithCredential({
-    providerId: 'providerId',
+firebase
+  .auth()
+  .currentUser.linkAndRetrieveDataWithCredential({
+    providerId: "providerId"
   })
   .then(userCredential => {
-    (userCredential.user);
+    userCredential.user;
     // $ExpectError
-    (userCredential.foobar);
-  })
+    userCredential.foobar;
+  });
 
 // #7
 const provider = new firebase.auth.GithubAuthProvider();
-firebase.auth()
-  .currentUser
-  .linkWithPopup(provider)
-  .then(result => {
-    (result.credential);
-    (result.additionalUserInfo);
-    (result.operationType);
-    (result.user);
-    // $ExpectError
-    (result.foobar);
-  });
+firebase.auth().currentUser.linkWithPopup(provider).then(result => {
+  result.credential;
+  result.additionalUserInfo;
+  result.operationType;
+  result.user;
+  // $ExpectError
+  result.foobar;
+});
 
 // #8
 const provider2 = new firebase.auth.EmailAuthProvider();
-firebase.auth()
-  .currentUser
-  // $ExpectError
+firebase
+  .auth()
+  .currentUser // $ExpectError
   .linkWithPopup(provider2)
   .then(result => {
-    (result.credential);
-    (result.additionalUserInfo);
-    (result.operationType);
-    (result.user);
+    result.credential;
+    result.additionalUserInfo;
+    result.operationType;
+    result.user;
     // $ExpectError
-    (result.foobar);
+    result.foobar;
   });
 
 // #9
 const prevUser = firebase.auth().currentUser;
-const credential = { providerId: 'providerId' };
-firebase.auth()
+const credential = { providerId: "providerId" };
+firebase
+  .auth()
   .signInWithCredential(credential)
-  .then(user => user.delete().then(() => prevUser.linkWithCredential(credential)))
-  .then(() => firebase.auth().signInWithCredential(credential))
+  .then(user =>
+    user.delete().then(() => prevUser.linkWithCredential(credential))
+  )
+  .then(() => firebase.auth().signInWithCredential(credential));
 
 // #10
-firebase.database().ref('users/42').set({username: 'foobar'});
+firebase.database().ref("users/42").set({ username: "foobar" });
 
 // #11
-firebase.database().ref('users/42').on('value', snp => {
-  (snp.val());
+firebase.database().ref("users/42").on("value", snp => {
+  snp.val();
 });
 
 // #12
-// $ExpectError
-firebase.database().ref('users/42').on('foo', snp => {
-  (snp.val());
+firebase.database().ref("users/42")// $ExpectError
+.on("foo", snp => {
+  snp.val();
 });
 
 // #13
-firebase.database()
-  .ref('users/42')
+firebase
+  .database()
+  .ref("users/42")
   .orderByKey()
   .limitToLast(17)
-  .once('child_added')
-  .then(snp => snp.forEach(_ => true))
+  .once("child_added")
+  .then(snp => snp.forEach(_ => true));
 
 // #14
-// $ExpectError
-firebase.database().ref('users/42').orderByKey().limitToLast('foo')
+firebase.database().ref("users/42").orderByKey()// $ExpectError
+.limitToLast("foo");
+
+// #15
+firebase.storage().ref().child("foo").child("bar");
+
+// #17
+firebase
+  .storage()
+  .ref("/foo")
+  .getMetadata()
+  .then(metadata => {
+    (metadata.bucket: string);
+    // $ExpectError
+    metadata.foo;
+  })
+  .catch();
+
+// #18
+firebase
+  .storage()
+  .ref("/foo")
+  .put(new File(["foo"], "foo.txt"))
+  .then(snp => {
+    (snp.bytesTransferred: number);
+    // $ExpectError
+    snp.foo;
+  })
+  .catch();
+
+// #19
+firebase.storage().ref("/foo")// $ExpectError
+.put("foobar");
+
+// #20
+const task = firebase.storage().ref("/foo").put(new File(["foo"], "foo.txt"));
+const subscribe = task.on("state_changed");
+const unsubscribe = subscribe(snp => {
+  (snp.bytesTransferred: number);
+  // $ExpectError
+  snp.foo;
+});
+(unsubscribe(): void);
+
+// #21
+firebase
+  .storage()
+  .ref("/foo")
+  .put(new File(["foo"], "foo.txt"))
+  .on("state_changed", snp => {
+    (snp.bytesTransferred: number);
+    // $ExpectError
+    snp.foo;
+  })();
+
+// #22
+firebase
+  .storage()
+  .ref("/foo")
+  .put(new File(["foo"], "foo.txt"))
+  .on("state_changed", {
+    next: snp => {
+      (snp.bytesTransferred: number);
+      // $ExpectError
+      snp.foo;
+    }
+  })();


### PR DESCRIPTION
Typings for firebase v4 were missing storage type. This PR is primarily to address this issue. 

Additionally, the following changes were necessary:

- Tests were fixed starting at the current master. The failure is probably due to a change in the treatment of suppression comments in a recent flow release.
- Namespaces were added to avoid conflicts between `storage` and `database`. All global declarations are now prefixed with `$npm$firebase$`.

Tagging @PCreations and @stevenyap.