### PR TITLE
Add library definition for normalize.css_v7.x.x

### DIFF
--- a/definitions/npm/normalize.css_v7.x.x/flow_v0.34.x-/normalize.css_v7.x.x.js
+++ b/definitions/npm/normalize.css_v7.x.x/flow_v0.34.x-/normalize.css_v7.x.x.js
@@ -1,0 +1,6 @@
+// normalize.css may be imported for side-effects,
+// e.g. to force webpack to bundle it alongside CSS modules
+
+declare module "normalize.css" {
+  declare export default empty
+}

--- a/definitions/npm/normalize.css_v7.x.x/flow_v0.34.x-/test_normalize.css-v7.x.x.js
+++ b/definitions/npm/normalize.css_v7.x.x/flow_v0.34.x-/test_normalize.css-v7.x.x.js
@@ -1,0 +1,2 @@
+// @flow
+import "normalize.css";


### PR DESCRIPTION
Normalize.css may be imported for side-effects, e.g. to force webpack's `css-loader` to bundle it with other CSS modules.