### PR TITLE
fix(ramda): fix where function declaration

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.28.x-v0.30.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.28.x-v0.30.x/ramda_v0.x.x.js
@@ -1,143 +1,231 @@
 /* eslint-disable no-unused-vars, no-redeclare */
 
-type Transformer<A,B> = {
-  '@@transducer/step': <I,R>(r: A, a: *) => R,
-  '@@transducer/init': () => A,
-  '@@transducer/result': (result: *) => B
-}
-
+type Transformer<A, B> = {
+  "@@transducer/step": <I, R>(r: A, a: *) => R,
+  "@@transducer/init": () => A,
+  "@@transducer/result": (result: *) => B
+};
 
 declare module ramda {
-  declare type UnaryFn<A,R> = (a: A) => R;
-  declare type BinaryFn<A,B,R> = ((a: A, b: B) => R) & ((a:A) => (b: B) => R);
-  declare type UnarySameTypeFn<T> = UnaryFn<T,T>
-  declare type BinarySameTypeFn<T> = BinaryFn<T,T,T>
-  declare type NestedObject<T> = { [k: string]: T | NestedObject<T> }
-  declare type UnaryPredicateFn<T> = (x:T) => boolean
-  declare type BinaryPredicateFn<T> = (x:T, y:T) => boolean
-  declare type BinaryPredicateFn2<T,S> = (x:T, y:S) => boolean
+  declare type UnaryFn<A, R> = (a: A) => R;
+  declare type BinaryFn<A, B, R> = ((a: A, b: B) => R) &
+    ((a: A) => (b: B) => R);
+  declare type UnarySameTypeFn<T> = UnaryFn<T, T>;
+  declare type BinarySameTypeFn<T> = BinaryFn<T, T, T>;
+  declare type NestedObject<T> = { [k: string]: T | NestedObject<T> };
+  declare type UnaryPredicateFn<T> = (x: T) => boolean;
+  declare type BinaryPredicateFn<T> = (x: T, y: T) => boolean;
+  declare type BinaryPredicateFn2<T, S> = (x: T, y: S) => boolean;
 
   declare interface ObjPredicate {
     (value: any, key: string): boolean;
   }
 
-  declare type CurriedFunction2<T1, T2, R> =
-    & ((t1: T1, t2: T2) => R)
-    & ((t1: T1, ...rest: Array<void>) => (t2: T2) => R)
+  declare type CurriedFunction2<T1, T2, R> = ((t1: T1, t2: T2) => R) &
+    ((t1: T1, ...rest: Array<void>) => (t2: T2) => R);
 
-  declare type CurriedFunction3<T1, T2, T3, R> =
-    & ((t1: T1, t2: T2, t3: T3) => R)
-    & ((t1: T1, t2: T2, ...rest: Array<void>) => (t3: T3) => R)
-    & ((t1: T1, ...rest: Array<void>) => CurriedFunction2<T2, T3, R>)
+  declare type CurriedFunction3<T1, T2, T3, R> = ((
+    t1: T1,
+    t2: T2,
+    t3: T3
+  ) => R) &
+    ((t1: T1, t2: T2, ...rest: Array<void>) => (t3: T3) => R) &
+    ((t1: T1, ...rest: Array<void>) => CurriedFunction2<T2, T3, R>);
 
-  declare type CurriedFunction4<T1, T2, T3, T4, R> =
-    & ((t1: T1, t2: T2, t3: T3, t4: T4) => R)
-    & ((t1: T1, t2: T2, t3: T3, ...rest: Array<void>) => (t4: T4) => R)
-    & ((t1: T1, t2: T2, ...rest: Array<void>) => CurriedFunction2<T3, T4, R>)
-    & ((t1: T1, ...rest: Array<void>) => CurriedFunction3<T2, T3, T4, R>)
+  declare type CurriedFunction4<T1, T2, T3, T4, R> = ((
+    t1: T1,
+    t2: T2,
+    t3: T3,
+    t4: T4
+  ) => R) &
+    ((t1: T1, t2: T2, t3: T3, ...rest: Array<void>) => (t4: T4) => R) &
+    ((t1: T1, t2: T2, ...rest: Array<void>) => CurriedFunction2<T3, T4, R>) &
+    ((t1: T1, ...rest: Array<void>) => CurriedFunction3<T2, T3, T4, R>);
 
-  declare type CurriedFunction5<T1, T2, T3, T4, T5, R> =
-    & ((t1: T1) => CurriedFunction4<T2, T3, T4, T5, R>)
-    & ((t1: T1, t2: T2) => CurriedFunction3<T3, T4, T5, R>)
-    & ((t1: T1, t2: T2, t3: T3) => CurriedFunction2<T4, T5, R>)
-    & ((t1: T1, t2: T2, t3: T3, t4: T4) => (t5: T5) => R)
-    & ((t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => R)
+  declare type CurriedFunction5<T1, T2, T3, T4, T5, R> = ((
+    t1: T1
+  ) => CurriedFunction4<T2, T3, T4, T5, R>) &
+    ((t1: T1, t2: T2) => CurriedFunction3<T3, T4, T5, R>) &
+    ((t1: T1, t2: T2, t3: T3) => CurriedFunction2<T4, T5, R>) &
+    ((t1: T1, t2: T2, t3: T3, t4: T4) => (t5: T5) => R) &
+    ((t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => R);
 
-  declare type CurriedFunction6<T1, T2, T3, T4, T5, T6, R> =
-    & ((t1: T1) => CurriedFunction5<T2, T3, T4, T5, T6, R>)
-    & ((t1: T1, t2: T2) => CurriedFunction4<T3, T4, T5, T6, R>)
-    & ((t1: T1, t2: T2, t3: T3) => CurriedFunction3<T4, T5, T6, R>)
-    & ((t1: T1, t2: T2, t3: T3, t4: T4) => CurriedFunction2<T5, T6, R>)
-    & ((t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => (t6: T6) => R)
-    & ((t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => R)
+  declare type CurriedFunction6<T1, T2, T3, T4, T5, T6, R> = ((
+    t1: T1
+  ) => CurriedFunction5<T2, T3, T4, T5, T6, R>) &
+    ((t1: T1, t2: T2) => CurriedFunction4<T3, T4, T5, T6, R>) &
+    ((t1: T1, t2: T2, t3: T3) => CurriedFunction3<T4, T5, T6, R>) &
+    ((t1: T1, t2: T2, t3: T3, t4: T4) => CurriedFunction2<T5, T6, R>) &
+    ((t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => (t6: T6) => R) &
+    ((t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => R);
 
-  declare type Pipe = (<A,B,C,D,E,F,G>(ab: UnaryFn<A,B>, bc: UnaryFn<B,C>, cd: UnaryFn<C,D>, de: UnaryFn<D,E>, ef: UnaryFn<E,F>, fg: UnaryFn<F,G>, ...rest: Array<void>) => UnaryFn<A,G>)
-    & (<A,B,C,D,E,F>(ab: UnaryFn<A,B>, bc: UnaryFn<B,C>, cd: UnaryFn<C,D>, de: UnaryFn<D,E>, ef: UnaryFn<E,F>, ...rest: Array<void>) => UnaryFn<A,F>)
-    & (<A,B,C,D,E>(ab: UnaryFn<A,B>, bc: UnaryFn<B,C>, cd: UnaryFn<C,D>, de: UnaryFn<D,E>, ...rest: Array<void>) => UnaryFn<A,E>)
-    & (<A,B,C,D>(ab: UnaryFn<A,B>, bc: UnaryFn<B,C>, cd: UnaryFn<C,D>, ...rest: Array<void>) => UnaryFn<A,D>)
-    & (<A,B,C>(ab: UnaryFn<A,B>, bc: UnaryFn<B,C>, ...rest: Array<void>) => UnaryFn<A,C>)
-    & (<A,B>(ab: UnaryFn<A,B>, ...rest: Array<void>) => UnaryFn<A,B>)
+  declare type Pipe = (<A, B, C, D, E, F, G>(
+    ab: UnaryFn<A, B>,
+    bc: UnaryFn<B, C>,
+    cd: UnaryFn<C, D>,
+    de: UnaryFn<D, E>,
+    ef: UnaryFn<E, F>,
+    fg: UnaryFn<F, G>,
+    ...rest: Array<void>
+  ) => UnaryFn<A, G>) &
+    (<A, B, C, D, E, F>(
+      ab: UnaryFn<A, B>,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
+      de: UnaryFn<D, E>,
+      ef: UnaryFn<E, F>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, F>) &
+    (<A, B, C, D, E>(
+      ab: UnaryFn<A, B>,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
+      de: UnaryFn<D, E>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, E>) &
+    (<A, B, C, D>(
+      ab: UnaryFn<A, B>,
+      bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, D>) &
+    (<A, B, C>(
+      ab: UnaryFn<A, B>,
+      bc: UnaryFn<B, C>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, C>) &
+    (<A, B>(ab: UnaryFn<A, B>, ...rest: Array<void>) => UnaryFn<A, B>);
 
-  declare type Compose = & (<A,B,C,D,E,F,G>(fg: UnaryFn<F,G>, ef: UnaryFn<E,F>, de: UnaryFn<D,E>, cd: UnaryFn<C,D>, bc: UnaryFn<B,C>, ab: UnaryFn<A,B>, ...rest: Array<void>) => UnaryFn<A,G>)
-    & (<A,B,C,D,E,F>(ef: UnaryFn<E,F>, de: UnaryFn<D,E>, cd: UnaryFn<C,D>, bc: UnaryFn<B,C>, ab: UnaryFn<A,B>, ...rest: Array<void>) => UnaryFn<A,F>)
-    & (<A,B,C,D,E>(de: UnaryFn<D,E>, cd: UnaryFn<C,D>, bc: UnaryFn<B,C>, ab: UnaryFn<A,B>, ...rest: Array<void>) => UnaryFn<A,E>)
-    & (<A,B,C,D>(cd: UnaryFn<C,D>, bc: UnaryFn<B,C>, ab: UnaryFn<A,B>, ...rest: Array<void>) => UnaryFn<A,D>)
-    & (<A,B,C>(bc: UnaryFn<B,C>, ab: UnaryFn<A,B>, ...rest: Array<void>) => UnaryFn<A,C>)
-    & (<A,B>(ab: UnaryFn<A,B>, ...rest: Array<void>) => UnaryFn<A,B>)
+  declare type Compose = (<A, B, C, D, E, F, G>(
+    fg: UnaryFn<F, G>,
+    ef: UnaryFn<E, F>,
+    de: UnaryFn<D, E>,
+    cd: UnaryFn<C, D>,
+    bc: UnaryFn<B, C>,
+    ab: UnaryFn<A, B>,
+    ...rest: Array<void>
+  ) => UnaryFn<A, G>) &
+    (<A, B, C, D, E, F>(
+      ef: UnaryFn<E, F>,
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, F>) &
+    (<A, B, C, D, E>(
+      de: UnaryFn<D, E>,
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, E>) &
+    (<A, B, C, D>(
+      cd: UnaryFn<C, D>,
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, D>) &
+    (<A, B, C>(
+      bc: UnaryFn<B, C>,
+      ab: UnaryFn<A, B>,
+      ...rest: Array<void>
+    ) => UnaryFn<A, C>) &
+    (<A, B>(ab: UnaryFn<A, B>, ...rest: Array<void>) => UnaryFn<A, B>);
 
-  declare type Curry = & (<T1, T2, TResult>(fn: (a: T1, b: T2) => TResult) => CurriedFunction2<T1,T2, TResult>)
-    & (<T1, T2, T3, TResult>(fn: (a: T1, b: T2, c: T3) => TResult) => CurriedFunction3<T1,T2, T3, TResult>)
-    & (<T1, T2, T3, T4, TResult>(fn: (a: T1, b: T2, c: T3, d: T4) => TResult) => CurriedFunction4<T1,T2, T3, T4, TResult>)
-    & (<T1, T2, T3, T4, T5, TResult>(fn: (a: T1, b: T2, c: T3, d: T4, e: T5) => TResult) => CurriedFunction5<T1,T2, T3, T4, T5, TResult>)
-    & (<T1, T2, T3, T4, T5, T6, TResult>(fn: (a: T1, b: T2, c: T3, d: T4, e: T5, f: T6) => TResult) => CurriedFunction6<T1,T2, T3, T4, T5, T6, TResult>)
-    & ((fn: Function) => Function)
+  declare type Curry = (<T1, T2, TResult>(
+    fn: (a: T1, b: T2) => TResult
+  ) => CurriedFunction2<T1, T2, TResult>) &
+    (<T1, T2, T3, TResult>(
+      fn: (a: T1, b: T2, c: T3) => TResult
+    ) => CurriedFunction3<T1, T2, T3, TResult>) &
+    (<T1, T2, T3, T4, TResult>(
+      fn: (a: T1, b: T2, c: T3, d: T4) => TResult
+    ) => CurriedFunction4<T1, T2, T3, T4, TResult>) &
+    (<T1, T2, T3, T4, T5, TResult>(
+      fn: (a: T1, b: T2, c: T3, d: T4, e: T5) => TResult
+    ) => CurriedFunction5<T1, T2, T3, T4, T5, TResult>) &
+    (<T1, T2, T3, T4, T5, T6, TResult>(
+      fn: (a: T1, b: T2, c: T3, d: T4, e: T5, f: T6) => TResult
+    ) => CurriedFunction6<T1, T2, T3, T4, T5, T6, TResult>) &
+    ((fn: Function) => Function);
 
-  declare type Filter =
-    & (<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>, xs:T) => T)
-    & (<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>) => (xs:T) => T)
-
+  declare type Filter = (<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ) => T) &
+    (<K, V, T: Array<V> | { [key: K]: V }>(
+      fn: UnaryPredicateFn<V>
+    ) => (xs: T) => T);
 
   declare class Monad<T> {
-    chain: Function
+    chain: Function;
   }
 
   declare class Semigroup<T> {}
 
   declare class Chain {
-    chain<T,V: Monad<T>|Array<T>>(fn: (a:T) => V, x: V): V;
-    chain<T,V: Monad<T>|Array<T>>(fn: (a:T) => V): (x: V) => V;
+    chain<T, V: Monad<T> | Array<T>>(fn: (a: T) => V, x: V): V;
+    chain<T, V: Monad<T> | Array<T>>(fn: (a: T) => V): (x: V) => V;
   }
 
   declare class GenericContructor<T> {
-    constructor(x: T): GenericContructor<any>
+    constructor(x: T): GenericContructor<any>;
   }
 
   declare class GenericContructorMulti {
-    constructor(...args: Array<any>): GenericContructor<any>
+    constructor(...args: Array<any>): GenericContructor<any>;
   }
 
-
   /**
-  * DONE:
-  * Function*
-  * List*
-  * Logic
-  * Math
-  * Object*
-  * Relation
-  * String
-  * Type
-  */
+   * DONE:
+   * Function*
+   * List*
+   * Logic
+   * Math
+   * Object*
+   * Relation
+   * String
+   * Type
+   */
 
   declare var compose: Compose;
   declare var pipe: Pipe;
   declare var curry: Curry;
-  declare function curryN(length: number, fn: (...args: Array<any>) => any): Function
+  declare function curryN(
+    length: number,
+    fn: (...args: Array<any>) => any
+  ): Function;
 
   // *Math
-  declare var add: CurriedFunction2<number,number,number>;
-  declare var inc: UnaryFn<number,number>;
-  declare var dec: UnaryFn<number,number>;
-  declare var mean: UnaryFn<Array<number>,number>;
-  declare var divide: CurriedFunction2<number,number,number>
-  declare var mathMod: CurriedFunction2<number,number,number>;
-  declare var median: UnaryFn<Array<number>,number>;
-  declare var modulo: CurriedFunction2<number,number,number>;
-  declare var multiply: CurriedFunction2<number,number,number>;
-  declare var negate: UnaryFn<number,number>;
-  declare var product: UnaryFn<Array<number>,number>;
-  declare var subtract: CurriedFunction2<number,number,number>;
-  declare var sum: UnaryFn<Array<number>,number>;
+  declare var add: CurriedFunction2<number, number, number>;
+  declare var inc: UnaryFn<number, number>;
+  declare var dec: UnaryFn<number, number>;
+  declare var mean: UnaryFn<Array<number>, number>;
+  declare var divide: CurriedFunction2<number, number, number>;
+  declare var mathMod: CurriedFunction2<number, number, number>;
+  declare var median: UnaryFn<Array<number>, number>;
+  declare var modulo: CurriedFunction2<number, number, number>;
+  declare var multiply: CurriedFunction2<number, number, number>;
+  declare var negate: UnaryFn<number, number>;
+  declare var product: UnaryFn<Array<number>, number>;
+  declare var subtract: CurriedFunction2<number, number, number>;
+  declare var sum: UnaryFn<Array<number>, number>;
 
   // Filter
   declare var filter: Filter;
   declare var reject: Filter;
 
   // *String
-  declare var match: CurriedFunction2<RegExp,string,Array<string|void>>;
-  declare var replace: CurriedFunction3<RegExp|string,string,string,string>;
-  declare var split: CurriedFunction2<RegExp|string,string,Array<string>>
-  declare var test: CurriedFunction2<RegExp,string,boolean>
+  declare var match: CurriedFunction2<RegExp, string, Array<string | void>>;
+  declare var replace: CurriedFunction3<
+    RegExp | string,
+    string,
+    string,
+    string
+  >;
+  declare var split: CurriedFunction2<RegExp | string, string, Array<string>>;
+  declare var test: CurriedFunction2<RegExp, string, boolean>;
   declare function toLower(a: string): string;
   declare function toString(a: any): string;
   declare function toUpper(a: string): string;
@@ -146,237 +234,582 @@ declare module ramda {
   // *Type
   declare function is<T>(t: T, ...rest: Array<void>): (v: any) => boolean;
   declare function is<T>(t: T, v: any): boolean;
-  declare var propIs: CurriedFunction3<any,string,Object,boolean>;
+  declare var propIs: CurriedFunction3<any, string, Object, boolean>;
   declare function type(x: ?any): string;
   declare function isArrayLike(x: any): boolean;
   declare function isNil(x: ?any): boolean;
 
   // *List
-  declare function adjust<T>(fn:(a: T) => T, ...rest: Array<void>): (index: number, ...rest: Array<void>) => (src: Array<T>) => Array<T>;
-  declare function adjust<T>(fn:(a: T) => T, index: number, ...rest: Array<void>): (src: Array<T>) => Array<T>;
-  declare function adjust<T>(fn:(a: T) => T, index: number, src: Array<T>): Array<T>;
+  declare function adjust<T>(
+    fn: (a: T) => T,
+    ...rest: Array<void>
+  ): (index: number, ...rest: Array<void>) => (src: Array<T>) => Array<T>;
+  declare function adjust<T>(
+    fn: (a: T) => T,
+    index: number,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<T>;
+  declare function adjust<T>(
+    fn: (a: T) => T,
+    index: number,
+    src: Array<T>
+  ): Array<T>;
 
   declare function all<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
-  declare function all<T>(fn: UnaryPredicateFn<T>, ...rest: Array<void>): (xs: Array<T>) => boolean;
+  declare function all<T>(
+    fn: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => boolean;
 
   declare function any<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
-  declare function any<T>(fn: UnaryPredicateFn<T>, ...rest: Array<void>): (xs: Array<T>) => boolean;
+  declare function any<T>(
+    fn: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => boolean;
 
   declare function aperture<T>(n: number, xs: Array<T>): Array<Array<T>>;
-  declare function aperture<T>(n: number, ...rest: Array<void>): (xs: Array<T>) => Array<Array<T>>;
+  declare function aperture<T>(
+    n: number,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => Array<Array<T>>;
 
-  declare function append<E>(x: E, xs: Array<E>): Array<E>
-  declare function append<E>(x: E, ...rest: Array<void>): (xs: Array<E>) => Array<E>
+  declare function append<E>(x: E, xs: Array<E>): Array<E>;
+  declare function append<E>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: Array<E>) => Array<E>;
 
-  declare function prepend<E>(x: E, xs: Array<E>): Array<E>
-  declare function prepend<E>(x: E, ...rest: Array<void>): (xs: Array<E>) => Array<E>
+  declare function prepend<E>(x: E, xs: Array<E>): Array<E>;
+  declare function prepend<E>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: Array<E>) => Array<E>;
 
-  declare function concat<V,T:Array<V>|string>(x: T, y: T): T;
-  declare function concat<V,T:Array<V>|string>(x: T): (y: T) => T;
+  declare function concat<V, T: Array<V> | string>(x: T, y: T): T;
+  declare function concat<V, T: Array<V> | string>(x: T): (y: T) => T;
 
-  declare function contains<E,T:Array<E>|string>(x: E, xs: T): boolean
-  declare function contains<E,T:Array<E>|string>(x: E, ...rest: Array<void>): (xs: T) => boolean
+  declare function contains<E, T: Array<E> | string>(x: E, xs: T): boolean;
+  declare function contains<E, T: Array<E> | string>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: T) => boolean;
 
-  declare function drop<V,T:Array<V>|string>(n: number, ...rest: Array<void>):(xs: T) => T;
-  declare function drop<V,T:Array<V>|string>(n: number, xs: T): T;
+  declare function drop<V, T: Array<V> | string>(
+    n: number,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+  declare function drop<V, T: Array<V> | string>(n: number, xs: T): T;
 
-  declare function dropLast<V,T:Array<V>|string>(n: number, ...rest: Array<void>):(xs: T) => T;
-  declare function dropLast<V,T:Array<V>|string>(n: number, xs: T): T;
+  declare function dropLast<V, T: Array<V> | string>(
+    n: number,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+  declare function dropLast<V, T: Array<V> | string>(n: number, xs: T): T;
 
-  declare function dropLastWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>, ...rest: Array<void>): (xs:T) => T;
-  declare function dropLastWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>, xs:T): T;
+  declare function dropLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+  declare function dropLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): T;
 
-  declare function dropWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>, ...rest: Array<void>): (xs:T) => T;
-  declare function dropWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>, xs:T): T;
+  declare function dropWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+  declare function dropWhile<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T): T;
 
-  declare function dropRepeats<V,T:Array<V>>(xs:T): T;
+  declare function dropRepeats<V, T: Array<V>>(xs: T): T;
 
-  declare function dropRepeatsWith<V,T:Array<V>>(fn: BinaryPredicateFn<V>, ...rest: Array<void>): (xs:T) => T;
-  declare function dropRepeatsWith<V,T:Array<V>>(fn: BinaryPredicateFn<V>, xs:T): T;
+  declare function dropRepeatsWith<V, T: Array<V>>(
+    fn: BinaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => T;
+  declare function dropRepeatsWith<V, T: Array<V>>(
+    fn: BinaryPredicateFn<V>,
+    xs: T
+  ): T;
 
-  declare function groupBy<T>(fn: (x: T) => string, xs: Array<T>): {[key: string]: Array<T>}
-  declare function groupBy<T>(fn: (x: T) => string, ...rest: Array<void>): (xs: Array<T>) => {[key: string]: Array<T>}
+  declare function groupBy<T>(
+    fn: (x: T) => string,
+    xs: Array<T>
+  ): { [key: string]: Array<T> };
+  declare function groupBy<T>(
+    fn: (x: T) => string,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => { [key: string]: Array<T> };
 
-  declare function groupWith<T,V:Array<T>|string>(fn: BinaryPredicateFn<T>, xs: V): Array<V>
-  declare function groupWith<T,V:Array<T>|string>(fn: BinaryPredicateFn<T>, ...rest: Array<void>): (xs: V) => Array<V>
+  declare function groupWith<T, V: Array<T> | string>(
+    fn: BinaryPredicateFn<T>,
+    xs: V
+  ): Array<V>;
+  declare function groupWith<T, V: Array<T> | string>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): (xs: V) => Array<V>;
 
-  declare function head<T,V:Array<T>>(xs: V): ?T
-  declare function head<T,V:string>(xs: V): V
+  declare function head<T, V: Array<T>>(xs: V): ?T;
+  declare function head<T, V: string>(xs: V): V;
 
-  declare function into<I,T,A:Array<T>,R:Array<*>|string|Object>(accum: R, xf: (a: A) => I, input: A): R
-  declare function into<I,T,A:Array<T>,R>(accum: Transformer<I,R>, xf: (a: A) => R, input: A): R
+  declare function into<I, T, A: Array<T>, R: Array<*> | string | Object>(
+    accum: R,
+    xf: (a: A) => I,
+    input: A
+  ): R;
+  declare function into<I, T, A: Array<T>, R>(
+    accum: Transformer<I, R>,
+    xf: (a: A) => R,
+    input: A
+  ): R;
 
-  declare function indexOf<E>(x: E, xs: Array<E>): number
-  declare function indexOf<E>(x: E, ...rest: Array<void>): (xs: Array<E>) => number
+  declare function indexOf<E>(x: E, xs: Array<E>): number;
+  declare function indexOf<E>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: Array<E>) => number;
 
-  declare function indexBy<V,T:{[key: string]:*}>(fn: (x: T) => string, ...rest: Array<void>): (xs: Array<T>) => {[key: string]: T}
-  declare function indexBy<V,T:{[key: string]:*}>(fn: (x: T) => string, xs: Array<T>): {[key: string]: T}
+  declare function indexBy<V, T: { [key: string]: * }>(
+    fn: (x: T) => string,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => { [key: string]: T };
+  declare function indexBy<V, T: { [key: string]: * }>(
+    fn: (x: T) => string,
+    xs: Array<T>
+  ): { [key: string]: T };
 
-  declare function insert<T>(index: number, ...rest: Array<void>): (elem: T) => (src: Array<T>) => Array<T>
-  declare function insert<T>(index: number, elem: T, ...rest: Array<void>): (src: Array<T>) => Array<T>
-  declare function insert<T>(index: number, elem: T, src: Array<T>): Array<T>
+  declare function insert<T>(
+    index: number,
+    ...rest: Array<void>
+  ): (elem: T) => (src: Array<T>) => Array<T>;
+  declare function insert<T>(
+    index: number,
+    elem: T,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<T>;
+  declare function insert<T>(index: number, elem: T, src: Array<T>): Array<T>;
 
-  declare function insertAll<T,S>(index: number, ...rest: Array<void>): (elem: Array<S>) => (src: Array<T>) => Array<S|T>
-  declare function insertAll<T,S>(index: number, elems: Array<S>, ...rest: Array<void>): (src: Array<T>) => Array<S|T>
-  declare function insertAll<T,S>(index: number, elems: Array<S>, src: Array<T>): Array<S|T>
+  declare function insertAll<T, S>(
+    index: number,
+    ...rest: Array<void>
+  ): (elem: Array<S>) => (src: Array<T>) => Array<S | T>;
+  declare function insertAll<T, S>(
+    index: number,
+    elems: Array<S>,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<S | T>;
+  declare function insertAll<T, S>(
+    index: number,
+    elems: Array<S>,
+    src: Array<T>
+  ): Array<S | T>;
 
-  declare function join(x: string, xs: Array<any>): string
-  declare function join(x: string, ...rest: Array<void>): (xs: Array<any>) => string
+  declare function join(x: string, xs: Array<any>): string;
+  declare function join(
+    x: string,
+    ...rest: Array<void>
+  ): (xs: Array<any>) => string;
 
-  declare function last<T,V:Array<T>>(xs: V): ?T
-  declare function last<T,V:string>(xs: V): V
+  declare function last<T, V: Array<T>>(xs: V): ?T;
+  declare function last<T, V: string>(xs: V): V;
 
   declare function none<T>(fn: UnaryPredicateFn<T>, xs: Array<T>): boolean;
-  declare function none<T>(fn: UnaryPredicateFn<T>, ...rest: Array<void>): (xs: Array<T>) => boolean;
+  declare function none<T>(
+    fn: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => boolean;
 
-  declare function nth<V,T:Array<V>>(i: number, xs: T): ?V
-  declare function nth<V,T:Array<V>|string>(i: number, ...rest: Array<void>): ((xs: string) => string)&((xs: T) => ?V)
-  declare function nth<T:string>(i: number, xs: T):  T
+  declare function nth<V, T: Array<V>>(i: number, xs: T): ?V;
+  declare function nth<V, T: Array<V> | string>(
+    i: number,
+    ...rest: Array<void>
+  ): ((xs: string) => string) & ((xs: T) => ?V);
+  declare function nth<T: string>(i: number, xs: T): T;
 
-  declare function find<V,O:{[key:string]:*},T:Array<V>|O>(fn: UnaryPredicateFn<V>, ...rest: Array<void>): (xs:T|O) => ?V|O;
-  declare function find<V,O:{[key:string]:*},T:Array<V>|O>(fn: UnaryPredicateFn<V>, xs:T|O): ?V|O;
-  declare function findLast<V,O:{[key:string]:*},T:Array<V>|O>(fn: UnaryPredicateFn<V>, ...rest: Array<void>): (xs:T|O) => ?V|O;
-  declare function findLast<V,O:{[key:string]:*},T:Array<V>|O>(fn: UnaryPredicateFn<V>, xs:T|O): ?V|O;
+  declare function find<V, O: { [key: string]: * }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T | O) => ?V | O;
+  declare function find<V, O: { [key: string]: * }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+    xs: T | O
+  ): ?V | O;
+  declare function findLast<V, O: { [key: string]: * }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T | O) => ?V | O;
+  declare function findLast<V, O: { [key: string]: * }, T: Array<V> | O>(
+    fn: UnaryPredicateFn<V>,
+    xs: T | O
+  ): ?V | O;
 
-  declare function findIndex<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>, ...rest: Array<void>): (xs:T) => number
-  declare function findIndex<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>, xs:T): number
-  declare function findLastIndex<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>, ...rest: Array<void>): (xs:T) => number
-  declare function findLastIndex<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>, xs:T): number
+  declare function findIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => number;
+  declare function findIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): number;
+  declare function findLastIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => number;
+  declare function findLastIndex<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): number;
 
-  declare function forEach<T,V>(fn:(x:T) => ?V, xs: Array<T>): Array<T>
-  declare function forEach<T,V>(fn:(x:T) => ?V, ...rest: Array<void>): (xs: Array<T>) => Array<T>
+  declare function forEach<T, V>(fn: (x: T) => ?V, xs: Array<T>): Array<T>;
+  declare function forEach<T, V>(
+    fn: (x: T) => ?V,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => Array<T>;
 
-  declare function forEachObjIndexed<O: Object, A, B>(n: (val: A, key: string, o: O) => B, o: { [key: string]: A }): O;
-  declare function forEachObjIndexed<O: Object, A, B>(fn: (val: A, key: string, o: O) => B,...args: Array<void>): (o: { [key: string]: A }) => O;
+  declare function forEachObjIndexed<O: Object, A, B>(
+    n: (val: A, key: string, o: O) => B,
+    o: { [key: string]: A }
+  ): O;
+  declare function forEachObjIndexed<O: Object, A, B>(
+    fn: (val: A, key: string, o: O) => B,
+    ...args: Array<void>
+  ): (o: { [key: string]: A }) => O;
 
-  declare function lastIndexOf<E>(x: E, xs: Array<E>): number
-  declare function lastIndexOf<E>(x: E, ...rest: Array<void>): (xs: Array<E>) => number
+  declare function lastIndexOf<E>(x: E, xs: Array<E>): number;
+  declare function lastIndexOf<E>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: Array<E>) => number;
 
-  declare function map<T,R>(fn: (x:T) => R, xs: Array<T>): Array<R>;
-  declare function map<T,R,S:{map:Function}>(fn: (x:T) => R, xs: S): S;
-  declare function map<T,R>(fn: (x:T) => R, ...rest: Array<void>): ((xs: {[key: string]: T}) => {[key: string]: R}) & ((xs: Array<T>) => Array<R>)
-  declare function map<T,R,S:{map:Function}>(fn: (x:T) => R, ...rest: Array<void>): ((xs:S) => S) & ((xs: S) => S)
-  declare function map<T,R>(fn: (x:T) => R, xs: {[key: string]: T}): {[key: string]: R}
+  declare function map<T, R>(fn: (x: T) => R, xs: Array<T>): Array<R>;
+  declare function map<T, R, S: { map: Function }>(fn: (x: T) => R, xs: S): S;
+  declare function map<T, R>(
+    fn: (x: T) => R,
+    ...rest: Array<void>
+  ): ((xs: { [key: string]: T }) => { [key: string]: R }) &
+    ((xs: Array<T>) => Array<R>);
+  declare function map<T, R, S: { map: Function }>(
+    fn: (x: T) => R,
+    ...rest: Array<void>
+  ): ((xs: S) => S) & ((xs: S) => S);
+  declare function map<T, R>(
+    fn: (x: T) => R,
+    xs: { [key: string]: T }
+  ): { [key: string]: R };
 
-  declare type AccumIterator<A,B,R> = (acc: R, x: A) => [R,B]
-  declare function mapAccum<A,B,R>(fn: AccumIterator<A,B,R>, acc: R, xs: Array<A>): [R, Array<B>];
-  declare function mapAccum<A,B,R>(fn: AccumIterator<A,B,R>, ...rest: Array<void>): (acc: R, xs: Array<A>) => [R, Array<B>];
+  declare type AccumIterator<A, B, R> = (acc: R, x: A) => [R, B];
+  declare function mapAccum<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    acc: R,
+    xs: Array<A>
+  ): [R, Array<B>];
+  declare function mapAccum<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    ...rest: Array<void>
+  ): (acc: R, xs: Array<A>) => [R, Array<B>];
 
-  declare function mapAccumRight<A,B,R>(fn: AccumIterator<A,B,R>, acc: R, xs: Array<A>): [R, Array<B>];
-  declare function mapAccumRight<A,B,R>(fn: AccumIterator<A,B,R>, ...rest: Array<void>): (acc: R, xs: Array<A>) => [R, Array<B>];
+  declare function mapAccumRight<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    acc: R,
+    xs: Array<A>
+  ): [R, Array<B>];
+  declare function mapAccumRight<A, B, R>(
+    fn: AccumIterator<A, B, R>,
+    ...rest: Array<void>
+  ): (acc: R, xs: Array<A>) => [R, Array<B>];
 
-  declare function intersperse<E>(x: E, xs: Array<E>): Array<E>
-  declare function intersperse<E>(x: E, ...rest: Array<void>): (xs: Array<E>) => Array<E>
+  declare function intersperse<E>(x: E, xs: Array<E>): Array<E>;
+  declare function intersperse<E>(
+    x: E,
+    ...rest: Array<void>
+  ): (xs: Array<E>) => Array<E>;
 
-  declare function pair<A,B>(a:A, b:B): [A,B]
-  declare function pair<A,B>(a:A, ...rest: Array<void>): (b:B) => [A,B]
+  declare function pair<A, B>(a: A, b: B): [A, B];
+  declare function pair<A, B>(a: A, ...rest: Array<void>): (b: B) => [A, B];
 
-  declare function partition<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>, xs:T): [T,T]
-  declare function partition<K,V,T:Array<V>|{[key:K]:V}>(fn: UnaryPredicateFn<V>, ...rest: Array<void>): (xs:T) => [T,T]
+  declare function partition<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): [T, T];
+  declare function partition<K, V, T: Array<V> | { [key: K]: V }>(
+    fn: UnaryPredicateFn<V>,
+    ...rest: Array<void>
+  ): (xs: T) => [T, T];
 
