### PR TITLE
add express.json() middleware support (requires 4.16.x)

### DIFF
--- a/definitions/npm/express_v4.16.x/flow_v0.32.x-/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.32.x-/express_v4.16.x.js
@@ -1,0 +1,274 @@
+import type { Server } from "http";
+import type { Socket } from "net";
+
+declare type express$RouterOptions = {
+  caseSensitive?: boolean,
+  mergeParams?: boolean,
+  strict?: boolean
+};
+
+declare class express$RequestResponseBase {
+  app: express$Application;
+  get(field: string): string | void;
+}
+
+declare type express$RequestParams = {
+  [param: string]: string
+};
+
+declare class express$Request extends http$IncomingMessage {
+  baseUrl: string;
+  body: any;
+  cookies: { [cookie: string]: string };
+  connection: Socket;
+  fresh: boolean;
+  hostname: string;
+  ip: string;
+  ips: Array<string>;
+  method: string;
+  originalUrl: string;
+  params: express$RequestParams;
+  path: string;
+  protocol: "https" | "http";
+  query: { [name: string]: string | Array<string> };
+  route: string;
+  secure: boolean;
+  signedCookies: { [signedCookie: string]: string };
+  stale: boolean;
+  subdomains: Array<string>;
+  xhr: boolean;
+  accepts(types: string): string | false;
+  accepts(types: Array<string>): string | false;
+  acceptsCharsets(...charsets: Array<string>): string | false;
+  acceptsEncodings(...encoding: Array<string>): string | false;
+  acceptsLanguages(...lang: Array<string>): string | false;
+  header(field: string): string | void;
+  is(type: string): boolean;
+  param(name: string, defaultValue?: string): string | void;
+}
+
+declare type express$CookieOptions = {
+  domain?: string,
+  encode?: (value: string) => string,
+  expires?: Date,
+  httpOnly?: boolean,
+  maxAge?: number,
+  path?: string,
+  secure?: boolean,
+  signed?: boolean
+};
+
+declare type express$Path = string | RegExp;
+
+declare type express$RenderCallback = (
+  err: Error | null,
+  html?: string
+) => mixed;
+
+declare type express$SendFileOptions = {
+  maxAge?: number,
+  root?: string,
+  lastModified?: boolean,
+  headers?: { [name: string]: string },
+  dotfiles?: "allow" | "deny" | "ignore"
+};
+
+declare class express$Response extends http$ServerResponse {
+  headersSent: boolean;
+  locals: { [name: string]: mixed };
+  append(field: string, value?: string): this;
+  attachment(filename?: string): this;
+  cookie(name: string, value: string, options?: express$CookieOptions): this;
+  clearCookie(name: string, options?: express$CookieOptions): this;
+  download(
+    path: string,
+    filename?: string,
+    callback?: (err?: ?Error) => void
+  ): this;
+  format(typesObject: { [type: string]: Function }): this;
+  json(body?: mixed): this;
+  jsonp(body?: mixed): this;
+  links(links: { [name: string]: string }): this;
+  location(path: string): this;
+  redirect(url: string, ...args: Array<void>): this;
+  redirect(status: number, url: string, ...args: Array<void>): this;
+  render(
+    view: string,
+    locals?: { [name: string]: mixed },
+    callback?: express$RenderCallback
+  ): this;
+  send(body?: mixed): this;
+  sendFile(
+    path: string,
+    options?: express$SendFileOptions,
+    callback?: (err?: ?Error) => mixed
+  ): this;
+  sendStatus(statusCode: number): this;
+  header(field: string, value?: string): this;
+  header(headers: { [name: string]: string }): this;
+  set(field: string, value?: string | string[]): this;
+  set(headers: { [name: string]: string }): this;
+  status(statusCode: number): this;
+  type(type: string): this;
+  vary(field: string): this;
+  req: express$Request;
+}
+
+declare type express$NextFunction = (err?: ?Error | "route") => mixed;
+declare type express$Middleware =
+  | ((
+      req: $Subtype<express$Request>,
+      res: express$Response,
+      next: express$NextFunction
+    ) => mixed)
+  | ((
+      error: Error,
+      req: $Subtype<express$Request>,
+      res: express$Response,
+      next: express$NextFunction
+    ) => mixed);
+declare interface express$RouteMethodType<T> {
+  (middleware: express$Middleware): T;
+  (...middleware: Array<express$Middleware>): T;
+  (
+    path: express$Path | express$Path[],
+    ...middleware: Array<express$Middleware>
+  ): T;
+}
+declare class express$Route {
+  all: express$RouteMethodType<this>;
+  get: express$RouteMethodType<this>;
+  post: express$RouteMethodType<this>;
+  put: express$RouteMethodType<this>;
+  head: express$RouteMethodType<this>;
+  delete: express$RouteMethodType<this>;
+  options: express$RouteMethodType<this>;
+  trace: express$RouteMethodType<this>;
+  copy: express$RouteMethodType<this>;
+  lock: express$RouteMethodType<this>;
+  mkcol: express$RouteMethodType<this>;
+  move: express$RouteMethodType<this>;
+  purge: express$RouteMethodType<this>;
+  propfind: express$RouteMethodType<this>;
+  proppatch: express$RouteMethodType<this>;
+  unlock: express$RouteMethodType<this>;
+  report: express$RouteMethodType<this>;
+  mkactivity: express$RouteMethodType<this>;
+  checkout: express$RouteMethodType<this>;
+  merge: express$RouteMethodType<this>;
+
+  // @TODO Missing 'm-search' but get flow illegal name error.
+
+  notify: express$RouteMethodType<this>;
+  subscribe: express$RouteMethodType<this>;
+  unsubscribe: express$RouteMethodType<this>;
+  patch: express$RouteMethodType<this>;
+  search: express$RouteMethodType<this>;
+  connect: express$RouteMethodType<this>;
+}
+
+declare class express$Router extends express$Route {
+  constructor(options?: express$RouterOptions): void;
+  route(path: string): express$Route;
+  static (options?: express$RouterOptions): express$Router;
+  use(middleware: express$Middleware): this;
+  use(...middleware: Array<express$Middleware>): this;
+  use(
+    path: express$Path | express$Path[],
+    ...middleware: Array<express$Middleware>
+  ): this;
+  use(path: string, router: express$Router): this;
+  handle(
+    req: http$IncomingMessage,
+    res: http$ServerResponse,
+    next: express$NextFunction
+  ): void;
+  param(
+    param: string,
+    callback: (
+      req: $Subtype<express$Request>,
+      res: express$Response,
+      next: express$NextFunction,
+      id: string
+    ) => mixed
+  ): void;
+
+  // Can't use regular callable signature syntax due to https://github.com/facebook/flow/issues/3084
+  $call: (
+    req: http$IncomingMessage,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ) => void;
+}
+
+declare class express$Application extends express$Router {
+  constructor(): void;
+  locals: { [name: string]: mixed };
+  mountpath: string;
+  listen(
+    port: number,
+    hostname?: string,
+    backlog?: number,
+    callback?: (err?: ?Error) => mixed
+  ): Server;
+  listen(
+    port: number,
+    hostname?: string,
+    callback?: (err?: ?Error) => mixed
+  ): Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): Server;
+  disable(name: string): void;
+  disabled(name: string): boolean;
+  enable(name: string): express$Application;
+  enabled(name: string): boolean;
+  engine(name: string, callback: Function): void;
+  /**
+   * Mixed will not be taken as a value option. Issue around using the GET http method name and the get for settings.
+   */
+  //   get(name: string): mixed;
+  set(name: string, value: mixed): mixed;
+  render(
+    name: string,
+    optionsOrFunction: { [name: string]: mixed },
+    callback: express$RenderCallback
+  ): void;
+  handle(
+    req: http$IncomingMessage,
+    res: http$ServerResponse,
+    next?: ?express$NextFunction
+  ): void;
+}
+
+declare type JsonOptions = {
+  inflate?: boolean,
+  limit?: string | number,
+  reviver?: (key: string, value: mixed) => mixed,
+  strict?: boolean,
+  type?: string | Array<string> | ((req: express$Request) => boolean),
+  verify?: (
+    req: express$Request,
+    res: express$Response,
+    buf: Buffer,
+    encoding: string
+  ) => mixed
+};
+
+declare module "express" {
+  declare export type RouterOptions = express$RouterOptions;
+  declare export type CookieOptions = express$CookieOptions;
+  declare export type Middleware = express$Middleware;
+  declare export type NextFunction = express$NextFunction;
+  declare export type RequestParams = express$RequestParams;
+  declare export type $Response = express$Response;
+  declare export type $Request = express$Request;
+  declare export type $Application = express$Application;
+
+  declare module.exports: {
+    (): express$Application, // If you try to call like a function, it will use this signature
+    json: (opts: ?JsonOptions) => express$Middleware,
+    static: (root: string, options?: Object) => express$Middleware, // `static` property on the function
+    Router: typeof express$Router // `Router` property on the function
+  };
+}

