### PR TITLE
Moved body-parser imports inside module declaration

### DIFF
--- a/definitions/npm/body-parser_v1.x.x/flow_v0.17.x-/body-parser_v1.x.x.js
+++ b/definitions/npm/body-parser_v1.x.x/flow_v0.17.x-/body-parser_v1.x.x.js
@@ -1,33 +1,28 @@
-import type { Middleware, $Request, $Response } from 'express';
-
-declare type bodyParser$Options = {
-  inflate?: boolean;
-  limit?: number | string;
-  type?: string | string[] | ((req: $Request) => any);
-  verify?: (req: $Request, res: $Response, buf: Buffer, encoding: string) => void;
-};
-
-declare type bodyParser$OptionsText = bodyParser$Options & {
-  reviver?: (key: string, value: any) => any;
-  strict?: boolean;
-};
-
-declare type bodyParser$OptionsJson = bodyParser$Options & {
-  reviver?: (key: string, value: any) => any;
-  strict?: boolean;
-};
-
-declare type bodyParser$OptionsUrlencoded = bodyParser$Options & {
-  extended?: boolean;
-  parameterLimit?: number;
-};
-
 declare module "body-parser" {
 
-    declare type Options = bodyParser$Options;
-    declare type OptionsText = bodyParser$OptionsText;
-    declare type OptionsJson = bodyParser$OptionsJson;
-    declare type OptionsUrlencoded = bodyParser$OptionsUrlencoded;
+    import type { Middleware, $Request, $Response } from 'express';
+
+    declare type Options = {
+      inflate?: boolean;
+      limit?: number | string;
+      type?: string | string[] | ((req: $Request) => any);
+      verify?: (req: $Request, res: $Response, buf: Buffer, encoding: string) => void;
+    };
+
+    declare type OptionsText = Options & {
+      reviver?: (key: string, value: any) => any;
+      strict?: boolean;
+    };
+
+    declare type OptionsJson = Options & {
+      reviver?: (key: string, value: any) => any;
+      strict?: boolean;
+    };
+
+    declare type OptionsUrlencoded = Options & {
+      extended?: boolean;
+      parameterLimit?: number;
+    };
 
     declare function json(options?: OptionsJson): Middleware;
 


### PR DESCRIPTION
Disclaimer: I'm not sure this works and won't break things.

I discovered that the types imported from express currently have no effect in the body-parser libdefs, they basically behave like `any`.

After some digging, I found that type imports inside libdefs used to not work at all, but at some point support was added for type imports inside the module declarations: https://github.com/flowtype/flow-typed/issues/16#issuecomment-320484413

If I locally change the body-parser libdef to this, it works exactly as expected, as long as the libdefs for express are also installed.
But if the libdefs for express are missing, I get this error: "identifier \`.$module__express\`. Required module not found" when I run Flow.

So, this PR should be fine if flow-typed automatically downloads libdefs that are imported from other libdefs (even if they're not explicitly declared in package.json).
But I'm not sure if it does (I suspect it doesn't) and it's tricky to test that since the download behavior depends on published libdefs.

@calebmer could you take a look?