-  declare function pluck<V,K:string|number,T:Array<Array<V>|{[key:string]:V}>>(k: K, xs: T): Array<V>
-  declare function pluck<V,K:string|number,T:Array<Array<V>|{[key:string]:V}>>(k: K,...rest: Array<void>): (xs: T) => Array<V>
+  declare function pluck<
+    V,
+    K: string | number,
+    T: Array<Array<V> | { [key: string]: V }>
+  >(
+    k: K,
+    xs: T
+  ): Array<V>;
+  declare function pluck<
+    V,
+    K: string | number,
+    T: Array<Array<V> | { [key: string]: V }>
+  >(
+    k: K,
+    ...rest: Array<void>
+  ): (xs: T) => Array<V>;
 
-  declare var range: CurriedFunction2<number,number,Array<number>>;
+  declare var range: CurriedFunction2<number, number, Array<number>>;
 
-  declare function remove<T>(from: number, ...rest: Array<void>): ((to: number, ...rest: Array<void>) => (src: Array<T>) => Array<T>) & ((to: number, src: Array<T>) => Array<T>)
-  declare function remove<T>(from: number, to: number, ...rest: Array<void>): (src: Array<T>) => Array<T>
-  declare function remove<T>(from: number, to: number, src: Array<T>): Array<T>
+  declare function remove<T>(
+    from: number,
+    ...rest: Array<void>
+  ): ((to: number, ...rest: Array<void>) => (src: Array<T>) => Array<T>) &
+    ((to: number, src: Array<T>) => Array<T>);
+  declare function remove<T>(
+    from: number,
+    to: number,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<T>;
+  declare function remove<T>(from: number, to: number, src: Array<T>): Array<T>;
 
-  declare function repeat<T>(x: T, times: number): Array<T>
-  declare function repeat<T>(x: T, ...rest: Array<void>): (times: number) => Array<T>
+  declare function repeat<T>(x: T, times: number): Array<T>;
+  declare function repeat<T>(
+    x: T,
+    ...rest: Array<void>
+  ): (times: number) => Array<T>;
 
-  declare function slice<V,T:Array<V>|string>(from: number, ...rest: Array<void>): ((to: number, ...rest: Array<void>) => (src: T) => T) & ((to: number, src: T) => T)
-  declare function slice<V,T:Array<V>|string>(from: number, to: number, ...rest: Array<void>): (src: T) => T
-  declare function slice<V,T:Array<V>|string>(from: number, to: number, src: T): T
+  declare function slice<V, T: Array<V> | string>(
+    from: number,
+    ...rest: Array<void>
+  ): ((to: number, ...rest: Array<void>) => (src: T) => T) &
+    ((to: number, src: T) => T);
+  declare function slice<V, T: Array<V> | string>(
+    from: number,
+    to: number,
+    ...rest: Array<void>
+  ): (src: T) => T;
+  declare function slice<V, T: Array<V> | string>(
+    from: number,
+    to: number,
+    src: T
+  ): T;
 
-  declare function sort<V,T:Array<V>>(fn: (a:V, b:V) => number, xs:T): T
-  declare function sort<V,T:Array<V>>(fn: (a:V, b:V) => number, ...rest: Array<void>): (xs:T) => T
+  declare function sort<V, T: Array<V>>(fn: (a: V, b: V) => number, xs: T): T;
+  declare function sort<V, T: Array<V>>(
+    fn: (a: V, b: V) => number,
+    ...rest: Array<void>
+  ): (xs: T) => T;
 
-  declare function times<T>(fn:(i: number) => T, n: number): Array<T>
-  declare function times<T>(fn:(i: number) => T, ...rest: Array<void>): (n: number) => Array<T>
+  declare function times<T>(fn: (i: number) => T, n: number): Array<T>;
+  declare function times<T>(
+    fn: (i: number) => T,
+    ...rest: Array<void>
+  ): (n: number) => Array<T>;
 
-  declare function take<V,T:Array<V>|string>(n: number, xs: T): T;
-  declare function take<V,T:Array<V>|string>(n: number):(xs: T) => T;
+  declare function take<V, T: Array<V> | string>(n: number, xs: T): T;
+  declare function take<V, T: Array<V> | string>(n: number): (xs: T) => T;
 
-  declare function takeLast<V,T:Array<V>|string>(n: number, xs: T): T;
-  declare function takeLast<V,T:Array<V>|string>(n: number):(xs: T) => T;
+  declare function takeLast<V, T: Array<V> | string>(n: number, xs: T): T;
+  declare function takeLast<V, T: Array<V> | string>(n: number): (xs: T) => T;
 
-  declare function takeLastWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>, xs:T): T;
-  declare function takeLastWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>): (xs:T) => T;
+  declare function takeLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): T;
+  declare function takeLastWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ): (xs: T) => T;
 
