### PR TITLE
patch(koa-router): fix param middleware

### DIFF
--- a/definitions/npm/koa-router_v7.2.x/flow_v0.25.x-/koa-router_v7.2.x.js
+++ b/definitions/npm/koa-router_v7.2.x/flow_v0.25.x-/koa-router_v7.2.x.js
@@ -4,7 +4,13 @@
 
 type KoaRouter$Middleware = (
   ctx: any,
-  next: () => Promise<void>
+  next: () => void | Promise<void>
+) => Promise<void> | void;
+
+type KoaRouter$ParamMiddleware = (
+  param: string,
+  ctx: any,
+  next: () => void | Promise<void>
 ) => Promise<void> | void;
 
 declare module "koa-router" {
@@ -50,7 +56,7 @@ declare module "koa-router" {
       methodNotAllowed?: () => any
     }): KoaRouter$Middleware;
 
-    param(param: string, middleware: KoaRouter$Middleware): this;
+    param(param: string, middleware: KoaRouter$ParamMiddleware): this;
 
     redirect(source: string, destination: string, code?: number): this;
 

--- a/definitions/npm/koa-router_v7.2.x/test_koa-router_v7.2.x.js
+++ b/definitions/npm/koa-router_v7.2.x/test_koa-router_v7.2.x.js
@@ -34,3 +34,10 @@ goodRouter.get("/", async ctx => {
 goodRouter.use(10);
 goodRouter.use(async ctx => {});
 goodRouter.use("/foo", async ctx => {});
+
+goodRouter.param("foo", async ctx => {
+  // $ExpectError
+  console.log(ctx.params.foo);
+});
+goodRouter.param("foo", async (foo, ctx) => {});
+goodRouter.param("foo", (foo, ctx, next) => {});


### PR DESCRIPTION
The middleware function for `.param()` is slightly different from the usual koa middleware.

See [the readme](https://github.com/alexmingoia/koa-router#module_koa-router--Router+param).