### PR TITLE
fix(npm/rxjs_v5.0.x/flow_v0.34.x): mixin Observer with Observable for Subject

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -1333,19 +1333,17 @@ declare interface rxjs$Operator<T, R> {
   call(subscriber: rxjs$Subscriber<R>, source: any): rxjs$TeardownLogic;
 }
 
-// FIXME(samgoldman) should be `mixins rxjs$Observable<T>, rxjs$Observer<T>`
-// once Babel parsing support exists: https://phabricator.babeljs.io/T6821
-declare class rxjs$Subject<T> extends rxjs$Observable<T> {
+declare class rxjs$Subject<T> extends rxjs$Observable<T> mixins rxjs$Observer<T> {
+  static create<T>(
+    destination: rxjs$Observer<T>,
+    source: rxjs$Observable<T>
+  ): rxjs$AnonymousSubject<T>;
+
   asObservable(): rxjs$Observable<T>;
 
   observers: Array<rxjs$Observer<T>>;
 
   unsubscribe(): void;
-
-  // Copied from rxjs$Observer<T>
-  next(value: T): mixed;
-  error(error: any): mixed;
-  complete(): mixed;
 
   // For use in subclasses only:
   _next(value: T): void;


### PR DESCRIPTION
This extends the RxJS Subject to mixin RxJS Observer while also adding the correct definition of `Subject.create`.

The mentioned issue, https://phabricator.babeljs.io/T6821, now lives at https://github.com/babel/babel/issues/3871 and was fixed in https://github.com/facebook/flow/commit/b72d1c61487f9e95ddbe68c4f994d9699b7b71c9 as referenced in https://github.com/babel/babel/issues/3871.

/cc @samwgoldman @jayphelps