-  declare function takeWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>, xs:T): T;
-  declare function takeWhile<V,T:Array<V>>(fn: UnaryPredicateFn<V>): (xs:T) => T;
+  declare function takeWhile<V, T: Array<V>>(fn: UnaryPredicateFn<V>, xs: T): T;
+  declare function takeWhile<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ): (xs: T) => T;
 
-  declare function unfold<T,R>(fn: (seed: T) => [R, T]|boolean, ...rest: Array<void>): (seed: T) => Array<R>
-  declare function unfold<T,R>(fn: (seed: T) => [R, T]|boolean, seed: T): Array<R>
+  declare function unfold<T, R>(
+    fn: (seed: T) => [R, T] | boolean,
+    ...rest: Array<void>
+  ): (seed: T) => Array<R>;
+  declare function unfold<T, R>(
+    fn: (seed: T) => [R, T] | boolean,
+    seed: T
+  ): Array<R>;
 
-  declare function uniqBy<T,V>(fn:(x: T) => V, ...rest: Array<void>): (xs: Array<T>) => Array<T>
-  declare function uniqBy<T,V>(fn:(x: T) => V, xs: Array<T>): Array<T>
+  declare function uniqBy<T, V>(
+    fn: (x: T) => V,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => Array<T>;
+  declare function uniqBy<T, V>(fn: (x: T) => V, xs: Array<T>): Array<T>;
 
-  declare function uniqWith<T>(fn: BinaryPredicateFn<T>, ...rest: Array<void>): (xs: Array<T>) => Array<T>
-  declare function uniqWith<T>(fn: BinaryPredicateFn<T>, xs: Array<T>): Array<T>
+  declare function uniqWith<T>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => Array<T>;
+  declare function uniqWith<T>(
+    fn: BinaryPredicateFn<T>,
+    xs: Array<T>
+  ): Array<T>;
 
-  declare function update<T>(index: number, ...rest: Array<void>): ((elem: T, ...rest: Array<void>) => (src: Array<T>) => Array<T>) & ((elem: T, src: Array<T>) => Array<T>)
-  declare function update<T>(index: number, elem: T, ...rest: Array<void>): (src: Array<T>) => Array<T>
-  declare function update<T>(index: number, elem: T, src: Array<T>): Array<T>
+  declare function update<T>(
+    index: number,
+    ...rest: Array<void>
+  ): ((elem: T, ...rest: Array<void>) => (src: Array<T>) => Array<T>) &
+    ((elem: T, src: Array<T>) => Array<T>);
+  declare function update<T>(
+    index: number,
+    elem: T,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<T>;
+  declare function update<T>(index: number, elem: T, src: Array<T>): Array<T>;
 
   // TODO `without` as a transducer
-  declare function without<T>(xs: Array<T>, src: Array<T>): Array<T>
-  declare function without<T>(xs: Array<T>, ...rest: Array<void>): (src: Array<T>) => Array<T>
+  declare function without<T>(xs: Array<T>, src: Array<T>): Array<T>;
+  declare function without<T>(
+    xs: Array<T>,
+    ...rest: Array<void>
+  ): (src: Array<T>) => Array<T>;
 
-  declare function xprod<T,S>(xs: Array<T>, ys: Array<S>): Array<[T,S]>
-  declare function xprod<T,S>(xs: Array<T>, ...rest: Array<void>): (ys: Array<S>) => Array<[T,S]>
+  declare function xprod<T, S>(xs: Array<T>, ys: Array<S>): Array<[T, S]>;
+  declare function xprod<T, S>(
+    xs: Array<T>,
+    ...rest: Array<void>
+  ): (ys: Array<S>) => Array<[T, S]>;
 
-  declare function zip<T,S>(xs: Array<T>, ys: Array<S>): Array<[T,S]>
-  declare function zip<T,S>(xs: Array<T>, ...rest: Array<void>): (ys: Array<S>) => Array<[T,S]>
+  declare function zip<T, S>(xs: Array<T>, ys: Array<S>): Array<[T, S]>;
+  declare function zip<T, S>(
+    xs: Array<T>,
+    ...rest: Array<void>
+  ): (ys: Array<S>) => Array<[T, S]>;
 
-  declare function zipObj<T:string,S>(xs: Array<T>, ys: Array<S>): {[key:T]:S}
-  declare function zipObj<T:string,S>(xs: Array<T>, ...rest: Array<void>): (ys: Array<S>) => {[key:T]:S}
+  declare function zipObj<T: string, S>(
+    xs: Array<T>,
+    ys: Array<S>
+  ): { [key: T]: S };
+  declare function zipObj<T: string, S>(
+    xs: Array<T>,
+    ...rest: Array<void>
+  ): (ys: Array<S>) => { [key: T]: S };
 
-  declare type NestedArray<T> = Array<T | NestedArray<T>>
+  declare type NestedArray<T> = Array<T | NestedArray<T>>;
   declare function flatten<T>(xs: NestedArray<T>): Array<T>;
 
-  declare function fromPairs<T,V>(pair: Array<[T,V]>): {[key: string]:V};
+  declare function fromPairs<T, V>(pair: Array<[T, V]>): { [key: string]: V };
 
-  declare function init<T,V:Array<T>|string>(xs: V): V;
+  declare function init<T, V: Array<T> | string>(xs: V): V;
 
   declare function length<T>(xs: Array<T>): number;
 
-  declare function mergeAll(objs: Array<{[key: string]: any}>):{[key: string]: any};
+  declare function mergeAll(
+    objs: Array<{ [key: string]: any }>
+  ): { [key: string]: any };
 
-  declare function reverse<T,V:Array<T>|string>(xs: V): V;
+  declare function reverse<T, V: Array<T> | string>(xs: V): V;
 
-  declare function reduce<A, B>(fn: (acc: A, elem: B) => A, ...rest: Array<void>): ((init: A, xs: Array<B>) => A) & ((init: A, ...rest: Array<void>) => (xs: Array<B>) => A);
-  declare function reduce<A, B>(fn: (acc: A, elem: B) => A, init: A, ...rest: Array<void>): (xs: Array<B>) => A;
-  declare function reduce<A, B>(fn: (acc: A, elem: B) => A, init: A, xs: Array<B>): A;
+  declare function reduce<A, B>(
+    fn: (acc: A, elem: B) => A,
+    ...rest: Array<void>
+  ): ((init: A, xs: Array<B>) => A) &
+    ((init: A, ...rest: Array<void>) => (xs: Array<B>) => A);
+  declare function reduce<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    ...rest: Array<void>
+  ): (xs: Array<B>) => A;
+  declare function reduce<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    xs: Array<B>
+  ): A;
 
-  declare function reduceBy<A, B>(fn: (acc: B, elem: A) => B, ...rest: Array<void>):
-  ((acc: B, ...rest: Array<void>) => ((keyFn:(elem: A) => string, ...rest: Array<void>) => (xs: Array<A>) => {[key: string]: B}) & ((keyFn:(elem: A) => string, xs: Array<A>) => {[key: string]: B}))
-  & ((acc: B, keyFn:(elem: A) => string, ...rest: Array<void>) => (xs: Array<A>) => {[key: string]: B})
-  & ((acc: B, keyFn:(elem: A) => string, xs: Array<A>) => {[key: string]: B})
-  declare function reduceBy<A, B>(fn: (acc: B, elem: A) => B, acc: B, ...rest: Array<void>):
-  ((keyFn:(elem: A) => string, ...rest: Array<void>) => (xs: Array<A>) => {[key: string]: B})
-  & ((keyFn:(elem: A) => string, xs: Array<A>) => {[key: string]: B})
-  declare function reduceBy<A, B>(fn: (acc: B, elem: A) => B, acc: B, keyFn:(elem: A) => string): (xs: Array<A>) => {[key: string]: B};
-  declare function reduceBy<A, B>(fn: (acc: B, elem: A) => B, acc: B, keyFn:(elem: A) => string, xs: Array<A>): {[key: string]: B};
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    ...rest: Array<void>
+  ): ((
+    acc: B,
+    ...rest: Array<void>
+  ) => ((
+    keyFn: (elem: A) => string,
+    ...rest: Array<void>
+  ) => (xs: Array<A>) => { [key: string]: B }) &
+    ((keyFn: (elem: A) => string, xs: Array<A>) => { [key: string]: B })) &
+    ((
+      acc: B,
+      keyFn: (elem: A) => string,
+      ...rest: Array<void>
+    ) => (xs: Array<A>) => { [key: string]: B }) &
+    ((
+      acc: B,
+      keyFn: (elem: A) => string,
+      xs: Array<A>
+    ) => { [key: string]: B });
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    acc: B,
+    ...rest: Array<void>
+  ): ((
+    keyFn: (elem: A) => string,
+    ...rest: Array<void>
+  ) => (xs: Array<A>) => { [key: string]: B }) &
+    ((keyFn: (elem: A) => string, xs: Array<A>) => { [key: string]: B });
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    acc: B,
+    keyFn: (elem: A) => string
+  ): (xs: Array<A>) => { [key: string]: B };
+  declare function reduceBy<A, B>(
+    fn: (acc: B, elem: A) => B,
+    acc: B,
+    keyFn: (elem: A) => string,
+    xs: Array<A>
+  ): { [key: string]: B };
 
-  declare function reduceRight<A, B>(fn: (acc: A, elem: B) => A, ...rest: Array<void>): ((init: A, xs: Array<B>) => A) & ((init: A, ...rest: Array<void>) => (xs: Array<B>) => A);
-  declare function reduceRight<A, B>(fn: (acc: A, elem: B) => A, init: A, ...rest: Array<void>): (xs: Array<B>) => A;
-  declare function reduceRight<A, B>(fn: (acc: A, elem: B) => A, init: A, xs: Array<B>): A;
+  declare function reduceRight<A, B>(
+    fn: (acc: A, elem: B) => A,
+    ...rest: Array<void>
+  ): ((init: A, xs: Array<B>) => A) &
+    ((init: A, ...rest: Array<void>) => (xs: Array<B>) => A);
+  declare function reduceRight<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    ...rest: Array<void>
+  ): (xs: Array<B>) => A;
+  declare function reduceRight<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    xs: Array<B>
+  ): A;
 
-  declare function scan<A, B>(fn: (acc: A, elem: B) => A, ...rest: Array<void>): ((init: A, xs: Array<B>) => A) & ((init: A, ...rest: Array<void>) => (xs: Array<B>) => A);
-  declare function scan<A, B>(fn: (acc: A, elem: B) => A, init: A, ...rest: Array<void>): (xs: Array<B>) => A;
-  declare function scan<A, B>(fn: (acc: A, elem: B) => A, init: A, xs: Array<B>): A;
+  declare function scan<A, B>(
+    fn: (acc: A, elem: B) => A,
+    ...rest: Array<void>
+  ): ((init: A, xs: Array<B>) => A) &
+    ((init: A, ...rest: Array<void>) => (xs: Array<B>) => A);
+  declare function scan<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    ...rest: Array<void>
+  ): (xs: Array<B>) => A;
+  declare function scan<A, B>(
+    fn: (acc: A, elem: B) => A,
+    init: A,
+    xs: Array<B>
+  ): A;
 
-  declare function splitAt<V,T:Array<V>|string>(i: number, xs: T): [T,T];
-  declare function splitAt<V,T:Array<V>|string>(i: number): (xs: T) => [T,T];
-  declare function splitEvery<V,T:Array<V>|string>(i: number, xs: T): Array<T>;
-  declare function splitEvery<V,T:Array<V>|string>(i: number): (xs: T) => Array<T>;
-  declare function splitWhen<V,T:Array<V>>(fn: UnaryPredicateFn<V>, xs:T): [T,T];
-  declare function splitWhen<V,T:Array<V>>(fn: UnaryPredicateFn<V>): (xs:T) => [T,T];
+  declare function splitAt<V, T: Array<V> | string>(i: number, xs: T): [T, T];
+  declare function splitAt<V, T: Array<V> | string>(
+    i: number
+  ): (xs: T) => [T, T];
+  declare function splitEvery<V, T: Array<V> | string>(
+    i: number,
+    xs: T
+  ): Array<T>;
+  declare function splitEvery<V, T: Array<V> | string>(
+    i: number
+  ): (xs: T) => Array<T>;
+  declare function splitWhen<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>,
+    xs: T
+  ): [T, T];
+  declare function splitWhen<V, T: Array<V>>(
+    fn: UnaryPredicateFn<V>
+  ): (xs: T) => [T, T];
 
-  declare function tail<T,V:Array<T>|string>(xs: V): V;
+  declare function tail<T, V: Array<T> | string>(xs: V): V;
 
   declare function transpose<T>(xs: Array<Array<T>>): Array<Array<T>>;
 
