### PR TITLE
[firebase] onDisconnect.cancel and onDisconnect.remove callbacks are optional

### DIFF
--- a/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/firebase_v4.x.x.js
+++ b/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/firebase_v4.x.x.js
@@ -312,8 +312,8 @@ declare class $npm$firebase$database$DataSnapshot {
 }
 
 declare class $npm$firebase$database$OnDisconnect {
-  cancel(onComplete: $npm$firebase$database$OnCompleteCallback): Promise<void>,
-  remove(onComplete: $npm$firebase$database$OnCompleteCallback): Promise<void>,
+  cancel(onComplete?: $npm$firebase$database$OnCompleteCallback): Promise<void>,
+  remove(onComplete?: $npm$firebase$database$OnCompleteCallback): Promise<void>,
   set(
     value: $npm$firebase$database$Value,
     onComplete?: $npm$firebase$database$OnCompleteCallback


### PR DESCRIPTION
FirebaseReference.onDisconnect.cancel() and FirebaseReference.onDisconnect.remove() have optional callback params [1]; they were previously typed as required

[1] https://firebase.google.com/docs/reference/node/firebase.database.OnDisconnect