### PR TITLE
ramda#reduceRight, fixes incorrect argument order

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
@@ -944,17 +944,17 @@ declare module ramda {
   ): { [key: string]: B };
 
   declare function reduceRight<A, B>(
-    fn: (acc: A, elem: B) => A,
+    fn: (elem: B, acc: A) => A,
     ...rest: Array<void>
   ): ((init: A, xs: Array<B>) => A) &
     ((init: A, ...rest: Array<void>) => (xs: Array<B>) => A);
   declare function reduceRight<A, B>(
-    fn: (acc: A, elem: B) => A,
+    fn: (elem: B, acc: A) => A,
     init: A,
     ...rest: Array<void>
   ): (xs: Array<B>) => A;
   declare function reduceRight<A, B>(
-    fn: (acc: A, elem: B) => A,
+    fn: (elem: B, acc: A) => A,
     init: A,
     xs: Array<B>
   ): A;

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_list.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_list.js
@@ -194,6 +194,18 @@ const str: string = "hello world";
   const redxs5: Array<string> = _.reduceRight(_.concat, [])(
     _.map(x => [x], ss)
   );
+  //$ExpectError
+  const redxs5a: string = _.reduceRight(
+    (acc: string, value: number): string => acc,
+    "",
+    ns
+  );
+  const redxs5b: string = _.reduceRight(
+    (value: number, acc: string): string => acc,
+    "",
+    ns
+  );
+
   const redxs6: Array<number> = _.scan(_.add)(10)(ns);
   const redxs7: Array<number> = _.scan(_.add, 10)(ns);
   const redxs8: Array<number> = _.scan(_.add)(10, ns);


### PR DESCRIPTION
http://ramdajs.com/docs/#reduceRight

> The iterator function receives two values: (value, acc), while the arguments' order of reduce's iterator function is (acc, value).

