### PR TITLE
support ramda's propEq's === nature

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
@@ -1034,24 +1034,21 @@ declare module ramda {
   ): (y: A) => boolean;
   declare function eqBy<A, B>(fn: (x: A) => B, x: A, y: A): boolean;
 
-  // Workaround for $ElementType.
-  // See https://github.com/facebook/flow/issues/4804
-  declare type $Ramda_ElementType<A, B> = $ElementType<A, B>;
   // Flow cares about the order in which these appear. Generally function
   // siguatures should go from smallest arity to largest arity.
   declare type PropEq = (<T>(
     prop: $Keys<T>
-  ) => ((val: $Ramda_ElementType<T, $Keys<T>>) => (obj: T) => boolean) &
-    ((val: $ElementType<T, $Keys<T>>, obj: T) => boolean)) &
+  ) => ((val: mixed) => (obj: T) => boolean) &
+    ((val: mixed, obj: T) => boolean)) &
+    (<T>(prop: $Keys<T>, val: mixed) => (obj: T) => boolean) &
+    (<T>(prop: $Keys<T>, val: mixed, obj: T) => boolean) &
+    // Array variants.
     (<T>(
-      prop: $Keys<T>,
-      val: $Ramda_ElementType<T, $Keys<T>>
-    ) => (obj: T) => boolean) &
-    (<T>(
-      prop: $Keys<T>,
-      val: $Ramda_ElementType<T, $Keys<T>>,
-      obj: T
-    ) => boolean);
+      prop: number
+    ) => ((val: mixed) => (obj: Array<*>) => boolean) &
+      ((val: mixed, obj: Array<*>) => boolean)) &
+    (<T>(prop: number, val: mixed) => (obj: Array<*>) => boolean) &
+    (<T>(prop: number, val: mixed, obj: Array<*>) => boolean);
   declare var propEq: PropEq;
 
   declare function pathEq(

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_relation.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_relation.js
@@ -53,29 +53,40 @@ const interBy: Array<number> = _.intersectionWith(_.eqBy(Math.abs), ns, ns);
 const pathEqObj: boolean = _.pathEq(["hello"], 1, obj);
 const pathEqObj2: boolean = _.pathEq(["hello"])(1)(obj);
 
-type PropEqFoo = { bar: number };
-const propEqFoo: PropEqFoo = { bar: 2 };
+// It's good to test this with multiple params since $Keys<T> is a union.
+type PropEqObj = { bar: number, baz: string };
+const propEqObj: PropEqObj = { bar: 2, baz: "qux" };
 
-const propEqResult1a: boolean = _.propEq("bar", 1, propEqFoo);
+const propEqResult1a: boolean = _.propEq("bar", 1, propEqObj);
 // Test curried versions.
-const propEqResult1b: boolean = _.propEq("bar")(1)(propEqFoo);
-const propEqResult1c: boolean = _.propEq("bar")(1, propEqFoo);
-const propEqResult1d: boolean = _.propEq("bar", 1)(propEqFoo);
+const propEqResult1b: boolean = _.propEq("bar")(1)(propEqObj);
+const propEqResult1c: boolean = _.propEq("bar")(1, propEqObj);
+const propEqResult1d: boolean = _.propEq("bar", 1)(propEqObj);
 
-// The type compared should be the type of the property.
-// $ExpectError
-const propEqResult2a: boolean = _.propEq("bar", "wrong", propEqFoo);
-// Test the same comparison param against the various arities.
-// $ExpectError
-const propEqResult2b: boolean = _.propEq("bar")("wrong")(propEqFoo);
-// $ExpectError
-const propEqResult2c: boolean = _.propEq("bar")("wrong", propEqFoo);
-// $ExpectError
-const propEqResult2d: boolean = _.propEq("bar", "wrong")(propEqFoo);
+// The type compared can be any type just like any other === comparison.
+// Also test the various arities.
+const propEqResult2a: boolean = _.propEq("bar", "always false", propEqObj);
+const propEqResult2b: boolean = _.propEq("bar")("always false")(propEqObj);
+const propEqResult2c: boolean = _.propEq("bar")("always false", propEqObj);
+const propEqResult2d: boolean = _.propEq("bar", "always false")(propEqObj);
 
 // The property name must be a property on the object supplied.
 // $ExpectError
-const propEqResult3: boolean = _.propEq("baz", 1, propEqFoo);
+const propEqResultError: boolean = _.propEq("missing", 1, propEqObj);
+
+// propEq must work with key value pairs.
+const propEqKvp: { [string]: mixed } = { foo: 1, bar: "2", baz: 3 };
+const propEqResult3a: boolean = _.propEq("qux", "value", propEqKvp);
+const propEqResult3b: boolean = _.propEq("qux")("value")(propEqKvp);
+const propEqResult3c: boolean = _.propEq("qux")("value", propEqKvp);
+const propEqResult3d: boolean = _.propEq("qux", "value")(propEqKvp);
+
+// propEq must work with arrays.
+const propEqArray = [1, 2, 3];
+const propEqResult4a: boolean = _.propEq(1, 2, propEqArray);
+const propEqResult4b: boolean = _.propEq(1)(2)(propEqArray);
+const propEqResult4c: boolean = _.propEq(1)(2, propEqArray);
+const propEqResult4d: boolean = _.propEq(1, 2)(propEqArray);
 
 const sortByFirstItem = _.sortBy(([first]) => first);
 const pairs = [[-1, 1], [-2, 2], [-3, 3]];


### PR DESCRIPTION
I ran into some problems with the `$ElementType` utility type. `$Keys<T>` is a union of property names. I added some test cases to include objects with multiple names and the typedef we had broke.  

After exploring with a repl I've found `propEq` is totally fine with comparing values of varied types. The behavior of `propEq` is that of `===` ([example](http://ramdajs.com/repl/#?const%20foo%20%3D%20%7B%20bar%3A%20%27string%27%7D%0AR.propEq%28%27bar%27%2C%205%2C%20foo%29)), and in Flow you can compare using `===` with anything and that type checks ok ([example](https://flow.org/try/#0KwAgvBIOTFBQcDGB7AdgZwC4lQVwLbggCMSaWIWATkVAEzxkbZUCm6uANtmDgeJGpMKyTAAtWNXnkKDMVOEA)). This means we can treat the comparison value as `mixed` and we can drop the use of `$ElementType`. No more workaround needed, and the type signature more accurately reflects the runtime behavior of `propEq`.

Also we found out `propEq` supports treating `number` as a property for `Array` ([example](http://ramdajs.com/repl/#?const%20xs%20%3D%20%5B1%2C%202%2C%203%5D%0A%2F%2F%20Is%20element%201%20the%20value%20of%202%3F%0AR.propEq%281%2C%202%2C%20xs%29%20%2F%2F%20true)). This PR also adds the array support.