### PR TITLE
(Ramda) Add missing `UnaryFn<C, D>` in `Pipe` definition

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
@@ -328,6 +328,7 @@ declare module ramda {
     (<A, B, C, D, E>(
       ab: UnaryFn<A, B>,
       bc: UnaryFn<B, C>,
+      cd: UnaryFn<C, D>,
       de: UnaryFn<D, E>,
       ...rest: Array<void>
     ) => UnaryFn<A, E>) &


### PR DESCRIPTION
There was a missing UnaryFn argument that prevented types to flow correctly. 