### PR TITLE
[axios] Headers should be optional in a request config

### DIFF
--- a/definitions/npm/axios_v0.16.x/flow_v0.25.x-/axios_v0.16.x.js
+++ b/definitions/npm/axios_v0.16.x/flow_v0.25.x-/axios_v0.16.x.js
@@ -57,7 +57,7 @@ declare module 'axios' {
   declare class AxiosXHR<T> {
     config: AxiosXHRConfig<T>;
     data: T;
-    headers: Object;
+    headers?: Object;
     status: number;
     statusText: string,
     request: http$ClientRequest | XMLHttpRequest


### PR DESCRIPTION
Hi.  Sorry if I am misunderstanding this however I think that this property should be optional.
https://github.com/axios/axios#request-config