### PR TITLE
lodash: Use $ReadOnlyArray as an input to `find*` functions

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.55.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.55.x-/lodash_v4.x.x.js
@@ -226,12 +226,12 @@ declare module "lodash" {
       end?: number
     ): Array<T | U>;
     findIndex<T>(
-      array: ?Array<T>,
+      array: ?$ReadOnlyArray<T>,
       predicate?: Predicate<T>,
       fromIndex?: number
     ): number;
     findLastIndex<T>(
-      array: ?Array<T>,
+      array: ?$ReadOnlyArray<T>,
       predicate?: Predicate<T>,
       fromIndex?: number
     ): number;
@@ -462,7 +462,7 @@ declare module "lodash" {
       predicate?: OPredicate<A, T>
     ): Array<A>;
     find<T>(
-      array: ?Array<T>,
+      array: ?$ReadOnlyArray<T>,
       predicate?: Predicate<T>,
       fromIndex?: number
     ): T | void;
@@ -472,7 +472,7 @@ declare module "lodash" {
       fromIndex?: number
     ): V;
     findLast<T>(
-      array: ?Array<T>,
+      array: ?$ReadOnlyArray<T>,
       predicate?: Predicate<T>,
       fromIndex?: number
     ): T | void;
@@ -1444,35 +1444,37 @@ declare module "lodash/fp" {
       value: U,
       array: Array<T>
     ): Array<T | U>;
-    findIndex<T>(predicate: Predicate<T>): (array: Array<T>) => number;
-    findIndex<T>(predicate: Predicate<T>, array: Array<T>): number;
+    findIndex<T>(predicate: Predicate<T>): (array: $ReadOnlyArray<T>) => number;
+    findIndex<T>(predicate: Predicate<T>, array: $ReadOnlyArray<T>): number;
     findIndexFrom<T>(
       predicate: Predicate<T>
-    ): ((fromIndex: number) => (array: Array<T>) => number) &
-      ((fromIndex: number, array: Array<T>) => number);
+    ): ((fromIndex: number) => (array: $ReadOnlyArray<T>) => number) &
+      ((fromIndex: number, array: $ReadOnlyArray<T>) => number);
     findIndexFrom<T>(
       predicate: Predicate<T>,
       fromIndex: number
-    ): (array: Array<T>) => number;
+    ): (array: $ReadOnlyArray<T>) => number;
     findIndexFrom<T>(
       predicate: Predicate<T>,
       fromIndex: number,
-      array: Array<T>
+      array: $ReadOnlyArray<T>
     ): number;
-    findLastIndex<T>(predicate: Predicate<T>): (array: Array<T>) => number;
-    findLastIndex<T>(predicate: Predicate<T>, array: Array<T>): number;
+    findLastIndex<T>(
+      predicate: Predicate<T>
+    ): (array: $ReadOnlyArray<T>) => number;
+    findLastIndex<T>(predicate: Predicate<T>, array: $ReadOnlyArray<T>): number;
     findLastIndexFrom<T>(
       predicate: Predicate<T>
-    ): ((fromIndex: number) => (array: Array<T>) => number) &
-      ((fromIndex: number, array: Array<T>) => number);
+    ): ((fromIndex: number) => (array: $ReadOnlyArray<T>) => number) &
+      ((fromIndex: number, array: $ReadOnlyArray<T>) => number);
     findLastIndexFrom<T>(
       predicate: Predicate<T>,
       fromIndex: number
-    ): (array: Array<T>) => number;
+    ): (array: $ReadOnlyArray<T>) => number;
     findLastIndexFrom<T>(
       predicate: Predicate<T>,
       fromIndex: number,
-      array: Array<T>
+      array: $ReadOnlyArray<T>
     ): number;
     // alias of _.head
     first<T>(array: Array<T>): T;