@@ -384,40 +817,103 @@ declare module ramda {
 
   declare function unnest<T>(xs: NestedArray<T>): NestedArray<T>;
 
-  declare function zipWith<T,S,R>(fn: (a: T, b: S) => R, ...rest: Array<void>): ((xs: Array<T>, ys: Array<S>) => Array<R>) & ((xs: Array<T>, ...rest: Array<void> ) => (ys: Array<S>) => Array<R>)
-  declare function zipWith<T,S,R>(fn: (a: T, b: S) => R, xs: Array<T>, ...rest: Array<void>): (ys: Array<S>) => Array<R>;
-  declare function zipWith<T,S,R>(fn: (a: T, b: S) => R, xs: Array<T>, ys: Array<S>): Array<R>;
+  declare function zipWith<T, S, R>(
+    fn: (a: T, b: S) => R,
+    ...rest: Array<void>
+  ): ((xs: Array<T>, ys: Array<S>) => Array<R>) &
+    ((xs: Array<T>, ...rest: Array<void>) => (ys: Array<S>) => Array<R>);
+  declare function zipWith<T, S, R>(
+    fn: (a: T, b: S) => R,
+    xs: Array<T>,
+    ...rest: Array<void>
+  ): (ys: Array<S>) => Array<R>;
+  declare function zipWith<T, S, R>(
+    fn: (a: T, b: S) => R,
+    xs: Array<T>,
+    ys: Array<S>
+  ): Array<R>;
 
   // *Relation
   declare function equals<T>(x: T, ...rest: Array<void>): (y: T) => boolean;
   declare function equals<T>(x: T, y: T): boolean;
 
-  declare function eqBy<A,B>(fn: (x: A) => B, ...rest: Array<void>): ((x: A, y: A) => boolean) & ((x: A, ...rest: Array<void>) => (y: A) => boolean);
-  declare function eqBy<A,B>(fn: (x: A) => B, x: A, ...rest: Array<void>): (y: A) => boolean;
-  declare function eqBy<A,B>(fn: (x: A) => B, x: A, y: A): boolean;
+  declare function eqBy<A, B>(
+    fn: (x: A) => B,
+    ...rest: Array<void>
+  ): ((x: A, y: A) => boolean) &
+    ((x: A, ...rest: Array<void>) => (y: A) => boolean);
+  declare function eqBy<A, B>(
+    fn: (x: A) => B,
+    x: A,
+    ...rest: Array<void>
+  ): (y: A) => boolean;
+  declare function eqBy<A, B>(fn: (x: A) => B, x: A, y: A): boolean;
 
-  declare function propEq(prop: string, ...rest: Array<void>): ((val: *, o: {[k:string]: *}) => boolean) & ((val: *, ...rest: Array<void>) => (o: {[k:string]: *}) => boolean)
-  declare function propEq(prop: string, val: *, ...rest: Array<void>): (o: {[k:string]: *}) => boolean;
-  declare function propEq(prop: string, val: *, o: {[k:string]:*}): boolean;
+  declare function propEq(
+    prop: string,
+    ...rest: Array<void>
+  ): ((val: *, o: { [k: string]: * }) => boolean) &
+    ((val: *, ...rest: Array<void>) => (o: { [k: string]: * }) => boolean);
+  declare function propEq(
+    prop: string,
+    val: *,
+    ...rest: Array<void>
+  ): (o: { [k: string]: * }) => boolean;
+  declare function propEq(prop: string, val: *, o: { [k: string]: * }): boolean;
 
-  declare function pathEq(path: Array<string>, ...rest: Array<void>): ((val: any, o: Object) => boolean) & ((val: any, ...rest: Array<void>) => (o: Object) => boolean);
-  declare function pathEq(path: Array<string>, val: any, ...rest: Array<void>): (o: Object) => boolean;
+  declare function pathEq(
+    path: Array<string>,
+    ...rest: Array<void>
+  ): ((val: any, o: Object) => boolean) &
+    ((val: any, ...rest: Array<void>) => (o: Object) => boolean);
+  declare function pathEq(
+    path: Array<string>,
+    val: any,
+    ...rest: Array<void>
+  ): (o: Object) => boolean;
   declare function pathEq(path: Array<string>, val: any, o: Object): boolean;
 
-  declare function clamp<T:number|string|Date>(min: T, ...rest: Array<void>):
-    ((max: T, ...rest: Array<void>) => (v: T) => T) & ((max: T, v: T) => T);
-  declare function clamp<T:number|string|Date>(min: T, max: T, ...rest: Array<void>): (v: T) => T;
-  declare function clamp<T:number|string|Date>(min: T, max: T, v: T): T;
+  declare function clamp<T: number | string | Date>(
+    min: T,
+    ...rest: Array<void>
+  ): ((max: T, ...rest: Array<void>) => (v: T) => T) & ((max: T, v: T) => T);
+  declare function clamp<T: number | string | Date>(
+    min: T,
+    max: T,
+    ...rest: Array<void>
+  ): (v: T) => T;
+  declare function clamp<T: number | string | Date>(min: T, max: T, v: T): T;
 
-  declare function countBy<T>(fn: (x: T) => string, ...rest: Array<void>): (list: Array<T>) => {[key: string]: number};
-  declare function countBy<T>(fn: (x: T) => string, list: Array<T>): {[key: string]: number};
+  declare function countBy<T>(
+    fn: (x: T) => string,
+    ...rest: Array<void>
+  ): (list: Array<T>) => { [key: string]: number };
+  declare function countBy<T>(
+    fn: (x: T) => string,
+    list: Array<T>
+  ): { [key: string]: number };
 
-  declare function difference<T>(xs1: Array<T>, ...rest: Array<void>): (xs2: Array<T>) => Array<T>;
+  declare function difference<T>(
+    xs1: Array<T>,
+    ...rest: Array<void>
+  ): (xs2: Array<T>) => Array<T>;
   declare function difference<T>(xs1: Array<T>, xs2: Array<T>): Array<T>;
 
-  declare function differenceWith<T>(fn: BinaryPredicateFn<T>, ...rest: Array<void>): ((xs1: Array<T>) => (xs2: Array<T>) => Array<T>) & ((xs1: Array<T>, xs2: Array<T>) => Array<T>);
-  declare function differenceWith<T>(fn: BinaryPredicateFn<T>, xs1: Array<T>, ...rest: Array<void>): (xs2: Array<T>) => Array<T>;
-  declare function differenceWith<T>(fn: BinaryPredicateFn<T>, xs1: Array<T>, xs2: Array<T>): Array<T>;
+  declare function differenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((xs1: Array<T>) => (xs2: Array<T>) => Array<T>) &
+    ((xs1: Array<T>, xs2: Array<T>) => Array<T>);
+  declare function differenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    xs1: Array<T>,
+    ...rest: Array<void>
+  ): (xs2: Array<T>) => Array<T>;
+  declare function differenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    xs1: Array<T>,
+    xs2: Array<T>
+  ): Array<T>;
 
   declare function eqBy<T>(fn: (x: T) => T, x: T, y: T): boolean;
   declare function eqBy<T>(fn: (x: T) => T): (x: T, y: T) => boolean;
@@ -436,9 +932,21 @@ declare module ramda {
   declare function intersection<T>(x: Array<T>, y: Array<T>): Array<T>;
   declare function intersection<T>(x: Array<T>): (y: Array<T>) => Array<T>;
 
-  declare function intersectionWith<T>(fn: BinaryPredicateFn<T>, ...rest: Array<void>): ((x: Array<T>, y: Array<T>) => Array<T>) & ((x: Array<T>) => (y: Array<T>) => Array<T>);
-  declare function intersectionWith<T>(fn: BinaryPredicateFn<T>, x: Array<T>, ...rest: Array<void>): (y: Array<T>) => Array<T>;
-  declare function intersectionWith<T>(fn: BinaryPredicateFn<T>, x: Array<T>, y: Array<T>): Array<T>;
+  declare function intersectionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((x: Array<T>, y: Array<T>) => Array<T>) &
+    ((x: Array<T>) => (y: Array<T>) => Array<T>);
+  declare function intersectionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    ...rest: Array<void>
+  ): (y: Array<T>) => Array<T>;
+  declare function intersectionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    y: Array<T>
+  ): Array<T>;
 
   declare function lt<T>(x: T, ...rest: Array<void>): (y: T) => boolean;
   declare function lt<T>(x: T, y: T): boolean;
@@ -449,76 +957,189 @@ declare module ramda {
   declare function max<T>(x: T, ...rest: Array<void>): (y: T) => T;
   declare function max<T>(x: T, y: T): T;
 
-  declare function maxBy<T,V>(fn: (x:T) => V, ...rest: Array<void>): ((x: T, y: T) => T) & ((x: T) => (y: T) => T);
-  declare function maxBy<T,V>(fn: (x:T) => V, x: T, ...rest: Array<void>): (y: T) => T;
-  declare function maxBy<T,V>(fn: (x:T) => V, x: T, y: T): T;
+  declare function maxBy<T, V>(
+    fn: (x: T) => V,
+    ...rest: Array<void>
+  ): ((x: T, y: T) => T) & ((x: T) => (y: T) => T);
+  declare function maxBy<T, V>(
+    fn: (x: T) => V,
+    x: T,
+    ...rest: Array<void>
+  ): (y: T) => T;
+  declare function maxBy<T, V>(fn: (x: T) => V, x: T, y: T): T;
 
   declare function min<T>(x: T, ...rest: Array<void>): (y: T) => T;
   declare function min<T>(x: T, y: T): T;
 
-  declare function minBy<T,V>(fn: (x:T) => V, ...rest: Array<void>): ((x: T, y: T) => T) & ((x: T) => (y: T) => T);
-  declare function minBy<T,V>(fn: (x:T) => V, x: T, ...rest: Array<void>): (y: T) => T;
-  declare function minBy<T,V>(fn: (x:T) => V, x: T, y: T): T;
+  declare function minBy<T, V>(
+    fn: (x: T) => V,
+    ...rest: Array<void>
+  ): ((x: T, y: T) => T) & ((x: T) => (y: T) => T);
+  declare function minBy<T, V>(
+    fn: (x: T) => V,
+    x: T,
+    ...rest: Array<void>
+  ): (y: T) => T;
+  declare function minBy<T, V>(fn: (x: T) => V, x: T, y: T): T;
 
-  declare function sortBy<T,V>(fn: (x:T) => V, ...rest: Array<void>): (x: Array<T>) => Array<T>;
-  declare function sortBy<T,V>(fn: (x:T) => V, x: Array<T>): Array<T>;
+  declare function sortBy<T, V>(
+    fn: (x: T) => V,
+    ...rest: Array<void>
+  ): (x: Array<T>) => Array<T>;
+  declare function sortBy<T, V>(fn: (x: T) => V, x: Array<T>): Array<T>;
 
-  declare function symmetricDifference<T>(x: Array<T>, ...rest: Array<void>): (y: Array<T>) => Array<T>;
+  declare function symmetricDifference<T>(
+    x: Array<T>,
+    ...rest: Array<void>
+  ): (y: Array<T>) => Array<T>;
   declare function symmetricDifference<T>(x: Array<T>, y: Array<T>): Array<T>;
 
-  declare function symmetricDifferenceWith<T>(fn: BinaryPredicateFn<T>, ...rest: Array<void>): ((x: Array<T>, ...rest: Array<void>) => (y: Array<T>) => Array<T>) & ((x: Array<T>, y: Array<T>) => Array<T>);
-  declare function symmetricDifferenceWith<T>(fn: BinaryPredicateFn<T>, x: Array<T>, ...rest: Array<void>): (y: Array<T>) => Array<T>;
-  declare function symmetricDifferenceWith<T>(fn: BinaryPredicateFn<T>, x: Array<T>, y: Array<T>): Array<T>;
+  declare function symmetricDifferenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((x: Array<T>, ...rest: Array<void>) => (y: Array<T>) => Array<T>) &
+    ((x: Array<T>, y: Array<T>) => Array<T>);
+  declare function symmetricDifferenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    ...rest: Array<void>
+  ): (y: Array<T>) => Array<T>;
+  declare function symmetricDifferenceWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    y: Array<T>
+  ): Array<T>;
 
-  declare function union<T>(x: Array<T>, ...rest: Array<void>): (y: Array<T>) => Array<T>;
+  declare function union<T>(
+    x: Array<T>,
+    ...rest: Array<void>
+  ): (y: Array<T>) => Array<T>;
   declare function union<T>(x: Array<T>, y: Array<T>): Array<T>;
 
-  declare function unionWith<T>(fn: BinaryPredicateFn<T>, ...rest: Array<void>): ((x: Array<T>, ...rest: Array<void>) => (y: Array<T>) => Array<T>) & (x: Array<T>, y: Array<T>) => Array<T>;
-  declare function unionWith<T>(fn: BinaryPredicateFn<T>, x: Array<T>, ...rest: Array<void>): (y: Array<T>) => Array<T>;
-  declare function unionWith<T>(fn: BinaryPredicateFn<T>, x: Array<T>, y: Array<T>): Array<T>;
+  declare function unionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((x: Array<T>, ...rest: Array<void>) => (y: Array<T>) => Array<T>) &
+    ((x: Array<T>, y: Array<T>) => Array<T>);
+  declare function unionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    ...rest: Array<void>
+  ): (y: Array<T>) => Array<T>;
+  declare function unionWith<T>(
+    fn: BinaryPredicateFn<T>,
+    x: Array<T>,
+    y: Array<T>
+  ): Array<T>;
 
   // *Object
-  declare function assoc<T,S>(key: string, ...args: Array<void>):
-    ((val: T, ...rest: Array<void>) => (src: {[k:string]:S}) => {[k:string]:S|T}) & ((val: T, src: {[k:string]:S}) => {[k:string]:S|T});
-  declare function assoc<T,S>(key: string, val:T, ...args: Array<void>): (src: {[k:string]:S}) => {[k:string]:S|T};
-  declare function assoc<T,S>(key: string, val: T, src: {[k:string]:S}): {[k:string]:S|T};
+  declare function assoc<T, S>(
+    key: string,
+    ...args: Array<void>
+  ): ((
+    val: T,
+    ...rest: Array<void>
+  ) => (src: { [k: string]: S }) => { [k: string]: S | T }) &
+    ((val: T, src: { [k: string]: S }) => { [k: string]: S | T });
+  declare function assoc<T, S>(
+    key: string,
+    val: T,
+    ...args: Array<void>
+  ): (src: { [k: string]: S }) => { [k: string]: S | T };
+  declare function assoc<T, S>(
+    key: string,
+    val: T,
+    src: { [k: string]: S }
+  ): { [k: string]: S | T };
 
-  declare function assocPath<T,S>(key: Array<string>, ...args: Array<void>):
-    ((val: T, ...rest: Array<void>) => (src: {[k:string]:S}) => {[k:string]:S|T})
-    & ((val: T) => (src: {[k:string]:S}) => {[k:string]:S|T});
-  declare function assocPath<T,S>(key: Array<string>, val:T, ...args: Array<void>): (src: {[k:string]:S}) => {[k:string]:S|T};
-  declare function assocPath<T,S>(key: Array<string>, val:T, src: {[k:string]:S}): {[k:string]:S|T};
+  declare function assocPath<T, S>(
+    key: Array<string>,
+    ...args: Array<void>
+  ): ((
+    val: T,
+    ...rest: Array<void>
+  ) => (src: { [k: string]: S }) => { [k: string]: S | T }) &
+    ((val: T) => (src: { [k: string]: S }) => { [k: string]: S | T });
+  declare function assocPath<T, S>(
+    key: Array<string>,
+    val: T,
+    ...args: Array<void>
+  ): (src: { [k: string]: S }) => { [k: string]: S | T };
+  declare function assocPath<T, S>(
+    key: Array<string>,
+    val: T,
+    src: { [k: string]: S }
+  ): { [k: string]: S | T };
 
   declare function clone<T>(src: T): $Shape<T>;
 
-  declare function dissoc<T>(key: string, ...args: Array<void>):
-    ((val: T, ...rest: Array<void>) => (src: {[k:string]:T}) => {[k:string]:T}) & ((val: T, src: {[k:string]:T}) => {[k:string]:T});
-  declare function dissoc<T>(key: string, val:T, ...args: Array<void>): (src: {[k:string]:T}) => {[k:string]:T};
-  declare function dissoc<T>(key: string, val: T, src: {[k:string]:T}): {[k:string]:T};
+  declare function dissoc<T>(
+    key: string,
+    ...args: Array<void>
+  ): ((
+    val: T,
+    ...rest: Array<void>
+  ) => (src: { [k: string]: T }) => { [k: string]: T }) &
+    ((val: T, src: { [k: string]: T }) => { [k: string]: T });
+  declare function dissoc<T>(
+    key: string,
+    val: T,
+    ...args: Array<void>
+  ): (src: { [k: string]: T }) => { [k: string]: T };
+  declare function dissoc<T>(
+    key: string,
+    val: T,
+    src: { [k: string]: T }
+  ): { [k: string]: T };
 
-  declare function dissocPath<T>(key: Array<string>, ...args: Array<void>):
-    ((val: T, ...rest: Array<void>) => (src: {[k:string]:T}) => {[k:string]:T})
-    & ((val: T) => (src: {[k:string]:T}) => {[k:string]:T});
-  declare function dissocPath<T>(key: Array<string>, val:T, ...args: Array<void>): (src: {[k:string]:T}) => {[k:string]:T};
-  declare function dissocPath<T>(key: Array<string>, val:T, src: {[k:string]:T}): {[k:string]:T};
+  declare function dissocPath<T>(
+    key: Array<string>,
+    ...args: Array<void>
+  ): ((
+    val: T,
+    ...rest: Array<void>
+  ) => (src: { [k: string]: T }) => { [k: string]: T }) &
+    ((val: T) => (src: { [k: string]: T }) => { [k: string]: T });
+  declare function dissocPath<T>(
+    key: Array<string>,
+    val: T,
+    ...args: Array<void>
+  ): (src: { [k: string]: T }) => { [k: string]: T };
+  declare function dissocPath<T>(
+    key: Array<string>,
+    val: T,
+    src: { [k: string]: T }
+  ): { [k: string]: T };
 
-  declare function evolve<V,R>(fn: NestedObject<(x:any) => R>, ...rest: Array<void>): (src: NestedObject<any>) => NestedObject<R>;
-  declare function evolve<V,R>(fn: NestedObject<(x:any) => R>, src: NestedObject<any>): NestedObject<R>;
+  declare function evolve<V, R>(
+    fn: NestedObject<(x: any) => R>,
+    ...rest: Array<void>
+  ): (src: NestedObject<any>) => NestedObject<R>;
+  declare function evolve<V, R>(
+    fn: NestedObject<(x: any) => R>,
+    src: NestedObject<any>
+  ): NestedObject<R>;
 
-  declare function eqProps(key: string, ...args: Array<void>):
-  ((o1: Object, ...rest: Array<void>) => (o2: Object) => boolean)
-  & ((o1: Object, o2: Object) => boolean);
-  declare function eqProps(key: string, o1: Object, ...args: Array<void>): (o2: Object) => boolean;
+  declare function eqProps(
+    key: string,
+    ...args: Array<void>
+  ): ((o1: Object, ...rest: Array<void>) => (o2: Object) => boolean) &
+    ((o1: Object, o2: Object) => boolean);
+  declare function eqProps(
+    key: string,
+    o1: Object,
+    ...args: Array<void>
+  ): (o2: Object) => boolean;
   declare function eqProps(key: string, o1: Object, o2: Object): boolean;
 
   declare function has(key: string, o: Object): boolean;
-  declare function has(key: string):(o: Object) => boolean;
+  declare function has(key: string): (o: Object) => boolean;
 
   declare function hasIn(key: string, o: Object): boolean;
   declare function hasIn(key: string): (o: Object) => boolean;
 
-  declare function invert(o: Object): {[k: string]: Array<string>};
-  declare function invertObj(o: Object): {[k: string]: string};
+  declare function invert(o: Object): { [k: string]: Array<string> };
+  declare function invertObj(o: Object): { [k: string]: string };
 
   declare function keys(o: Object): Array<string>;
 
@@ -529,83 +1150,223 @@ declare module ramda {
   lensProp
   */
 
-  declare function mapObjIndexed<A,B>(fn: (val: A, key: string, o: Object) => B, o: {[key: string]: A}): {[key: string]: B};
-  declare function mapObjIndexed<A,B>(fn: (val: A, key: string, o: Object) => B, ...args: Array<void>): (o: {[key: string]: A}) => {[key: string]: B};
+  declare function mapObjIndexed<A, B>(
+    fn: (val: A, key: string, o: Object) => B,
+    o: { [key: string]: A }
+  ): { [key: string]: B };
+  declare function mapObjIndexed<A, B>(
+    fn: (val: A, key: string, o: Object) => B,
+    ...args: Array<void>
+  ): (o: { [key: string]: A }) => { [key: string]: B };
 
-  declare function merge<A,B>(o1: A, ...rest: Array<void>): (o2: B) => A & B;
-  declare function merge<A,B>(o1: A, o2: B): A & B;
+  declare function merge<A, B>(o1: A, ...rest: Array<void>): (o2: B) => A & B;
+  declare function merge<A, B>(o1: A, o2: B): A & B;
 
-  declare function mergeAll<T>(os: Array<{[k:string]:T}>): {[k:string]:T};
+  declare function mergeAll<T>(
+    os: Array<{ [k: string]: T }>
+  ): { [k: string]: T };
 
-  declare function mergeWith<T,S,R,A:{[k:string]:T},B:{[k:string]:S}>(fn: (v1: T, v2: S) => R):
-  ((o1: A, ...rest: Array<void>) => (o2: B) => A & B) & ((o1: A, o2: B) => A & B);
-  declare function mergeWith<T,S,R,A:{[k:string]:T},B:{[k:string]:S}>(fn: (v1: T, v2: S) => R, o1: A, o2: B): A & B;
-  declare function mergeWith<T,S,R,A:{[k:string]:T},B:{[k:string]:S}>(fn: (v1: T, v2: S) => R, o1: A, ...rest: Array<void>): (o2: B) => A & B;
+  declare function mergeWith<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (v1: T, v2: S) => R
+  ): ((o1: A, ...rest: Array<void>) => (o2: B) => A & B) &
+    ((o1: A, o2: B) => A & B);
+  declare function mergeWith<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (v1: T, v2: S) => R,
+    o1: A,
+    o2: B
+  ): A & B;
+  declare function mergeWith<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (v1: T, v2: S) => R,
+    o1: A,
+    ...rest: Array<void>
+  ): (o2: B) => A & B;
 
