### PR TITLE
Fix toThrow and toThrowError type definitions

### DIFF
--- a/definitions/npm/jest_v21.x.x/flow_v0.39.x-/jest_v21.x.x.js
+++ b/definitions/npm/jest_v21.x.x/flow_v0.39.x-/jest_v21.x.x.js
@@ -268,8 +268,8 @@ type JestExpectType = {
    *
    * Alias: .toThrowError
    */
-  toThrow(message?: string | Error | RegExp): void,
-  toThrowError(message?: string | Error | RegExp): void,
+  toThrow(message?: string | Error | Class<Error> | RegExp): void,
+  toThrowError(message?: string | Error | Class<Error> | RegExp): void,
   /**
    * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
    * matching the most recent snapshot when it is called.


### PR DESCRIPTION
These two methods also accept a class as argument. See https://github.com/facebook/jest/blob/master/packages/expect/src/to_throw_matchers.js#L53