### PR TITLE
use stricter typing on ramda's propEq

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
@@ -369,16 +369,16 @@ declare module ramda {
   }
 
   /**
-  * DONE:
-  * Function*
-  * List*
-  * Logic
-  * Math
-  * Object*
-  * Relation
-  * String
-  * Type
-  */
+   * DONE:
+   * Function*
+   * List*
+   * Logic
+   * Math
+   * Object*
+   * Relation
+   * String
+   * Type
+   */
 
   declare var compose: Compose;
   declare var pipe: Pipe;
@@ -1034,17 +1034,25 @@ declare module ramda {
   ): (y: A) => boolean;
   declare function eqBy<A, B>(fn: (x: A) => B, x: A, y: A): boolean;
 
-  declare function propEq(
-    prop: string,
-    ...rest: Array<void>
-  ): ((val: *, o: { [k: string]: * }) => boolean) &
-    ((val: *, ...rest: Array<void>) => (o: { [k: string]: * }) => boolean);
-  declare function propEq(
-    prop: string,
-    val: *,
-    ...rest: Array<void>
-  ): (o: { [k: string]: * }) => boolean;
-  declare function propEq(prop: string, val: *, o: { [k: string]: * }): boolean;
+  // Workaround for $ElementType.
+  // See https://github.com/facebook/flow/issues/4804
+  declare type $Ramda_ElementType<A, B> = $ElementType<A, B>;
+  // Flow cares about the order in which these appear. Generally function
+  // siguatures should go from smallest arity to largest arity.
+  declare type PropEq = (<T>(
+    prop: $Keys<T>
+  ) => ((val: $ElementType<T, $Keys<T>>) => (obj: T) => boolean) &
+    ((val: $ElementType<T, $Keys<T>>, obj: T) => boolean)) &
+    (<T>(
+      prop: $Keys<T>,
+      val: $ElementType<T, $Keys<T>>
+    ) => (obj: T) => boolean) &
+    (<T>(
+      prop: $Keys<T>,
+      val: $Ramda_ElementType<T, $Keys<T>>,
+      obj: T
+    ) => boolean);
+  declare var propEq: PropEq;
 
   declare function pathEq(
     path: Array<string>,

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_relation.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_relation.js
@@ -53,8 +53,22 @@ const interBy: Array<number> = _.intersectionWith(_.eqBy(Math.abs), ns, ns);
 const pathEqObj: boolean = _.pathEq(["hello"], 1, obj);
 const pathEqObj2: boolean = _.pathEq(["hello"])(1)(obj);
 
-const propEqObj: boolean = _.propEq("hello", 1, obj);
-const propEqObj2: boolean = _.propEq("hello")(1)(obj);
+type PropEqFoo = { bar: number };
+const propEqFoo: PropEqFoo = { bar: 2 };
+
+const propEqResult1: boolean = _.propEq("bar", 1, propEqFoo);
+// Test curried versions.
+const propEqResult1a: boolean = _.propEq("bar")(1)(propEqFoo);
+const propEqResult1b: boolean = _.propEq("bar")(1, propEqFoo);
+const propEqResult1c: boolean = _.propEq("bar", 1)(propEqFoo);
+
+// The type compared should be the type of the property.
+// $ExpectError
+const propEqResult2: boolean = _.propEq("bar", "wrong", propEqFoo);
+
+// The property name must be a property on the object supplied.
+// $ExpectError
+const propEqResult3: boolean = _.propEq("baz", 1, propEqFoo);
 
 const sortByFirstItem = _.sortBy(([first]) => first);
 const pairs = [[-1, 1], [-2, 2], [-3, 3]];


### PR DESCRIPTION
`propEq` now requires the key to be on the object supplied, and the comparison value must be the same type as the value of the property on that key.