-  declare function mergeWithKey<T,S,R,A:{[k:string]:T},B:{[k:string]:S}>(fn: (key: $Keys<A&B>, v1: T, v2: S) => R):
-  ((o1: A, ...rest: Array<void>) => (o2: B) => A & B) & ((o1: A, o2: B) => A & B);
-  declare function mergeWithKey<T,S,R,A:{[k:string]:T},B:{[k:string]:S}>(fn: (key: $Keys<A&B>, v1: T, v2: S) => R, o1: A, o2: B): A & B;
-  declare function mergeWithKey<T,S,R,A:{[k:string]:T},B:{[k:string]:S}>(fn: (key: $Keys<A&B>, v1: T, v2: S) => R, o1: A, ...rest: Array<void>): (o2: B) => A & B;
+  declare function mergeWithKey<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (key: $Keys<A & B>, v1: T, v2: S) => R
+  ): ((o1: A, ...rest: Array<void>) => (o2: B) => A & B) &
+    ((o1: A, o2: B) => A & B);
+  declare function mergeWithKey<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (key: $Keys<A & B>, v1: T, v2: S) => R,
+    o1: A,
+    o2: B
+  ): A & B;
+  declare function mergeWithKey<
+    T,
+    S,
+    R,
+    A: { [k: string]: T },
+    B: { [k: string]: S }
+  >(
+    fn: (key: $Keys<A & B>, v1: T, v2: S) => R,
+    o1: A,
+    ...rest: Array<void>
+  ): (o2: B) => A & B;
 
-  declare function objOf<T>(key: string, ...rest: Array<void>): (val: T) => {[key: string]: T};
-  declare function objOf<T>(key: string, val: T): {[key: string]: T};
+  declare function objOf<T>(
+    key: string,
+    ...rest: Array<void>
+  ): (val: T) => { [key: string]: T };
+  declare function objOf<T>(key: string, val: T): { [key: string]: T };
 
-  declare function omit<T:Object>(keys: Array<$Keys<T>>, ...rest: Array<void>): (val: T) => Object;
-  declare function omit<T:Object>(keys: Array<$Keys<T>>, val: T): Object;
+  declare function omit<T: Object>(
+    keys: Array<$Keys<T>>,
+    ...rest: Array<void>
+  ): (val: T) => Object;
+  declare function omit<T: Object>(keys: Array<$Keys<T>>, val: T): Object;
 
   // TODO over
 
-  declare function path<V,A:?NestedObject<V>>(p: Array<string>, ...rest: Array<void>): (o: A) => ?V;
-  declare function path<V,A:?NestedObject<V>>(p: Array<string>, o: A): ?V;
+  declare function path<V, A: ?NestedObject<V>>(
+    p: Array<string>,
+    ...rest: Array<void>
+  ): (o: A) => ?V;
+  declare function path<V, A: ?NestedObject<V>>(p: Array<string>, o: A): ?V;
 
-  declare function pathOr<T,V,A:NestedObject<V>>(or: T, ...rest: Array<void>):
-  ((p: Array<string>, ...rest: Array<void>) => (o: ?A) => V|T)
-  & ((p: Array<string>, o: ?A) => V|T);
-  declare function pathOr<T,V,A:NestedObject<V>>(or: T, p: Array<string>, ...rest: Array<void>): (o: ?A) => V|T;
-  declare function pathOr<T,V,A:NestedObject<V>>(or: T, p: Array<string>, o: ?A): V|T;
+  declare function pathOr<T, V, A: NestedObject<V>>(
+    or: T,
+    ...rest: Array<void>
+  ): ((p: Array<string>, ...rest: Array<void>) => (o: ?A) => V | T) &
+    ((p: Array<string>, o: ?A) => V | T);
+  declare function pathOr<T, V, A: NestedObject<V>>(
+    or: T,
+    p: Array<string>,
+    ...rest: Array<void>
+  ): (o: ?A) => V | T;
+  declare function pathOr<T, V, A: NestedObject<V>>(
+    or: T,
+    p: Array<string>,
+    o: ?A
+  ): V | T;
 
-  declare function pick<A>(keys: Array<string>, ...rest: Array<void>): (val: {[key:string]: A}) => {[key:string]: A};
-  declare function pick<A>(keys: Array<string>, val: {[key:string]: A}): {[key:string]: A};
+  declare function pick<A>(
+    keys: Array<string>,
+    ...rest: Array<void>
+  ): (val: { [key: string]: A }) => { [key: string]: A };
+  declare function pick<A>(
+    keys: Array<string>,
+    val: { [key: string]: A }
+  ): { [key: string]: A };
 
-  declare function pickAll<A>(keys: Array<string>, ...rest: Array<void>): (val: {[key:string]: A}) => {[key:string]: ?A};
-  declare function pickAll<A>(keys: Array<string>, val: {[key:string]: A}): {[key:string]: ?A};
+  declare function pickAll<A>(
+    keys: Array<string>,
+    ...rest: Array<void>
+  ): (val: { [key: string]: A }) => { [key: string]: ?A };
+  declare function pickAll<A>(
+    keys: Array<string>,
+    val: { [key: string]: A }
+  ): { [key: string]: ?A };
 
-  declare function pickBy<A>(fn: BinaryPredicateFn2<A,string>, ...rest: Array<void>): (val: {[key:string]: A}) => {[key:string]: A};
-  declare function pickBy<A>(fn: BinaryPredicateFn2<A,string>, val: {[key:string]: A}): {[key:string]: A};
+  declare function pickBy<A>(
+    fn: BinaryPredicateFn2<A, string>,
+    ...rest: Array<void>
+  ): (val: { [key: string]: A }) => { [key: string]: A };
+  declare function pickBy<A>(
+    fn: BinaryPredicateFn2<A, string>,
+    val: { [key: string]: A }
+  ): { [key: string]: A };
 
-  declare function project<T>(keys: Array<string>, ...rest: Array<void>): (val: Array<{[key:string]: T}>) => Array<{[key:string]: T}>;
-  declare function project<T>(keys: Array<string>, val: Array<{[key:string]: T}>): Array<{[key:string]: T}>;
+  declare function project<T>(
+    keys: Array<string>,
+    ...rest: Array<void>
+  ): (val: Array<{ [key: string]: T }>) => Array<{ [key: string]: T }>;
+  declare function project<T>(
+    keys: Array<string>,
+    val: Array<{ [key: string]: T }>
+  ): Array<{ [key: string]: T }>;
 
-  declare function prop<T,O:{[k:string]:T}>(key: $Keys<O>, ...rest: Array<void>): (o: O) => ?T;
-  declare function prop<T,O:{[k:string]:T}>(key: $Keys<O>, o: O): ?T;
+  declare function prop<T, O: { [k: string]: T }>(
+    key: $Keys<O>,
+    ...rest: Array<void>
+  ): (o: O) => ?T;
+  declare function prop<T, O: { [k: string]: T }>(key: $Keys<O>, o: O): ?T;
 
-  declare function propOr<T,V,A:{[k:string]:V}>(or: T, ...rest: Array<void>):
-  ((p: $Keys<A>, ...rest: Array<void>) => (o: A) => V|T)
-  & ((p: $Keys<A>, o: A) => V|T);
-  declare function propOr<T,V,A:{[k:string]:V}>(or: T, p: $Keys<A>, ...rest: Array<void>): (o: A) => V|T;
-  declare function propOr<T,V,A:{[k:string]:V}>(or: T, p: $Keys<A>, o: A): V|T;
+  declare function propOr<T, V, A: { [k: string]: V }>(
+    or: T,
+    ...rest: Array<void>
+  ): ((p: $Keys<A>, ...rest: Array<void>) => (o: A) => V | T) &
+    ((p: $Keys<A>, o: A) => V | T);
+  declare function propOr<T, V, A: { [k: string]: V }>(
+    or: T,
+    p: $Keys<A>,
+    ...rest: Array<void>
+  ): (o: A) => V | T;
+  declare function propOr<T, V, A: { [k: string]: V }>(
+    or: T,
+    p: $Keys<A>,
+    o: A
+  ): V | T;
 
   declare function keysIn(o: Object): Array<string>;
 
-  declare function props<T,O:{[k:string]:T}>(keys: Array<$Keys<O>>, ...rest: Array<void>): (o: O) => Array<?T>;
-  declare function props<T,O:{[k:string]:T}>(keys: Array<$Keys<O>>, o: O): Array<?T>;
+  declare function props<T, O: { [k: string]: T }>(
+    keys: Array<$Keys<O>>,
+    ...rest: Array<void>
+  ): (o: O) => Array<?T>;
+  declare function props<T, O: { [k: string]: T }>(
+    keys: Array<$Keys<O>>,
+    o: O
+  ): Array<?T>;
 
   // TODO set
 
-  declare function toPairs<T,O:{[k:string]:T}>(o: O): Array<[$Keys<O>, T]>;
+  declare function toPairs<T, O: { [k: string]: T }>(
+    o: O
+  ): Array<[$Keys<O>, T]>;
 
-  declare function toPairsIn<T,O:{[k:string]:T}>(o: O): Array<[string, T]>;
+  declare function toPairsIn<T, O: { [k: string]: T }>(
+    o: O
+  ): Array<[string, T]>;
 
+  declare function values<T, O: { [k: string]: T }>(o: O): Array<T>;
 
-  declare function values<T,O:{[k:string]:T}>(o: O): Array<T>;
+  declare function valuesIn<T, O: { [k: string]: T }>(o: O): Array<T | any>;
 
-  declare function valuesIn<T,O:{[k:string]:T}>(o: O): Array<T|any>;
+  declare function where(
+    predObj: { [key: string]: UnaryPredicateFn<any> },
+    o: Object
+  ): boolean;
+  declare function where(predObj: { [key: string]: UnaryPredicateFn<any> }): (
+    o: Object
+  ) => boolean;
 
-  declare function where<T>(predObj: {[key: string]: UnaryPredicateFn<T>}, ...rest: Array<void>): (o: {[k:string]:T}) => boolean;
-  declare function where<T>(predObj: {[key: string]: UnaryPredicateFn<T>}, o: {[k:string]:T}): boolean;
-
-  declare function whereEq<T,S,O:{[k:string]:T},Q:{[k:string]:S}>(predObj: O, ...rest: Array<void>): (o: $Shape<O&Q>) => boolean;
-  declare function whereEq<T,S,O:{[k:string]:T},Q:{[k:string]:S}>(predObj: O, o: $Shape<O&Q>): boolean;
+  declare function whereEq<T, S, O: { [k: string]: T }, Q: { [k: string]: S }>(
+    predObj: O,
+    ...rest: Array<void>
+  ): (o: $Shape<O & Q>) => boolean;
+  declare function whereEq<T, S, O: { [k: string]: T }, Q: { [k: string]: S }>(
+    predObj: O,
+    o: $Shape<O & Q>
+  ): boolean;
 
   // TODO view
 
