### PR TITLE
Allow a dependency to be listed in multiple package.json dep fields

### DIFF
--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -222,10 +222,8 @@ describe("install (command)", () => {
             }
           })
         ]);
-        await gitInit(FAKE_CACHE_REPO_DIR), await gitAdd(
-          FAKE_CACHE_REPO_DIR,
-          "definitions"
-        );
+        await gitInit(FAKE_CACHE_REPO_DIR),
+          await gitAdd(FAKE_CACHE_REPO_DIR, "definitions");
         await gitCommit(FAKE_CACHE_REPO_DIR, "FIRST");
 
         setCustomCacheDir(FAKE_CACHE_DIR);
@@ -272,10 +270,11 @@ describe("install (command)", () => {
           touchFile(path.join(FLOWPROJ_DIR, ".flowconfig"))
         ]);
 
-        await gitInit(FAKE_CACHE_REPO_DIR), await Promise.all([
-          gitConfig(FAKE_CACHE_REPO_DIR, "user.name", "Test Author"),
-          gitConfig(FAKE_CACHE_REPO_DIR, "user.email", "test@flow-typed.org")
-        ]);
+        await gitInit(FAKE_CACHE_REPO_DIR),
+          await Promise.all([
+            gitConfig(FAKE_CACHE_REPO_DIR, "user.name", "Test Author"),
+            gitConfig(FAKE_CACHE_REPO_DIR, "user.email", "test@flow-typed.org")
+          ]);
         await gitAdd(FAKE_CACHE_REPO_DIR, "definitions");
         await gitCommit(FAKE_CACHE_REPO_DIR, "FIRST");
 
