### PR TITLE
feat(sequelize_v4.x.x/flow_v0.42.x-/sequelize_v4.x.x.js) close() meth…

### DIFF
--- a/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/sequelize_v4.x.x.js
+++ b/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/sequelize_v4.x.x.js
@@ -6945,7 +6945,7 @@ declare module "sequelize" {
     Normally this is done on process exit, so you only need to call this method if you are creating multiple
     instances, and want to garbage collect some of them.
     */
-    close(): void,
+    close(): Promise<void>,
 
     /**
      * Returns the database version


### PR DESCRIPTION
Hi, 

In the Sequelize v4.x version, the close() method return a `Promise<Void>`.
You can verify it [here](https://github.com/sequelize/sequelize/blob/master/lib/sequelize.js#L1072).

Regards,