@@ -615,61 +1376,115 @@ declare module ramda {
   declare var T: (_: any) => true;
   declare var F: (_: any) => false;
 
-  declare function addIndex<A,B>(iterFn:(fn:(x:A) => B, xs: Array<A>) => Array<B>): (fn: (x: A, idx: number, xs: Array<A>) => B, xs: Array<A>) => Array<B>;
+  declare function addIndex<A, B>(
+    iterFn: (fn: (x: A) => B, xs: Array<A>) => Array<B>
+  ): (fn: (x: A, idx: number, xs: Array<A>) => B, xs: Array<A>) => Array<B>;
 
-  declare function always<T>(x:T): (x: any) => T;
+  declare function always<T>(x: T): (x: any) => T;
 
-  declare function ap<T,V>(fns: Array<(x:T) => V>, ...rest: Array<void>): (xs: Array<T>) => Array<V>;
-  declare function ap<T,V>(fns: Array<(x:T) => V>, xs: Array<T>): Array<V>;
+  declare function ap<T, V>(
+    fns: Array<(x: T) => V>,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => Array<V>;
+  declare function ap<T, V>(fns: Array<(x: T) => V>, xs: Array<T>): Array<V>;
 
-  declare function apply<T,V>(fn: (...args: Array<T>) => V, ...rest: Array<void>): (xs: Array<T>) => V;
-  declare function apply<T,V>(fn: (...args: Array<T>) => V, xs: Array<T>): V;
+  declare function apply<T, V>(
+    fn: (...args: Array<T>) => V,
+    ...rest: Array<void>
+  ): (xs: Array<T>) => V;
+  declare function apply<T, V>(fn: (...args: Array<T>) => V, xs: Array<T>): V;
 
-  declare function applySpec<S,V,T:NestedObject<(...args: Array<V>) => S>>(spec: T): (...args: Array<V>) => NestedObject<S>;
+  declare function applySpec<S, V, T: NestedObject<(...args: Array<V>) => S>>(
+    spec: T
+  ): (...args: Array<V>) => NestedObject<S>;
 
-  declare function binary<T>(fn:(...args: Array<any>) => T): (x: any, y: any) => T;
+  declare function binary<T>(
+    fn: (...args: Array<any>) => T
+  ): (x: any, y: any) => T;
 
-  declare function bind<T>(fn: (...args: Array<any>) => any, thisObj: T): (...args: Array<any>) => any;
+  declare function bind<T>(
+    fn: (...args: Array<any>) => any,
+    thisObj: T
+  ): (...args: Array<any>) => any;
 
-  declare function call<T,V>(fn: (...args: Array<V>) => T, ...args: Array<V>): T;
+  declare function call<T, V>(
+    fn: (...args: Array<V>) => T,
+    ...args: Array<V>
+  ): T;
 
-  declare function comparator<T>(fn: BinaryPredicateFn<T>): (x:T, y:T) => number;
+  declare function comparator<T>(
+    fn: BinaryPredicateFn<T>
+  ): (x: T, y: T) => number;
 
   // TODO add tests
-  declare function construct<T>(ctor: Class<GenericContructor<T>>): (x: T) => GenericContructor<T>;
+  declare function construct<T>(
+    ctor: Class<GenericContructor<T>>
+  ): (x: T) => GenericContructor<T>;
 
   // TODO add tests
-  declare function constructN<T>(n: number, ctor: Class<GenericContructorMulti<any>>): (...args: any) => GenericContructorMulti<any>;
+  declare function constructN<T>(
+    n: number,
+    ctor: Class<GenericContructorMulti<any>>
+  ): (...args: any) => GenericContructorMulti<any>;
 
   // TODO make less generic
   declare function converge(after: Function, fns: Array<Function>): Function;
 
   declare function empty<T>(x: T): T;
 
-  declare function flip<A,B,TResult>(fn: (arg0: A, arg1: B) => TResult): CurriedFunction2<B,A,TResult>;
-  declare function flip<A,B,C,TResult>(fn: (arg0: A, arg1: B, arg2: C) => TResult): (( arg0: B, arg1: A, ...rest: Array<void>) => (arg2: C) => TResult) & (( arg0: B, arg1: A, arg2: C) => TResult);
-  declare function flip<A,B,C,D,TResult>(fn: (arg0: A, arg1: B, arg2: C, arg3: D) => TResult): ((arg1: B, arg0: A, ...rest: Array<void>) => (arg2: C, arg3: D) => TResult) & ((arg1: B, arg0: A, arg2: C, arg3: D) => TResult);
-  declare function flip<A,B,C,D,E,TResult>(fn: (arg0: A, arg1: B, arg2: C, arg3: D, arg4:E) => TResult): ((arg1: B, arg0: A, ...rest: Array<void>) => (arg2: C, arg3: D, arg4: E) => TResult) & ((arg1: B, arg0: A, arg2: C, arg3: D, arg4: E) => TResult);
+  declare function flip<A, B, TResult>(
+    fn: (arg0: A, arg1: B) => TResult
+  ): CurriedFunction2<B, A, TResult>;
+  declare function flip<A, B, C, TResult>(
+    fn: (arg0: A, arg1: B, arg2: C) => TResult
+  ): ((arg0: B, arg1: A, ...rest: Array<void>) => (arg2: C) => TResult) &
+    ((arg0: B, arg1: A, arg2: C) => TResult);
+  declare function flip<A, B, C, D, TResult>(
+    fn: (arg0: A, arg1: B, arg2: C, arg3: D) => TResult
+  ): ((
+    arg1: B,
+    arg0: A,
+    ...rest: Array<void>
+  ) => (arg2: C, arg3: D) => TResult) &
+    ((arg1: B, arg0: A, arg2: C, arg3: D) => TResult);
+  declare function flip<A, B, C, D, E, TResult>(
+    fn: (arg0: A, arg1: B, arg2: C, arg3: D, arg4: E) => TResult
+  ): ((
+    arg1: B,
+    arg0: A,
+    ...rest: Array<void>
+  ) => (arg2: C, arg3: D, arg4: E) => TResult) &
+    ((arg1: B, arg0: A, arg2: C, arg3: D, arg4: E) => TResult);
 
-  declare function identity<T>(x:T): T;
+  declare function identity<T>(x: T): T;
 
-  declare function invoker<A,B,C,D,O:{[k:string]: Function}>(arity: number, name: $Enum<O>): CurriedFunction2<A,O,D> & CurriedFunction3<A,B,O,D> & CurriedFunction4<A,B,C,O,D>
+  declare function invoker<A, B, C, D, O: { [k: string]: Function }>(
+    arity: number,
+    name: $Enum<O>
+  ): CurriedFunction2<A, O, D> &
+    CurriedFunction3<A, B, O, D> &
+    CurriedFunction4<A, B, C, O, D>;
 
-  declare function juxt<T,S>(fns: Array<(...args: Array<S>) => T>): (...args: Array<S>) => Array<T>;
+  declare function juxt<T, S>(
+    fns: Array<(...args: Array<S>) => T>
+  ): (...args: Array<S>) => Array<T>;
 
   // TODO lift
 
   // TODO liftN
 
-  declare function memoize<A,B,T:(...args: Array<A>) => B>(fn:T):T;
+  declare function memoize<A, B, T: (...args: Array<A>) => B>(fn: T): T;
 
-  declare function nAry<T>(arity: number, fn:(...args: Array<any>) => T): (...args: Array<any>) => T;
+  declare function nAry<T>(
+    arity: number,
+    fn: (...args: Array<any>) => T
+  ): (...args: Array<any>) => T;
 
   declare function nthArg<T>(n: number): (...args: Array<T>) => T;
 
   declare function of<T>(x: T): Array<T>;
 
-  declare function once<A,B,T:(...args: Array<A>) => B>(fn:T):T;
+  declare function once<A, B, T: (...args: Array<A>) => B>(fn: T): T;
 
   // TODO partial
   // TODO partialRight
@@ -681,82 +1496,173 @@ declare module ramda {
 
   // TODO tryCatch
 
-  declare function unapply<T,V>(fn: (xs: Array<T>) => V): (...args: Array<T>) => V;
+  declare function unapply<T, V>(
+    fn: (xs: Array<T>) => V
+  ): (...args: Array<T>) => V;
 
-  declare function unary<T>(fn:(...args: Array<any>) => T): (x: any) => T;
+  declare function unary<T>(fn: (...args: Array<any>) => T): (x: any) => T;
 
   // TODO uncurryN
 
   //TODO useWith
 
-  declare function wrap<A,B,C,D,F:(...args: Array<A>) => B>(fn: F, fn2: (fn: F, ...args: Array<C>) => D): (...args: Array<A|C>) => D;
+  declare function wrap<A, B, C, D, F: (...args: Array<A>) => B>(
+    fn: F,
+    fn2: (fn: F, ...args: Array<C>) => D
+  ): (...args: Array<A | C>) => D;
 
   // *Logic
 
-  declare function allPass<T>(fns: Array<(...args: Array<T>) => boolean>): (...args: Array<T>) => boolean;
+  declare function allPass<T>(
+    fns: Array<(...args: Array<T>) => boolean>
+  ): (...args: Array<T>) => boolean;
 
-  declare function and(x: boolean, ...rest: Array<void>): (y: boolean) => boolean;
+  declare function and(
+    x: boolean,
+    ...rest: Array<void>
+  ): (y: boolean) => boolean;
   declare function and(x: boolean, y: boolean): boolean;
 
-  declare function anyPass<T>(fns: Array<(...args: Array<T>) => boolean>): (...args: Array<T>) => boolean;
+  declare function anyPass<T>(
+    fns: Array<(...args: Array<T>) => boolean>
+  ): (...args: Array<T>) => boolean;
 
-  declare function both<T>(x: (...args: Array<T>) => boolean, ...rest: Array<void>): (y: (...args: Array<T>) => boolean) => (...args: Array<T>) => boolean;
-  declare function both<T>(x: (...args: Array<T>) => boolean, y: (...args: Array<T>) => boolean): (...args: Array<T>) => boolean;
+  declare function both<T>(
+    x: (...args: Array<T>) => boolean,
+    ...rest: Array<void>
+  ): (y: (...args: Array<T>) => boolean) => (...args: Array<T>) => boolean;
+  declare function both<T>(
+    x: (...args: Array<T>) => boolean,
+    y: (...args: Array<T>) => boolean
+  ): (...args: Array<T>) => boolean;
 
-  declare function complement<T>(x: (...args: Array<T>) => boolean): (...args: Array<T>) => boolean;
+  declare function complement<T>(
+    x: (...args: Array<T>) => boolean
+  ): (...args: Array<T>) => boolean;
 
-  declare function cond<A,B>(fns: Array<[(...args: Array<A>) => boolean, (...args: Array<A>) => B]>): (...args: Array<A>) => B;
+  declare function cond<A, B>(
+    fns: Array<[(...args: Array<A>) => boolean, (...args: Array<A>) => B]>
+  ): (...args: Array<A>) => B;
 
+  declare function defaultTo<T, V>(
+    d: T,
+    ...rest: Array<void>
+  ): (x: ?V) => V | T;
+  declare function defaultTo<T, V>(d: T, x: ?V): V | T;
 
-  declare function defaultTo<T,V>(d: T, ...rest: Array<void>): (x: ?V) => V|T;
-  declare function defaultTo<T,V>(d: T, x: ?V): V|T;
+  declare function either(
+    x: (...args: Array<any>) => boolean,
+    ...rest: Array<void>
+  ): (y: (...args: Array<any>) => boolean) => (...args: Array<any>) => boolean;
+  declare function either(
+    x: (...args: Array<any>) => boolean,
+    y: (...args: Array<any>) => boolean
+  ): (...args: Array<any>) => boolean;
 
-  declare function either(x: (...args: Array<any>) => boolean, ...rest: Array<void>): (y: (...args: Array<any>) => boolean) => (...args: Array<any>) => boolean;
-  declare function either(x: (...args: Array<any>) => boolean, y: (...args: Array<any>) => boolean): (...args: Array<any>) => boolean;
-
-  declare function ifElse<A,B,C>(cond:(...args: Array<A>) => boolean, ...rest: Array<void>):
-  ((f1: (...args: Array<A>) => B, ...rest: Array<void>) => (f2: (...args: Array<A>) => C) => (...args: Array<A>) => B|C)
-  & ((f1: (...args: Array<A>) => B, f2: (...args: Array<A>) => C) => (...args: Array<A>) => B|C)
-  declare function ifElse<A,B,C>(
-    cond:(...args: Array<any>) => boolean,
+  declare function ifElse<A, B, C>(
+    cond: (...args: Array<A>) => boolean,
+    ...rest: Array<void>
+  ): ((
+    f1: (...args: Array<A>) => B,
+    ...rest: Array<void>
+  ) => (f2: (...args: Array<A>) => C) => (...args: Array<A>) => B | C) &
+    ((
+      f1: (...args: Array<A>) => B,
+      f2: (...args: Array<A>) => C
+    ) => (...args: Array<A>) => B | C);
+  declare function ifElse<A, B, C>(
+    cond: (...args: Array<any>) => boolean,
     f1: (...args: Array<any>) => B,
     f2: (...args: Array<any>) => C
-  ): (...args: Array<A>) => B|C;
+  ): (...args: Array<A>) => B | C;
 
-  declare function isEmpty(x:?Array<any>|Object|string): boolean;
+  declare function isEmpty(x: ?Array<any> | Object | string): boolean;
 
-  declare function not(x:boolean): boolean;
+  declare function not(x: boolean): boolean;
 
   declare function or(x: boolean, y: boolean): boolean;
   declare function or(x: boolean): (y: boolean) => boolean;
 
-  declare function pathSatisfies<T>(cond: (x: T) => boolean, path: Array<string>, o: NestedObject<T>): boolean;
-  declare function pathSatisfies<T>(cond: (x: T) => boolean, path: Array<string>, ...rest: Array<void>): (o: NestedObject<T>) => boolean;
-  declare function pathSatisfies<T>(cond: (x: T) => boolean, ...rest: Array<void>):
-  ((path: Array<string>, ...rest: Array<void>) => (o: NestedObject<T>) => boolean)
-  & ((path: Array<string>, o: NestedObject<T>) => boolean)
+  declare function pathSatisfies<T>(
+    cond: (x: T) => boolean,
+    path: Array<string>,
+    o: NestedObject<T>
+  ): boolean;
+  declare function pathSatisfies<T>(
+    cond: (x: T) => boolean,
+    path: Array<string>,
+    ...rest: Array<void>
+  ): (o: NestedObject<T>) => boolean;
+  declare function pathSatisfies<T>(
+    cond: (x: T) => boolean,
+    ...rest: Array<void>
+  ): ((
+    path: Array<string>,
+    ...rest: Array<void>
+  ) => (o: NestedObject<T>) => boolean) &
+    ((path: Array<string>, o: NestedObject<T>) => boolean);
 
-  declare function propSatisfies<T>(cond: (x: T) => boolean, prop: string, o: NestedObject<T>): boolean;
-  declare function propSatisfies<T>(cond: (x: T) => boolean, prop: string, ...rest: Array<void>): (o: NestedObject<T>) => boolean;
-  declare function propSatisfies<T>(cond: (x: T) => boolean, ...rest: Array<void>):
-  ((prop: string, ...rest: Array<void>) => (o: NestedObject<T>) => boolean)
-  & ((prop: string, o: NestedObject<T>) => boolean)
+  declare function propSatisfies<T>(
+    cond: (x: T) => boolean,
+    prop: string,
+    o: NestedObject<T>
+  ): boolean;
+  declare function propSatisfies<T>(
+    cond: (x: T) => boolean,
+    prop: string,
+    ...rest: Array<void>
+  ): (o: NestedObject<T>) => boolean;
+  declare function propSatisfies<T>(
+    cond: (x: T) => boolean,
+    ...rest: Array<void>
+  ): ((prop: string, ...rest: Array<void>) => (o: NestedObject<T>) => boolean) &
+    ((prop: string, o: NestedObject<T>) => boolean);
 
-  declare function unless<T,V,S>(pred: UnaryPredicateFn<T>, ...rest: Array<void>):
-  ((fn: (x: S) => V, ...rest: Array<void>) => (x: T|S) => T|V)
-  & ((fn: (x: S) => V, x: T|S) => T|V);
-  declare function unless<T,V,S>(pred: UnaryPredicateFn<T>, fn: (x: S) => V, ...rest: Array<void>): (x: T|S) => V|T;
-  declare function unless<T,V,S>(pred: UnaryPredicateFn<T>, fn: (x: S) => V, x: T|S): T|V;
+  declare function unless<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((fn: (x: S) => V, ...rest: Array<void>) => (x: T | S) => T | V) &
+    ((fn: (x: S) => V, x: T | S) => T | V);
+  declare function unless<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    ...rest: Array<void>
+  ): (x: T | S) => V | T;
+  declare function unless<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    x: T | S
+  ): T | V;
 
-  declare function until<T>(pred: UnaryPredicateFn<T>, ...rest: Array<void>):
-  ((fn: (x: T) => T, ...rest: Array<void>) => (x: T) => T)
-  & ((fn: (x: T) => T, x: T) => T);
-  declare function until<T>(pred: UnaryPredicateFn<T>, fn: (x: T) => T, ...rest: Array<void>): (x: T) => T;
-  declare function until<T>(pred: UnaryPredicateFn<T>, fn: (x: T) => T, x: T): T;
+  declare function until<T>(
+    pred: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((fn: (x: T) => T, ...rest: Array<void>) => (x: T) => T) &
+    ((fn: (x: T) => T, x: T) => T);
+  declare function until<T>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: T) => T,
+    ...rest: Array<void>
+  ): (x: T) => T;
+  declare function until<T>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: T) => T,
+    x: T
+  ): T;
 
-  declare function when<T,V,S>(pred: UnaryPredicateFn<T>, ...rest: Array<void>):
-  ((fn: (x: S) => V, ...rest: Array<void>) => (x: T|S) => T|V)
-  & ((fn: (x: S) => V, x: T|S) => T|V);
-  declare function when<T,V,S>(pred: UnaryPredicateFn<T>, fn: (x: S) => V, ...rest: Array<void>): (x: T|S) => V|T;
-  declare function when<T,V,S>(pred: UnaryPredicateFn<T>, fn: (x: S) => V, x: T|S): T|V;
+  declare function when<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    ...rest: Array<void>
+  ): ((fn: (x: S) => V, ...rest: Array<void>) => (x: T | S) => T | V) &
+    ((fn: (x: S) => V, x: T | S) => T | V);
+  declare function when<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    ...rest: Array<void>
+  ): (x: T | S) => V | T;
+  declare function when<T, V, S>(
+    pred: UnaryPredicateFn<T>,
+    fn: (x: S) => V,
+    x: T | S
+  ): T | V;
 }

--- a/definitions/npm/ramda_v0.x.x/flow_v0.28.x-v0.30.x/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.28.x-v0.30.x/test_ramda_v0.x.x_object.js
@@ -1,166 +1,200 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from 'ramda'
+import _, { compose, pipe, curry, filter, find, repeat, zipWith } from "ramda";
 
-const ns: Array<number> = [ 1, 2, 3, 4, 5 ]
-const ss: Array<string> = [ 'one', 'two', 'three', 'four' ]
-const obj: {[k:string]:number} = { a: 1, c: 2 }
-const objMixed: {[k:string]:mixed} = { a: 1, c: 'd' }
-const os: Array<{[k:string]: *}> = [ { a: 1, c: 'd' }, { b: 2 } ]
-const str: string = 'hello world'
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: * }> = [{ a: 1, c: "d" }, { b: 2 }];
+const str: string = "hello world";
 
 // Object
-const a:{[k:string]:number|string} = _.assoc('c', 's', { a: 1, b: 2 })
+const a: { [k: string]: number | string } = _.assoc("c", "s", { a: 1, b: 2 });
 //$ExpectError
-const a1:{[k:string]:number|boolean} = _.assoc('c', 's', { a: 1, b: 2 })
+const a1: { [k: string]: number | boolean } = _.assoc("c", "s", { a: 1, b: 2 });
 
-const apath: {[k:string]:number|string|Object} = _.assocPath([ 'a', 'b', 'c' ], 's', { a: { b: { c: 0 } } })
+const apath: { [k: string]: number | string | Object } = _.assocPath(
+  ["a", "b", "c"],
+  "s",
+  { a: { b: { c: 0 } } }
+);
 
-const tomato  = { firstName: '  Tomato ', data: { elapsed: 100, remaining: 1400 }, id: 123 }
-const tomato1  = { firstName: '  Tomato ', data: { elapsed: 100, remaining: 1400 } }
+const tomato = {
+  firstName: "  Tomato ",
+  data: { elapsed: 100, remaining: 1400 },
+  id: 123
+};
+const tomato1 = {
+  firstName: "  Tomato ",
+  data: { elapsed: 100, remaining: 1400 }
+};
 
 const transformations = {
   firstName: _.trim,
   lastName: _.trim,
   data: {
     elapsed: _.add(1),
-    remaining: _.add(-1),
-  },
-}
-const evolved:{firstName: string, data: {elapsed: number, remaining: number}, id: number} = _.evolve(transformations, tomato)
+    remaining: _.add(-1)
+  }
+};
+const evolved: {
+  firstName: string,
+  data: { elapsed: number, remaining: number },
+  id: number
+} = _.evolve(transformations, tomato);
 
-const objects = [ {}, {}, {} ]
-const objectsClone: Array<Object> = _.clone(objects)
-const objectsClone1: number = _.clone(1)
-const objectsClone2: typeof tomato = _.clone(tomato)
+const objects = [{}, {}, {}];
+const objectsClone: Array<Object> = _.clone(objects);
+const objectsClone1: number = _.clone(1);
+const objectsClone2: typeof tomato = _.clone(tomato);
 //$ExpectError
-const objectsClone3: $Shape<typeof tomato1> = _.clone(tomato)
-const objectsClone4: $Shape<typeof tomato1> = _.clone(tomato1)
+const objectsClone3: $Shape<typeof tomato1> = _.clone(tomato);
+const objectsClone4: $Shape<typeof tomato1> = _.clone(tomato1);
 
-const id = objectsClone2.id
+const id = objectsClone2.id;
 //$ExpectError
-const idE = objectsClone4.id
+const idE = objectsClone4.id;
 
-const o1 = { a: 1, b: 2, c: 3, d: 4 }
-const o2 = { a: 10, b: 20, c: 3, d: 40 }
-const ep: boolean = _.eqProps('a')(o1, o2)
-const ep2: boolean = _.eqProps('c', o1)(o2)
+const o1 = { a: 1, b: 2, c: 3, d: 4 };
+const o2 = { a: 10, b: 20, c: 3, d: 40 };
+const ep: boolean = _.eqProps("a")(o1, o2);
+const ep2: boolean = _.eqProps("c", o1)(o2);
 
-const hasid = _.has('id')
-const has: boolean = hasid(tomato)
+const hasid = _.has("id");
+const has: boolean = hasid(tomato);
 
 function Rectangle(width, height) {
-  this.width = width
-  this.height = height
+  this.width = width;
+  this.height = height;
 }
-Rectangle.prototype.area = function () {
-  return this.width * this.height
-}
+Rectangle.prototype.area = function() {
+  return this.width * this.height;
+};
 
-const square = new Rectangle(2, 2)
-const hasIn: boolean = _.hasIn('width', square)
-const hasIn1: boolean = _.hasIn('area', square)
+const square = new Rectangle(2, 2);
+const hasIn: boolean = _.hasIn("width", square);
+const hasIn1: boolean = _.hasIn("area", square);
 
 const raceResultsByFirstName = {
-  first: 'alice',
-  second: 'jake',
-  third: 'alice',
-}
-const inverted: {[k: string]: Array<string>} = _.invert(raceResultsByFirstName)
-const inverted1: {[k: string]: string} = _.invertObj(raceResultsByFirstName)
+  first: "alice",
+  second: "jake",
+  third: "alice"
+};
+const inverted: { [k: string]: Array<string> } = _.invert(
+  raceResultsByFirstName
+);
+const inverted1: { [k: string]: string } = _.invertObj(raceResultsByFirstName);
 
-const ks: Array<string> = _.keys(raceResultsByFirstName)
-const ksi: Array<string> = _.keysIn(square)
+const ks: Array<string> = _.keys(raceResultsByFirstName);
+const ksi: Array<string> = _.keysIn(square);
 
-const values = { x: 1, y: 2, z: 3 }
-const prependKeyAndDouble = (num, key, obj) => key + (num * 2)
+const values = { x: 1, y: 2, z: 3 };
+const prependKeyAndDouble = (num, key, obj) => key + num * 2;
 
-const obI: {[k:string]: string} = _.mapObjIndexed(prependKeyAndDouble, values)
+const obI: { [k: string]: string } = _.mapObjIndexed(
+  prependKeyAndDouble,
+  values
+);
 //$ExpectError
-const obI2: {[k:string]: number} = _.mapObjIndexed(prependKeyAndDouble, values)
+const obI2: { [k: string]: number } = _.mapObjIndexed(
+  prependKeyAndDouble,
+  values
+);
 
-const ob1 = { a: 1 }
-const ob2 = { b: 3 }
-const ob3 = _.merge(ob1, ob2)
+const ob1 = { a: 1 };
+const ob2 = { b: 3 };
+const ob3 = _.merge(ob1, ob2);
 //$ExpectError
