### PR TITLE
Export `StyleDefinition` type from aphrodite

### DIFF
--- a/definitions/npm/aphrodite_v0.5.x/flow_v0.28.x-/aphrodite_v0.5.x.js
+++ b/definitions/npm/aphrodite_v0.5.x/flow_v0.28.x-/aphrodite_v0.5.x.js
@@ -11,7 +11,7 @@ declare module "aphrodite" {
     [key: string]: Object
   };
 
-  declare type StyleDefinition = {
+  declare export type StyleDefinition = {
     [key: string]: {
       _name: string,
       _definition: Object


### PR DESCRIPTION
Make the `StyleDefinition` type an export from the Aphrodite definitions.
I needed to use `StyleDefinition` in order for a component to receive custom classes:

```JSX
<MyComponent
  classes={[styles.class1, styles.class2]}
/>
```

```JSX
import * as React from 'react';
import { css } from 'aphrodite';
import type { StyleDefinition } from 'aphrodite';

type Props = {
  classes: Array<StyleDefinition>,
};

class MyComponent extends React.PureComponent<Props> {
  render () {
    return (
      <p className={css(styles.mainClass, ...this.props.classes)}>
        Hello, world!
      </p>
    );
  }
}
```