### PR TITLE
Better angular 1.4.7 types

### DIFF
--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -119,7 +119,7 @@ declare module angular {
 
   declare function module(
     name: string,
-    deps: ?Array<Dependency>
+    deps?: ?Array<Dependency>
   ): AngularModule
 
   declare function element(html: string | Element | Document): JqliteElement

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -94,7 +94,7 @@ declare module angular {
 
   declare type ValueDeclaration = (
     name: string,
-    di: $npm$angular$DependencyInjection<(...a: Array<mixed>) => Object>,
+    value: mixed,
   ) => AngularModule
 
   declare type ConstantDeclaration = (

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -77,6 +77,11 @@ declare module angular {
     di: $npm$angular$DependencyInjection<(...a: Array<mixed>) => Object>,
   ) => AngularModule
 
+  declare type FilterDeclaration = (
+    name: string,
+    di: $npm$angular$DependencyInjection<(...a: Array<*>) => Function>,
+  ) => AngularModule
+
   declare type ServiceDeclaration = (
     name: string,
     di: $npm$angular$DependencyInjection<(...a: Array<mixed>) => Function>,
@@ -103,6 +108,7 @@ declare module angular {
     run: RunDeclaration,
     config: ConfigDeclaration,
     factory: FactoryDeclaration,
+    filter: FilterDeclaration,
     service: ServiceDeclaration,
     value: ValueDeclaration,
     constant: ConstantDeclaration,

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -102,7 +102,7 @@ declare module angular {
     di: $npm$angular$DependencyInjection<(...a: Array<mixed>) => Object>,
   ) => AngularModule
 
-  declare type AngularModule = {
+  declare type AngularModule = {|
     controller: ControllerDeclaration,
     directive: DirectiveDeclaration,
     run: RunDeclaration,
@@ -113,7 +113,7 @@ declare module angular {
     value: ValueDeclaration,
     constant: ConstantDeclaration,
     name: string,
-  }
+  |}
 
   declare type Dependency = AngularModule | string
 

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -7,6 +7,8 @@
 
 declare module angular {
 
+  declare type ScopeBindings = '<' | '=' | '&' | '<?' | '=?' | '&?' | '=ngModel';
+  declare type Scope = {[key: string]: ScopeBindings};
   declare type ControllerFunction = (...a: Array<*>) => void;
 
   // I'm not sure how represent this properly: Angular DI declarations are a
@@ -46,20 +48,22 @@ declare module angular {
   // TODO: Expand to cover the whole matrix of AECM, in any order. Probably
   // should write something to handle it.
   declare type DirectiveRestrict = 'A' | 'E' | 'AE' | 'EA'
-  declare type Directive = {
-    restrict?: string,
+  declare type Directive = {|
+    restrict?: DirectiveRestrict,
     template?: string,
     templateUrl?: string,
-    scope?: mixed,
-    controller?: $npm$angular$DependencyInjection<*>,
+    scope?: Scope,
+    controller?: ControllerFunction,
     link?: AngularLinkFunction,
+    controllerAs?: string,
+    bindToController?: boolean,
     // TODO: flesh out this definition
     compile?: (...a: any) => AngularCompileLink,
-  }
+  |}
 
   declare type DirectiveDeclaration = (
     name: string,
-    di: $npm$angular$DependencyInjection<(...a: Array<mixed>) => Directive>,
+    di: $npm$angular$DependencyInjection<(...a: Array<*>) => Directive>,
   ) => AngularModule
 
 

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -122,12 +122,18 @@ declare module angular {
     deps: ?Array<Dependency>
   ): AngularModule
 
-  declare function element(html: string | Element): JqliteElement
+  declare function element(html: string | Element | Document): JqliteElement
   declare function copy<T>(object: T): T
-  declare function extend<T>(dst: T, src: Object): T
-  declare function forEach<T>(obj: Array<T>, iterator: (value: T, key: string) => void): void
 
+  declare function extend<A, B>(a: A, b: B): A & B;
+  declare function extend<A, B, C>(a: A, b: B, c: C): A & B & C;
+  declare function extend<A, B, C, D>(a: A, b: B, c: C, d: D): A & B & C & D;
+  declare function extend<A, B, C, D, E>(a: A, b: B, c: C, d: D, e: E): A & B & C & D & E;
 
+  declare function forEach<T>(obj: Object | Array<T>, iterator: (value: T, key: string) => void): void;
+  declare function fromJson(json: string): Object | Array<*> | string | number;
+  declare function toJson(obj: Object | Array<any> | string | Date | number | boolean, pretty?: boolean | number): string;
+  declare function isDefined(val: any): boolean;
   declare type AngularQ = {
     when: <T>(value: T) => AngularPromise<T>,
   }

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -80,7 +80,7 @@ declare module angular {
 
   declare type FactoryDeclaration = (
     name: string,
-    di: $npm$angular$DependencyInjection<(...a: Array<mixed>) => Object>,
+    di: $npm$angular$DependencyInjection<(...a: Array<*>) => Object>,
   ) => AngularModule
 
   declare type FilterDeclaration = (
@@ -154,7 +154,7 @@ declare module angular {
   //****************************************************************************
 
   declare type AngularMock = {
-    inject: (...a: Array<mixed>) => Function,
+    inject: (...a: Array<*>) => Function,
     module: (...a: Array<string | Function | Object>) => () => void
   }
   declare var mock: AngularMock

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -138,6 +138,7 @@ declare module angular {
 
   declare type AngularMock = {
     inject: (...a: Array<mixed>) => Function,
+    module: (...a: Array<string | Function | Object>) => () => void
   }
   declare var mock: AngularMock
 

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -84,7 +84,7 @@ declare module angular {
 
   declare type ServiceDeclaration = (
     name: string,
-    di: $npm$angular$DependencyInjection<(...a: Array<mixed>) => Function>,
+    di: $npm$angular$DependencyInjection<(...a: Array<*>) => Function | Object>,
   ) => AngularModule
 
   declare type RunDeclaration = (

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -26,12 +26,12 @@ declare module angular {
     injector: Function,
   }
 
-  declare function AngularLinkFunction(
-    scope: mixed,
+  declare type AngularLinkFunction = (
+    scope: $Scope<*>,
     element: JqliteElement,
     attrs: mixed,
     controller: mixed
-  ): void
+  ) => void
 
   declare type AngularCompileLink = {
     post?: AngularLinkFunction,

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -69,7 +69,7 @@ declare module angular {
 
   declare type ConfigDeclaration = (
     name: string,
-    di: $npm$angular$DependencyInjection<*>,
+    di: $npm$angular$DependencyInjection<(...a: Array<*>) => void>,
   ) => AngularModule
 
   declare type FactoryDeclaration = (

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -42,7 +42,7 @@ declare module angular {
   declare function CompileFunction(
     element: JqliteElement,
     attrs: mixed,
-    controller: mixed
+    controller: ControllerFunction
   ): AngularLinkFunction
 
   // TODO: Expand to cover the whole matrix of AECM, in any order. Probably

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -14,6 +14,9 @@ declare module angular {
   // I'm not sure how represent this properly: Angular DI declarations are a
   // list of strings with a single function at the end. The function can vary,
   // so it is a type param.
+  //
+  // NOTE: if you use compile step to mangle array, replace below with
+  // declare type $npm$angular$DependencyInjection<T> = T
   declare type $npm$angular$DependencyInjection<T> = Array<string | T>
 
   // Extending Array<Element> allows us to do the `jq[0]` expression and friends

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -7,7 +7,9 @@
 
 declare module angular {
 
-  declare type ScopeBindings = '<' | '=' | '&' | '<?' | '=?' | '&?' | '=ngModel';
+  // NOTE: if you don't use named scope bindings, remove string type in the end
+  // for stricter types
+  declare type ScopeBindings = '<' | '=' | '&' | '<?' | '=?' | '&?' | string;
   declare type Scope = {[key: string]: ScopeBindings};
   declare type ControllerFunction = (...a: Array<*>) => void;
 

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -88,8 +88,7 @@ declare module angular {
   ) => AngularModule
 
   declare type RunDeclaration = (
-    name: string,
-    di: $npm$angular$DependencyInjection<void>,
+    fn: $npm$angular$DependencyInjection<(...a: Array<*>) => void>,
   ) => AngularModule
 
   declare type ValueDeclaration = (

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -7,6 +7,8 @@
 
 declare module angular {
 
+  declare type ControllerFunction = (...a: Array<*>) => void;
+
   // I'm not sure how represent this properly: Angular DI declarations are a
   // list of strings with a single function at the end. The function can vary,
   // so it is a type param.
@@ -63,7 +65,7 @@ declare module angular {
 
   declare type ControllerDeclaration = (
     name: string,
-    di: $npm$angular$DependencyInjection<*>,
+    di: $npm$angular$DependencyInjection<ControllerFunction>,
   ) => AngularModule
 
 

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -240,4 +240,6 @@ declare module angular {
     $parent: $Scope<*>,
     $root: $Scope<*>
   |} & T;
+
+  declare type $Timeout = (fn?: Function, delay?: number, invokeApply?: boolean, additionalParams?: *) => AngularPromise<*>
 }

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/angular_v1.4.7.js
@@ -99,7 +99,7 @@ declare module angular {
 
   declare type ConstantDeclaration = (
     name: string,
-    di: $npm$angular$DependencyInjection<(...a: Array<mixed>) => Object>,
+    value: mixed,
   ) => AngularModule
 
   declare type AngularModule = {|

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_timeout_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_timeout_v1.4.7.js
@@ -1,0 +1,25 @@
+// @flow
+import type {$Timeout, AngularPromise} from 'angular';
+
+function testTimeout($timeout: $Timeout) {
+  //can be called without arguments
+  $timeout();
+  //first argument is a function
+  $timeout(() => {});
+  //$ExpectError takes in only function as first argument
+  $timeout(123);
+  //second argument is number
+  $timeout(() => {}, 123);
+  //$ExpectError takes in only number as second argument
+  $timeout(() => {}, '123');
+  //third argument is boolean
+  $timeout(() => {}, 123, true);
+  //$ExpectError takes in only number as third argument
+  $timeout(() => {}, 123, 'text');
+  //fourth argument can be anything
+  $timeout(() => {}, 123, true, 123);
+  $timeout(() => {}, 123, true, 'text');
+  $timeout(() => {}, 123, true, {});
+  //returns back angular promise
+  ($timeout(): AngularPromise<*>);
+}

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
@@ -99,6 +99,11 @@ describe('filter', () => {
 
 })
 
+describe('filter', () => {
+  it('can be declared', () => {
+    angular.module('foo', []).run(['bar', 'bazz', (bar, bazz) => {}])
+  })
+})
 
 describe('value', () => {
   it('can be declared to any value', () => {

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
@@ -85,6 +85,20 @@ describe('factory', () => {
 
 })
 
+describe('filter', () => {
+  it('can be declared', () => {
+    angular.module('foo', []).filter('foo', ['bar', 'bazz', (bar, bazz) => {
+      return () => {};
+    }])
+  })
+
+  it('requires a return value of some kind', () => {
+    // $ExpectError cant return object
+    angular.module('foo', []).filter('foo', ['bar', 'bazz', () => ({})])
+  })
+
+})
+
 describe('value', () => {
   it('can be declared', () => {
     angular.module('foo', []).value('foo', ['bar', 'bazz', (bar, bazz) => {

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
@@ -98,6 +98,12 @@ describe('factory', () => {
 
 })
 
+describe('controller', () => {
+  it('can be declared', () => {
+    angular.module('foo', []).controller('foo', ['bar', 'bazz', (bar, bazz) => {}])
+  })
+})
+
 describe('config', () => {
   it('can be declared', () => {
     angular.module('foo', []).config('foo', ['bar', 'bazz', (bar, bazz) => {}])

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
@@ -88,18 +88,6 @@ describe('directives', () => {
       }
     }])
   })
-
-  it('scope does not accept bad binding direction markings', () => {
-    angular.module('foo', []).directive('foo', ['bar', 'bazz', (bar, bazz) => {
-      // $ExpectError
-      return {
-        templateUrl: 'foo.html',
-        scope: {
-          prop: 'this is not accepted'
-        }
-      }
-    }])
-  })
 })
 
 describe('service', () => {

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
@@ -99,18 +99,15 @@ describe('filter', () => {
 
 })
 
-describe('value', () => {
-  it('can be declared', () => {
-    angular.module('foo', []).value('foo', ['bar', 'bazz', (bar, bazz) => {
-      return { a: bar, b: bazz }
-    }])
-  })
 
-  it('requires a return value of some kind', () => {
-    // $ExpectError undefined. This type is incompatible with
-    angular.module('foo', []).value('foo', ['bar', 'bazz', (bar, bazz) => {}])
+describe('value', () => {
+  it('can be declared to any value', () => {
+    angular.module('foo', []).value('foo', 123)
+    angular.module('foo', []).value('foo', 'str')
+    angular.module('foo', []).value('foo', {})
   })
 })
+
 
 describe('constant', () => {
   it('can be declared to any value', () => {

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
@@ -54,6 +54,52 @@ describe('directives', () => {
       return 'this is clearly not a directive'
     }])
   })
+
+  it('requires proper restrict when defined', () => {
+    angular.module('foo', []).directive('foo', ['bar', 'bazz', (bar, bazz) => {
+      // $ExpectError
+      return {
+        restrict: 'fails to this',
+        templateUrl: 'foo.html',
+      }
+    }])
+  })
+
+  it('does not accept random properties', () => {
+    angular.module('foo', []).directive('foo', ['bar', 'bazz', (bar, bazz) => {
+      // $ExpectError
+      return {
+        random: 'prop which is not allowed',
+        templateUrl: 'foo.html',
+      }
+    }])
+  })
+
+  it('all bells and whistles for directive', () => {
+    angular.module('foo', []).directive('foo', ['bar', 'bazz', (bar, bazz) => {
+      return {
+        bindToController: true,
+        controllerAs: 'ctrl',
+        templateUrl: 'foo.html',
+        scope: {
+          prop: '<'
+        },
+        controller: () => {}
+      }
+    }])
+  })
+
+  it('scope does not accept bad binding direction markings', () => {
+    angular.module('foo', []).directive('foo', ['bar', 'bazz', (bar, bazz) => {
+      // $ExpectError
+      return {
+        templateUrl: 'foo.html',
+        scope: {
+          prop: 'this is not accepted'
+        }
+      }
+    }])
+  })
 })
 
 describe('service', () => {

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
@@ -239,6 +239,23 @@ describe('$q', () => {
   })
 })
 
+describe("mock", () => {
+  describe("module", () => {
+    it("takes strings, functions and objects", () => {
+      angular.mock.module("string", () => {}, {});
+    });
+
+    it("does not accept numbers", () => {
+      //$ExpectError
+      angular.mock.module(123);
+    });
+
+    it("returns a function", () => {
+      angular.mock.module("string", {})();
+    });
+  });
+});
+
 describe('$http', () => {
   it('can POST', () => {
     angular.mock.inject(($http: AngularHttpService) => {

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
@@ -113,17 +113,10 @@ describe('value', () => {
 })
 
 describe('constant', () => {
-  it('can be declared', () => {
-    angular.module('foo', []).constant('foo', ['bar', 'bazz', (bar, bazz) => {
-      return { a: bar, b: bazz }
-    }])
-  })
-
-  it('requires a return value of some kind', () => {
-    // $ExpectError undefined. This type is incompatible with
-    angular.module('foo', []).constant('foo', ['bar', 'bazz', (bar, bazz) => {
-      // intentionally return nothing
-    }])
+  it('can be declared to any value', () => {
+    angular.module('foo', []).constant('foo', 123)
+    angular.module('foo', []).constant('foo', 'str')
+    angular.module('foo', []).constant('foo', {})
   })
 })
 

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
@@ -98,6 +98,13 @@ describe('factory', () => {
 
 })
 
+describe('config', () => {
+  it('can be declared', () => {
+    angular.module('foo', []).config('foo', ['bar', 'bazz', (bar, bazz) => {}])
+  })
+
+})
+
 describe('filter', () => {
   it('can be declared', () => {
     angular.module('foo', []).filter('foo', ['bar', 'bazz', (bar, bazz) => {

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_angular_v1.4.7.js
@@ -63,10 +63,23 @@ describe('service', () => {
     }])
   })
 
-  it('requires a return value of a function', () => {
+  it('can return object', () => {
     angular.module('foo', []).service('foo', ['bar', 'bazz', (bar, bazz) => {
-      // $ExpectError object. This type is incompatible with Function
       return { foo: 'bar' }
+    }])
+  })
+
+  it('can return function', () => {
+    angular.module('foo', []).service('foo', ['bar', 'bazz', (bar, bazz) => {
+      return () => {};
+    }])
+  })
+
+
+  it('cant return other types', () => {
+    angular.module('foo', []).service('foo', ['bar', 'bazz', (bar, bazz) => {
+      //$ExpectError
+      return 123;
     }])
   })
 })

--- a/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_utility_functions_v1.4.7.js
+++ b/definitions/npm/angular_v1.4.7/flow_v0.47.x-/test_utility_functions_v1.4.7.js
@@ -1,0 +1,64 @@
+// @flow
+
+import angular, {type JqliteElement} from 'angular'
+
+function testElement() {
+  //accepts string
+  angular.element('str');
+  // accepts document
+  angular.element(document);
+  // returns JqLite object
+  (angular.element(document): JqliteElement);
+}
+
+function testCopy() {
+  //returns given type
+  (angular.copy('str'): string);
+  (angular.copy(123): number);
+  (angular.copy({a: 123}).a: number);
+}
+
+function testExtend() {
+  // extends object type
+  (angular.extend({a: 1}, {b: 2}): {a: number, b: number});
+  (angular.extend({a: 1}, {b: 2}, {c: 'str', d: 123}): {a: number, b: number, c: string, d: number});
+}
+
+function testForEach() {
+  //accepts object
+  angular.forEach({}, () => {});
+  // accepts array
+  angular.forEach([], () => {});
+  //$ExpectError does not accept anything else
+  angular.forEach(123, () => {});
+
+  // callback gets array stuff in
+  angular.forEach([1,2,3], (val) => {
+    (val: number)
+  });
+
+  // key is string
+  angular.forEach([1,2,3], (val, key) => {
+    (key: string)
+  });
+}
+
+function testFromJson() {
+  // accepts string
+  angular.fromJson('')
+  //$ExpectError does not take in other types
+  angular.fromJson(123)
+}
+
+function testToJson() {
+  // returns string
+  (angular.toJson({}): string)
+  // takes boolean as second argument
+  angular.toJson({}, true)
+  // takes number as second argument
+  angular.toJson({}, 123)
+  //$ExpectError does not take anything else as second argument
+  angular.toJson({}, '')
+  //$ExpectError cannot be called without parameters
+  angular.toJson()
+}


### PR DESCRIPTION
Plenty of enhancements for angular 1.x libdefs. These are the types we currently use at Smartly for angular. So not perfect, but better. Some utility function types missing etc.
Some of the commits have link to appropriate angular documentation to make reviewing slightly easier.

ping @LoganBarnett 