### PR TITLE
Headers issue in node-fetch.

### DIFF
--- a/definitions/npm/node-fetch_v1.x.x/flow_v0.44.x-/node-fetch_v1.x.x.js
+++ b/definitions/npm/node-fetch_v1.x.x/flow_v0.44.x-/node-fetch_v1.x.x.js
@@ -20,11 +20,13 @@ declare module 'node-fetch' {
     size: number
   }
 
+  declare type HeaderObject = {
+    [index: string]: string
+  }
+
   declare interface RequestInit {
     method?: string,
-    headers?: HeaderInit | {
-      [index: string]: string
-    },
+    headers?: HeaderObject,
     body?: BodyInit,
     redirect?: RequestRedirect,
 

--- a/definitions/npm/node-fetch_v1.x.x/test_node-fetch_v1.js
+++ b/definitions/npm/node-fetch_v1.x.x/test_node-fetch_v1.js
@@ -10,7 +10,10 @@ import type { Readable } from 'stream';
 (nodeFetch(123): Promise<Response>);
 
 nodeFetch('foo', {
-    method: 'GET'
+    method: 'GET',
+    headers: {
+      Authorization: "Foo",
+    },
 });
 
 nodeFetch('foo', {


### PR DESCRIPTION
Consider the following code using `node-fetch`:

```
// @flow

import fetch from "node-fetch"

fetch("https://requestb.in/xzxek2xz", {
  headers: {
    Authorization: "Bearer foo",
  },
})
.then(function (res) {
  console.log(res)
})
```

This works fine as it should. Yet checking the flow types returns the following error:

```
example.js:6
                v
  6:   headers: {
  7:     Authorization: "Bearer foo",
  8:   },
       ^ object literal. This type is incompatible with an argument type of
 28:     headers?: HeaderInit | {
                   ^^^^^^^^^^ array type. See lib: flow-typed/npm/node-fetch_v1.x.x.js:28

example.js:6
                v
  6:   headers: {
  7:     Authorization: "Bearer foo",
  8:   },
       ^ property `Authorization`. Property not found in
 28:     headers?: HeaderInit | {
                   ^^^^^^^^^^ Headers. See lib: flow-typed/npm/node-fetch_v1.x.x.js:28


Found 2 errors
```

When looking into the `node-fetch` definition, I saw the `RequestInit` type is an interface instead of a simple type and after fooling around a bit, I concluded that was the issue.

I'm not 100% sure why it should've been an interface in the first place (it only has properties, no behaviour).

I've added the bug to the the test and fixed the definition.

Here's a [Try Flow](https://flow.org/try/#0CYUwxgNghgTiAEBLAdgFxDAZlMCBKIAjgK4gDOqAksoqvAN4BQ88AkABYhSgxkD8ALgbNWrANoUYKAOYBdIZJkAaRqwC+jDYzAB7ZBXhxC8IQRLkqNOgF5hLTtwxkhTFiwCCxVOx1SAXlCoiHpCAEQAQlxwMPCYOjqhKiwaakA) that shows the issue, and [here's one with the fix applied](https://flow.org/try/#0CYUwxgNghgTiAEAXAngBwQJRARwK4gGdEBJAOwEtF4BeeAbwCh54BIACxClBgIH4AuekxYsA2kRjlSAcwC6giVOkAaBiwC+DTQzAB7UkXhxs8QVjyESFKrUbMOXED0F3m8AIK5EbXZIBeUIjk+oIARABCnHAw8ABmurqhqsya6kA).