### PR TITLE
apply $ElementType workaround to other ramda propEq arities

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
@@ -1041,11 +1041,11 @@ declare module ramda {
   // siguatures should go from smallest arity to largest arity.
   declare type PropEq = (<T>(
     prop: $Keys<T>
-  ) => ((val: $ElementType<T, $Keys<T>>) => (obj: T) => boolean) &
+  ) => ((val: $Ramda_ElementType<T, $Keys<T>>) => (obj: T) => boolean) &
     ((val: $ElementType<T, $Keys<T>>, obj: T) => boolean)) &
     (<T>(
       prop: $Keys<T>,
-      val: $ElementType<T, $Keys<T>>
+      val: $Ramda_ElementType<T, $Keys<T>>
     ) => (obj: T) => boolean) &
     (<T>(
       prop: $Keys<T>,

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_relation.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_relation.js
@@ -56,15 +56,22 @@ const pathEqObj2: boolean = _.pathEq(["hello"])(1)(obj);
 type PropEqFoo = { bar: number };
 const propEqFoo: PropEqFoo = { bar: 2 };
 
-const propEqResult1: boolean = _.propEq("bar", 1, propEqFoo);
+const propEqResult1a: boolean = _.propEq("bar", 1, propEqFoo);
 // Test curried versions.
-const propEqResult1a: boolean = _.propEq("bar")(1)(propEqFoo);
-const propEqResult1b: boolean = _.propEq("bar")(1, propEqFoo);
-const propEqResult1c: boolean = _.propEq("bar", 1)(propEqFoo);
+const propEqResult1b: boolean = _.propEq("bar")(1)(propEqFoo);
+const propEqResult1c: boolean = _.propEq("bar")(1, propEqFoo);
+const propEqResult1d: boolean = _.propEq("bar", 1)(propEqFoo);
 
 // The type compared should be the type of the property.
 // $ExpectError
-const propEqResult2: boolean = _.propEq("bar", "wrong", propEqFoo);
+const propEqResult2a: boolean = _.propEq("bar", "wrong", propEqFoo);
+// Test the same comparison param against the various arities.
+// $ExpectError
+const propEqResult2b: boolean = _.propEq("bar")("wrong")(propEqFoo);
+// $ExpectError
+const propEqResult2c: boolean = _.propEq("bar")("wrong", propEqFoo);
+// $ExpectError
+const propEqResult2d: boolean = _.propEq("bar", "wrong")(propEqFoo);
 
 // The property name must be a property on the object supplied.
 // $ExpectError


### PR DESCRIPTION
This is a followup to #1499. Per a discussion with @AndrewSouthpaw and (out of band) @forticulous, the usage of `$ElementType` needs a [workaround](https://github.com/facebook/flow/issues/4804) applied. Use of the workaround is already documented in the libdef here but I had not applied the workaround to all versions of `propEq` - just the 3 param version.

This PR adds additional negative test cases for the other arities of `propEq` and applies the workaround to the remaining versions of `propEq`.