--- a/definitions/npm/express_v4.16.x/flow_v0.32.x-/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.32.x-/express_v4.16.x.js
@@ -201,7 +201,7 @@ declare class express$Router extends express$Route {
   ) => void;
 }
 
-declare class express$Application extends express$Router {
+declare class express$Application extends express$Router mixins events$EventEmitter {
   constructor(): void;
   locals: { [name: string]: mixed };
   mountpath: string;

--- a/definitions/npm/express_v4.16.x/flow_v0.32.x-/test_overrideUseMethodClassExtension.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.32.x-/test_overrideUseMethodClassExtension.js
@@ -1,0 +1,90 @@
+// @flow
+import express from "express";
+
+// Class Extensions: Global Class/Type Declarations (prefixed to prevent name clashes)
+// Use method needs to be covarient: https://github.com/facebook/flow/issues/2770#issuecomment-258955097
+declare class test_express$CustomRequest extends express$Request {
+  foo: string;
+}
+declare class test_express$CustomResponse extends express$Response {
+  bar: string;
+}
+
+declare type test_express$CustomPath = string | RegExp;
+
+declare type test_express$CustomNextFunction = express$NextFunction;
+
+declare type test_express$CustomMiddleware =
+  | ((
+      req: test_express$CustomRequest,
+      res: test_express$CustomResponse,
+      next: test_express$CustomNextFunction
+    ) => mixed)
+  | ((
+      error: Error,
+      req: test_express$CustomRequest,
+      res: test_express$CustomResponse,
+      next: test_express$CustomNextFunction
+    ) => mixed);
+
+declare class test_express$CustomApplication extends express$Application {
+  constructor(expressConstructor: () => express$Application): this;
+  use(middleware: test_express$CustomMiddleware): this;
+  use(...middleware: Array<test_express$CustomMiddleware>): this;
+  use(
+    path: test_express$CustomPath | test_express$CustomPath[],
+    ...middleware: Array<test_express$CustomMiddleware>
+  ): this;
+  use(path: string, router: express$Router): this;
+}
+
+// Class Extensions: Test Functions
+function test_express$CustomApplication(
+  expressConstructor: () => express$Application
+) {
+  const express = expressConstructor();
+  express.use((req: any, res: any, next: express$NextFunction) => {
+    // Private Constructor Mutation: Add new properties
+    req.foo = "hello";
+    res.bar = "goodbye";
+    next();
+  });
+  return express;
+}
+
+// Class Extensions: Test
+const customApp = new test_express$CustomApplication(express);
+
+// $ExpectError
+const customApp_error = new test_express$CustomApplication();
+
+customApp.use(
+  "/something",
+  (req: express$Request, res: express$Response, next: express$NextFunction) => {
+    // $ExpectError
+    req.foo;
+    // $ExpectError
+    res.bar;
+    next();
+  }
+);
+customApp.use(
+  "/something",
+  (
+    req: test_express$CustomRequest,
+    res: test_express$CustomResponse,
+    next: test_express$CustomNextFunction
+  ) => {
+    req.foo;
+    res.bar;
+    // $ExpectError
+    req.notHere;
+    // $ExpectError
+    res.notHere;
+  }
+);
+
+// $ExpectError
+customApp.use("/something", (req: string, res: string, next: Function) => {
+  next();
+});

--- a/definitions/npm/express_v4.16.x/flow_v0.32.x-/test_response.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.32.x-/test_response.js
@@ -1,0 +1,40 @@
+// @flow
+
+import express, { Router } from "express";
+import http from "http";
+
+const app = express();
+
+app.use("/response_api", (req: express$Request, res: express$Response) => {
+  const contentLength = String(2);
+  res.set("Content-Length", contentLength);
+  res.set("Content-Type", "application/json");
+  res.writeHead(200, {
+    "Content-Length": contentLength,
+    "Content-Type": "application/json"
+  });
+  res.end("{}");
+  res.req;
+});
+
+// Can manually invoke router.handle() to handle a request.
+const router = new Router();
+app.use(
+  "/router",
+  (req: express$Request, res: express$Response, next: express$NextFunction) => {
+    router.handle(req, res, next);
+  }
+);
+app.post("/post-router-callable", router);
+
+// Can use an express app directly as a server listener
+const httpServer = http.createServer(app);
+httpServer.listen(9000);
+
+const badHttpServer = null;
+// $ExpectError
+badHttpServer.listen();
+
+// Can manually invoke app.handle() to handle a request
+const httpServer2 = http.createServer((req, res) => app.handle(req, res));
+httpServer.listen(9000);

--- a/definitions/npm/express_v4.16.x/test_express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/test_express_v4.16.x.js
@@ -1,0 +1,205 @@
+/* @flow */
+import express, { Router } from "express";
+
+const app = express();
+
+// $ExpectError property `foo` Property not found in Application:
+app.foo();
+
+app.locals.title = "My Express App";
+
+// $ExpectError Symbol: This type is incompatible with string
+app.locals[Symbol("bad")] = "Should not work";
+
+// $ExpectError
+const num: number = app.mountpath;
+
+const myRouter = new express.Router();
+
+myRouter.use(
+  "/dang",
+  (req, res: express$Response, next: express$NextFunction) => {
+    res.set("My Header", "Value");
+    res.header("Another-Header", "different value");
+    res.set({ "third-header": "123", "forth-header": "abc" });
+    res.header({ "fifth-header": "456", "sixth-header": "def" });
+    res.status(200);
+    res.render("someTemplate", {}, (err, html: ?string) => null);
+    res.render("someTemplate", (err, html: ?string) => null);
+    // $ExpectError String: This type is incompatible with Function | {[name: string]: mixed}
+    res.render("someTemplate", "Error");
+    // $ExpectError
+    res.sendFile("/myfile.txt", { dotfiles: "none" });
+    // $ExpectError
+    next("Error");
+  }
+);
+
+function handleRequest<MiddleWare>(
+  req: express$Request,
+  res: express$Response,
+  next: express$NextFunction
+): void {
+  (Math.random() >= 0.5
+    ? Promise.resolve({ books: ["Catcher and the Rye"] })
+    : Promise.reject(new Error("Something went wrong"))
+  )
+    .then(data => {
+      res.json(data);
+    })
+    .catch(err => {
+      next(err);
+    });
+}
+
+myRouter.use(
+  handleRequest,
+  (
+    err: Error,
+    req: express$Request,
+    res: express$Response,
+    next: express$NextFunction
+  ): void => {
+    console.error(err);
+    next(err);
+  }
+);
+
+app.on("mount", (parent: express$Application) => {
+  console.log("Parent Loaded", parent);
+  // $ExpectError
+  parent.fail();
+});
+
+app.use("/foo", (req: express$Request, res: express$Response, next) => {
+  // $ExpectError
+  res.status("400");
+  res.send("should work").status(300);
+});
+
+const bar: express$Router = new Router();
+
+bar.get("/", (req: express$Request, res: express$Response): void => {
+  // $ExpectError should be of type object
+  const locals: Array<any> = res.locals;
+  res.locals.title = "Home Page";
+  // $ExpectError should not allow to set keys to non string value.
+  res.locals[0] = "Fail";
+  res.send("bar").status(200);
+});
+
+app.use("/bar", bar);
+
+app.listen(9000);
+
+app.listen(9001, "127.0.0.1");
+
+app.listen(9002, "127.0.0.1", 256);
+
+app.listen(9003, "127.0.0.1", 256, () => {
+  console.log("Example app listening on port 9003!");
+});
+
+app.listen(9004, () => {
+  console.log("Example app listening on port 9004!");
+});
+
+// $ExpectError backlog should be number
+app.listen(9005, "127.0.0.1", "256", () => {
+  console.log("Example app listening on port 9005!");
+});
+
+app.set("foo");
+
+app.get("foo");
+// $ExpectError
+app.enable(100);
+// $ExpectError
+const f: number = app.enabled("100");
+
+const g: express$Application = app.enable("foo");
+
+app.render(
+  "view",
+  { title: "News Feed" },
+  (err: ?Error, html: ?string): void => {
+    if (err) return console.log(err);
+    console.log(html);
+  }
+);
+
+app.use("/somewhere", (req: express$Request, res: express$Response) => {
+  res.redirect("/somewhere-else");
+});
+
+app.use("/again", (req: express$Request, res: express$Response) => {
+  res.redirect(200, "/different");
+});
+
+app.use("/something", (req: express$Request, res: express$Response) => {
+  // $ExpectError
+  res.redirect("/different", 200);
+});
+
+// False positive since 0.39
+// app.use('/failure', (req: express$Request, res: express$Response) => {
+//   res.redirect();
+// });
+
+app.use(
+  (
+    err: Error,
+    req: express$Request,
+    res: express$Response,
+    next: express$NextFunction
+  ) => {
+    // test req
+    req.accepts("accepted/type");
+    req.accepts(["json", "text"]);
+    if (typeof req.query.foo === "string") console.log((req.query.foo: string));
+    else console.log((req.query.foo: Array<string>));
+    // test response
+    res.redirect("/somewhere");
+    // test next
+    next();
+    next(err);
+  }
+);
+
+// $ExpectError path could not be an Object
+const invalidPath: express$Path = {};
+
+let validPath: express$Path = "string_path";
+validPath = "pattern?path";
+validPath = new RegExp("some.*regexp");
+
+const validPaths = ["string", "pattern?", /a[b-f]+g/];
+
+app.get(validPaths, (req: express$Request, res: express$Response) => {
+  res.end();
+});
+
+// http://expressjs.com/en/4x/api.html#express.json
+// express.json() is incorporated from body-parser.
+
+// Simple case - it can be called with no args.
+express.json();
+
+// The result of express.json() is a middleware the app can use.
+app.use(express.json());
+
+// Reviver comes from JSON.parse's reviver function.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter
+express.json({
+  reviver: (key, value) => {
+    typeof value === "number"
+      ? value * 2 // return value * 2 for numbers
+      : value; // return everything else unchanged
+  }
+});
+
+// type says it must be truthy, but intent is more clearly expressed as a bool.
+express.json({
+  // $ExpectError
+  type: req => 0
+});


### PR DESCRIPTION
This adds the ability to use `express.json()` per the [documentation](http://expressjs.com/en/4x/api.html#express.json). This was introduced in 4.16.0 so there's a new version section for express that covers 4.16.x and above.