### PR TITLE
fixes: 1385 fail test if not valid success message

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -337,6 +337,7 @@ async function runTestGroup(
       "",
       "[options]",
       "suppress_comment=\\\\(.\\\\|\\n\\\\)*\\\\$ExpectError",
+      "include_warnings=true",
       "",
 
       // Be sure to ignore stuff in the node_modules directory of the flow-typed
@@ -394,7 +395,7 @@ async function runTestGroup(
             errors.push(
               testRunId + ": Error executing Flow process: " + execError.stack
             );
-          } else if (errCode !== 0) {
+          } else if (stdErrOut !== "Found 0 errors\n") {
             errors.push(
               testRunId +
                 ": Unexpected Flow errors(" +

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -336,7 +336,7 @@ async function runFlowTypeDefTests(flowVersionsToRun, groupId, testDirPath) {
           errors.push(
             testRunId + ": Error executing Flow process: " + execError.stack
           );
-        } else if (stdErrOut !== "Found 0 errors\n") {
+        } else if (!stdErrOut.endsWith("Found 0 errors\n")) {
           errors.push(
             testRunId +
               ": Unexpected Flow errors(" +

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -415,18 +415,11 @@ async function runTestGroup(
     });
     let lowestFlowVersionRan = flowVersionsToRun[0];
 
-    const higherVersions = flowVersionsToRun.filter(flowVer =>
-      semver.gte(flowVer, "0.53.0")
-    );
     const lowerVersions = flowVersionsToRun.filter(flowVer =>
       semver.lt(flowVer, "0.53.0")
     );
-
-    await writeFlowConfig(testDirPath, testGroup.libDefPath, true);
-    const higherVersionErrors = await runFlowTypeDefTests(
-      higherVersions,
-      testGroup.id,
-      testDirPath
+    const higherVersions = flowVersionsToRun.filter(flowVer =>
+      semver.gte(flowVer, "0.53.0")
     );
 
     await writeFlowConfig(testDirPath, testGroup.libDefPath, false);
@@ -436,7 +429,14 @@ async function runTestGroup(
       testDirPath
     );
 
-    errors.push(...lowerVersionErrors, ...higherVersionErrors);
+    await writeFlowConfig(testDirPath, testGroup.libDefPath, true);
+    const higherVersionErrors = await runFlowTypeDefTests(
+      higherVersions,
+      testGroup.id,
+      testDirPath
+    );
+
+    errors.push(...higherVersionErrors, ...lowerVersionErrors);
     let lowerFlowVersionsToRun = orderedFlowVersions.filter(flowVer => {
       return semver.lt(flowVer, lowestFlowVersionRan);
     });


### PR DESCRIPTION
This is naive solution for the https://github.com/flowtype/flow-typed/issues/1385 . Flow returns errCode 0 if it only detects warnings so it can't be used unless someone makes changes to Flow it self.

Failing on all the warnings might not be bad idea either as type definitions should follow as good practices as possible imo.

Testing the type definitions would benefit a lot of tests too. This bug could perhaps have been caught by them.

Fixing this might reveal quite a lot of broken type definitions.