### PR TITLE
Adding axios v0.17.x

### DIFF
--- a/definitions/npm/axios_v0.17.x/flow_v0.25.x-/axios_v0.17.x.js
+++ b/definitions/npm/axios_v0.17.x/flow_v0.25.x-/axios_v0.17.x.js
@@ -1,0 +1,117 @@
+declare module 'axios' {
+  declare interface ProxyConfig {
+    host: string;
+    port: number;
+  }
+  declare interface Cancel {
+    constructor(message?: string): Cancel;
+    message: string;
+  }
+  declare interface Canceler {
+    (message?: string): void;
+  }
+  declare interface CancelTokenSource {
+    token: CancelToken;
+    cancel: Canceler;
+  }
+  declare interface CancelToken {
+    constructor(executor: (cancel: Canceler) => void): CancelToken;
+    static source(): CancelTokenSource;
+    promise: Promise<Cancel>;
+    reason?: Cancel;
+    throwIfRequested(): void;
+  }
+  declare interface AxiosXHRConfigBase<T> {
+    adapter?: <T>(config: AxiosXHRConfig<T>) => Promise<AxiosXHR<T>>;
+    auth?: {
+      username: string,
+      password: string
+    };
+    baseURL?: string,
+    cancelToken?: CancelToken;
+    headers?: Object;
+    httpAgent?: mixed; // Missing the type in the core flow node libdef
+    httpsAgent?: mixed; // Missing the type in the core flow node libdef
+    maxContentLength?: number;
+    maxRedirects?: 5,
+    params?: Object;
+    paramsSerializer?: (params: Object) => string;
+    progress?: (progressEvent: Event) => void | mixed;
+    proxy?: ProxyConfig | false;
+    responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
+    timeout?: number;
+    transformRequest?: Array<<U>(data: T) => U|Array<<U>(data: T) => U>>;
+    transformResponse?: Array<<U>(data: T) => U>;
+    validateStatus?: (status: number) => boolean,
+    withCredentials?: boolean;
+    xsrfCookieName?: string;
+    xsrfHeaderName?: string;
+  }
+  declare type $AxiosXHRConfigBase<T> = AxiosXHRConfigBase<T>;
+  declare interface AxiosXHRConfig<T> extends AxiosXHRConfigBase<T> {
+    data?: T;
+    method?: string;
+    url: string;
+  }
+  declare type $AxiosXHRConfig<T> = AxiosXHRConfig<T>;
+  declare class AxiosXHR<T> {
+    config: AxiosXHRConfig<T>;
+    data: T;
+    headers?: Object;
+    status: number;
+    statusText: string,
+    request: http$ClientRequest | XMLHttpRequest
+  }
+  declare type $AxiosXHR<T> = AxiosXHR<T>;
+  declare class AxiosInterceptorIdent extends String {}
+  declare class AxiosRequestInterceptor<T> {
+    use(
+      successHandler: ?(response: AxiosXHRConfig<T>) => Promise<AxiosXHRConfig<*>> | AxiosXHRConfig<*>,
+      errorHandler: ?(error: mixed) => mixed,
+    ): AxiosInterceptorIdent;
+    eject(ident: AxiosInterceptorIdent): void;
+  }
+  declare class AxiosResponseInterceptor<T> {
+    use(
+      successHandler: ?(response: AxiosXHR<T>) => mixed,
+      errorHandler: ?(error: $AxiosError<any>) => mixed,
+    ): AxiosInterceptorIdent;
+    eject(ident: AxiosInterceptorIdent): void;
+  }
+  declare type AxiosPromise<T> = Promise<AxiosXHR<T>>;
+  declare class Axios {
+    constructor<T>(config?: AxiosXHRConfigBase<T>): void;
+    $call: <T>(config: AxiosXHRConfig<T> | string, config?: AxiosXHRConfig<T>) => AxiosPromise<T>;
+    request<T>(config: AxiosXHRConfig<T>): AxiosPromise<T>;
+    delete<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
+    get<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
+    head<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
+    post<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
+    put<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
+    patch<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
+    interceptors: {
+      request: AxiosRequestInterceptor<mixed>,
+      response: AxiosResponseInterceptor<mixed>,
+    };
+    defaults: AxiosXHRConfig<*> & { headers: Object };
+  }
+
+  declare class AxiosError<T> extends Error {
+    config: AxiosXHRConfig<T>;
+    response: AxiosXHR<T>;
+    code?: string;
+  }
+
+  declare type $AxiosError<T> = AxiosError<T>;
+
+  declare interface AxiosExport extends Axios {
+    Axios: typeof Axios;
+    Cancel: Class<Cancel>;
+    CancelToken: Class<CancelToken>;
+    isCancel(value: any): boolean;
+    create(config?: AxiosXHRConfigBase<any>): Axios;
+    all: typeof Promise.all;
+    spread(callback: Function): (arr: Array<any>) => Function
+  }
+  declare module.exports: AxiosExport;
+}

--- a/definitions/npm/axios_v0.17.x/test_axios-v0.17.js
+++ b/definitions/npm/axios_v0.17.x/test_axios-v0.17.js
@@ -1,0 +1,88 @@
+// @flow
+import axios from 'axios';
+import type {
+  $AxiosXHR,
+  CancelTokenSource,
+  Cancel,
+} from 'axios';
+(axios.get('foo'): Promise<*>);
+(axios.post('bar', {}, {
+  headers: {
+    foo: 'asdf',
+  },
+  xsrfCookieName: 'cookie',
+}): Promise<*>);
+// $ExpectError
+(axios.post(123): Promise<*>);
+
+(axios('url'): Promise<*>);
+
+const client = axios.create();
+
+client.post('/something', {});
+
+(client.defaults.headers.common.Authorization = 'test')
+  
+const source: CancelTokenSource = axios.CancelToken.source();
+source.token.promise.then((cancel: Cancel) => {
+  const x: string = cancel.message;
+});
+client.get('/something', {
+  cancelToken: source.token,
+});
+client.get('/something', {
+  // $ExpectError
+  cancelToken: source,
+});
+
+source.cancel();
+source.cancel('canceled');
+// $ExpectError
+source.cancel(42);
+
+// $ExpectError
+client.post(232);
+
+type Data = {
+    items: Array<string>
+};
+
+axios.get('/user', {
+  params: {
+    ID: 12345
+  }
+}).then((res) => {
+    res.data[0];
+});
+
+// Send a POST request
+axios({
+  method: 'post',
+  url: '/user/12345',
+  data: {
+    firstName: 'Fred',
+    lastName: 'Flintstone'
+  }
+}).then(r => {
+  // $ExpectError
+  (r.status: string);
+});
+
+class AxiosExtended extends axios.Axios {
+  specialPut(...args) {
+    return super.put(...args);
+  }
+}
+
+const extended = new AxiosExtended();
+axios.all([
+  extended.specialPut('foo')
+    .then((r) => {
+        // $ExpectError
+        (r.statusText: number)
+    }),
+    Promise.reject(12)
+]).then(([a, b]) => {
+    // $ExpectError
+    (a: string);
+})


### PR DESCRIPTION
The only type change I could see from [v0.16.2](https://github.com/axios/axios/compare/v0.16.2...v0.17.0) was in the `proxy` configuration, which now accepts `false` or a `ProxyConfig` object.