### PR TITLE
Make the signature of 'spyOn' (in jest) more restrictive

### DIFF
--- a/definitions/npm/jest_v20.x.x/flow_v0.39.x-/jest_v20.x.x.js
+++ b/definitions/npm/jest_v20.x.x/flow_v0.39.x-/jest_v20.x.x.js
@@ -407,7 +407,7 @@ type JestObjectType = {
    * Creates a mock function similar to jest.fn but also tracks calls to
    * object[methodName].
    */
-  spyOn(object: Object, methodName: string): JestMockFn<any, any>
+  spyOn<T: Object, K: $Keys<T>>(object: T, methodName: K): JestMockFn<any, any>
 };
 
 type JestSpyType = {
@@ -514,7 +514,7 @@ declare var expect: {
 
 // TODO handle return type
 // http://jasmine.github.io/2.4/introduction.html#section-Spies
-declare function spyOn(value: mixed, method: string): Object;
+declare function spyOn<T: mixed, K: $Keys<T>>(value: T, method: K): Object;
 
 /** Holds all functions related to manipulating test runner */
 declare var jest: JestObjectType;

--- a/definitions/npm/jest_v21.x.x/flow_v0.39.x-/jest_v21.x.x.js
+++ b/definitions/npm/jest_v21.x.x/flow_v0.39.x-/jest_v21.x.x.js
@@ -417,7 +417,7 @@ type JestObjectType = {
    * Creates a mock function similar to jest.fn but also tracks calls to
    * object[methodName].
    */
-  spyOn(object: Object, methodName: string): JestMockFn<any, any>,
+  spyOn<T: Object, K: $Keys<T>>(object: T, methodName: K): JestMockFn<any, any>,
   /**
    * Set the default timeout interval for tests and before/after hooks in milliseconds.
    * Note: The default timeout interval is 5 seconds if this method is not called.
@@ -556,7 +556,7 @@ declare var expect: {
 
 // TODO handle return type
 // http://jasmine.github.io/2.4/introduction.html#section-Spies
-declare function spyOn(value: mixed, method: string): Object;
+declare function spyOn<T: mixed, K: $Keys<T>>(value: T, method: K): Object;
 
 /** Holds all functions related to manipulating test runner */
 declare var jest: JestObjectType;


### PR DESCRIPTION
Currently spyOn allows the second parameter to be any string. This PR will ensure that spyOn only allows strings that are keys of the first argument.