### PR TITLE
fix(filterLibDefs): fix scoped packages bug

### DIFF
--- a/cli/src/lib/npm/npmLibDefs.js
+++ b/cli/src/lib/npm/npmLibDefs.js
@@ -334,8 +334,9 @@ function filterLibDefs(
       let filterMatch = false;
       switch (filter.type) {
         case 'exact':
+          const fullName = def.scope ? `${def.scope}/${def.name}` : def.name;
           filterMatch =
-            filter.pkgName.toLowerCase() === def.name.toLowerCase() &&
+            filter.pkgName.toLowerCase() === fullName.toLowerCase() &&
             pkgVersionMatch(filter.pkgVersion, def.version);
           break;
         default:


### PR DESCRIPTION
I discovered while working on another PR that the logic in filterLibDefs filters out all valid matches for a scoped package.