### PR TITLE
Add direct recompose/compose export

### DIFF
--- a/definitions/npm/recompose_v0.24.x/flow_v0.55.x-v0.56.x/recompose_v0.24.x.js
+++ b/definitions/npm/recompose_v0.24.x/flow_v0.55.x-v0.56.x/recompose_v0.24.x.js
@@ -473,3 +473,7 @@ declare module "recompose/createEventHandler" {
     "createEventHandler"
   >;
 }
+
+declare module "recompose/compose" {
+  declare module.exports: $PropertyType<$Exports<"recompose">, "compose">;
+}

--- a/definitions/npm/recompose_v0.24.x/flow_v0.57.x-/recompose_v0.24.x.js
+++ b/definitions/npm/recompose_v0.24.x/flow_v0.57.x-/recompose_v0.24.x.js
@@ -473,3 +473,7 @@ declare module "recompose/createEventHandler" {
     "createEventHandler"
   >;
 }
+
+declare module "recompose/compose" {
+  declare module.exports: $PropertyType<$Exports<"recompose">, "compose">;
+}


### PR DESCRIPTION
I noticed in my project that type inference doesn't work when I'm using `compose` from recompose imported directly as single module:

```
import compose from 'recompose/compose';
```

This works as supposed:

```
import { compose } from 'recompose';
```