-const propX = ob3.x
-const propA = ob3.a
+const propX = ob3.x;
+const propA = ob3.a;
 
-const mwith = _.mergeWith((a, b) => Array.isArray(a) && _.concat,
-{ a: true, values: [ 10, 20 ] },
-{ b: true, values: [ 15, 35 ] },
-)
-const propB: boolean = mwith.b
+const mwith = _.mergeWith(
+  (a, b) => Array.isArray(a) && _.concat,
+  { a: true, values: [10, 20] },
+  { b: true, values: [15, 35] }
+);
+const propB: boolean = mwith.b;
 
-const mwithK = _.mergeWithKey((k, a, b) => Array.isArray(a) && k === 'd' && _.concat,
-{ a: true, values: [ 10, 20 ] },
-{ b: true, values: [ 15, 35 ] },
-)
-const propB1: boolean = mwithK.b
+const mwithK = _.mergeWithKey(
+  (k, a, b) => Array.isArray(a) && k === "d" && _.concat,
+  { a: true, values: [10, 20] },
+  { b: true, values: [15, 35] }
+);
+const propB1: boolean = mwithK.b;
 
-const objA = _.objOf('a', false)
+const objA = _.objOf("a", false);
 //$ExpectError
-const propAA: number = objA.a
+const propAA: number = objA.a;
 
 //$ExpectError
-const om: Object = _.omit([ 'a', 'd', 'h' ], { a: 1, b: 2, c: 3, d: 4 })
+const om: Object = _.omit(["a", "d", "h"], { a: 1, b: 2, c: 3, d: 4 });
 
 //$ExpectError
-const om2 = _.omit([ 'a', 'd', 'h' ])
-const omap = om2({ a: 1, b: 2, c: 3, d: 4 })
+const om2 = _.omit(["a", "d", "h"]);
+const omap = om2({ a: 1, b: 2, c: 3, d: 4 });
 
-const path1:?Object|number = _.path([ 'a', 'b' ], { a: { b: 2 } })
+const path1: ?Object | number = _.path(["a", "b"], { a: { b: 2 } });
 
-const pathOr: string|Object|number = _.pathOr('N/A', [ 'a', 'b' ], { a: { b: 2 } })
+const pathOr: string | Object | number = _.pathOr("N/A", ["a", "b"], {
+  a: { b: 2 }
+});
 
-const pck: Object = _.pick([ 'a', 'd' ], { a: 1, b: 2, c: 3, d: 4 })
+const pck: Object = _.pick(["a", "d"], { a: 1, b: 2, c: 3, d: 4 });
 
-const ooo = { a: 1, b: 2, A: 3, B: 4 }
-const isUpperCase = (val, key) => key.toUpperCase() === key
-const pb:Object = _.pickBy(isUpperCase, ooo)
+const ooo = { a: 1, b: 2, A: 3, B: 4 };
+const isUpperCase = (val, key) => key.toUpperCase() === key;
+const pb: Object = _.pickBy(isUpperCase, ooo);
 
-const ppp:?number = _.prop('x', { x: 100 })
+const ppp: ?number = _.prop("x", { x: 100 });
 //$ExpectError
-const ppp1:?number = _.prop('y', { x: 100 })
+const ppp1: ?number = _.prop("y", { x: 100 });
 
 const alice = {
-  name: 'ALICE',
-  age: 101,
-}
+  name: "ALICE",
+  age: 101
+};
 
 //$ExpectError
-const favoriteWithDefault = _.propOr('Ramda', 'favoriteLibrary')
-const fav = favoriteWithDefault(alice)
+const favoriteWithDefault = _.propOr("Ramda", "favoriteLibrary");
+const fav = favoriteWithDefault(alice);
 
-const nameWithDefault = _.propOr('Ramda', 'name')
-const nm: number|string = nameWithDefault(alice)
+const nameWithDefault = _.propOr("Ramda", "name");
+const nm: number | string = nameWithDefault(alice);
 
-const pss: Array<?number|boolean> = _.props([ 'x', 'y' ], { x: true, y: 2 })
+const pss: Array<?number | boolean> = _.props(["x", "y"], { x: true, y: 2 });
 //$ExpectError
-const pssE: Array<?number|boolean> = _.props([ 'd', 'y' ], { x: true, y: 2 })
+const pssE: Array<?number | boolean> = _.props(["d", "y"], { x: true, y: 2 });
 
-const top: Array<['a'|'b'|'c', number]> = _.toPairs({ a: 1, b: 2, c: 3 })
+const top: Array<["a" | "b" | "c", number]> = _.toPairs({ a: 1, b: 2, c: 3 });
 
 //$ExpectError
-const topE: Array<['a'|'b'|'c'|'z', number]> = _.toPairs({ a: 1, b: 2, c: 3 })
+const topE: Array<["a" | "b" | "c" | "z", number]> = _.toPairs({
+  a: 1,
+  b: 2,
+  c: 3
+});
 
-const F = function () { this.x = 'X' }
-F.prototype.y = 'Y'
-const f = new F()
-const topin = _.toPairsIn(f)
+const F = function() {
+  this.x = "X";
+};
+F.prototype.y = "Y";
+const f = new F();
+const topin = _.toPairsIn(f);
 
-const val = _.values({ a: 1, b: 2, c: true })
-const val1: number|boolean = val[0]
+const val = _.values({ a: 1, b: 2, c: true });
+const val1: number | boolean = val[0];
 
 const pred = _.where({
-  a: _.equals('foo'),
-  b: _.complement(_.equals('bar')),
+  a: (a: string) => a === "foo",
+  b: _.complement(_.equals("bar")),
+  c: (c: Object) => !!c,
   x: _.gt(10),
-  y: _.lt(20),
-})
+  y: _.lt(20)
+});
 
-const w: boolean = pred({ a: 'foo', b: 'xxx', x: 11, y: 19 })
+const w: boolean = pred({ a: "foo", b: "xxx", x: 11, y: 19 });
 
-const pred1 = _.whereEq({ a: 1, b: 2 })
+const pred1 = _.whereEq({ a: 1, b: 2 });
 
-const win: boolean = pred1({ a: 1, d: 1 })
+const win: boolean = pred1({ a: 1, d: 1 });

--- a/definitions/npm/ramda_v0.x.x/flow_v0.31.x-v0.33.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.31.x-v0.33.x/ramda_v0.x.x.js
@@ -1347,14 +1347,13 @@ declare module ramda {
 
   declare function valuesIn<T, O: { [k: string]: T }>(o: O): Array<T | any>;
 
-  declare function where<T>(
-    predObj: { [key: string]: UnaryPredicateFn<T> },
-    ...rest: Array<void>
-  ): (o: { [k: string]: T }) => boolean;
-  declare function where<T>(
-    predObj: { [key: string]: UnaryPredicateFn<T> },
-    o: { [k: string]: T }
+  declare function where(
+    predObj: { [key: string]: UnaryPredicateFn<any> },
+    o: Object
   ): boolean;
+  declare function where(predObj: { [key: string]: UnaryPredicateFn<any> }): (
+    o: Object
+  ) => boolean;
 
   declare function whereEq<T, S, O: { [k: string]: T }, Q: { [k: string]: S }>(
     predObj: O,

--- a/definitions/npm/ramda_v0.x.x/flow_v0.31.x-v0.33.x/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.31.x-v0.33.x/test_ramda_v0.x.x_object.js
@@ -1,21 +1,32 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from 'ramda'
+import _, { compose, pipe, curry, filter, find, repeat, zipWith } from "ramda";
 
-const ns: Array<number> = [ 1, 2, 3, 4, 5 ]
-const ss: Array<string> = [ 'one', 'two', 'three', 'four' ]
-const obj: {[k:string]:number} = { a: 1, c: 2 }
-const objMixed: {[k:string]:mixed} = { a: 1, c: 'd' }
-const os: Array<{[k:string]: *}> = [ { a: 1, c: 'd' }, { b: 2 } ]
-const str: string = 'hello world'
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: * }> = [{ a: 1, c: "d" }, { b: 2 }];
+const str: string = "hello world";
 
 // Object
-const a:{[k:string]:number|string} = _.assoc('c', 's', { a: 1, b: 2 })
+const a: { [k: string]: number | string } = _.assoc("c", "s", { a: 1, b: 2 });
 
-const apath: {[k:string]:number|string|Object} = _.assocPath([ 'a', 'b', 'c' ], 's', { a: { b: { c: 0 } } })
+const apath: { [k: string]: number | string | Object } = _.assocPath(
+  ["a", "b", "c"],
+  "s",
+  { a: { b: { c: 0 } } }
+);
 
-const tomato  = { firstName: '  Tomato ', data: { elapsed: 100, remaining: 1400 }, id: 123 }
-const tomato1  = { firstName: '  Tomato ', data: { elapsed: 100, remaining: 1400 } }
+const tomato = {
+  firstName: "  Tomato ",
+  data: { elapsed: 100, remaining: 1400 },
+  id: 123
+};
+const tomato1 = {
+  firstName: "  Tomato ",
+  data: { elapsed: 100, remaining: 1400 }
+};
 
 // TODO: Started failing in v31...
 // const transformations = {
@@ -28,112 +39,124 @@ const tomato1  = { firstName: '  Tomato ', data: { elapsed: 100, remaining: 1400
 // }
 // const evolved:{firstName: string, data: {elapsed: number, remaining: number}, id: number} = _.evolve(transformations, tomato)
 
-const objects = [ {}, {}, {} ]
-const objectsClone: Array<Object> = _.clone(objects)
-const objectsClone1: number = _.clone(1)
-const objectsClone2: typeof tomato = _.clone(tomato)
-const objectsClone4: $Shape<typeof tomato1> = _.clone(tomato1)
+const objects = [{}, {}, {}];
+const objectsClone: Array<Object> = _.clone(objects);
+const objectsClone1: number = _.clone(1);
+const objectsClone2: typeof tomato = _.clone(tomato);
+const objectsClone4: $Shape<typeof tomato1> = _.clone(tomato1);
 
-const id = objectsClone2.id
+const id = objectsClone2.id;
 //$ExpectError
-const idE = objectsClone4.id
+const idE = objectsClone4.id;
 
-const o1 = { a: 1, b: 2, c: 3, d: 4 }
-const o2 = { a: 10, b: 20, c: 3, d: 40 }
-const ep: boolean = _.eqProps('a')(o1, o2)
-const ep2: boolean = _.eqProps('c', o1)(o2)
+const o1 = { a: 1, b: 2, c: 3, d: 4 };
+const o2 = { a: 10, b: 20, c: 3, d: 40 };
+const ep: boolean = _.eqProps("a")(o1, o2);
+const ep2: boolean = _.eqProps("c", o1)(o2);
 
-const hasid = _.has('id')
-const has: boolean = hasid(tomato)
+const hasid = _.has("id");
+const has: boolean = hasid(tomato);
 
 function Rectangle(width, height) {
-  this.width = width
-  this.height = height
+  this.width = width;
+  this.height = height;
 }
-Rectangle.prototype.area = function () {
-  return this.width * this.height
-}
+Rectangle.prototype.area = function() {
+  return this.width * this.height;
+};
 
-const square = new Rectangle(2, 2)
-const hasIn: boolean = _.hasIn('width', square)
-const hasIn1: boolean = _.hasIn('area', square)
+const square = new Rectangle(2, 2);
+const hasIn: boolean = _.hasIn("width", square);
+const hasIn1: boolean = _.hasIn("area", square);
 
 const raceResultsByFirstName = {
-  first: 'alice',
-  second: 'jake',
-  third: 'alice',
-}
-const inverted: {[k: string]: Array<string>} = _.invert(raceResultsByFirstName)
-const inverted1: {[k: string]: string} = _.invertObj(raceResultsByFirstName)
+  first: "alice",
+  second: "jake",
+  third: "alice"
+};
+const inverted: { [k: string]: Array<string> } = _.invert(
+  raceResultsByFirstName
+);
+const inverted1: { [k: string]: string } = _.invertObj(raceResultsByFirstName);
 
-const ks: Array<string> = _.keys(raceResultsByFirstName)
-const ksi: Array<string> = _.keysIn(square)
+const ks: Array<string> = _.keys(raceResultsByFirstName);
+const ksi: Array<string> = _.keysIn(square);
 
-const values = { x: 1, y: 2, z: 3 }
-const prependKeyAndDouble = (num, key, obj) => key + (num * 2)
+const values = { x: 1, y: 2, z: 3 };
+const prependKeyAndDouble = (num, key, obj) => key + num * 2;
 
-const obI: {[k:string]: string} = _.mapObjIndexed(prependKeyAndDouble, values)
+const obI: { [k: string]: string } = _.mapObjIndexed(
+  prependKeyAndDouble,
+  values
+);
 
-const ob1 = { a: 1 }
-const ob2 = { b: 3 }
-const ob3 = _.merge(ob1, ob2)
-const propA = ob3.a
+const ob1 = { a: 1 };
+const ob2 = { b: 3 };
+const ob3 = _.merge(ob1, ob2);
+const propA = ob3.a;
 
-const mwith = _.mergeWith((a, b) => Array.isArray(a) && _.concat,
-{ a: true, values: [ 10, 20 ] },
-{ b: true, values: [ 15, 35 ] },
-)
-const propB: boolean = mwith.b
+const mwith = _.mergeWith(
+  (a, b) => Array.isArray(a) && _.concat,
+  { a: true, values: [10, 20] },
+  { b: true, values: [15, 35] }
+);
+const propB: boolean = mwith.b;
 
-const mwithK = _.mergeWithKey((k, a, b) => Array.isArray(a) && k === 'd' && _.concat,
-{ a: true, values: [ 10, 20 ] },
-{ b: true, values: [ 15, 35 ] },
-)
-const propB1: boolean = mwithK.b
+const mwithK = _.mergeWithKey(
+  (k, a, b) => Array.isArray(a) && k === "d" && _.concat,
+  { a: true, values: [10, 20] },
+  { b: true, values: [15, 35] }
+);
+const propB1: boolean = mwithK.b;
 
-const objA = _.objOf('a', false)
+const objA = _.objOf("a", false);
 
-const path1:?Object|number = _.path([ 'a', 'b' ], { a: { b: 2 } })
+const path1: ?Object | number = _.path(["a", "b"], { a: { b: 2 } });
 
-const pathOr: string|Object|number = _.pathOr('N/A', [ 'a', 'b' ], { a: { b: 2 } })
+const pathOr: string | Object | number = _.pathOr("N/A", ["a", "b"], {
+  a: { b: 2 }
+});
 
-const pck: Object = _.pick([ 'a', 'd' ], { a: 1, b: 2, c: 3, d: 4 })
+const pck: Object = _.pick(["a", "d"], { a: 1, b: 2, c: 3, d: 4 });
 
-const ooo = { a: 1, b: 2, A: 3, B: 4 }
-const isUpperCase = (val, key) => key.toUpperCase() === key
-const pb:Object = _.pickBy(isUpperCase, ooo)
+const ooo = { a: 1, b: 2, A: 3, B: 4 };
+const isUpperCase = (val, key) => key.toUpperCase() === key;
+const pb: Object = _.pickBy(isUpperCase, ooo);
 
-const ppp:?number = _.prop('x', { x: 100 })
+const ppp: ?number = _.prop("x", { x: 100 });
 
 const alice = {
-  name: 'ALICE',
-  age: 101,
-}
+  name: "ALICE",
+  age: 101
+};
 
-const nameWithDefault = _.propOr('Ramda', 'name')
-const nm: number|string = nameWithDefault(alice)
+const nameWithDefault = _.propOr("Ramda", "name");
+const nm: number | string = nameWithDefault(alice);
 
-const pss: Array<?number|boolean> = _.props([ 'x', 'y' ], { x: true, y: 2 })
+const pss: Array<?number | boolean> = _.props(["x", "y"], { x: true, y: 2 });
 
-const top: Array<['a'|'b'|'c', number]> = _.toPairs({ a: 1, b: 2, c: 3 })
+const top: Array<["a" | "b" | "c", number]> = _.toPairs({ a: 1, b: 2, c: 3 });
 
-const F = function () { this.x = 'X' }
-F.prototype.y = 'Y'
-const f = new F()
-const topin = _.toPairsIn(f)
+const F = function() {
+  this.x = "X";
+};
+F.prototype.y = "Y";
+const f = new F();
+const topin = _.toPairsIn(f);
 
-const val = _.values({ a: 1, b: 2, c: true })
-const val1: number|boolean = val[0]
+const val = _.values({ a: 1, b: 2, c: true });
+const val1: number | boolean = val[0];
 
 const pred = _.where({
-  a: _.equals('foo'),
-  b: _.complement(_.equals('bar')),
+  a: (a: string) => a === "foo",
+  b: _.complement(_.equals("bar")),
+  c: (c: Object) => !!c,
   x: _.gt(10),
-  y: _.lt(20),
-})
+  y: _.lt(20)
+});
 
-const w: boolean = pred({ a: 'foo', b: 'xxx', x: 11, y: 19 })
+const w: boolean = pred({ a: "foo", b: "xxx", x: 11, y: 19 });
 
-const pred1 = _.whereEq({ a: 1, b: 2 })
+const pred1 = _.whereEq({ a: 1, b: 2 });
 
-const win: boolean = pred1({ a: 1, d: 1 })
+const win: boolean = pred1({ a: 1, d: 1 });

