### PR TITLE
fix bugs and extend coverage of redis package

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -1,15 +1,24 @@
 /* This module definition is by no means complete. A lot of methods of the
-Client class are missing */
+RedisClient class are missing */
 declare module "redis" {
-  declare class Client extends events$EventEmitter {
+  declare class RedisClient extends events$EventEmitter {
     hmset: (key: string, map: any, callback: (?Error) => void) => void;
-
     rpush: (key: string, value: string, callback: (?Error) => void) => void;
+    get: (key: string) => any;
+    set: (key: string, value: any) => void;
+    del: (...keys: Array<string>) => void;
+    publish: (topic: string, value: any) => void;
+    subscribe: (topic: string) => void;
+    unsubscribe: (topic: string) => void;
+    psubscribe: (pattern: string) => void;
+    punsubscribe: (pattern: string) => void;
+    duplicate: () => RedisClient;
+    quit: () => void;
   }
 
   declare module.exports: {
-    Client: typeof Client,
+    RedisClient: typeof RedisClient,
 
-    createClient: (settings: any) => Client
+    createClient: (settings: any) => RedisClient
   };
 }

--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
@@ -2,7 +2,7 @@
 
 const redis = require("redis");
 
-const client: redis.Client = redis.createClient();
+const client: redis.RedisClient = redis.createClient();
 
 client.hmset("some-key", { key1: "value1" }, err =>
   console.log("hmset error:", err)


### PR DESCRIPTION
The module exports `RedisClient`, not `Client`:

```js
> require('redis')
{ debug_mode: false,
  createClient: [Function],
  RedisClient: 
   { [Function: RedisClient]
     super_: 
      { [Function: EventEmitter]
        EventEmitter: [Circular],
        usingDomains: true,
        defaultMaxListeners: [Getter/Setter],
        init: [Function],
        listenerCount: [Function] },
     connection_id: 0 },
  print: [Function: print],
  Multi: [Function: Multi],
  AbortError: { [Function: AbortError] super_: { [Function: RedisError] super_: [Object] } },
  RedisError: 
   { [Function: RedisError]
     super_: 
      { [Function: Error]
        captureStackTrace: [Function: captureStackTrace],
        stackTraceLimit: 10 } },
  ParserError: 
   { [Function: RedisError]
     super_: 
      { [Function: Error]
        captureStackTrace: [Function: captureStackTrace],
        stackTraceLimit: 10 } },
  ReplyError: { [Function: ReplyError] super_: { [Function: RedisError] super_: [Object] } },
  AggregateError: { [Function: AggregateError] super_: { [Function: AbortError] super_: [Object] } },
  add_command: [Function: addCommand],
  addCommand: [Function: addCommand] }
```