### PR TITLE
prevent ramda's find from searching an object

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
@@ -621,14 +621,13 @@ declare module ramda {
   ): ((xs: string) => string) & ((xs: T) => ?V);
   declare function nth<T: string>(i: number, xs: T): T;
 
-  declare function find<V, O: { [key: string]: * }, T: Array<V> | O>(
-    fn: UnaryPredicateFn<V>,
-    ...rest: Array<void>
-  ): (xs: T | O) => ?V | O;
-  declare function find<V, O: { [key: string]: * }, T: Array<V> | O>(
-    fn: UnaryPredicateFn<V>,
-    xs: T | O
-  ): ?V | O;
+  declare type Find = (<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ) => (xs: T) => ?V) &
+    (<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T) => ?V);
+
+  declare var find: Find;
+
   declare function findLast<V, O: { [key: string]: * }, T: Array<V> | O>(
     fn: UnaryPredicateFn<V>,
     ...rest: Array<void>

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_list.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_list.js
@@ -50,6 +50,11 @@ const str: string = "hello world";
   const findxs1: ?{ [k: string]: number | string } = _.find(_.propEq("a", 4))(
     os
   );
+  // Ramda doesn't strictly break if you pass it an object, but it always
+  // returns undefined.
+  // $ExpectError
+  const findObj = find(o => o == "bar", { foo: "bar" });
+
   const findxs2: ?{ [k: string]: number | string } = _.findLast(
     _.propEq("a", 2),
     os
@@ -75,7 +80,7 @@ const str: string = "hello world";
   const s7: number = _.findIndex(x => x === "2", { a: "1", b: "2" });
   const forEachxs = _.forEach(x => console.log(x), ns);
 
-  const forEachObj = _.forEachObjIndexed((value, key) => {}, {x: 1, y: 2});
+  const forEachObj = _.forEachObjIndexed((value, key) => {}, { x: 1, y: 2 });
 
   const groupedBy: { [k: string]: Array<number> } = _.groupBy(
     x => (x > 1 ? "more" : "less"),


### PR DESCRIPTION
Ramda's documentation for [find](http://ramdajs.com/docs/#find) as well as a [quick example](http://ramdajs.com/repl/#?R.find%28o%20%3D%3E%20o%20%3D%3D%20%27bar%27%2C%20%7Bfoo%3A%20%27bar%27%7D%29) shows that it cannot meaningfully perform a search over an object. This corrects the type and adds an assertion in the test that expects an error when trying to call `find` with an object.

Ramda handles these situations gracefully but in a Flow ecosystem I don't believe it will be desired to pass objects into `find` and expect that to type check successfully.