### PR TITLE
run 'yarn test' in defintions, which enforces eslint rules

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -2,8 +2,8 @@
 #set -o errexit
 
 cd definitions && \
-#yarn install && \
-#yarn test && \
+yarn install && \
+yarn test && \
 cd ../cli && \
 yarn && \
 yarn run flow && \


### PR DESCRIPTION
Recently I found that I was unable to successfully run `./run_def_tests.sh` after updating a ramda defintion because another definition test was committed without a negative test (in violation of the "flow-typed/negative-tests" rule in `definitions/.eslintrc`. https://github.com/flowtype/flow-typed/pull/1479

FWIW, this commit [https://github.com/flowtype/flow-typed/commit/fb7612683c8a2546d95bfe58f91f50c654ecd066](https://github.com/flowtype/flow-typed/commit/fb7612683c8a2546d95bfe58f91f50c654ecd066), a year ago, commented out `yarn test` in `/definitions`, which enforces the rule and is also run by `./run_def_tests.sh`.