### PR TITLE
skip test if flow version is unavaliable for platform

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -491,6 +491,11 @@ async function runTestGroup(
     const flowVersionsToRun = orderedFlowVersions.filter(flowVer => {
       return semver.satisfies(flowVer, testGrpFlowSemVerRange);
     });
+    
+    // Windows hasn't flow < 30.0 but we have tests for flow < 30.0. We need skip it. Example: redux_v3
+    if (!flowVersionsToRun.length) {
+      return [];
+    }
     let lowestFlowVersionRan = flowVersionsToRun[0];
 
     const lowerVersions = flowVersionsToRun.filter(flowVer =>


### PR DESCRIPTION
Fix error
```
PS C:\Users\andrey.vassilyev\projects\flow-typed\cli> node dist/cli.js run-tests redux_v3
Running definition tests in C:\Users\andrey.vassilyev\projects\flow-typed\definitions\npm...

Fetching all Flow binaries...
Finished fetching Flow binaries.

UNCAUGHT ERROR: TypeError: Invalid Version: undefined
    at new SemVer (C:\Users\andrey.vassilyev\projects\flow-typed\cli\node_modules\semver\semver.js:279:11)
    at SemVer.compare (C:\Users\andrey.vassilyev\projects\flow-typed\cli\node_modules\semver\semver.js:342:13)
    at compare (C:\Users\andrey.vassilyev\projects\flow-typed\cli\node_modules\semver\semver.js:566:31)
    at Object.lt (C:\Users\andrey.vassilyev\projects\flow-typed\cli\node_modules\semver\semver.js:600:10)
    at C:\Users\andrey.vassilyev\projects\flow-typed\cli\dist\commands\runTests.js:615:27
    at Array.filter (<anonymous>)
    at findLowestCapableFlowVersion$ (C:\Users\andrey.vassilyev\projects\flow-typed\cli\dist\commands\runTests.js:614:56)
    at tryCatch (C:\Users\andrey.vassilyev\projects\flow-typed\cli\node_modules\regenerator-runtime\runtime.js:64:40)
    at Generator.invoke [as _invoke] (C:\Users\andrey.vassilyev\projects\flow-typed\cli\node_modules\regenerator-runtime\runtime.js:355:22)
    at Generator.prototype.(anonymous function) [as next] (C:\Users\andrey.vassilyev\projects\flow-typed\cli\node_modules\regenerator-runtime\runtime.js:116:21)
```