### PR TITLE
stop declaring that ramda's partial returns curried functions

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
@@ -155,29 +155,14 @@ declare module ramda {
     ) => CurriedFunction6<A, B, C, D, E, F, R>);
 
   declare type Partial = (<A, R>((...r: [A]) => R, args: [A]) => () => R) &
-    (<A, B, R>((...r: [A, B]) => R, args: [A]) => CurriedFunction1<B, R>) &
+    (<A, B, R>((...r: [A, B]) => R, args: [A]) => B => R) &
     (<A, B, R>((...r: [A, B]) => R, args: [A, B]) => () => R) &
-    (<A, B, C, R>(
-      (...r: [A, B, C]) => R,
-      args: [A]
-    ) => CurriedFunction2<B, C, R>) &
-    (<A, B, C, R>(
-      (...r: [A, B, C]) => R,
-      args: [A, B]
-    ) => CurriedFunction1<C, R>) &
+    (<A, B, C, R>((...r: [A, B, C]) => R, args: [A]) => (B, C) => R) &
+    (<A, B, C, R>((...r: [A, B, C]) => R, args: [A, B]) => C => R) &
     (<A, B, C, R>((...r: [A, B, C]) => R, args: [A, B, C]) => () => R) &
-    (<A, B, C, D, R>(
-      (...r: [A, B, C, D]) => R,
-      args: [A]
-    ) => CurriedFunction3<B, C, D, R>) &
-    (<A, B, C, D, R>(
-      (...r: [A, B, C, D]) => R,
-      args: [A, B]
-    ) => CurriedFunction2<C, D, R>) &
-    (<A, B, C, D, R>(
-      (...r: [A, B, C, D]) => R,
-      args: [A, B, C]
-    ) => CurriedFunction1<D, R>) &
+    (<A, B, C, D, R>((...r: [A, B, C, D]) => R, args: [A]) => (B, C, D) => R) &
+    (<A, B, C, D, R>((...r: [A, B, C, D]) => R, args: [A, B]) => (C, D) => R) &
+    (<A, B, C, D, R>((...r: [A, B, C, D]) => R, args: [A, B, C]) => D => R) &
     (<A, B, C, D, R>(
       (...r: [A, B, C, D]) => R,
       args: [A, B, C, D]
@@ -185,19 +170,19 @@ declare module ramda {
     (<A, B, C, D, E, R>(
       (...r: [A, B, C, D, E]) => R,
       args: [A]
-    ) => CurriedFunction4<B, C, D, E, R>) &
+    ) => (B, C, D, E) => R) &
     (<A, B, C, D, E, R>(
       (...r: [A, B, C, D, E]) => R,
       args: [A, B]
-    ) => CurriedFunction3<C, D, E, R>) &
+    ) => (C, D, E) => R) &
     (<A, B, C, D, E, R>(
       (...r: [A, B, C, D, E]) => R,
       args: [A, B, C]
-    ) => CurriedFunction2<D, E, R>) &
+    ) => (D, E) => R) &
     (<A, B, C, D, E, R>(
       (...r: [A, B, C, D, E]) => R,
       args: [A, B, C, D]
-    ) => CurriedFunction1<E, R>) &
+    ) => E => R) &
     (<A, B, C, D, E, R>(
       (...r: [A, B, C, D, E]) => R,
       args: [A, B, C, D, E]
@@ -205,26 +190,122 @@ declare module ramda {
     (<A, B, C, D, E, F, R>(
       (...r: [A, B, C, D, E, F]) => R,
       args: [A]
-    ) => CurriedFunction5<B, C, D, E, F, R>) &
+    ) => (B, C, D, E, F) => R) &
     (<A, B, C, D, E, F, R>(
       (...r: [A, B, C, D, E, F]) => R,
       args: [A, B]
-    ) => CurriedFunction4<C, D, E, F, R>) &
+    ) => (C, D, E, F) => R) &
     (<A, B, C, D, E, F, R>(
       (...r: [A, B, C, D, E, F]) => R,
       args: [A, B, C]
-    ) => CurriedFunction3<D, E, F, R>) &
+    ) => (D, E, F) => R) &
     (<A, B, C, D, E, F, R>(
       (...r: [A, B, C, D, E, F]) => R,
       args: [A, B, C, D]
-    ) => CurriedFunction2<E, F, R>) &
+    ) => (E, F) => R) &
     (<A, B, C, D, E, F, R>(
       (...r: [A, B, C, D, E, F]) => R,
       args: [A, B, C, D, E]
-    ) => CurriedFunction1<F, R>) &
+    ) => F => R) &
     (<A, B, C, D, E, F, R>(
       (...r: [A, B, C, D, E, F]) => R,
       args: [A, B, C, D, E, F]
+    ) => () => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A]
+    ) => (B, C, D, E, F, G) => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B]
+    ) => (C, D, E, F, G) => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B, C]
+    ) => (D, E, F, G) => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B, C, D]
+    ) => (E, F, G) => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B, C, D, E]
+    ) => (F, G) => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B, C, D, E, F]
+    ) => G => R) &
+    (<A, B, C, D, E, F, G, R>(
+      (...r: [A, B, C, D, E, F, G]) => R,
+      args: [A, B, C, D, E, F, G]
+    ) => () => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A]
+    ) => (B, C, D, E, F, G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B]
+    ) => (C, D, E, F, G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C]
+    ) => (D, E, F, G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C, D]
+    ) => (E, F, G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C, D, E]
+    ) => (F, G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C, D, E, F]
+    ) => (G, H) => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C, D, E, F, G]
+    ) => H => R) &
+    (<A, B, C, D, E, F, G, H, R>(
+      (...r: [A, B, C, D, E, F, G, H]) => R,
+      args: [A, B, C, D, E, F, G, H]
+    ) => () => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A]
+    ) => (B, C, D, E, F, G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B]
+    ) => (C, D, E, F, G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C]
+    ) => (D, E, F, G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D]
+    ) => (E, F, G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D, E]
+    ) => (F, G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D, E, F]
+    ) => (G, H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D, E, F, G]
+    ) => (H, I) => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D, E, F, G, H]
+    ) => I => R) &
+    (<A, B, C, D, E, F, G, H, I, R>(
+      (...r: [A, B, C, D, E, F, G, H, I]) => R,
+      args: [A, B, C, D, E, F, G, H, I]
     ) => () => R);
 
   declare type Pipe = (<A, B, C, D, E, F, G>(
@@ -247,7 +328,6 @@ declare module ramda {
     (<A, B, C, D, E>(
       ab: UnaryFn<A, B>,
       bc: UnaryFn<B, C>,
-      cd: UnaryFn<C, D>,
       de: UnaryFn<D, E>,
       ...rest: Array<void>
     ) => UnaryFn<A, E>) &

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0..x.x_partial.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0..x.x_partial.js
@@ -5,9 +5,13 @@ import { partial } from "ramda";
 // --- Partial ---
 const method1 = (foo: string, bah: number, baz: boolean) => baz;
 
-const partial1: Function = partial(method1, ["foo"]);
+const partial1: (number, boolean) => boolean = partial(method1, ["foo"]);
 const partial2: boolean = partial(method1, ["foo"])(4, true);
 // $ExpectError
-const partial3: Function = partial(method1, [4]);
+const partial3 = partial(method1, [4]);
 const partial4: boolean = partial(method1, ["foo", 4])(true);
 const partial5: boolean = partial(method1, ["foo", 4, true])();
+
+// Functions produced from partial are not curried.
+// $ExpectError
+const partial6 = partial(method1, ["foo"])(4);


### PR DESCRIPTION
According to Ramda's [docs on partial](http://ramdajs.com/docs/#partial), and a [quick example](http://ramdajs.com/repl/?v=0.25.0#?const%20add3%20%3D%20%28a%2C%20b%2C%20c%29%20%3D%3E%20a%20%2B%20b%20%2B%20c%0AR.partial%28add3%2C%20%5B1%5D%29%282%29%284%29) both point to Ramda not returning an auto-curried function (this is [curry](http://ramdajs.com/docs/#curry)'s job).

Producing a proper implementation for `partial` is rather tedious and error prone. I built a generator for it which can be found on this [typedef-gen](https://github.com/LoganBarnett/typedef-gen) repository I put together. The current variation supports up to 10 arguments in a function, but supporting more is a simple means of running the generator with a higher number and pasting the results in the Ramda libdef. I believe the prior number supported was 6.

This addresses #1507.