### PR TITLE
Make styled-components ThemeProvider theme prop covariant

### DIFF
--- a/definitions/npm/styled-components_v1.4.x/flow_v0.25.x-v0.52.x/styled-components_v1.4.x.js
+++ b/definitions/npm/styled-components_v1.4.x/flow_v0.25.x-v0.52.x/styled-components_v1.4.x.js
@@ -9,7 +9,7 @@ type $npm$styledComponents$StyledComponent = (
 ) => ReactClass<*>;
 
 
-type $npm$styledComponents$Theme = {[key: string]: mixed};
+type $npm$styledComponents$Theme = {+[key: string]: mixed};
 type $npm$styledComponents$ThemeProviderProps = {
   theme: $npm$styledComponents$Theme | ((outerTheme: $npm$styledComponents$Theme) => void)
 };


### PR DESCRIPTION
Object properties are invariant by default which means that we cannot pass a type like:

```js
type Theme = { stuff: { ... } };
```

into `<ThemeProvider theme={}>` because in ThemeProvider could modify our object, but it does not so making it covariant is valid.