### PR TITLE
koa-router: Allow multiple middlewares for verb methods, fix middleware definition

### DIFF
--- a/definitions/npm/koa-router_v7.2.x/flow_v0.25.x-/koa-router_v7.2.x.js
+++ b/definitions/npm/koa-router_v7.2.x/flow_v0.25.x-/koa-router_v7.2.x.js
@@ -27,42 +27,70 @@ declare module "koa-router" {
       route: string | string[],
       handler: KoaRouter$Middleware
     ): this;
-    get(route: string | string[], handler: KoaRouter$Middleware): this;
+    get(
+      route: string | string[],
+      ...middleware: Array<KoaRouter$Middleware>
+    ): this;
 
     patch(
       name: string,
       route: string | string[],
       handler: KoaRouter$Middleware
     ): this;
-    patch(route: string | string[], handler: KoaRouter$Middleware): this;
+    patch(
+      route: string | string[],
+      ...middleware: Array<KoaRouter$Middleware>
+    ): this;
 
     post(
       name: string,
       route: string | string[],
       handler: KoaRouter$Middleware
     ): this;
-    post(route: string | string[], handler: KoaRouter$Middleware): this;
+    post(
+      route: string | string[],
+      ...middleware: Array<KoaRouter$Middleware>
+    ): this;
 
     put(
       name: string,
       route: string | string[],
       handler: KoaRouter$Middleware
     ): this;
-    put(route: string | string[], handler: KoaRouter$Middleware): this;
+    put(
+      route: string | string[],
+      ...middleware: Array<KoaRouter$Middleware>
+    ): this;
 
     delete(
       name: string,
       route: string | string[],
       handler: KoaRouter$Middleware
     ): this;
-    delete(route: string | string[], handler: KoaRouter$Middleware): this;
+    delete(
+      route: string | string[],
+      ...middleware: Array<KoaRouter$Middleware>
+    ): this;
 
     del(
       name: string,
       route: string | string[],
       handler: KoaRouter$Middleware
     ): this;
-    del(route: string | string[], handler: KoaRouter$Middleware): this;
+    del(
+      route: string | string[],
+      ...middleware: Array<KoaRouter$Middleware>
+    ): this;
+
+    all(
+      name: string,
+      route: string | string[],
+      handler: KoaRouter$Middleware
+    ): this;
+    all(
+      route: string | string[],
+      ...middleware: Array<KoaRouter$Middleware>
+    ): this;
 
     use(...middleware: Array<KoaRouter$Middleware>): this;
     use(

--- a/definitions/npm/koa-router_v7.2.x/flow_v0.25.x-/koa-router_v7.2.x.js
+++ b/definitions/npm/koa-router_v7.2.x/flow_v0.25.x-/koa-router_v7.2.x.js
@@ -4,13 +4,13 @@
 
 type KoaRouter$Middleware = (
   ctx: any,
-  next: () => void | Promise<void>
+  next: () => Promise<void>
 ) => Promise<void> | void;
 
 type KoaRouter$ParamMiddleware = (
   param: string,
   ctx: any,
-  next: () => void | Promise<void>
+  next: () => Promise<void>
 ) => Promise<void> | void;
 
 declare module "koa-router" {

--- a/definitions/npm/koa-router_v7.2.x/test_koa-router_v7.2.x.js
+++ b/definitions/npm/koa-router_v7.2.x/test_koa-router_v7.2.x.js
@@ -25,11 +25,12 @@ const goodRouter = new Router({ prefix: "/api" });
  */
 
 // $ExpectError
-goodRouter.get("/");
+goodRouter.get(10);
 goodRouter.get("/", async ctx => {
   ctx.body = "Hello World";
 });
 goodRouter.get(["/", "/foo"], ctx => {});
+goodRouter.get(["/", "/foo"], ctx => {}, ctx => {});
 
 // $ExpectError
 goodRouter.use(10);


### PR DESCRIPTION
`koa-router` allows passing multiple middleware to verb methods:

```javascript
router.get('/route', middleware(), (ctx) => {})
```

Additionally, `next` in a middleware should always return a `Promise<void>`.