--- a/definitions/npm/ramda_v0.x.x/flow_v0.34.x-v0.38.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.34.x-v0.38.x/ramda_v0.x.x.js
@@ -14,6 +14,7 @@ declare module ramda {
   declare type BinarySameTypeFn<T> = BinaryFn<T, T, T>;
   declare type NestedObject<T> = { [k: string]: T | NestedObject<T> };
   declare type UnaryPredicateFn<T> = (x: T) => boolean;
+  declare type MapUnaryPredicateFn = <V>(V) => V => boolean;
   declare type BinaryPredicateFn<T> = (x: T, y: T) => boolean;
   declare type BinaryPredicateFn2<T, S> = (x: T, y: S) => boolean;
 
@@ -1372,14 +1373,13 @@ declare module ramda {
 
   declare function valuesIn<T, O: { [k: string]: T }>(o: O): Array<T | any>;
 
-  declare function where<T>(
-    predObj: { [key: string]: UnaryPredicateFn<T> },
-    ...rest: Array<void>
-  ): (o: { [k: string]: T }) => boolean;
-  declare function where<T>(
-    predObj: { [key: string]: UnaryPredicateFn<T> },
-    o: { [k: string]: T }
+  declare function where<O>(
+    predObj: $ObjMap<O, MapUnaryPredicateFn>,
+    o: O
   ): boolean;
+  declare function where<O>(
+    predObj: $ObjMap<O, MapUnaryPredicateFn>
+  ): O => boolean;
 
   declare function whereEq<T, S, O: { [k: string]: T }, Q: { [k: string]: S }>(
     predObj: O,

--- a/definitions/npm/ramda_v0.x.x/flow_v0.34.x-v0.38.x/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.34.x-v0.38.x/test_ramda_v0.x.x_object.js
@@ -1,23 +1,34 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from 'ramda'
+import _, { compose, pipe, curry, filter, find, repeat, zipWith } from "ramda";
 
-const ns: Array<number> = [ 1, 2, 3, 4, 5 ]
-const ss: Array<string> = [ 'one', 'two', 'three', 'four' ]
-const obj: {[k:string]:number} = { a: 1, c: 2 }
-const objMixed: {[k:string]:mixed} = { a: 1, c: 'd' }
-const os: Array<{[k:string]: *}> = [ { a: 1, c: 'd' }, { b: 2 } ]
-const str: string = 'hello world'
+const ns: Array<number> = [1, 2, 3, 4, 5];
+const ss: Array<string> = ["one", "two", "three", "four"];
+const obj: { [k: string]: number } = { a: 1, c: 2 };
+const objMixed: { [k: string]: mixed } = { a: 1, c: "d" };
+const os: Array<{ [k: string]: * }> = [{ a: 1, c: "d" }, { b: 2 }];
+const str: string = "hello world";
 
 // Object
-const a:{[k:string]:number|string} = _.assoc('c', 's', { a: 1, b: 2 })
+const a: { [k: string]: number | string } = _.assoc("c", "s", { a: 1, b: 2 });
 //$ExpectError
-const a1:{[k:string]:number|boolean} = _.assoc('c', 's', { a: 1, b: 2 })
+const a1: { [k: string]: number | boolean } = _.assoc("c", "s", { a: 1, b: 2 });
 
-const apath: {[k:string]:number|string|Object} = _.assocPath([ 'a', 'b', 'c' ], 's', { a: { b: { c: 0 } } })
+const apath: { [k: string]: number | string | Object } = _.assocPath(
+  ["a", "b", "c"],
+  "s",
+  { a: { b: { c: 0 } } }
+);
 
-const tomato  = { firstName: '  Tomato ', data: { elapsed: 100, remaining: 1400 }, id: 123 }
-const tomato1  = { firstName: '  Tomato ', data: { elapsed: 100, remaining: 1400 } }
+const tomato = {
+  firstName: "  Tomato ",
+  data: { elapsed: 100, remaining: 1400 },
+  id: 123
+};
+const tomato1 = {
+  firstName: "  Tomato ",
+  data: { elapsed: 100, remaining: 1400 }
+};
 
 // TODO: Started failing in v31...
 // const transformations = {
@@ -30,148 +41,171 @@ const tomato1  = { firstName: '  Tomato ', data: { elapsed: 100, remaining: 1400
 // }
 // const evolved:{firstName: string, data: {elapsed: number, remaining: number}, id: number} = _.evolve(transformations, tomato)
 
-const objects = [ {}, {}, {} ]
-const objectsClone: Array<Object> = _.clone(objects)
-const objectsClone1: number = _.clone(1)
-const objectsClone2: typeof tomato = _.clone(tomato)
+const objects = [{}, {}, {}];
+const objectsClone: Array<Object> = _.clone(objects);
+const objectsClone1: number = _.clone(1);
+const objectsClone2: typeof tomato = _.clone(tomato);
 //$ExpectError
-const objectsClone3: $Shape<typeof tomato1> = _.clone(tomato)
-const objectsClone4: $Shape<typeof tomato1> = _.clone(tomato1)
+const objectsClone3: $Shape<typeof tomato1> = _.clone(tomato);
+const objectsClone4: $Shape<typeof tomato1> = _.clone(tomato1);
 
-const id = objectsClone2.id
+const id = objectsClone2.id;
 //$ExpectError
-const idE = objectsClone4.id
+const idE = objectsClone4.id;
 
-const o1 = { a: 1, b: 2, c: 3, d: 4 }
-const o2 = { a: 10, b: 20, c: 3, d: 40 }
-const ep: boolean = _.eqProps('a')(o1, o2)
-const ep2: boolean = _.eqProps('c', o1)(o2)
+const o1 = { a: 1, b: 2, c: 3, d: 4 };
+const o2 = { a: 10, b: 20, c: 3, d: 40 };
+const ep: boolean = _.eqProps("a")(o1, o2);
+const ep2: boolean = _.eqProps("c", o1)(o2);
 
-const hasid = _.has('id')
-const has: boolean = hasid(tomato)
+const hasid = _.has("id");
+const has: boolean = hasid(tomato);
 
 function Rectangle(width, height) {
-  this.width = width
-  this.height = height
+  this.width = width;
+  this.height = height;
 }
-Rectangle.prototype.area = function () {
-  return this.width * this.height
-}
+Rectangle.prototype.area = function() {
+  return this.width * this.height;
+};
 
-const square = new Rectangle(2, 2)
-const hasIn: boolean = _.hasIn('width', square)
-const hasIn1: boolean = _.hasIn('area', square)
+const square = new Rectangle(2, 2);
+const hasIn: boolean = _.hasIn("width", square);
+const hasIn1: boolean = _.hasIn("area", square);
 
 const raceResultsByFirstName = {
-  first: 'alice',
-  second: 'jake',
-  third: 'alice',
-}
-const inverted: {[k: string]: Array<string>} = _.invert(raceResultsByFirstName)
-const inverted1: {[k: string]: string} = _.invertObj(raceResultsByFirstName)
+  first: "alice",
+  second: "jake",
+  third: "alice"
+};
+const inverted: { [k: string]: Array<string> } = _.invert(
+  raceResultsByFirstName
+);
+const inverted1: { [k: string]: string } = _.invertObj(raceResultsByFirstName);
 
-const ks: Array<string> = _.keys(raceResultsByFirstName)
-const ksi: Array<string> = _.keysIn(square)
+const ks: Array<string> = _.keys(raceResultsByFirstName);
+const ksi: Array<string> = _.keysIn(square);
 
-const values = { x: 1, y: 2, z: 3 }
-const prependKeyAndDouble = (num, key, obj) => key + (num * 2)
+const values = { x: 1, y: 2, z: 3 };
+const prependKeyAndDouble = (num, key, obj) => key + num * 2;
 
-const obI: {[k:string]: string} = _.mapObjIndexed(prependKeyAndDouble, values)
+const obI: { [k: string]: string } = _.mapObjIndexed(
+  prependKeyAndDouble,
+  values
+);
 //$ExpectError
-const obI2: {[k:string]: number} = _.mapObjIndexed(prependKeyAndDouble, values)
+const obI2: { [k: string]: number } = _.mapObjIndexed(
+  prependKeyAndDouble,
+  values
+);
 
-const ob1 = { a: 1 }
-const ob2 = { b: 3 }
-const ob3 = _.merge(ob1, ob2)
+const ob1 = { a: 1 };
+const ob2 = { b: 3 };
+const ob3 = _.merge(ob1, ob2);
 //$ExpectError
-const propX = ob3.x
-const propA = ob3.a
+const propX = ob3.x;
+const propA = ob3.a;
 
-const mwith = _.mergeWith((a, b) => Array.isArray(a) && _.concat,
-{ a: true, values: [ 10, 20 ] },
-{ b: true, values: [ 15, 35 ] },
-)
-const propB: boolean = mwith.b
+const mwith = _.mergeWith(
+  (a, b) => Array.isArray(a) && _.concat,
+  { a: true, values: [10, 20] },
+  { b: true, values: [15, 35] }
+);
+const propB: boolean = mwith.b;
 
-const mwithK = _.mergeWithKey((k, a, b) => Array.isArray(a) && k === 'd' && _.concat,
-{ a: true, values: [ 10, 20 ] },
-{ b: true, values: [ 15, 35 ] },
-)
-const propB1: boolean = mwithK.b
+const mwithK = _.mergeWithKey(
+  (k, a, b) => Array.isArray(a) && k === "d" && _.concat,
+  { a: true, values: [10, 20] },
+  { b: true, values: [15, 35] }
+);
+const propB1: boolean = mwithK.b;
 
-const objA = _.objOf('a', false)
+const objA = _.objOf("a", false);
 //$ExpectError
-const propAA: number = objA.a
+const propAA: number = objA.a;
 
 //$ExpectError
-const om: Object = _.omit([ 'a', 'd', 'h' ], { a: 1, b: 2, c: 3, d: 4 })
+const om: Object = _.omit(["a", "d", "h"], { a: 1, b: 2, c: 3, d: 4 });
 
 //$ExpectError
-const om2 = _.omit([ 'a', 'd', 'h' ])
-const omap = om2({ a: 1, b: 2, c: 3, d: 4 })
+const om2 = _.omit(["a", "d", "h"]);
+const omap = om2({ a: 1, b: 2, c: 3, d: 4 });
 
-const path1:Object|number = _.path([ 'a', 'b' ], { a: { b: 2 } })
-const path2:Object|number = _.path([ 'a', 1 ], { a: { '1': 2 } })
-const path3:?Object = _.path(['a', 'b'], {c: {b: 2}})
-const path4:void = _.path([ 'a' ], null)
+const path1: Object | number = _.path(["a", "b"], { a: { b: 2 } });
+const path2: Object | number = _.path(["a", 1], { a: { "1": 2 } });
+const path3: ?Object = _.path(["a", "b"], { c: { b: 2 } });
+const path4: void = _.path(["a"], null);
 
-const pathOr: string|Object|number = _.pathOr('N/A', [ 'a', 'b' ], { a: { b: 2 } })
+const pathOr: string | Object | number = _.pathOr("N/A", ["a", "b"], {
+  a: { b: 2 }
+});
 
-const pck1: Object = _.pick([ 'a', 'd' ], { a: 1, b: 2, c: 3, d: 4 })
+const pck1: Object = _.pick(["a", "d"], { a: 1, b: 2, c: 3, d: 4 });
 //$ExpectError
-const pck2: Object = _.pick([ 'a', 'b' ], { a: 1 })
+const pck2: Object = _.pick(["a", "b"], { a: 1 });
 // should allow passing in a typed object literal
-const pickedObj: { a: string, b: number, c: boolean } = { a: 'hello', b: 1, c: true }
-const pck3: { a: string, b: number } = _.pick(['a', 'b'], pickedObj)
+const pickedObj: { a: string, b: number, c: boolean } = {
+  a: "hello",
+  b: 1,
+  c: true
+};
+const pck3: { a: string, b: number } = _.pick(["a", "b"], pickedObj);
 //$ExpectError
-const pck4: { a: string, b: string } = _.pick(['a', 'b'], pickedObj)
+const pck4: { a: string, b: string } = _.pick(["a", "b"], pickedObj);
 
-const ooo = { a: 1, b: 2, A: 3, B: 4 }
-const isUpperCase = (val, key) => key.toUpperCase() === key
-const pb:Object = _.pickBy(isUpperCase, ooo)
+const ooo = { a: 1, b: 2, A: 3, B: 4 };
+const isUpperCase = (val, key) => key.toUpperCase() === key;
+const pb: Object = _.pickBy(isUpperCase, ooo);
 
-const ppp:?number = _.prop('x', { x: 100 })
+const ppp: ?number = _.prop("x", { x: 100 });
 //$ExpectError
-const ppp1:?number = _.prop('y', { x: 100 })
+const ppp1: ?number = _.prop("y", { x: 100 });
 
 const alice = {
-  name: 'ALICE',
-  age: 101,
-}
+  name: "ALICE",
+  age: 101
+};
 
 //$ExpectError
-const favoriteWithDefault = _.propOr('Ramda', 'favoriteLibrary')
-const fav = favoriteWithDefault(alice)
+const favoriteWithDefault = _.propOr("Ramda", "favoriteLibrary");
+const fav = favoriteWithDefault(alice);
 
-const nameWithDefault = _.propOr('Ramda', 'name')
-const nm: number|string = nameWithDefault(alice)
+const nameWithDefault = _.propOr("Ramda", "name");
+const nm: number | string = nameWithDefault(alice);
 
-const pss: Array<?number|boolean> = _.props([ 'x', 'y' ], { x: true, y: 2 })
+const pss: Array<?number | boolean> = _.props(["x", "y"], { x: true, y: 2 });
 //$ExpectError
-const pssE: Array<?number|boolean> = _.props([ 'd', 'y' ], { x: true, y: 2 })
+const pssE: Array<?number | boolean> = _.props(["d", "y"], { x: true, y: 2 });
 
-const top: Array<['a'|'b'|'c', number]> = _.toPairs({ a: 1, b: 2, c: 3 })
+const top: Array<["a" | "b" | "c", number]> = _.toPairs({ a: 1, b: 2, c: 3 });
 
 //$ExpectError
-const topE: Array<['a'|'b'|'c'|'z', number]> = _.toPairs({ a: 1, b: 2, c: 3 })
+const topE: Array<["a" | "b" | "c" | "z", number]> = _.toPairs({
+  a: 1,
+  b: 2,
+  c: 3
+});
 
-const F = function () { this.x = 'X' }
-F.prototype.y = 'Y'
-const f = new F()
-const topin = _.toPairsIn(f)
+const F = function() {
+  this.x = "X";
+};
+F.prototype.y = "Y";
+const f = new F();
+const topin = _.toPairsIn(f);
 
-const val = _.values({ a: 1, b: 2, c: true })
-const val1: number|boolean = val[0]
+const val = _.values({ a: 1, b: 2, c: true });
+const val1: number | boolean = val[0];
 
 const pred = _.where({
-  a: _.equals('foo'),
-  b: _.complement(_.equals('bar')),
+  a: (a: string) => a === "foo",
+  b: _.complement(_.equals("bar")),
+  c: (c: Object) => !!c,
   x: _.gt(10),
-  y: _.lt(20),
-})
+  y: _.lt(20)
+});
 
-const w: boolean = pred({ a: 'foo', b: 'xxx', x: 11, y: 19 })
+const w: boolean = pred({ a: "foo", b: "xxx", x: 11, y: 19 });
 
-const pred1 = _.whereEq({ a: 1, b: 2 })
+const pred1 = _.whereEq({ a: 1, b: 2 });
 
-const win: boolean = pred1({ a: 1, d: 1 })
+const win: boolean = pred1({ a: 1, d: 1 });

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-v0.48.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-v0.48.x/ramda_v0.x.x.js
@@ -16,6 +16,7 @@ declare module ramda {
   declare type BinarySameTypeFn<T> = BinaryFn<T, T, T>;
   declare type NestedObject<T> = { [k: string]: T | NestedObject<T> };
   declare type UnaryPredicateFn<T> = (x: T) => boolean;
+  declare type MapUnaryPredicateFn = <V>(V) => V => boolean;
   declare type BinaryPredicateFn<T> = (x: T, y: T) => boolean;
   declare type BinaryPredicateFn2<T, S> = (x: T, y: S) => boolean;
 
@@ -1506,14 +1507,13 @@ declare module ramda {
 
   declare function valuesIn<T, O: { [k: string]: T }>(o: O): Array<T | any>;
 
-  declare function where<T>(
-    predObj: { [key: string]: UnaryPredicateFn<T> },
-    ...rest: Array<void>
-  ): (o: { [k: string]: T }) => boolean;
-  declare function where<T>(
-    predObj: { [key: string]: UnaryPredicateFn<T> },
-    o: { [k: string]: T }
+  declare function where<O>(
+    predObj: $ObjMap<O, MapUnaryPredicateFn>,
+    o: O
   ): boolean;
+  declare function where<O>(
+    predObj: $ObjMap<O, MapUnaryPredicateFn>
+  ): O => boolean;
 
   declare function whereEq<T, S, O: { [k: string]: T }, Q: { [k: string]: S }>(
     predObj: O,

--- a/definitions/npm/ramda_v0.x.x/flow_v0.39.x-v0.48.x/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.39.x-v0.48.x/test_ramda_v0.x.x_object.js
@@ -217,8 +217,9 @@ const val = _.values({ a: 1, b: 2, c: true });
 const val1: number | boolean = val[0];
 
 const pred = _.where({
-  a: _.equals("foo"),
+  a: (a: string) => a === "foo",
   b: _.complement(_.equals("bar")),
+  c: (c: Object) => !!c,
   x: _.gt(10),
   y: _.lt(20)
 });

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
@@ -17,6 +17,7 @@ declare module ramda {
   declare type BinarySameTypeFn<T> = BinaryFn<T, T, T>;
   declare type NestedObject<T> = { [k: string]: T | NestedObject<T> };
   declare type UnaryPredicateFn<T> = (x: T) => boolean;
+  declare type MapUnaryPredicateFn = <V>(V) => V => boolean;
   declare type BinaryPredicateFn<T> = (x: T, y: T) => boolean;
   declare type BinaryPredicateFn2<T, S> = (x: T, y: S) => boolean;
 
@@ -1628,14 +1629,13 @@ declare module ramda {
 
   declare function valuesIn<T, O: { [k: string]: T }>(o: O): Array<T | any>;
 
-  declare function where<T>(
-    predObj: { [key: string]: UnaryPredicateFn<T> },
-    ...rest: Array<void>
-  ): (o: { [k: string]: T }) => boolean;
-  declare function where<T>(
-    predObj: { [key: string]: UnaryPredicateFn<T> },
-    o: { [k: string]: T }
+  declare function where<O>(
+    predObj: $ObjMap<O, MapUnaryPredicateFn>,
+    o: O
   ): boolean;
+  declare function where<O>(
+    predObj: $ObjMap<O, MapUnaryPredicateFn>
+  ): O => boolean;
 
   declare function whereEq<T, S, O: { [k: string]: T }, Q: { [k: string]: S }>(
     predObj: O,

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_object.js
@@ -278,13 +278,14 @@ const val = _.values({ a: 1, b: 2, c: true });
 const val1: number | boolean = val[0];
 
 const pred = _.where({
-  a: _.equals("foo"),
+  a: (a: string) => a === "foo",
   b: _.complement(_.equals("bar")),
+  c: (c: Object) => !!c,
   x: _.gt(10),
   y: _.lt(20)
 });
 
-const w: boolean = pred({ a: "foo", b: "xxx", x: 11, y: 19 });
+const w: boolean = pred({ a: "foo", b: "xxx", c: {}, x: 11, y: 19 });
 
 const pred1 = _.whereEq({ a: 1, b: 2 });
 


### PR DESCRIPTION
The `where` declaration originally expected every predicate unary function to only except the same
type. I've tried to remedy that with the new utility type `$ObjMap` (where possible).

There's also the usual "prettier" changes.