### PR TITLE
Add awilix v2.x type definition

### DIFF
--- a/definitions/npm/awilix_v2.x.x/flow_v0.56.x-/awilix_v2.x.x.js
+++ b/definitions/npm/awilix_v2.x.x/flow_v0.56.x-/awilix_v2.x.x.js
@@ -1,5 +1,5 @@
-declare module 'awilix' {
-  declare module .exports: {
+declare module "awilix" {
+  declare module.exports: {
     createContainer(?awilix$ContainerOptions): awilix$Container<{}>,
     ResolutionMode: Class<awilix$ResolutionMode>,
     Lifetime: Class<awilix$Lifetime>,
@@ -7,22 +7,22 @@ declare module 'awilix' {
     asClass: awilix$asClass,
     asFunction: awilix$asFunction,
     AwilixResolutionError: awilix$ResolutionError,
-    listModules: awilix$listModules,
-
-  }
+    listModules: awilix$listModules
+  };
 }
 
-declare class awilix$ResolutionError extends Error {
+declare class awilix$ResolutionError extends Error {}
 
-}
-
-declare type awilix$POJO<T> = {
-  [string]: T
-};
-
-declare type awilix$listModules = (globPatterns: string | string[] | Array<awilix$LoadModulesTuple<*>>, options?: awilix$LoadModulesOptions<*>) => awilix$ModuleDescriptor[];
-
-declare type $Return<F> = $Call<(<V>(() => V) => V), F>;
+declare type awilix$POJO<T> = { [string]: T };
+declare type awilix$Name<T> = $PropertyType<T, "name">;
+declare type awilix$ClassName<T> = awilix$Name<Class<T>>;
+declare type awilix$ClassIdx<T> = { [awilix$ClassName<T>]: T };
+declare type awilix$FnIdx<T> = { [awilix$Name<T>]: awilix$Return<T> };
+declare type awilix$derefReturn = <V>(() => V) => V;
+declare type awilix$Return<F> = $Call<awilix$derefReturn, F>;
+declare type awilix$MergedRegistrations<T1, T2> = awilix$Container<
+  T1 & $ObjMap<T2, <T>(awilix$Registration<T>) => T>
+>;
 
 declare class awilix$Container<R> {
   cradle: R;
@@ -31,64 +31,122 @@ declare class awilix$Container<R> {
 
   createScope(): awilix$Container<R>;
 
-  register<Name: string, T>(name: Name, registration: awilix$Registration<T>): awilix$MergedRegistrations<R, { [Name]: T }>;
+  register<Name: string, T>(
+    name: Name,
+    registration: awilix$Registration<T>
+  ): awilix$MergedRegistrations<R, { [Name]: T }>;
+  register<RegistrationMap: *>(
+    registrations: RegistrationMap,
+    opts?: awilix$ContainerRegOptions<RegistrationMap>
+  ): awilix$MergedRegistrations<R, RegistrationMap>;
 
-  register<RegistrationMap: *>(registrations: RegistrationMap, opts?: awilix$ContainerRegOptions<RegistrationMap>): awilix$MergedRegistrations<R, RegistrationMap>;
+  registerClass<T>(
+    className: Class<T>
+  ): awilix$Container<R & { [awilix$ClassName<T>]: T }>;
+  registerClass<T, Name: string>(
+    name: Name,
+    clazz: Class<T>,
+    opts?: awilix$ContainerRegOptions<T>
+  ): awilix$Container<{ [Name]: T } & R>;
+  registerClass<T, Name: string>(
+    name: Name,
+    ctorAndOptionsPair: [Class<T>, awilix$ContainerRegOptions<T>]
+  ): awilix$Container<{ [Name]: T } & R>;
+  registerClass<T>(
+    ctorAndOptionsPair: [Class<T>, awilix$ContainerRegOptions<T>]
+  ): awilix$Container<awilix$ClassIdx<T> & R>;
 
-  registerClass<T>(className: Class<T>): awilix$Container<R & { [$PropertyType<Class<T>, 'name'>]: T }>;
-  registerClass<T, Name: string>(name: Name, clazz: Class<T>, opts?: awilix$ContainerRegOptions<T>): awilix$Container<{ [Name]: T } & R>;
-  registerClass<T, Name: string>(name: Name, ctorAndOptionsPair: [Class<T>, awilix$ContainerRegOptions<T>]): awilix$Container<{ [Name]: T } & R>;
-  registerClass<T>([Class<T>, awilix$ContainerRegOptions<T>]): awilix$Container<{ [$PropertyType<Class<T>, 'name'>]: T } & R>;
+  registerFunction<F: () => *>(
+    fn: F,
+    opts?: awilix$ContainerRegOptions<awilix$Return<F>>
+  ): awilix$Container<awilix$FnIdx<F> & R>;
+  registerFunction<F: () => *>(
+    fn: F,
+    opts?: awilix$ContainerRegOptions<awilix$Return<F>>
+  ): awilix$Container<awilix$FnIdx<F> & R>;
+  registerFunction<Name: string, F: () => *>(
+    name: Name,
+    fn: F,
+    opts?: awilix$ContainerRegOptions<awilix$Return<F>>
+  ): awilix$Container<{ [Name]: awilix$Return<F> } & R>;
+  registerFunction<Name: string, F: () => *>(
+    name: string,
+    funcAndOptionsPair: [Function, awilix$ContainerRegOptions<awilix$Return<F>>]
+  ): awilix$Container<{ [Name]: awilix$Return<F> } & R>;
+  registerFunction<F: () => *, RegistrationMap: awilix$RegistrationMap<F>>(
+    registrations: RegistrationMap
+  ): awilix$MergedRegistrations<
+    R,
+    $ObjMap<RegistrationMap, awilix$derefReturn>
+  >;
 
+  registerValue<Name: string, T>(
+    name: Name,
+    value: T
+  ): awilix$Container<{ [Name]: T } & R>;
+  registerValue<Registrations: { [string]: * }>(
+    Registrations
+  ): awilix$Container<Registrations & R>;
 
-  registerFunction<F: () => *>(fn: F, opts?: awilix$ContainerRegOptions<$Return<F>>): awilix$Container<{ [$PropertyType<F, 'name'>]: $Return<F> } & R>;
-  registerFunction<F: () => *>(fn: F, opts?: awilix$ContainerRegOptions<$Return<F>>): awilix$Container<{ [$PropertyType<F, 'name'>]: $Return<F> } & R>;
-  registerFunction<Name:string, F: () => *>(name: Name, fn: F, opts?: awilix$ContainerRegOptions<$Return<F>>): awilix$Container<{ [Name]: $Return<F> } & R>;
-  registerFunction<Name:string, F: () => *>(name: string, funcAndOptionsPair: [Function, awilix$ContainerRegOptions<$Return<F>>]): awilix$Container<{ [Name]: $Return<F> } & R>;
-  registerFunction<F: () => *, RegistrationMap: {
-    [string]: F | [F, awilix$ContainerRegOptions<$Return<F>>]
-  }>(RegistrationMap): awilix$MergedRegistrations<R, $ObjMap<RegistrationMap, (<V>(() => V) => V)>>;
+  resolve<Name: string>(name: Name): $ElementType<R, Name>;
 
-  registerValue<Name: string, T>(name: Name, value: T): awilix$Container<{ [Name]: T } & R>;
-  registerValue<Registrations: { [string]: * }>(Registrations): awilix$Container<Registrations & R>;
+  loadModules(
+    globPatterns: string[] | Array<awilix$LoadModulesTuple<*>>,
+    options?: awilix$LoadModulesOptions<*>
+  ): awilix$Container<R>;
 
-  resolve<Name:string>(name: Name): $ElementType<R, Name>;
-
-  loadModules(globPatterns: string[] | Array<awilix$LoadModulesTuple<*>>, options?: awilix$LoadModulesOptions<*>): awilix$Container<R>;
-
-  build<T:Function>(target: T | awilix$Registration<T>): $Return<T>;
-  build<T>(target: Class<T> | awilix$Registration<T>): $Return<T>;
-
+  build<T: Function>(target: T | awilix$Registration<T>): awilix$Return<T>;
+  build<T>(target: Class<T> | awilix$Registration<T>): T;
 }
 
-declare type awilix$LoadModulesTuple<T> = [string] | [string, awilix$ContainerRegOptions<T>];
+declare type awilix$listModules = (
+  globPatterns: string | string[] | awilix$LoadModulesTuple<*>[],
+  options?: awilix$LoadModulesOptions<*>
+) => awilix$ModuleDescriptor[];
+
+declare type awilix$RegistrationMap<F> = {
+  [string]: F | [F, awilix$ContainerRegOptions<awilix$Return<F>>]
+};
+
+declare type awilix$LoadModulesTuple<T> =
+  | [string]
+  | [string, awilix$ContainerRegOptions<T>];
 declare type awilix$LoadModulesOptions<T> = {
   cwd?: string,
   formatName?: awilix$NameFormatter | awilix$BuiltInNameFormatters,
-  registrationOptions?: awilix$ContainerRegOptions<T>,
-}
+  registrationOptions?: awilix$ContainerRegOptions<T>
+};
 
 declare type awilix$ModuleDescriptor = {
   name: string,
   path: string
 };
 
-declare type awilix$BuiltInNameFormatters = 'camelCase';
-declare type awilix$NameFormatter = (name: string, descriptor: awilix$ModuleDescriptor) => string
+declare type awilix$BuiltInNameFormatters = "camelCase";
 
-declare interface awilix$AsProviderFunction {
-}
+declare type awilix$NameFormatter = (
+  name: string,
+  descriptor: awilix$ModuleDescriptor
+) => string;
+
+declare interface awilix$AsProviderFunction {}
 
 declare interface awilix$asFunction extends awilix$AsProviderFunction {
-  $call: <F: () => *>(fn: F, options?: awilix$ContainerRegOptions<$Return<F>>) => awilix$FluidRegistration<$Return<F>>;
+  <F: () => *>(
+    fn: F,
+    options?: awilix$ContainerRegOptions<awilix$Return<F>>
+  ): awilix$FluidRegistration<awilix$Return<F>>;
 }
 
 declare interface awilix$asValue extends awilix$AsProviderFunction {
-  $call: <T>(val: T, options?: awilix$ContainerRegOptions<T>) => awilix$Registration<T>;
+  <T>(val: T, options?: awilix$ContainerRegOptions<T>): awilix$Registration<T>;
 }
 
 declare interface awilix$asClass extends awilix$AsProviderFunction {
-  $call: <T>(type: Class<T>, options?: awilix$ContainerRegOptions<T>) => awilix$FluidRegistration<T>
+  <T>(
+    type: Class<T>,
+    options?: awilix$ContainerRegOptions<T>
+  ): awilix$FluidRegistration<T>;
 }
 
 declare interface awilix$FluidRegistration<T> extends awilix$Registration<T> {
@@ -106,36 +164,38 @@ declare interface awilix$FluidRegistration<T> extends awilix$Registration<T> {
 }
 
 declare type awilix$ContainerOptions = {|
-  require?: typeof require;
-  resolutionMode ?: awilix$ResolutionMode
-|}
+  require?: typeof require,
+  resolutionMode?: awilix$ResolutionMode
+|};
 
-declare type awilix$ContainerRegOptions<T> = string | {|
-  name?: string,
-  lifetime?: awilix$Lifetime,
-  resolutionMode?: awilix$ResolutionMode,
-  injector?: awilix$InjectorFunction<T>,
-  register?: awilix$AsProviderFunction
-|}
+declare type awilix$ContainerRegOptions<T> =
+  | string
+  | {|
+      name?: string,
+      lifetime?: awilix$Lifetime,
+      resolutionMode?: awilix$ResolutionMode,
+      injector?: awilix$InjectorFunction<T>,
+      register?: awilix$AsProviderFunction
+    |};
 
 declare class awilix$Lifetime {
-  static SCOPED: awilix$Lifetime,
-  static SINGLETON: awilix$Lifetime,
-  static TRANSIENT: awilix$Lifetime,
+  static SCOPED: awilix$Lifetime;
+  static SINGLETON: awilix$Lifetime;
+  static TRANSIENT: awilix$Lifetime;
 }
 
 declare class awilix$ResolutionMode {
-  static PROXY: awilix$ResolutionMode,
-  static CLASSIC: awilix$ResolutionMode,
+  static PROXY: awilix$ResolutionMode;
+  static CLASSIC: awilix$ResolutionMode;
 }
 
-declare type awilix$MergedRegistrations<T1, T2> = awilix$Container<T1 & $ObjMap<T2, <T>(awilix$Registration<T>) => T>>;
-
-declare type awilix$InjectorFunction<T> = (container: awilix$Container<T>) => awilix$POJO<any>
+declare type awilix$InjectorFunction<T> = (
+  container: awilix$Container<T>
+) => awilix$POJO<any>;
 
 declare interface awilix$Registration<T> {
-  resolve(): T,
+  resolve(): T;
 
-  lifetime: awilix$Lifetime,
-  resolutionMode: awilix$ResolutionMode
+  lifetime: awilix$Lifetime;
+  resolutionMode: awilix$ResolutionMode;
 }

--- a/definitions/npm/awilix_v2.x.x/flow_v0.56.x-/awilix_v2.x.x.js
+++ b/definitions/npm/awilix_v2.x.x/flow_v0.56.x-/awilix_v2.x.x.js
@@ -1,141 +1,141 @@
 declare module 'awilix' {
   declare module .exports: {
-    createContainer(?ContainerOptions): Container<{}>,
-    ResolutionMode: Class<ResolutionMode>,
-    Lifetime: Class<Lifetime>,
-    asValue: asValue,
-    asClass: asClass,
-    asFunction: asFunction,
-    AwilixResolutionError: ResolutionError,
-    listModules: listModules,
+    createContainer(?awilix$ContainerOptions): awilix$Container<{}>,
+    ResolutionMode: Class<awilix$ResolutionMode>,
+    Lifetime: Class<awilix$Lifetime>,
+    asValue: awilix$asValue,
+    asClass: awilix$asClass,
+    asFunction: awilix$asFunction,
+    AwilixResolutionError: awilix$ResolutionError,
+    listModules: awilix$listModules,
 
   }
 }
 
-declare class ResolutionError extends Error {
+declare class awilix$ResolutionError extends Error {
 
 }
 
-declare type POJO<T> = {
+declare type awilix$POJO<T> = {
   [string]: T
 };
 
-declare type listModules = (globPatterns: string | string[] | Array<LoadModulesTuple<*>>, options?: LoadModulesOptions<*>) => ModuleDescriptor[];
+declare type awilix$listModules = (globPatterns: string | string[] | Array<awilix$LoadModulesTuple<*>>, options?: awilix$LoadModulesOptions<*>) => awilix$ModuleDescriptor[];
 
 declare type $Return<F> = $Call<(<V>(() => V) => V), F>;
 
-declare class Container<R> {
+declare class awilix$Container<R> {
   cradle: R;
-  registrations: Registration<$Values<R>>[];
-  options: ContainerOptions;
+  registrations: awilix$Registration<$Values<R>>[];
+  options: awilix$ContainerOptions;
 
-  createScope(): Container<R>;
+  createScope(): awilix$Container<R>;
 
-  register<Name: string, T>(name: Name, registration: Registration<T>): MergedRegistrations<R, { [Name]: T }>;
+  register<Name: string, T>(name: Name, registration: awilix$Registration<T>): awilix$MergedRegistrations<R, { [Name]: T }>;
 
-  register<RegistrationMap: *>(registrations: RegistrationMap, opts?: ContainerRegOptions<RegistrationMap>): MergedRegistrations<R, RegistrationMap>;
+  register<RegistrationMap: *>(registrations: RegistrationMap, opts?: awilix$ContainerRegOptions<RegistrationMap>): awilix$MergedRegistrations<R, RegistrationMap>;
 
-  registerClass<T>(className: Class<T>): Container<R & { [$PropertyType<Class<T>, 'name'>]: T }>;
-  registerClass<T, Name: string>(name: Name, clazz: Class<T>, opts?: ContainerRegOptions<T>): Container<{ [Name]: T } & R>;
-  registerClass<T, Name: string>(name: Name, ctorAndOptionsPair: [Class<T>, ContainerRegOptions<T>]): Container<{ [Name]: T } & R>;
-  registerClass<T>([Class<T>, ContainerRegOptions<T>]): Container<{ [$PropertyType<Class<T>, 'name'>]: T } & R>;
+  registerClass<T>(className: Class<T>): awilix$Container<R & { [$PropertyType<Class<T>, 'name'>]: T }>;
+  registerClass<T, Name: string>(name: Name, clazz: Class<T>, opts?: awilix$ContainerRegOptions<T>): awilix$Container<{ [Name]: T } & R>;
+  registerClass<T, Name: string>(name: Name, ctorAndOptionsPair: [Class<T>, awilix$ContainerRegOptions<T>]): awilix$Container<{ [Name]: T } & R>;
+  registerClass<T>([Class<T>, awilix$ContainerRegOptions<T>]): awilix$Container<{ [$PropertyType<Class<T>, 'name'>]: T } & R>;
 
 
-  registerFunction<F: () => *>(fn: F, opts?: ContainerRegOptions<$Return<F>>): Container<{ [$PropertyType<F, 'name'>]: $Return<F> } & R>;
-  registerFunction<F: () => *>(fn: F, opts?: ContainerRegOptions<$Return<F>>): Container<{ [$PropertyType<F, 'name'>]: $Return<F> } & R>;
-  registerFunction<Name:string, F: () => *>(name: Name, fn: F, opts?: ContainerRegOptions<$Return<F>>): Container<{ [Name]: $Return<F> } & R>;
-  registerFunction<Name:string, F: () => *>(name: string, funcAndOptionsPair: [Function, ContainerRegOptions<$Return<F>>]): Container<{ [Name]: $Return<F> } & R>;
+  registerFunction<F: () => *>(fn: F, opts?: awilix$ContainerRegOptions<$Return<F>>): awilix$Container<{ [$PropertyType<F, 'name'>]: $Return<F> } & R>;
+  registerFunction<F: () => *>(fn: F, opts?: awilix$ContainerRegOptions<$Return<F>>): awilix$Container<{ [$PropertyType<F, 'name'>]: $Return<F> } & R>;
+  registerFunction<Name:string, F: () => *>(name: Name, fn: F, opts?: awilix$ContainerRegOptions<$Return<F>>): awilix$Container<{ [Name]: $Return<F> } & R>;
+  registerFunction<Name:string, F: () => *>(name: string, funcAndOptionsPair: [Function, awilix$ContainerRegOptions<$Return<F>>]): awilix$Container<{ [Name]: $Return<F> } & R>;
   registerFunction<F: () => *, RegistrationMap: {
-    [string]: F | [F, ContainerRegOptions<$Return<F>>]
-  }>(RegistrationMap): MergedRegistrations<R, $ObjMap<RegistrationMap, (<V>(() => V) => V)>>;
+    [string]: F | [F, awilix$ContainerRegOptions<$Return<F>>]
+  }>(RegistrationMap): awilix$MergedRegistrations<R, $ObjMap<RegistrationMap, (<V>(() => V) => V)>>;
 
-  registerValue<Name: string, T>(name: Name, value: T): Container<{ [Name]: T } & R>;
-  registerValue<Registrations: { [string]: * }>(Registrations): Container<Registrations & R>;
+  registerValue<Name: string, T>(name: Name, value: T): awilix$Container<{ [Name]: T } & R>;
+  registerValue<Registrations: { [string]: * }>(Registrations): awilix$Container<Registrations & R>;
 
   resolve<Name:string>(name: Name): $ElementType<R, Name>;
 
-  loadModules(globPatterns: string[] | Array<LoadModulesTuple<*>>, options?: LoadModulesOptions<*>): Container<R>;
+  loadModules(globPatterns: string[] | Array<awilix$LoadModulesTuple<*>>, options?: awilix$LoadModulesOptions<*>): awilix$Container<R>;
 
-  build<T:Function>(target: T | Registration<T>): $Return<T>;
-  build<T>(target: Class<T> | Registration<T>): $Return<T>;
+  build<T:Function>(target: T | awilix$Registration<T>): $Return<T>;
+  build<T>(target: Class<T> | awilix$Registration<T>): $Return<T>;
 
 }
 
-declare type LoadModulesTuple<T> = [string] | [string, ContainerRegOptions<T>];
-declare type LoadModulesOptions<T> = {
+declare type awilix$LoadModulesTuple<T> = [string] | [string, awilix$ContainerRegOptions<T>];
+declare type awilix$LoadModulesOptions<T> = {
   cwd?: string,
-  formatName?: NameFormatter | BuiltInNameFormatters,
-  registrationOptions?: ContainerRegOptions<T>,
+  formatName?: awilix$NameFormatter | awilix$BuiltInNameFormatters,
+  registrationOptions?: awilix$ContainerRegOptions<T>,
 }
 
-declare type ModuleDescriptor = {
+declare type awilix$ModuleDescriptor = {
   name: string,
   path: string
 };
 
-declare type BuiltInNameFormatters = 'camelCase';
-declare type NameFormatter = (name: string, descriptor: ModuleDescriptor) => string
+declare type awilix$BuiltInNameFormatters = 'camelCase';
+declare type awilix$NameFormatter = (name: string, descriptor: awilix$ModuleDescriptor) => string
 
-declare interface AsProviderFunction {
+declare interface awilix$AsProviderFunction {
 }
 
-declare interface asFunction extends AsProviderFunction {
-  $call: <F: () => *>(fn: F, options?: ContainerRegOptions<$Return<F>>) => FluidRegistration<$Return<F>>;
+declare interface awilix$asFunction extends awilix$AsProviderFunction {
+  $call: <F: () => *>(fn: F, options?: awilix$ContainerRegOptions<$Return<F>>) => awilix$FluidRegistration<$Return<F>>;
 }
 
-declare interface asValue extends AsProviderFunction {
-  $call: <T>(val: T, options?: ContainerRegOptions<T>) => Registration<T>;
+declare interface awilix$asValue extends awilix$AsProviderFunction {
+  $call: <T>(val: T, options?: awilix$ContainerRegOptions<T>) => awilix$Registration<T>;
 }
 
-declare interface asClass extends AsProviderFunction {
-  $call: <T>(type: Class<T>, options?: ContainerRegOptions<T>) => FluidRegistration<T>
+declare interface awilix$asClass extends awilix$AsProviderFunction {
+  $call: <T>(type: Class<T>, options?: awilix$ContainerRegOptions<T>) => awilix$FluidRegistration<T>
 }
 
-declare interface FluidRegistration<T> extends Registration<T> {
-  singleton(): FluidRegistration<T>;
+declare interface awilix$FluidRegistration<T> extends awilix$Registration<T> {
+  singleton(): awilix$FluidRegistration<T>;
 
-  scoped(): FluidRegistration<T>;
+  scoped(): awilix$FluidRegistration<T>;
 
-  transient(): FluidRegistration<T>;
+  transient(): awilix$FluidRegistration<T>;
 
-  proxy(): FluidRegistration<T>;
+  proxy(): awilix$FluidRegistration<T>;
 
-  classic(): FluidRegistration<T>;
+  classic(): awilix$FluidRegistration<T>;
 
-  inject<R>(injector: InjectorFunction<R>): FluidRegistration<T>;
+  inject<R>(injector: awilix$InjectorFunction<R>): awilix$FluidRegistration<T>;
 }
 
-declare type ContainerOptions = {|
+declare type awilix$ContainerOptions = {|
   require?: typeof require;
-  resolutionMode ?: ResolutionMode
+  resolutionMode ?: awilix$ResolutionMode
 |}
 
-declare type ContainerRegOptions<T> = string | {|
+declare type awilix$ContainerRegOptions<T> = string | {|
   name?: string,
-  lifetime?: Lifetime,
-  resolutionMode?: ResolutionMode,
-  injector?: InjectorFunction<T>,
-  register?: AsProviderFunction
+  lifetime?: awilix$Lifetime,
+  resolutionMode?: awilix$ResolutionMode,
+  injector?: awilix$InjectorFunction<T>,
+  register?: awilix$AsProviderFunction
 |}
 
-declare class Lifetime {
-  static SCOPED: Lifetime,
-  static SINGLETON: Lifetime,
-  static TRANSIENT: Lifetime,
+declare class awilix$Lifetime {
+  static SCOPED: awilix$Lifetime,
+  static SINGLETON: awilix$Lifetime,
+  static TRANSIENT: awilix$Lifetime,
 }
 
-declare class ResolutionMode {
-  static PROXY: ResolutionMode,
-  static CLASSIC: ResolutionMode,
+declare class awilix$ResolutionMode {
+  static PROXY: awilix$ResolutionMode,
+  static CLASSIC: awilix$ResolutionMode,
 }
 
-declare type MergedRegistrations<T1, T2> = Container<T1 & $ObjMap<T2, <T>(Registration<T>) => T>>;
+declare type awilix$MergedRegistrations<T1, T2> = awilix$Container<T1 & $ObjMap<T2, <T>(awilix$Registration<T>) => T>>;
 
-declare type InjectorFunction<T> = (container: Container<T>) => POJO<any>
+declare type awilix$InjectorFunction<T> = (container: awilix$Container<T>) => awilix$POJO<any>
 
-declare interface Registration<T> {
+declare interface awilix$Registration<T> {
   resolve(): T,
 
-  lifetime: Lifetime,
-  resolutionMode: ResolutionMode
+  lifetime: awilix$Lifetime,
+  resolutionMode: awilix$ResolutionMode
 }

--- a/definitions/npm/awilix_v2.x.x/flow_v0.56.x-/awilix_v2.x.x.js
+++ b/definitions/npm/awilix_v2.x.x/flow_v0.56.x-/awilix_v2.x.x.js
@@ -1,0 +1,141 @@
+declare module 'awilix' {
+  declare module .exports: {
+    createContainer(?ContainerOptions): Container<{}>,
+    ResolutionMode: Class<ResolutionMode>,
+    Lifetime: Class<Lifetime>,
+    asValue: asValue,
+    asClass: asClass,
+    asFunction: asFunction,
+    AwilixResolutionError: ResolutionError,
+    listModules: listModules,
+
+  }
+}
+
+declare class ResolutionError extends Error {
+
+}
+
+declare type POJO<T> = {
+  [string]: T
+};
+
+declare type listModules = (globPatterns: string | string[] | Array<LoadModulesTuple<*>>, options?: LoadModulesOptions<*>) => ModuleDescriptor[];
+
+declare type $Return<F> = $Call<(<V>(() => V) => V), F>;
+
+declare class Container<R> {
+  cradle: R;
+  registrations: Registration<$Values<R>>[];
+  options: ContainerOptions;
+
+  createScope(): Container<R>;
+
+  register<Name: string, T>(name: Name, registration: Registration<T>): MergedRegistrations<R, { [Name]: T }>;
+
+  register<RegistrationMap: *>(registrations: RegistrationMap, opts?: ContainerRegOptions<RegistrationMap>): MergedRegistrations<R, RegistrationMap>;
+
+  registerClass<T>(className: Class<T>): Container<R & { [$PropertyType<Class<T>, 'name'>]: T }>;
+  registerClass<T, Name: string>(name: Name, clazz: Class<T>, opts?: ContainerRegOptions<T>): Container<{ [Name]: T } & R>;
+  registerClass<T, Name: string>(name: Name, ctorAndOptionsPair: [Class<T>, ContainerRegOptions<T>]): Container<{ [Name]: T } & R>;
+  registerClass<T>([Class<T>, ContainerRegOptions<T>]): Container<{ [$PropertyType<Class<T>, 'name'>]: T } & R>;
+
+
+  registerFunction<F: () => *>(fn: F, opts?: ContainerRegOptions<$Return<F>>): Container<{ [$PropertyType<F, 'name'>]: $Return<F> } & R>;
+  registerFunction<F: () => *>(fn: F, opts?: ContainerRegOptions<$Return<F>>): Container<{ [$PropertyType<F, 'name'>]: $Return<F> } & R>;
+  registerFunction<Name:string, F: () => *>(name: Name, fn: F, opts?: ContainerRegOptions<$Return<F>>): Container<{ [Name]: $Return<F> } & R>;
+  registerFunction<Name:string, F: () => *>(name: string, funcAndOptionsPair: [Function, ContainerRegOptions<$Return<F>>]): Container<{ [Name]: $Return<F> } & R>;
+  registerFunction<F: () => *, RegistrationMap: {
+    [string]: F | [F, ContainerRegOptions<$Return<F>>]
+  }>(RegistrationMap): MergedRegistrations<R, $ObjMap<RegistrationMap, (<V>(() => V) => V)>>;
+
+  registerValue<Name: string, T>(name: Name, value: T): Container<{ [Name]: T } & R>;
+  registerValue<Registrations: { [string]: * }>(Registrations): Container<Registrations & R>;
+
+  resolve<Name:string>(name: Name): $ElementType<R, Name>;
+
+  loadModules(globPatterns: string[] | Array<LoadModulesTuple<*>>, options?: LoadModulesOptions<*>): Container<R>;
+
+  build<T:Function>(target: T | Registration<T>): $Return<T>;
+  build<T>(target: Class<T> | Registration<T>): $Return<T>;
+
+}
+
+declare type LoadModulesTuple<T> = [string] | [string, ContainerRegOptions<T>];
+declare type LoadModulesOptions<T> = {
+  cwd?: string,
+  formatName?: NameFormatter | BuiltInNameFormatters,
+  registrationOptions?: ContainerRegOptions<T>,
+}
+
+declare type ModuleDescriptor = {
+  name: string,
+  path: string
+};
+
+declare type BuiltInNameFormatters = 'camelCase';
+declare type NameFormatter = (name: string, descriptor: ModuleDescriptor) => string
+
+declare interface AsProviderFunction {
+}
+
+declare interface asFunction extends AsProviderFunction {
+  $call: <F: () => *>(fn: F, options?: ContainerRegOptions<$Return<F>>) => FluidRegistration<$Return<F>>;
+}
+
+declare interface asValue extends AsProviderFunction {
+  $call: <T>(val: T, options?: ContainerRegOptions<T>) => Registration<T>;
+}
+
+declare interface asClass extends AsProviderFunction {
+  $call: <T>(type: Class<T>, options?: ContainerRegOptions<T>) => FluidRegistration<T>
+}
+
+declare interface FluidRegistration<T> extends Registration<T> {
+  singleton(): FluidRegistration<T>;
+
+  scoped(): FluidRegistration<T>;
+
+  transient(): FluidRegistration<T>;
+
+  proxy(): FluidRegistration<T>;
+
+  classic(): FluidRegistration<T>;
+
+  inject<R>(injector: InjectorFunction<R>): FluidRegistration<T>;
+}
+
+declare type ContainerOptions = {|
+  require?: typeof require;
+  resolutionMode ?: ResolutionMode
+|}
+
+declare type ContainerRegOptions<T> = string | {|
+  name?: string,
+  lifetime?: Lifetime,
+  resolutionMode?: ResolutionMode,
+  injector?: InjectorFunction<T>,
+  register?: AsProviderFunction
+|}
+
+declare class Lifetime {
+  static SCOPED: Lifetime,
+  static SINGLETON: Lifetime,
+  static TRANSIENT: Lifetime,
+}
+
+declare class ResolutionMode {
+  static PROXY: ResolutionMode,
+  static CLASSIC: ResolutionMode,
+}
+
+declare type MergedRegistrations<T1, T2> = Container<T1 & $ObjMap<T2, <T>(Registration<T>) => T>>;
+
+declare type InjectorFunction<T> = (container: Container<T>) => POJO<any>
+
+declare interface Registration<T> {
+  resolve(): T,
+
+  lifetime: Lifetime,
+  resolutionMode: ResolutionMode
+}

--- a/definitions/npm/awilix_v2.x.x/test_awilix_v2.x.x.js
+++ b/definitions/npm/awilix_v2.x.x/test_awilix_v2.x.x.js
@@ -1,0 +1,257 @@
+//@flow
+
+const awilix = require('awilix');
+
+function emptyContainer() {
+  const container = awilix.createContainer();
+
+  // $ExpectError
+  container.cradle.foo = 'bar';
+}
+
+function containerOptions() {
+  awilix.createContainer({});
+  // $ExpectError
+  awilix.createContainer({
+    name: 'test'
+  });
+  awilix.createContainer({ require });
+  awilix.createContainer({
+    require,
+    resolutionMode: awilix.ResolutionMode.CLASSIC
+  });
+}
+
+function register() {
+  const validOpts = [
+    { name: 'test' },
+    { name: 'test', lifetime: awilix.Lifetime.SCOPED },
+    {
+      name: 'test', lifetime: awilix.Lifetime.SCOPED,
+      resolutionMode: awilix.ResolutionMode.PROXY
+    },
+    {
+      name: 'test', lifetime: awilix.Lifetime.SCOPED,
+      resolutionMode: awilix.ResolutionMode.PROXY,
+      injector: (container) => ({}),
+    },
+    {
+      name: 'test', lifetime: awilix.Lifetime.SCOPED,
+      resolutionMode: awilix.ResolutionMode.PROXY,
+      injector: (container) => ({}),
+      register: awilix.asClass
+    },
+  ];
+
+  const asValue = awilix.asValue;
+  let container = awilix.createContainer();
+
+  for (let i = 0; i < validOpts.length; i++) {
+    container.register({
+      foo: asValue('bar')
+    }, validOpts[i]);
+  }
+
+  // $ExpectError
+  container.cradle.foo = 'baz';
+
+  container = container.register({
+    foo: asValue('bar')
+  });
+
+  container.cradle.foo = 'baz';
+
+  // $ExpectError
+  container.cradle.num += 123;
+
+  container = container.register({
+    num: asValue(123)
+  });
+
+  container.cradle.num += 123;
+
+  // $ExpectError
+  container.cradle.nested.object.is.deeply.nested = 1;
+
+  container = container.register({
+    nested: asValue({
+      object: {
+        is: {
+          deeply: {
+            nested: 2,
+            nestedString: 'foo'
+          }
+        }
+      }
+    })
+  });
+
+  container.cradle.nested.object.is.deeply.nested++;
+
+  // $ExpectError
+  container.cradle.nested.object.is.deeply.nestedString++;
+
+  let aBool: boolean = true;
+
+  // $ExpectError
+  aBool = container.cradle.another;
+
+  container = container.register({ another: asValue(true) });
+
+  aBool = container.cradle.another;
+}
+
+function registerClass() {
+  let container = awilix.createContainer();
+  const asClass = awilix.asClass;
+
+  class TestOne {
+
+  }
+
+  class TestTwo {
+
+  }
+
+  class TestThree {
+  }
+
+  let test: TestOne;
+
+  // $ExpectError
+  test = container.cradle.TestOne;
+
+  container = container.registerClass(TestOne);
+
+  test = container.cradle.TestOne;
+
+  let test2: TestTwo;
+
+  // $ExpectError
+  test2 = container.cradle.TestTwo;
+
+  container = container.registerClass('TestDos', TestTwo);
+
+  test2 = container.cradle.TestDos;
+
+  container = container.registerClass('TestTres', [TestTwo, {}]);
+
+  test2 = container.cradle.TestTres;
+
+  let test3: TestThree;
+
+  // $ExpectError
+  test3 = container.cradle.TestThree;
+
+  container = container.registerClass([TestThree, {}]);
+
+  test3 = container.cradle.TestThree;
+
+}
+
+function registerFunction() {
+  const asFunction = awilix.asFunction;
+  let container = awilix.createContainer();
+
+  let test: boolean;
+
+  // $ExpectError
+  test = container.cradle.boo;
+
+  function boo() {
+    return 123;
+  }
+
+  container = container.registerFunction(boo);
+
+  let test1: number = container.cradle.boo;
+  // $ExpectError
+  let test2: boolean = container.cradle.boo;
+
+  container = container.registerFunction('boo2', boo);
+
+  test1 = container.cradle.boo2;
+  // $ExpectError
+  test2 = container.cradle.boo2;
+
+  container = container.registerFunction('boo3', boo);
+
+  test1 = container.cradle.boo3;
+  // $ExpectError
+  test2 = container.cradle.boo3;
+
+  container = container.registerFunction({
+    boo4: boo
+  });
+
+  test1 = container.cradle.boo4;
+  // $ExpectError
+  test2 = container.cradle.boo4;
+}
+
+function registerValue() {
+  let container = awilix.createContainer();
+  container = container.registerValue('foo', 'bar');
+
+  // $ExpectError
+  let a: boolean = container.cradle.foo;
+
+  let b: 'bar' = container.cradle.foo;
+
+  container = container.registerValue({ foo2: 'bar2' });
+
+  // $ExpectError
+  a = container.cradle.foo2;
+
+  let b2: 'bar2' = container.cradle.foo2;
+}
+
+function resolve() {
+  let container = awilix.createContainer();
+  let { asValue, asFunction, asClass } = awilix;
+
+  class FooClass {
+  }
+
+  function fn(): 123 {
+    return 123;
+  }
+
+  container = container.register({
+    foo: asValue('bar'),
+    inst: asClass(FooClass),
+    fn: asFunction(fn)
+  });
+
+  let foo: 'bar' = container.cradle.foo;
+  // $ExpectError
+  let foo: 'bar2' = container.cradle.foo;
+  let inst: FooClass = container.cradle.inst;
+  // $ExpectError
+  let inst2: Class<FooClass> = container.cradle.inst;
+  let fn2: 123 = container.cradle.fn;
+  // $ExpectError
+  let fn3: 122 = container.cradle.fn;
+
+  let fn4: 123 = container.resolve('fn');
+  // $ExpectError
+  let fn5: 124 = container.resolve('fn');
+}
+
+function build() {
+  let container = awilix.createContainer();
+  let asFunction = awilix.asFunction;
+
+  let t: true = container.build(() => true);
+
+  // $ExpectError
+  let f: true = container.build(() => false);
+
+  // $ExpectError
+  t = container.build(true);
+
+  class Foo {
+  }
+
+  let f: Foo = container.build(Foo);
+}


### PR DESCRIPTION
Hey there!

I made a typedef for Awilix v2 (latest).   It's more useful than the current TS file because it actually captures parameters passed to registration functions and forwards type information into the cradle, but you have to modify the type signature of the reference yourself because it doesn't seem to be possible to change `this` inside a libdef.  So `container = createContainer().register(...)` is type-aware but `container = createContainer(); container.register(...)` is not :(

It's tested as well and the tests pass.

Let me know if there's anything I need to do to get this bad boy merged!