@@ -346,16 +345,16 @@ describe("install (command)", () => {
           writePkgJson(path.join(FLOWPROJ_DIR, "package.json"), {
             name: "test",
             devDependencies: {
-              foo: "1.2.3"
-            },
-            peerDependencies: {
               "flow-bin": "^0.43.0"
             },
-            optionalDependencies: {
-              foo: "2.0.0"
+            peerDependencies: {
+              foo: "1.2.3"
             },
             bundledDependencies: {
               bar: "^1.6.9"
+            },
+            optionalDependencies: {
+              foo: "2.0.0"
             },
             dependencies: {
               foo: "1.2.3"
@@ -372,7 +371,7 @@ describe("install (command)", () => {
           overwrite: false,
           verbose: false,
           skip: false,
-          ignoreDeps: ["dev", "optional", "bundled"]
+          ignoreDeps: ["optional"]
         });
 
         // Installs libdefs

--- a/cli/src/lib/__tests__/npmProjectUtils-test.js
+++ b/cli/src/lib/__tests__/npmProjectUtils-test.js
@@ -1,0 +1,98 @@
+// @flow
+import { getPackageJsonDependencies } from "../npm/npmProjectUtils";
+
+describe("npmProjectUtils", () => {
+  describe("getPackageJsonDependencies", () => {
+    it("throws when a dep of differing versions is found in multiple dep fields", () => {
+      const pkgJson = {
+        pathStr: "",
+        content: {
+          name: "",
+          version: "",
+          devDependencies: {
+            "flow-bin": "^0.38.0"
+          },
+          dependencies: {
+            "flow-bin": "^0.37.4"
+          }
+        }
+      };
+
+      expect(() => {
+        getPackageJsonDependencies(pkgJson, []);
+      }).toThrow("Found multiple versions of flow-bin listed in package.json!");
+    });
+
+    it("does not throw when a dep of the same version is found in multiple dep fields", () => {
+      const pkgJson = {
+        pathStr: "",
+        content: {
+          name: "",
+          version: "",
+          devDependencies: {
+            "flow-bin": "^0.37.4"
+          },
+          dependencies: {
+            "flow-bin": "^0.37.4"
+          }
+        }
+      };
+
+      const actual = getPackageJsonDependencies(pkgJson, []);
+
+      expect(actual).toEqual({
+        "flow-bin": "^0.37.4"
+      });
+    });
+
+    it("does not throw when a dep of a different version is found in an ignored field", () => {
+      const pkgJson = {
+        pathStr: "",
+        content: {
+          name: "",
+          version: "",
+          devDependencies: {
+            "flow-bin": "^0.38.0"
+          },
+          dependencies: {
+            "flow-bin": "^0.37.4"
+          }
+        }
+      };
+
+      const actual = getPackageJsonDependencies(pkgJson, ["dev"]);
+
+      expect(actual).toEqual({
+        "flow-bin": "^0.37.4"
+      });
+    });
+
+    it("ignores packages outside of normal, dev and optional dependencies", () => {
+      const pkgJson = {
+        pathStr: "",
+        content: {
+          name: "",
+          version: "",
+          devDependencies: {
+            "flow-bin": "^0.37.0"
+          },
+          dependencies: {
+            "flow-bin": "^0.37.4"
+          },
+          optionalDependencies: {
+            "flow-bin": "^0.37.4"
+          },
+          bundleDependencies: {
+            "flow-bin": "^0.38.0"
+          }
+        }
+      };
+
+      const actual = getPackageJsonDependencies(pkgJson, []);
+
+      expect(actual).toEqual({
+        "flow-bin": "^0.37.4"
+      });
+    });
+  });
+});

--- a/cli/src/lib/npm/npmProjectUtils.js
+++ b/cli/src/lib/npm/npmProjectUtils.js
@@ -1,15 +1,15 @@
 // @flow
 
-import {searchUpDirPath} from '../fileUtils.js';
+import { searchUpDirPath } from "../fileUtils.js";
 
-import type {FlowSpecificVer} from '../flowVersion.js';
+import type { FlowSpecificVer } from "../flowVersion.js";
 
-import {fs, path} from '../node.js';
+import { fs, path } from "../node.js";
 
-import {stringToVersion} from '../semver.js';
-import type {Version} from '../semver.js';
+import { stringToVersion } from "../semver.js";
+import type { Version } from "../semver.js";
 
-import semver from 'semver';
+import semver from "semver";
 
 type PkgJson = {|
   pathStr: string,
@@ -17,23 +17,23 @@ type PkgJson = {|
     name: string,
     version: string,
 
-    bundledDependencies?: {[pkgName: string]: string},
-    dependencies?: {[pkgName: string]: string},
-    devDependencies?: {[pkgName: string]: string},
-    optionalDependencies?: {[pkgName: string]: string},
-    peerDependencies?: {[pkgName: string]: string},
-  },
+    bundledDependencies?: string[],
+    dependencies?: { [pkgName: string]: string },
+    devDependencies?: { [pkgName: string]: string },
+    optionalDependencies?: { [pkgName: string]: string },
+    peerDependencies?: { [pkgName: string]: string }
+  }
 |};
 
 const PKG_JSON_DEP_FIELDS = [
-  'dependencies',
-  'devDependencies',
-  'peerDependencies',
-  'bundledDependencies',
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies"
 ];
+
 export async function findPackageJsonDepVersionStr(
   pkgJson: PkgJson,
-  depName: string,
+  depName: string
 ): Promise<null | string> {
   let matchedFields = [];
   const deps = PKG_JSON_DEP_FIELDS.reduce((deps, section) => {
@@ -52,7 +52,7 @@ export async function findPackageJsonDepVersionStr(
   } else {
     throw new Error(
       `Found ${depName} listed in ${String(deps.length)} places in ` +
-        `${pkgJson.pathStr}!`,
+        `${pkgJson.pathStr}!`
     );
   }
 }
@@ -60,19 +60,18 @@ export async function findPackageJsonDepVersionStr(
 export async function findPackageJsonPath(pathStr: string): Promise<string> {
   const pkgJsonPathStr = await searchUpDirPath(
     pathStr,
-    async p => await fs.exists(path.join(p, 'package.json')),
+    async p => await fs.exists(path.join(p, "package.json"))
   );
   if (pkgJsonPathStr === null) {
     throw new Error(`Unable to find a package.json for ${pathStr}!`);
   }
-  return path.join(pkgJsonPathStr, 'package.json');
+  return path.join(pkgJsonPathStr, "package.json");
 }
 
-// TODO: Write tests for this
 export function getPackageJsonDependencies(
   pkgJson: PkgJson,
-  ignoreDeps: Array<string>,
-): {[depName: string]: string} {
+  ignoreDeps: Array<string>
+): { [depName: string]: string } {
   const depFields = PKG_JSON_DEP_FIELDS.filter(field => {
     return ignoreDeps.indexOf(field.slice(0, -12)) === -1;
   });
@@ -81,8 +80,11 @@ export function getPackageJsonDependencies(
     const contentSection = pkgJson.content[section];
     if (contentSection) {
       Object.keys(contentSection).forEach(pkgName => {
-        if (deps[pkgName]) {
-          throw new Error(`Found ${pkgName} listed twice in package.json!`);
+        const lastFoundVersion = deps[pkgName];
+        if (lastFoundVersion && lastFoundVersion !== contentSection[pkgName]) {
+          throw new Error(
+            `Found multiple versions of ${pkgName} listed in package.json!`
+          );
         }
         deps[pkgName] = contentSection[pkgName];
       });
@@ -96,17 +98,17 @@ export async function getPackageJsonData(pathStr: string): Promise<PkgJson> {
   const pkgJsonContent = await fs.readFile(pkgJsonPath);
   return {
     pathStr: pkgJsonPath,
-    content: JSON.parse(pkgJsonContent.toString()),
+    content: JSON.parse(pkgJsonContent.toString())
   };
 }
 
 export async function determineFlowVersion(
-  pathStr: string,
+  pathStr: string
 ): Promise<null | Version> {
   const pkgJsonData = await getPackageJsonData(pathStr);
   const flowBinVersionStr = await findPackageJsonDepVersionStr(
     pkgJsonData,
-    'flow-bin',
+    "flow-bin"
   );
 
   if (flowBinVersionStr !== null) {
@@ -116,50 +118,50 @@ export async function determineFlowVersion(
     } else {
       const flowVerRange = new semver.Range(flowBinVersionStr);
       if (flowVerRange.set[0].length !== 2) {
-        const cliPkgJson = require('../../../package.json');
-        const cliFlowVer = cliPkgJson.devDependencies['flow-bin'];
+        const cliPkgJson = require("../../../package.json");
+        const cliFlowVer = cliPkgJson.devDependencies["flow-bin"];
         throw new Error(
           `Unable to extract flow-bin version from package.json!\n` +
             `Never use a complex version range with flow-bin. Always use a ` +
-            `specific version (i.e. "${cliFlowVer}").`,
+            `specific version (i.e. "${cliFlowVer}").`
         );
       }
       flowVerStr = flowVerRange.set[0][0].semver.version;
     }
-    return stringToVersion('v' + flowVerStr);
+    return stringToVersion("v" + flowVerStr);
   }
 
   return null;
 }
 
 export async function findFlowSpecificVer(
-  startingPath: string,
+  startingPath: string
 ): Promise<FlowSpecificVer> {
   const flowSemver = await determineFlowVersion(startingPath);
   if (flowSemver === null) {
     throw new Error(
-      'Failed to find a flow-bin dependency in package.json.\n' +
-        'Please install flow-bin: `npm install --save-dev flow-bin`',
+      "Failed to find a flow-bin dependency in package.json.\n" +
+        "Please install flow-bin: `npm install --save-dev flow-bin`"
     );
   }
   if (flowSemver.range !== undefined) {
     throw new Error(
       `Unable to extract flow-bin version from package.json!\n` +
         `Never use a complex version range with flow-bin. Always use a ` +
-        `specific major/minor version (i.e. "^0.39").`,
+        `specific major/minor version (i.e. "^0.39").`
     );
   }
   const major = flowSemver.major;
-  if (major === 'x') {
+  if (major === "x") {
     throw new Error(
       `Unable to extract flow-bin version from package.json!\n` +
-        `Never use a wildcard major version with flow-bin!`,
+        `Never use a wildcard major version with flow-bin!`
     );
   }
   return {
     major,
     minor: flowSemver.minor,
     patch: flowSemver.patch,
-    prerel: flowSemver.prerel == null ? null : flowSemver.prerel,
+    prerel: flowSemver.prerel == null ? null : flowSemver.prerel
   };
 }


### PR DESCRIPTION
This PR does 2 things
- allows multiple entries of a package in `package.json`, as long as the versions match
- only installs definitions for packages under `dependencies`, `devDependencies` and `optionalDependencies`.

Dependencies listed under `bundleDependencie` and `peerDependencies` are no longer installed. In the case of `bundleDependencie`, we expect the package-version to be listed under another dependencies. In the case of `peerDependency`, packages under `peerDependencies` aren't actually used/installed, so it should be safe to ignore them.

Replaces and enhances #587 
Closes #379
Credit to @ahutchings for most of the work