### PR TITLE
formik, installs dummy expected error to fix eslint error

### DIFF
--- a/definitions/npm/formik_v0.9.x/test_formik.js
+++ b/definitions/npm/formik_v0.9.x/test_formik.js
@@ -1,15 +1,30 @@
 // @flow
 
 import * as React from "react";
-import { Formik, Form, Field, type FieldProps } from "formik";
+import {
+  Formik,
+  Form,
+  Field,
+  type FieldProps,
+  type FormikActions,
+  type FormikConfig
+} from "formik";
 
 <Formik
   initialValues={{ foo: "hi" }}
-  onSubmit={(values, formikActions) => {
+  onSubmit={(values: *, formikActions: FormikActions<*>) => {
     values.foo;
     values.bar;
   }}
 />;
+
+const config1: FormikConfig = {
+  onSubmit: (values: *, formikActions: FormikActions<*>) => {}
+};
+// $ExpectError
+const configRequiresOnSubmit: FormikConfig = {
+  onSubmit: null
+};
 
 const CustomInputComponent = (props: FieldProps) => <input />;
 


### PR DESCRIPTION
PR https://github.com/flowtype/flow-typed/pull/1395 introduced a definition test file that fails an eslint rule requiring a negative test. To be honest, I'm not sure how the travis build was successful for it. Is there something missing in the travis config?

Clone master to reproduce:
```
cd definitions
yarn install
yarn test

/Users/patrick.winters/projects/hack/flow-typed/definitions/npm/formik_v0.9.x/test_formik.js
  1:1  error  Test has to include at least 1 negative Tests  flow-typed/negative-tests
```