### PR TITLE
Batch of rxjs definition updates

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -336,7 +336,10 @@ declare class rxjs$Observable<+T> {
 
   buffer(bufferBoundaries: rxjs$Observable<any>): rxjs$Observable<Array<T>>,
 
-  bufferCount(bufferSize: number, startBufferEvery?: number): rxjs$Observable<Array<T>>;
+  bufferCount(
+    bufferSize: number,
+    startBufferEvery?: number
+  ): rxjs$Observable<Array<T>>,
 
   catch<U>(
     selector: (err: any, caught: rxjs$Observable<T>) => rxjs$Observable<U>
@@ -626,10 +629,7 @@ declare class rxjs$Observable<+T> {
     resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
   ): rxjs$Observable<H>,
 
-  static combineLatest<A>(
-    a: rxjs$Observable<A>,
-    _: void,
-  ): rxjs$Observable<[A]>;
+  static combineLatest<A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<[A]>,
 
   static combineLatest<A, B>(
     a: rxjs$Observable<A>,

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -329,6 +329,12 @@ declare class rxjs$Observable<+T> {
 
   static of(...values: T[]): rxjs$Observable<T>,
 
+  static range(
+    start?: number,
+    count?: number,
+    scheduler?: rxjs$SchedulerClass
+  ): rxjs$Observable<number>,
+
   static throw(error: any): rxjs$Observable<any>,
 
   audit(
@@ -344,6 +350,13 @@ declare class rxjs$Observable<+T> {
   bufferCount(
     bufferSize: number,
     startBufferEvery?: number
+  ): rxjs$Observable<Array<T>>,
+
+  bufferTime(
+    bufferTimeSpan: number,
+    bufferCreationInterval?: number,
+    maxBufferSize?: number,
+    scheduler?: rxjs$SchedulerClass
   ): rxjs$Observable<Array<T>>,
 
   catch<U>(
@@ -372,6 +385,8 @@ declare class rxjs$Observable<+T> {
     dueTime: number,
     scheduler?: rxjs$SchedulerClass
   ): rxjs$Observable<T>,
+
+  defaultIfEmpty<U>(defaultValue: U): rxjs$Observable<T | U>,
 
   delay(dueTime: number, scheduler?: rxjs$SchedulerClass): rxjs$Observable<T>,
 
@@ -437,11 +452,17 @@ declare class rxjs$Observable<+T> {
     defaultValue: U
   ): rxjs$Observable<U>,
 
-  groupBy(
-    keySelector: (value: T) => mixed,
-    elementSelector?: (value: T) => T,
-    compare?: (x: T, y: T) => boolean
-  ): rxjs$Observable<rxjs$Observable<T>>,
+  groupBy<K>(
+    keySelector: (value: T) => K,
+    _: void
+  ): rxjs$Observable<rxjs$GroupedObservable<K, T>>,
+  groupBy<K, V>(
+    keySelector: (value: T) => K,
+    elementSelector: (value: T) => V,
+    durationSelector?: (
+      grouped: rxjs$GroupedObservable<K, V>
+    ) => rxjs$Observable<any>
+  ): rxjs$Observable<rxjs$GroupedObservable<K, V>>,
 
   ignoreElements<U>(): rxjs$Observable<U>,
 
@@ -616,6 +637,12 @@ declare class rxjs$Observable<+T> {
   throttleTime(duration: number): rxjs$Observable<T>,
 
   timeout(due: number | Date, _: void): rxjs$Observable<T>,
+
+  timeoutWith<U>(
+    due: number | Date,
+    withObservable: rxjs$Observable<U>,
+    scheduler?: rxjs$SchedulerClass
+  ): rxjs$Observable<T | U>,
 
   toArray(): rxjs$Observable<T[]>,
 
@@ -999,6 +1026,10 @@ declare class rxjs$Observable<+T> {
 declare class rxjs$ConnectableObservable<T> extends rxjs$Observable<T> {
   connect(): rxjs$Subscription,
   refCount(): rxjs$Observable<T>
+}
+
+declare class rxjs$GroupedObservable<K, V> extends rxjs$Observable<V> {
+  key: K
 }
 
 declare class rxjs$Observer<T> {

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -39,6 +39,8 @@ type rxjs$EventListenerOptions =
     }
   | boolean;
 
+type rxjs$ObservableInput<T> = rxjs$Observable<T> | Promise<T> | Iterable<T>;
+
 declare class rxjs$Observable<+T> {
   static bindCallback(
     callbackFunc: (callback: (_: void) => any) => any,
@@ -265,7 +267,10 @@ declare class rxjs$Observable<+T> {
     observableFactory: () => rxjs$Observable<T> | Promise<T>
   ): rxjs$Observable<T>,
 
-  static from(iterable: Iterable<T>): rxjs$Observable<T>,
+  static from(
+    input: rxjs$ObservableInput<T>,
+    scheduler?: rxjs$SchedulerClass
+  ): rxjs$Observable<T>,
 
   static fromEvent(
     element: any,
@@ -350,8 +355,18 @@ declare class rxjs$Observable<+T> {
   concatAll<U>(): rxjs$Observable<U>,
 
   concatMap<U>(
-    f: (value: T) => rxjs$Observable<U> | Promise<U> | Iterable<U>
+    f: (value: T, index: number) => rxjs$ObservableInput<U>,
+    _: void
   ): rxjs$Observable<U>,
+  concatMap<U, V>(
+    f: (value: T, index: number) => rxjs$ObservableInput<U>,
+    resultSelector: (
+      outerValue: T,
+      innerValue: U,
+      outerIndex: number,
+      innerIndex: number
+    ) => V
+  ): rxjs$Observable<V>,
 
   debounceTime(
     dueTime: number,
@@ -373,6 +388,20 @@ declare class rxjs$Observable<+T> {
   ): rxjs$Observable<T>,
 
   elementAt(index: number, defaultValue?: T): rxjs$Observable<T>,
+
+  exhaustMap<U>(
+    project: (value: T, index: number) => rxjs$ObservableInput<U>,
+    _: void
+  ): rxjs$Observable<U>,
+  exhaustMap<U, V>(
+    project: (value: T, index: number) => rxjs$ObservableInput<U>,
+    resultSelector: (
+      outerValue: T,
+      innerValue: U,
+      outerIndex: number,
+      innerIndex: number
+    ) => V
+  ): rxjs$Observable<V>,
 
   expand(
     project: (value: T, index: number) => rxjs$Observable<T>,
@@ -429,9 +458,19 @@ declare class rxjs$Observable<+T> {
 
   // Alias for `mergeMap`
   flatMap<U>(
-    project: (value: T) => rxjs$Observable<U> | Promise<U> | Iterable<U>,
-    index?: number
+    project: (value: T, index: number) => rxjs$ObservableInput<U>,
+    concurrency?: number
   ): rxjs$Observable<U>,
+  flatMap<U, V>(
+    project: (value: T, index: number) => rxjs$ObservableInput<U>,
+    resultSelector: (
+      outerValue: T,
+      innerValue: U,
+      outerIndex: number,
+      innerIndex: number
+    ) => V,
+    concurrency?: number
+  ): rxjs$Observable<V>,
 
   flatMapTo<U>(innerObservable: rxjs$Observable<U>): rxjs$Observable<U>,
 
@@ -447,9 +486,18 @@ declare class rxjs$Observable<+T> {
   ): rxjs$Observable<V>,
 
   switchMap<U>(
-    project: (value: T) => rxjs$Observable<U> | Promise<U> | Iterable<U>,
-    index?: number
+    project: (value: T, index: number) => rxjs$ObservableInput<U>,
+    _: void
   ): rxjs$Observable<U>,
+  switchMap<U, V>(
+    project: (value: T, index: number) => rxjs$ObservableInput<U>,
+    resultSelector: (
+      outerValue: T,
+      innerValue: U,
+      outerIndex: number,
+      innerIndex: number
+    ) => V
+  ): rxjs$Observable<V>,
 
   switchMapTo<U>(innerObservable: rxjs$Observable<U>): rxjs$Observable<U>,
 
@@ -462,12 +510,19 @@ declare class rxjs$Observable<+T> {
   mergeAll<U>(): rxjs$Observable<U>,
 
   mergeMap<U>(
-    project: (
-      value: T,
-      index?: number
-    ) => rxjs$Observable<U> | Promise<U> | Iterable<U>,
-    index?: number
+    project: (value: T, index: number) => rxjs$ObservableInput<U>,
+    concurrency?: number
   ): rxjs$Observable<U>,
+  mergeMap<U, V>(
+    project: (value: T, index: number) => rxjs$ObservableInput<U>,
+    resultSelector: (
+      outerValue: T,
+      innerValue: U,
+      outerIndex: number,
+      innerIndex: number
+    ) => V,
+    concurrency?: number
+  ): rxjs$Observable<V>,
 
   mergeMapTo<U>(innerObservable: rxjs$Observable<U>): rxjs$Observable<U>,
 

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/test_rxjs.js
@@ -46,3 +46,37 @@ const anonymousSubject: AnonymousSubject<number> = new AnonymousSubject(
 );
 anonymousSubject.next(5);
 anonymousSubject.error(new Error());
+
+const from: Observable<number> = Observable.from(Promise.resolve(1));
+
+// Standard projection operators
+const project: Array<Observable<string>> = [
+  numbers.switchMap(x => Promise.resolve("")),
+  numbers.switchMap(
+    x => [x],
+    (x, y, index1, index2) => String(x + y + index1 + index2)
+  ),
+  numbers.switchMap(
+    x => [x],
+    (x, y, index1, index2) => String(x + y + index1 + index2)
+  ),
+  numbers.concatMap(
+    x => [x],
+    (x, y, index1, index2) => String(x + y + index1 + index2)
+  ),
+  numbers.mergeMap(x => Observable.of("")),
+  numbers.mergeMap(x => Observable.of(""), 5),
+  numbers.mergeMap(
+    x => [x],
+    (x, y, index1, index2) => String(x + y + index1 + index2),
+    /* concurrency */ 5
+  ),
+  // $ExpectError: the ordering is wrong
+  numbers.mergeMap(x => [x], 5, (x, y, index1, index2) =>
+    String(x + y + index1 + index2)
+  ),
+  numbers.exhaustMap(
+    x => [x],
+    (x, y, index1, index2) => String(x + y + index1 + index2)
+  )
+];

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/test_rxjs.js
@@ -80,3 +80,18 @@ const project: Array<Observable<string>> = [
     (x, y, index1, index2) => String(x + y + index1 + index2)
   )
 ];
+
+(Observable.range(0, 10, Scheduler.asap): Observable<number>);
+(numbers.bufferTime(1, 1, 1, Scheduler.asap): Observable<Array<number>>);
+(Observable.of(1).defaultIfEmpty(null): Observable<?number>);
+(Observable.of(1).defaultIfEmpty(1): Observable<number>);
+(Observable.of(1).timeoutWith(100, Observable.of(null)): Observable<?number>);
+
+(Observable.of(1).groupBy(elem => ""): Observable<
+  rxjs$GroupedObservable<string, number>
+>);
+(Observable.of(1).groupBy(
+  elem => elem,
+  elem => String(elem),
+  grouped => Observable.never()
+): Observable<rxjs$GroupedObservable<number, string>>);


### PR DESCRIPTION
This PR adds a bunch of updates:

1. Made the projection operators (switchMap, mergeMap, concatMap) more consistent - defined a common `ObservableInput` type to mirror the docs and made the `resultSelection` argument consistent (`switchMap` actually incorrectly took a numerical index as the second argument).

2. Adds the `exhaustMap` operator, following the patterns above.

3. Adds `Observable.range` and the member operators `bufferTime`, `defaultIfEmpty`, and `timeoutWith`. These are pretty straightforward.

4. Updates the `groupBy` operator to be more precise, along with a `rxjs$GroupedObservable` type (which has an additional 'key' member). The third argument is actually a duration selector rather than a comparison function.

I've added tests for most of the changes where appropriate.
As another sanity check, I imported this into the facebook/nuclide repo which uses all of the above.