### PR TITLE
Mousetrap update: Enable unbinding Array<string>

### DIFF
--- a/definitions/npm/mousetrap_v1.x.x/flow_v0.21.x-/mousetrap_v1.x.x.js
+++ b/definitions/npm/mousetrap_v1.x.x/flow_v0.21.x-/mousetrap_v1.x.x.js
@@ -1,6 +1,6 @@
 declare module 'mousetrap' {
   declare function bind(key: string|Array<string>, fn: (e: Event, combo?: string) => mixed, eventType?: string): void;
-  declare function unbind(key: string): void;
+  declare function unbind(key: string | Array<string>): void;
   declare function trigger(key: string): void;
   declare var stopCallback: (e: KeyboardEvent, element: Element, combo: string) => bool;
   declare function reset(): void;

--- a/definitions/npm/mousetrap_v1.x.x/test_moustrap-v1.js
+++ b/definitions/npm/mousetrap_v1.x.x/test_moustrap-v1.js
@@ -9,6 +9,7 @@ mousetrap.stopCallback = (e: KeyboardEvent, element: Element, combo: string) => 
 bind('c', (e: Event) => true);
 bind(['ctrl', 'c'], (e: Event) => true);
 unbind('c');
+unbind(['ctrl', 'c']);
 reset();
 trigger('c');
 


### PR DESCRIPTION
Moustrap's `unbind` function can accept either a string or an array of strings. This PR updates the definition to permit Array<string>.