@@ -1782,19 +1784,19 @@ declare module "lodash/fp" {
     ): Array<T>;
     find<T>(
       predicate: Predicate<T> | OPredicate<T>
-    ): (collection: Array<T> | { [id: any]: T }) => T | void;
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => T | void;
     find<T>(
       predicate: Predicate<T> | OPredicate<T>,
-      collection: Array<T> | { [id: any]: T }
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
     ): T | void;
     findFrom<T>(
       predicate: Predicate<T> | OPredicate<T>
     ): ((
       fromIndex: number
-    ) => (collection: Array<T> | { [id: any]: T }) => T | void) &
+    ) => (collection: $ReadOnlyArray<T> | { [id: any]: T }) => T | void) &
       ((
         fromIndex: number,
-        collection: Array<T> | { [id: any]: T }
+        collection: $ReadOnlyArray<T> | { [id: any]: T }
       ) => T | void);
     findFrom<T>(
       predicate: Predicate<T> | OPredicate<T>,
@@ -1803,32 +1805,32 @@ declare module "lodash/fp" {
     findFrom<T>(
       predicate: Predicate<T> | OPredicate<T>,
       fromIndex: number,
-      collection: Array<T> | { [id: any]: T }
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
     ): T | void;
     findLast<T>(
       predicate: Predicate<T> | OPredicate<T>
-    ): (collection: Array<T> | { [id: any]: T }) => T | void;
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => T | void;
     findLast<T>(
       predicate: Predicate<T> | OPredicate<T>,
-      collection: Array<T> | { [id: any]: T }
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
     ): T | void;
     findLastFrom<T>(
       predicate: Predicate<T> | OPredicate<T>
     ): ((
       fromIndex: number
-    ) => (collection: Array<T> | { [id: any]: T }) => T | void) &
+    ) => (collection: $ReadOnlyArray<T> | { [id: any]: T }) => T | void) &
       ((
         fromIndex: number,
-        collection: Array<T> | { [id: any]: T }
+        collection: $ReadOnlyArray<T> | { [id: any]: T }
       ) => T | void);
     findLastFrom<T>(
       predicate: Predicate<T> | OPredicate<T>,
       fromIndex: number
-    ): (collection: Array<T> | { [id: any]: T }) => T | void;
+    ): (collection: $ReadOnlyArray<T> | { [id: any]: T }) => T | void;
     findLastFrom<T>(
       predicate: Predicate<T> | OPredicate<T>,
       fromIndex: number,
-      collection: Array<T> | { [id: any]: T }
+      collection: $ReadOnlyArray<T> | { [id: any]: T }
     ): T | void;
     flatMap<T, U>(
       iteratee: FlatMapIteratee<T, U> | OFlatMapIteratee<T, U>

--- a/definitions/npm/lodash_v4.x.x/flow_v0.55.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.55.x-/test_lodash-v4.x.x.js
@@ -1,37 +1,37 @@
 // @flow
-import assignIn from 'lodash/assignIn';
-import attempt from 'lodash/attempt';
-import clone from 'lodash/clone';
-import concat from 'lodash/concat';
-import conformsTo from 'lodash/conformsTo';
-import countBy from 'lodash/countBy';
-import debounce from 'lodash/debounce';
-import defaultTo from 'lodash/defaultTo';
-import differenceBy from 'lodash/differenceBy';
-import extend from 'lodash/extend';
-import find from 'lodash/find';
-import first from 'lodash/first';
-import flatMap from 'lodash/flatMap';
-import get from 'lodash/get';
-import groupBy from 'lodash/groupBy';
-import intersectionBy from 'lodash/intersectionBy';
-import isEqual from 'lodash/isEqual';
-import isString from 'lodash/isString';
-import keyBy from 'lodash/keyBy';
-import map from 'lodash/map';
-import memoize from 'lodash/memoize';
-import noop from 'lodash/noop';
-import pullAllBy from 'lodash/pullAllBy';
-import range from 'lodash/range';
-import sortedIndexBy from 'lodash/sortedIndexBy';
-import sortedLastIndexBy from 'lodash/sortedLastIndexBy';
-import tap from 'lodash/tap';
-import thru from 'lodash/thru';
-import times from 'lodash/times';
-import unionBy from 'lodash/unionBy';
-import uniqBy from 'lodash/uniqBy';
-import xorBy from 'lodash/xorBy';
-import zip from 'lodash/zip';
+import assignIn from "lodash/assignIn";
+import attempt from "lodash/attempt";
+import clone from "lodash/clone";
+import concat from "lodash/concat";
+import conformsTo from "lodash/conformsTo";
+import countBy from "lodash/countBy";
+import debounce from "lodash/debounce";
+import defaultTo from "lodash/defaultTo";
+import differenceBy from "lodash/differenceBy";
+import extend from "lodash/extend";
+import find from "lodash/find";
+import first from "lodash/first";
+import flatMap from "lodash/flatMap";
+import get from "lodash/get";
+import groupBy from "lodash/groupBy";
+import intersectionBy from "lodash/intersectionBy";
+import isEqual from "lodash/isEqual";
+import isString from "lodash/isString";
+import keyBy from "lodash/keyBy";
+import map from "lodash/map";
+import memoize from "lodash/memoize";
+import noop from "lodash/noop";
+import pullAllBy from "lodash/pullAllBy";
+import range from "lodash/range";
+import sortedIndexBy from "lodash/sortedIndexBy";
+import sortedLastIndexBy from "lodash/sortedLastIndexBy";
+import tap from "lodash/tap";
+import thru from "lodash/thru";
+import times from "lodash/times";
+import unionBy from "lodash/unionBy";
+import uniqBy from "lodash/uniqBy";
+import xorBy from "lodash/xorBy";
+import zip from "lodash/zip";
 
 /**
  * _.attempt
@@ -67,6 +67,7 @@ find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.y == 3);
 find([{ x: 1 }, { x: 2 }, { x: 3 }], v => v.x == 3);
 find({ x: 1, y: 2 }, (a: number, b: string) => a);
 find({ x: 1, y: 2 }, { x: 3 });
+find((["a", "b"]: $ReadOnlyArray<string>), "c");
 
 // $ExpectError undefined. This type is incompatible with object type.
 var result: Object = find(users, "active");
@@ -187,11 +188,7 @@ map(users, "user");
 /**
  * _.pullAllBy
  */
-pullAllBy(
-  [{ x: 1 }, { x: 2 }, { x: 3 }, { x: 1 }],
-  [{ x: 1 }, { x: 3 }],
-  "x"
-);
+pullAllBy([{ x: 1 }, { x: 2 }, { x: 3 }, { x: 1 }], [{ x: 1 }, { x: 3 }], "x");
 
 /**
  * _.unionBy


### PR DESCRIPTION
This change solves part of an issue #1099. It doesn't touch functions other than find. Other immutable functions should be changed separately.

Change was straightforward, I just replaced `Array`  with `$ReadOnlyArray` on `find*` functions and added a single test case, but then `prettier` decided to convert every single quote to a double quote. Please let me know if I should submit these changes differently.