### PR TITLE
RxJS: Add missing type signatures for forkJoin.

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
@@ -1014,6 +1014,26 @@ declare class rxjs$Observable<+T> {
     _: void
   ): rxjs$Observable<[A, B, C, D, E, F, G, H]>;
 
+  static forkJoin<A>(
+    a: Array<rxjs$Observable<A>>,
+    _: void
+  ): rxjs$Observable<Array<A>>;
+
+  static forkJoin<A>(
+    a: Array<rxjs$Observable<any>>,
+    _: void
+  ): rxjs$Observable<A>;
+
+  static forkJoin<A, B>(
+    a: Array<rxjs$Observable<A>>,
+    resultSelector: (...values: Array<A>) => B
+  ): rxjs$Observable<B>;
+
+  static forkJoin<A>(
+    a: Array<rxjs$Observable<any>>,
+    resultSelector: (...values: Array<any>) => A
+  ): rxjs$Observable<A>;
+
   withLatestFrom<A>(a: rxjs$Observable<A>): rxjs$Observable<[T, A]>;
 
   withLatestFrom<A, B>(

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -41,8 +41,10 @@ type rxjs$EventListenerOptions =
 
 type rxjs$ObservableInput<T> = rxjs$Observable<T> | Promise<T> | Iterable<T>;
 
-type rxjs$OperatorFunction<T, R> = rxjs$Observable<T> => rxjs$Observable<R>;
-type rxjs$OperatorFunctionLast<T, R: rxjs$Observable<*>> = rxjs$Observable<T> => R;
+type rxjs$OperatorFunction<T, R> = (rxjs$Observable<T>) => rxjs$Observable<R>;
+type rxjs$OperatorFunctionLast<T, R: rxjs$Observable<*>> = (
+  rxjs$Observable<T>
+) => R;
 
 declare class rxjs$Observable<+T> {
   static bindCallback(
@@ -1199,6 +1201,26 @@ declare class rxjs$Observable<+T> {
     h: rxjs$Observable<H>,
     _: void
   ): rxjs$Observable<[A, B, C, D, E, F, G, H]>;
+
+  static forkJoin<A>(
+    a: Array<rxjs$Observable<A>>,
+    _: void
+  ): rxjs$Observable<Array<A>>;
+
+  static forkJoin<A>(
+    a: Array<rxjs$Observable<any>>,
+    _: void
+  ): rxjs$Observable<A>;
+
+  static forkJoin<A, B>(
+    a: Array<rxjs$Observable<A>>,
+    resultSelector: (...values: Array<A>) => B
+  ): rxjs$Observable<B>;
+
+  static forkJoin<A>(
+    a: Array<rxjs$Observable<any>>,
+    resultSelector: (...values: Array<any>) => A
+  ): rxjs$Observable<A>;
 
   withLatestFrom<A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<[T, A]>;
 

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -78,6 +78,28 @@ const forked2: Observable<[number, string]> = Observable.forkJoin(
   strings
 );
 
+const forked3a: Observable<Array<number>> = Observable.forkJoin(
+  [1, 2, 3].map(number => Observable.of(number))
+);
+
+const forked3b: Observable<
+  Array<number | string | boolean>
+> = Observable.forkJoin([1, "2", 3, true].map(val => Observable.of(val)));
+
+const forked3c: Observable<Array<any>> = Observable.forkJoin(
+  [1, "2", 3, true].map(val => Observable.of(val))
+);
+
+const forked4a: Observable<number> = Observable.forkJoin(
+  [1, 2, 3].map(number => Observable.of(number)),
+  (...numbers: Array<number>) => numbers.reduce((a, b) => a + b)
+);
+
+const forked4b: Observable<number> = Observable.forkJoin(
+  [1, "2", 3, true].map(val => Observable.of(val)),
+  (...vals: Array<any>) => vals.map(Number).reduce((a, b) => a + b)
+);
+
 // $ExpectError
 const forkedBad: Observable<{ n: number, s: string }> = Observable.forkJoin(
   numbers,


### PR DESCRIPTION
This PR adds some missing `forkJoin` RxJS signatures and adds tests for them.

Signatures added:
```
  static forkJoin<A>(
    a: Array<rxjs$Observable<A>>,
    _: void
  ): rxjs$Observable<Array<A>>;

  static forkJoin<A>(
    a: Array<rxjs$Observable<any>>,
    _: void
  ): rxjs$Observable<A>;

  static forkJoin<A, B>(
    a: Array<rxjs$Observable<A>>,
    resultSelector: (...values: Array<A>) => B
  ): rxjs$Observable<B>;

  static forkJoin<A>(
    a: Array<rxjs$Observable<any>>,
    resultSelector: (...values: Array<any>) => A
  ): rxjs$Observable<A>;
```

Related documentation:
https://github.com/ReactiveX/rxjs/blob/master/src/observable/ForkJoinObservable.ts#L34
https://github.com/ReactiveX/rxjs/blob/master/src/observable/ForkJoinObservable.ts#L35
https://github.com/ReactiveX/rxjs/blob/master/src/observable/ForkJoinObservable.ts#L36
https://github.com/ReactiveX/rxjs/blob/master/src/observable/ForkJoinObservable.ts#L37