### PR TITLE
include $ReadOnlyArray in the array types that reduce accepts

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
@@ -976,21 +976,21 @@ declare module ramda {
 
   declare function reverse<T, V: Array<T> | string>(xs: V): V;
 
-  declare function reduce<A, B>(
-    fn: (acc: A, elem: B) => A,
-    ...rest: Array<void>
-  ): ((init: A, xs: Array<B>) => A) &
-    ((init: A, ...rest: Array<void>) => (xs: Array<B>) => A);
-  declare function reduce<A, B>(
-    fn: (acc: A, elem: B) => A,
-    init: A,
-    ...rest: Array<void>
-  ): (xs: Array<B>) => A;
-  declare function reduce<A, B>(
-    fn: (acc: A, elem: B) => A,
-    init: A,
-    xs: Array<B>
-  ): A;
+  declare type Reduce = (<A, B>(
+    fn: (acc: A, elm: B) => A
+  ) => ((init: A) => (xs: Array<B> | $ReadOnlyArray<B>) => A) &
+    ((init: A, xs: Array<B> | $ReadOnlyArray<B>) => A)) &
+    (<A, B>(
+      fn: (acc: A, elm: B) => A,
+      init: A
+    ) => (xs: Array<B> | $ReadOnlyArray<B>) => A) &
+    (<A, B>(
+      fn: (acc: A, elm: B) => A,
+      init: A,
+      xs: Array<B> | $ReadOnlyArray<B>
+    ) => A);
+
+  declare var reduce: Reduce;
 
   declare function reduceBy<A, B>(
     fn: (acc: B, elem: A) => B,

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_list.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_list.js
@@ -209,6 +209,12 @@ const str: string = "hello world";
   const redxs2: Array<string> = reduce(_.concat, [])(_.map(x => [x], ss));
   // Example used in docs: http://ramdajs.com/docs/#reduce
   const redxs4: number = reduce(subtract, 0, [1, 2, 3, 4]);
+  // Using accumulator type that differs from the element type (A and B).
+  const redxs5: number = reduce((acc, s) => acc + parseInt(s), 0, [
+    "1",
+    "2",
+    "3"
+  ]);
 
   // Ramda works with $ReadOnlyArray as it is immutable.
   const readOnlyArray: $ReadOnlyArray<number> = [1, 2, 3, 4];

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_list.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_list.js
@@ -1,6 +1,16 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from "ramda";
+import _, {
+  compose,
+  pipe,
+  curry,
+  filter,
+  find,
+  reduce,
+  repeat,
+  subtract,
+  zipWith
+} from "ramda";
 
 const ns: Array<number> = [1, 2, 3, 4, 5];
 const ss: Array<string> = ["one", "two", "three", "four"];
@@ -193,34 +203,50 @@ const str: string = "hello world";
   const ys4: Array<string> = _.repeat("1", 10);
   const ys5: Array<number> = _.repeat(1, 10);
 
-  const redxs: number = _.reduce(_.add, 10, ns);
-  const redxs1: string = _.reduce(_.concat, "", ss);
-  const redxs2: Array<string> = _.reduce(_.concat, [])(_.map(x => [x], ss));
-  const redxs3: number = _.reduceRight(_.add, 10, ns);
-  const redxs4: string = _.reduceRight(_.concat, "", ss);
-  const redxs5: Array<string> = _.reduceRight(_.concat, [])(
+  // reduce
+  const redxs: number = reduce(_.add, 10, ns);
+  const redxs1: string = reduce(_.concat, "", ss);
+  const redxs2: Array<string> = reduce(_.concat, [])(_.map(x => [x], ss));
+  // Example used in docs: http://ramdajs.com/docs/#reduce
+  const redxs4: number = reduce(subtract, 0, [1, 2, 3, 4]);
+
+  // Ramda works with $ReadOnlyArray as it is immutable.
+  const readOnlyArray: $ReadOnlyArray<number> = [1, 2, 3, 4];
+  // $ReadOnlyArray with curried permutations:
+  const redxsReadOnly3: number = reduce(subtract, 0, readOnlyArray);
+  const redxsReadOnly2_1: number = reduce(subtract, 0)(readOnlyArray);
+  const redxsReadOnly1_2: number = reduce(subtract)(0, readOnlyArray);
+  const redxsReadOnly1_1_1: number = reduce(subtract)(0)(readOnlyArray);
+
+  // $ExpectError reduce will not work with an object.
+  reduce(subtract, 0, { foo: 1, bar: 2 });
+
+  // reduceRight
+  const redrxs1: number = _.reduceRight(_.add, 10, ns);
+  const redrxs2: string = _.reduceRight(_.concat, "", ss);
+  const redrxs3: Array<string> = _.reduceRight(_.concat, [])(
     _.map(x => [x], ss)
   );
   //$ExpectError
-  const redxs5a: string = _.reduceRight(
+  const redrxs3a: string = _.reduceRight(
     (acc: string, value: number): string => acc,
     "",
     ns
   );
-  const redxs5b: string = _.reduceRight(
+  const redrxs3b: string = _.reduceRight(
     (value: number, acc: string): string => acc,
     "",
     ns
   );
 
-  const redxs6: Array<number> = _.scan(_.add)(10)(ns);
-  const redxs7: Array<number> = _.scan(_.add, 10)(ns);
-  const redxs8: Array<number> = _.scan(_.add)(10, ns);
-  const redxs9: Array<number> = _.scan(_.add, 10, ns);
-  const redxs10: Array<string> = _.scan(_.concat)("")(ss);
-  const redxs11: Array<string> = _.scan(_.concat, "")(ss);
-  const redxs12: Array<string> = _.scan(_.concat)("", ss);
-  const redxs13: Array<string> = _.scan(_.concat, "", ss);
+  const scanxs6: Array<number> = _.scan(_.add)(10)(ns);
+  const scanxs7: Array<number> = _.scan(_.add, 10)(ns);
+  const scanxs8: Array<number> = _.scan(_.add)(10, ns);
+  const scanxs9: Array<number> = _.scan(_.add, 10, ns);
+  const scanxs10: Array<string> = _.scan(_.concat)("")(ss);
+  const scanxs11: Array<string> = _.scan(_.concat, "")(ss);
+  const scanxs12: Array<string> = _.scan(_.concat)("", ss);
+  const scanxs13: Array<string> = _.scan(_.concat, "", ss);
 
   const reduceToNamesBy = _.reduceBy(
     (acc, student) => acc.concat(student.name),


### PR DESCRIPTION
Prompted by a discussion [here](https://github.com/facebook/flow/issues/5457), I came across some issues with feeding `$ReadOnlyArray` to `reduce`. Since Ramda assumes immutability, I've added support of `$ReadOnlyArray` to `reduce`.

Side effects of this PR include:
1. Renaming output variables of `reduceRight` and `scan` to not overlap with `reduce`'s output variables.
2. Adding a negative test for `reduce`.
3. Using an example from the documentation for `reduce`.
4. Using the `declare type Foo = curried1_1_1 & curried1_2 & curried2_1 & curried_3 ...` form over `declare function`.
5. Removing the rest args as a means of ignoring unused arguments in `reduce`.

CC @AndrewSouthpaw due to recent work with Ramda's libdefs.