### PR TITLE
Minor correction to log4js@2.x.x types

### DIFF
--- a/definitions/npm/log4js_v2.x.x/flow_v0.38.x-/log4js_v2.x.x.js
+++ b/definitions/npm/log4js_v2.x.x/flow_v0.38.x-/log4js_v2.x.x.js
@@ -410,10 +410,6 @@ declare module "log4js" {
   };
 
   declare export interface Logger {
-    setLevel(level: string): void,
-    setLevel(level: Level): void,
-    new(dispatch: Function, name: string): Logger,
-
     level: string,
 
     log(...args: any[]): void,


### PR DESCRIPTION
`setLevel` and `new` don't actually exist. (`new` is a TypeScript-specific syntax, and it doesn't really make sense to port over anyway).

See also: https://github.com/log4js-node/log4js-node/pull/574