### PR TITLE
feat(ramda): add def for evolve

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
@@ -1365,12 +1365,8 @@ declare module ramda {
     src: { [k: string]: T }
   ): { [k: string]: T };
 
-  // TODO: Started failing in v31... (Attempt to fix below)
-  // declare type __UnwrapNestedObjectR<T, U, V: NestedObject<(t: T) => U>> = U
-  // declare type UnwrapNestedObjectR<T> = UnwrapNestedObjectR<*, *, T>
-  //
-  // declare function evolve<R, T: NestedObject<(x:any) => R>>(fn: T, ...rest: Array<void>): (src: NestedObject<any>) => UnwrapNestedObjectR<T>;
-  // declare function evolve<R: NestedObject<(x:any) => R>>(fn: T, src: NestedObject<any>): UnwrapNestedObjectR<T>;
+  declare function evolve<A: Object>({ [string]: Function }, A): A;
+  declare function evolve<A: Object>({ [string]: Function }): A => A;
 
   declare function eqProps(
     key: string,

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
@@ -1365,8 +1365,8 @@ declare module ramda {
     src: { [k: string]: T }
   ): { [k: string]: T };
 
-  declare function evolve<A: Object>({ [string]: Function }, A): A;
-  declare function evolve<A: Object>({ [string]: Function }): A => A;
+  declare function evolve<A: Object>(NestedObject<Function>, A): A;
+  declare function evolve<A: Object>(NestedObject<Function>): A => A;
 
   declare function eqProps(
     key: string,

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_object.js
@@ -83,6 +83,41 @@ const o2 = { a: 10, b: 20, c: 3, d: 40 };
 const ep: boolean = _.eqProps("a")(o1, o2);
 const ep2: boolean = _.eqProps("c", o1)(o2);
 
+const evolved1 = _.evolve(
+  {
+    foo: x => x + 1,
+    bar: x => x + 2
+  },
+  {
+    foo: 1,
+    bar: 2
+  }
+);
+const evolved2 = _.evolve({
+  foo: x => x + 1,
+  bar: x => x + 2
+})({
+  foo: 1,
+  bar: 2
+});
+const evolved3 = _.evolve(
+  {
+    foo: x => x + 1
+  },
+  {
+    bar: 1
+  }
+);
+const evolved4 = _.evolve({
+  foo: x => x + 1
+})({
+  bar: 1
+});
+//$ExpectError
+const evolved5: number = evolved4.foo;
+//$ExpectError
+const evolved6 = _.evolve(["foo"]);
+
 const hasid = _.has("id");
 const has: boolean = hasid(tomato);
 


### PR DESCRIPTION
The definition for the [evolve](http://ramdajs.com/docs/#evolve) method was missing.