### PR TITLE
Add Negative Test for Express Flow-Typed Test

### DIFF
--- a/definitions/npm/express_v4.x.x/flow_v0.32.x-/test_response.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.32.x-/test_response.js
@@ -32,7 +32,7 @@ const httpServer = http.createServer(app);
 httpServer.listen(9000);
 
 // $ExpectError
-httpServer.listen(3, 3, 3, 3);
+httpServer.listen([]);
 
 // Can manually invoke app.handle() to handle a request
 const httpServer2 = http.createServer((req, res) => app.handle(req, res));

--- a/definitions/npm/express_v4.x.x/flow_v0.32.x-/test_response.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.32.x-/test_response.js
@@ -1,32 +1,38 @@
 // @flow
 
-import express, { Router } from 'express';
-import http from 'http';
+import express, { Router } from "express";
+import http from "http";
 
 const app = express();
 
-app.use('/response_api', (req: express$Request, res: express$Response) => {
+app.use("/response_api", (req: express$Request, res: express$Response) => {
   const contentLength = String(2);
-  res.set('Content-Length', contentLength);
-  res.set('Content-Type', 'application/json');
+  res.set("Content-Length", contentLength);
+  res.set("Content-Type", "application/json");
   res.writeHead(200, {
-    'Content-Length': contentLength,
-    'Content-Type': 'application/json',
+    "Content-Length": contentLength,
+    "Content-Type": "application/json"
   });
-  res.end('{}');
+  res.end("{}");
   res.req;
 });
 
 // Can manually invoke router.handle() to handle a request.
 const router = new Router();
-app.use('/router', (req: express$Request, res: express$Response, next: express$NextFunction) => {
-  router.handle(req, res, next);
-});
-app.post('/post-router-callable', router);
+app.use(
+  "/router",
+  (req: express$Request, res: express$Response, next: express$NextFunction) => {
+    router.handle(req, res, next);
+  }
+);
+app.post("/post-router-callable", router);
 
 // Can use an express app directly as a server listener
 const httpServer = http.createServer(app);
 httpServer.listen(9000);
+
+// $ExpectError
+httpServer.listen("foo");
 
 // Can manually invoke app.handle() to handle a request
 const httpServer2 = http.createServer((req, res) => app.handle(req, res));

--- a/definitions/npm/express_v4.x.x/flow_v0.32.x-/test_response.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.32.x-/test_response.js
@@ -31,8 +31,9 @@ app.post("/post-router-callable", router);
 const httpServer = http.createServer(app);
 httpServer.listen(9000);
 
+const badHttpServer = null;
 // $ExpectError
-httpServer.listen([]);
+badHttpServer.listen();
 
 // Can manually invoke app.handle() to handle a request
 const httpServer2 = http.createServer((req, res) => app.handle(req, res));

--- a/definitions/npm/express_v4.x.x/flow_v0.32.x-/test_response.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.32.x-/test_response.js
@@ -32,7 +32,7 @@ const httpServer = http.createServer(app);
 httpServer.listen(9000);
 
 // $ExpectError
-httpServer.listen("foo");
+httpServer.listen(3, 3, 3, 3);
 
 // Can manually invoke app.handle() to handle a request
 const httpServer2 = http.createServer((req, res) => app.handle(req, res));


### PR DESCRIPTION
This commit fixes the following error when running the `./run_def_tests.sh` command:

`\flow-typed\definitions\npm\express_v4.x.x\flow_v0.32.x-\test_response.js`
 ` 1:1  error  Test has to include at least 1 negative Tests`

According to the Flow-Typed documentation, this is a requirement.  See also:
[https://github.com/flowtype/flow-typed/wiki/Contributing-Library-Definitions#writing-libdef-tests](https://github.com/flowtype/flow-typed/wiki/Contributing-Library-Definitions#writing-libdef-tests)