### PR TITLE
Improve typing for Ramda #pick.

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.34.x-v0.38.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.34.x-v0.38.x/ramda_v0.x.x.js
@@ -579,8 +579,8 @@ declare module ramda {
   declare function pathOr<T,V,A:NestedObject<V>>(or: T, p: Array<string>, ...rest: Array<void>): (o: ?A) => V|T;
   declare function pathOr<T,V,A:NestedObject<V>>(or: T, p: Array<string>, o: ?A): V|T;
 
-  declare function pick<A>(keys: Array<string>, ...rest: Array<void>): (val: {[key:string]: A}) => {[key:string]: A};
-  declare function pick<A>(keys: Array<string>, val: {[key:string]: A}): {[key:string]: A};
+  declare function pick<O>(keys: $Keys<O>[], ...rest: Array<void>): (val: O) => O;
+  declare function pick<O>(keys: $Keys<O>[], val: O): O;
 
   declare function pickAll<A>(keys: Array<string>, ...rest: Array<void>): (val: {[key:string]: A}) => {[key:string]: ?A};
   declare function pickAll<A>(keys: Array<string>, val: {[key:string]: A}): {[key:string]: ?A};

--- a/definitions/npm/ramda_v0.x.x/flow_v0.34.x-v0.38.x/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.34.x-v0.38.x/test_ramda_v0.x.x_object.js
@@ -117,7 +117,14 @@ const path4:void = _.path([ 'a' ], null)
 
 const pathOr: string|Object|number = _.pathOr('N/A', [ 'a', 'b' ], { a: { b: 2 } })
 
-const pck: Object = _.pick([ 'a', 'd' ], { a: 1, b: 2, c: 3, d: 4 })
+const pck1: Object = _.pick([ 'a', 'd' ], { a: 1, b: 2, c: 3, d: 4 })
+//$ExpectError
+const pck2: Object = _.pick([ 'a', 'b' ], { a: 1 })
+// should allow passing in a typed object literal
+const pickedObj: { a: string, b: number, c: boolean } = { a: 'hello', b: 1, c: true }
+const pck3: { a: string, b: number } = _.pick(['a', 'b'], pickedObj)
+//$ExpectError
+const pck4: { a: string, b: string } = _.pick(['a', 'b'], pickedObj)
 
 const ooo = { a: 1, b: 2, A: 3, B: 4 }
 const isUpperCase = (val, key) => key.toUpperCase() === key


### PR DESCRIPTION
There were some issues with the current definition for Ramda's `#pick`:

- Would not correctly detect invalid keys, so the following would not fail

```js
const pck2: Object = _.pick([ 'a', 'b' ], { a: 1 })
```

- Did not allow passing in typed object literals (a very common use case), so something like this would fail when the keys had different types:

```js
const pickedObj: { a: string, b: number, c: boolean } = { a: 'hello', b: 1, c: true }
const pck3: { a: string, b: number } = pick(['a', 'b'], pickedObj)
```

This PR addresses both issues.