### PR TITLE
fix(sequelize): add missing Model methods

### DIFF
--- a/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/sequelize_v4.x.x.js
+++ b/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/sequelize_v4.x.x.js
@@ -3891,6 +3891,9 @@ declare module "sequelize" {
       ThroughAttributes, Through
     >,
 
+    static getAssociations<Target: Model<any>>(model: Class<Target>): Array<Association<this, Target>>;
+    static getAssociationForAlias<Target: Model<any>>(model: Class<Target>, alias: ?string): ?Association<this, Target>;
+
     static associations: {[name: string]: Association<this, any>},
     static tableName: string,
     static rawAttributes: {[name: string]: Attribute},

--- a/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/test_sequelize.js
+++ b/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/test_sequelize.js
@@ -227,6 +227,9 @@ Customer.belongsToMany(Branch, { through: 'branchCustomer' });
 (Warehouse.attributes.blah.type: DataTypeAbstract);
 (Warehouse.primaryKeys.blah.type: DataTypeAbstract);
 
+Warehouse.getAssociations(WarehouseBranch)
+Warehouse.getAssociationForAlias(WarehouseBranch, 'blah')
+
 // hasOne
 product.getBarcode();
 product.getBarcode({ scope: null }).then(b => b && b.code);


### PR DESCRIPTION
adds the `getAssociations` and `getAssociationForAlias` methods to `Model`