### PR TITLE
Allow Jest's toMatchObject to receive an array of objects

### DIFF
--- a/definitions/npm/jest_v21.x.x/flow_v0.22.x-v0.38.x/jest_v21.x.x.js
+++ b/definitions/npm/jest_v21.x.x/flow_v0.22.x-v0.38.x/jest_v21.x.x.js
@@ -251,7 +251,7 @@ type JestExpectType = {
   /**
    * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
    */
-  toMatchObject(object: Object): void,
+  toMatchObject(object: Object | Array<Object>): void,
   /**
    * This ensures that a React component matches the most recent snapshot.
    */

--- a/definitions/npm/jest_v21.x.x/flow_v0.39.x-/jest_v21.x.x.js
+++ b/definitions/npm/jest_v21.x.x/flow_v0.39.x-/jest_v21.x.x.js
@@ -255,7 +255,7 @@ type JestExpectType = {
   /**
    * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
    */
-  toMatchObject(object: Object): void,
+  toMatchObject(object: Object | Array<Object>): void,
   /**
    * This ensures that a React component matches the most recent snapshot.
    */


### PR DESCRIPTION
Per [the docs](https://facebook.github.io/jest/docs/en/expect.html#tomatchobjectobject):

> You can also pass an array of objects, in which case the method will return true only if each object in the received array matches (in the `toMatchObject` sense described above) the corresponding object in the expected array.