### PR TITLE
Add type refinement to Ramda #isNil.

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
@@ -430,8 +430,8 @@ declare module ramda {
   declare function type(x: ?any): string;
   declare function isArrayLike(x: any): boolean;
 
-  declare function isNil(x: void | null): true;
-  declare function isNil(x: mixed): false;
+  declare function isNil(x: mixed): boolean %checks(x === undefined ||
+    x === null);
 
   // *List
   declare function adjust<T>(

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_misc.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_misc.js
@@ -1,6 +1,15 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from "ramda";
+import _, {
+  compose,
+  pipe,
+  curry,
+  filter,
+  find,
+  isNil,
+  repeat,
+  zipWith
+} from "ramda";
 
 const ns: Array<number> = [1, 2, 3, 4, 5];
 const ss: Array<string> = ["one", "two", "three", "four"];
@@ -36,8 +45,15 @@ const str: string = "hello world";
 //Type
 {
   const x: boolean = _.is(Number, 1);
-  const x1: false = _.isNil(1);
-  const x1a: true = _.isNil();
-  const x1b: true = _.isNil(null);
+  const x1: boolean = isNil(1);
+
+  // should refine type
+  const x1a: ?{ a: number } = { a: 1 };
+  //$ExpectError
+  x1a.a;
+  if (!isNil(x1a)) {
+    x1a.a;
+  }
+
   const x2: boolean = _.propIs(1, "num", { num: 1 });
 }


### PR DESCRIPTION
The Ramda `isNil` function is a useful predicate that should refine the type of a variable. The test added in the diff did not pass originally, but does not with the updated definition.

It's not possible to provide the type refinement while still specifying a boolean literal, so something like this isn't possible:

```js
declare function isNil(x: void | null): true %checks (x === undefined || x === null);
//1:   declare function isNil(x: void | null): true %checks (x === undefined || x === null);
//                                                                              ^ boolean. Expected boolean literal `true`
//1:   declare function isNil(x: void | null): true %checks (x === undefined || x === null);
//                                             ^ boolean literal `true`
```

Having a literal type isn't important though, since usually we'd be using this for something like type refinement, so returning `boolean` seems fine here and more useful than the previous definition.

