### PR TITLE
Add type definition for joi-to-json-schema v3.2.x

### DIFF
--- a/definitions/npm/joi-to-json-schema_v3.2.x/flow_v0.34.x-/joi-to-json-schema_v3.2.x.js
+++ b/definitions/npm/joi-to-json-schema_v3.2.x/flow_v0.34.x-/joi-to-json-schema_v3.2.x.js
@@ -1,0 +1,12 @@
+declare type joiToJsonSchema$json = {
+  [string]: boolean | string | number | joiToJsonSchema$json
+};
+
+declare type joiToJsonSchema$joiToJsonSchema = (
+  schema: Object,
+  transformer: ?(joiToJsonSchema$json) => joiToJsonSchema$json
+) => joiToJsonSchema$json;
+
+declare module "joi-to-json-schema" {
+  declare module.exports: joiToJsonSchema$joiToJsonSchema;
+}

--- a/definitions/npm/joi-to-json-schema_v3.2.x/test_joi-to-json-schema_v3.2.x.js
+++ b/definitions/npm/joi-to-json-schema_v3.2.x/test_joi-to-json-schema_v3.2.x.js
@@ -1,0 +1,11 @@
+const convert = require("joi-to-json-schema");
+
+convert({});
+
+convert({}, obj => {
+  obj.foo = "bar";
+  return obj;
+});
+
+// $ExpectError
+convert();


### PR DESCRIPTION
Hey there!

I'm back with another lib def, this one is real small.

I couldn't type hint the first arg which should be `npm$joi$ObjectSchema` but the joi libdef is not in scope and it doesn't seem there's any way to get it added to the test that I can find.  Let me know if there's something I can do to get the Joi type definition in scope in this libdef.

Thanks!