### PR TITLE
Add definition for pify

### DIFF
--- a/definitions/npm/pify_v3.x.x/flow_v0.25.x-/pify_v3.x.x.js
+++ b/definitions/npm/pify_v3.x.x/flow_v0.25.x-/pify_v3.x.x.js
@@ -1,0 +1,19 @@
+type $npm$pify$CPSFunction = (...args: any[]) => any;
+
+type $npm$pify$Options = {
+  multiArgs?: boolean,
+  include?: Array<string | RegExp>,
+  exclude?: Array<string | RegExp>,
+  excludeMain?: boolean,
+  errorFirst?: boolean,
+  promiseModule?: () => any
+};
+
+type $npm$pify$PromisifiedFunction = (...args: any[]) => Promise<*>;
+
+declare module "pify" {
+  declare module.exports: (
+    input: $npm$pify$CPSFunction | Object,
+    options?: $npm$pify$Options
+  ) => (...args: any[]) => Promise<*> | Object;
+}

--- a/definitions/npm/pify_v3.x.x/test_pify_v3.x.x.js
+++ b/definitions/npm/pify_v3.x.x/test_pify_v3.x.x.js
@@ -1,0 +1,30 @@
+const pify = require("pify");
+
+const cpsFunction: Function = (foo, callback) => {
+  setTimeout(() => {
+    callback(foo);
+  }, 1000);
+};
+
+const cpsObject = {
+  foo: cpsFunction,
+  bar: 123
+};
+
+pify(cpsFunction, { multiArgs: true })("hi").then(x => {
+  console.log(x);
+});
+pify(cpsObject).foo("hi").then(x => {
+  console.log(x);
+});
+
+// $ExpectError
+pify("asdf");
+
+// $ExpectError
+pify();
+
+pify({});
+
+// $ExpectError
+pify({}, 1);


### PR DESCRIPTION
Definition for [sindresorhus/pify](https://github.com/sindresorhus/pify) module.

`pify()` accepts either a promisifiable function **or** an object with promisifiable methods. For the latter case I'm not sure how I can make the typing more specific, as the passed object might also contain miscellaneous non-function properties which pify just passes through unmodified. So I've just used the weak `Object` type for this case. Let me know if there's a better way to do this.
