### PR TITLE
fixing issue 1581 - Sequelize.condition accepts 3 arguments

### DIFF
--- a/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/sequelize_v4.x.x.js
+++ b/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/sequelize_v4.x.x.js
@@ -6005,6 +6005,8 @@ declare module "sequelize" {
     where(attr: Object, comparator: string, logic: string | Object): where,
     static where(attr: Object, logic: string | Object): where,
     where(attr: Object, logic: string | Object): where,
+    static condition(attr: Object, comparator: string, logic: string | Object): where,
+    condition(attr: Object, comparator: string, logic: string | Object): where,
     static condition(attr: Object, logic: string | Object): where,
     condition(attr: Object, logic: string | Object): where,
 


### PR DESCRIPTION
As noted in issue #1581 - the `Sequelize.condition` method is exactly equal to `Sequelize.where` as of Sequelize 4.8.2. So the function signatures should be identical.