### PR TITLE
Fix lodash toPairs/toPairsIn/entries/entriesIn

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.28.x-v0.37.x/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.28.x-v0.37.x/lodash_v4.x.x.js
@@ -722,9 +722,9 @@ declare module "lodash" {
     defaults(object?: ?Object, ...sources?: Array<Object>): Object;
     defaultsDeep(object?: ?Object, ...sources?: Array<Object>): Object;
     // alias for _.toPairs
-    entries(object?: ?Object): NestedArray<any>;
+    entries(object?: ?Object): Array<[string, any]>;
     // alias for _.toPairsIn
-    entriesIn(object?: ?Object): NestedArray<any>;
+    entriesIn(object?: ?Object): Array<[string, any]>;
     // alias for _.assignIn
     extend<A, B>(a: A, b: B): A & B;
     extend<A, B, C>(a: A, b: B, c: C): A & B & C;
@@ -888,8 +888,8 @@ declare module "lodash" {
       value: any,
       customizer?: (nsValue: any, key: string, nsObject: T) => any
     ): Object;
-    toPairs(object?: ?Object | Array<*>): NestedArray<any>;
-    toPairsIn(object?: ?Object): NestedArray<any>;
+    toPairs(object?: ?Object | Array<*>): Array<[string, any]>;
+    toPairsIn(object?: ?Object): Array<[string, any]>;
     transform(
       collection: Object | Array<any>,
       iteratee?: OIteratee<*>,

--- a/definitions/npm/lodash_v4.x.x/flow_v0.28.x-v0.37.x/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.28.x-v0.37.x/test_lodash-v4.x.x.js
@@ -233,3 +233,7 @@ timesNums = _.times(5, function(i: number) { return JSON.stringify(i); });
 // https://github.com/facebook/flow/issues/1948
 _.flatMap([1, 2, 3], (n): number[] => [n, n]);
 _.flatMap({a: 1, b: 2}, n => [n, n]);
+
+var pairs: [string, number][];
+pairs = _.toPairs({ a: 12, b: 100 });
+pairs = _.toPairsIn({ a: 12, b: 100 });

--- a/definitions/npm/lodash_v4.x.x/flow_v0.38.x-v0.46.x/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.38.x-v0.46.x/lodash_v4.x.x.js
@@ -744,9 +744,9 @@ declare module "lodash" {
     defaults(object?: ?Object, ...sources?: Array<Object>): Object;
     defaultsDeep(object?: ?Object, ...sources?: Array<Object>): Object;
     // alias for _.toPairs
-    entries(object?: ?Object): NestedArray<any>;
+    entries(object?: ?Object): Array<[string, any]>;
     // alias for _.toPairsIn
-    entriesIn(object?: ?Object): NestedArray<any>;
+    entriesIn(object?: ?Object): Array<[string, any]>;
     // alias for _.assignIn
     extend<A, B>(a: A, b: B): A & B;
     extend<A, B, C>(a: A, b: B, c: C): A & B & C;
@@ -910,8 +910,8 @@ declare module "lodash" {
       value: any,
       customizer?: (nsValue: any, key: string, nsObject: T) => any
     ): Object;
-    toPairs(object?: ?Object | Array<*>): NestedArray<any>;
-    toPairsIn(object?: ?Object): NestedArray<any>;
+    toPairs(object?: ?Object | Array<*>): Array<[string, any]>;
+    toPairsIn(object?: ?Object): Array<[string, any]>;
     transform(
       collection: Object | Array<any>,
       iteratee?: OIteratee<*>,

--- a/definitions/npm/lodash_v4.x.x/flow_v0.38.x-v0.46.x/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.38.x-v0.46.x/test_lodash-v4.x.x.js
@@ -28,6 +28,8 @@ import defaultTo from 'lodash/defaultTo';
 import tap from 'lodash/tap';
 import thru from 'lodash/thru';
 import times from 'lodash/times';
+import toPairs from "lodash/toPairs";
+import toPairsIn from "lodash/toPairsIn";
 import flatMap from 'lodash/flatMap';
 
 /**
@@ -375,3 +377,10 @@ noop('a', 2, [], null);
 (noop: (number, string) => void);
 // $ExpectError functions are contravariant in return types
 (noop: (string) => string);
+
+/**
+ * _.toPairs / _.toPairsIn
+ */
+var pairs: [string, number][];
+pairs = toPairs({ a: 12, b: 100 });
+pairs = toPairsIn({ a: 12, b: 100 });

--- a/definitions/npm/lodash_v4.x.x/flow_v0.47.x-v0.54.x/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.47.x-v0.54.x/lodash_v4.x.x.js
@@ -958,9 +958,9 @@ declare module "lodash" {
     defaults(object?: ?Object, ...sources?: Array<Object>): Object;
     defaultsDeep(object?: ?Object, ...sources?: Array<Object>): Object;
     // alias for _.toPairs
-    entries(object?: ?Object): NestedArray<any>;
+    entries(object?: ?Object): Array<[string, any]>;
     // alias for _.toPairsIn
-    entriesIn(object?: ?Object): NestedArray<any>;
+    entriesIn(object?: ?Object): Array<[string, any]>;
     // alias for _.assignIn
     extend<A, B>(a: A, b: B): A & B;
     extend<A, B, C>(a: A, b: B, c: C): A & B & C;
@@ -1124,8 +1124,8 @@ declare module "lodash" {
       value: any,
       customizer?: (nsValue: any, key: string, nsObject: T) => any
     ): Object;
-    toPairs(object?: ?Object | Array<*>): NestedArray<any>;
-    toPairsIn(object?: ?Object): NestedArray<any>;
+    toPairs(object?: ?Object | Array<*>): Array<[string, any]>;
+    toPairsIn(object?: ?Object): Array<[string, any]>;
     transform(
       collection: Object | Array<any>,
       iteratee?: OIteratee<*>,
@@ -2604,9 +2604,9 @@ declare module "lodash/fp" {
     defaultsDeep(source: Object, object: Object): Object;
     defaultsDeepAll(objects: Array<Object>): Object;
     // alias for _.toPairs
-    entries(object: Object): NestedArray<any>;
+    entries(object: Object): Array<[string, any]>;
     // alias for _.toPairsIn
-    entriesIn(object: Object): NestedArray<any>;
+    entriesIn(object: Object): Array<[string, any]>;
     // alias for _.assignIn
     extend<A, B>(a: A): (b: B) => A & B;
     extend<A, B>(a: A, b: B): A & B;
@@ -2861,8 +2861,8 @@ declare module "lodash/fp" {
       value: any,
       object: T
     ): Object;
-    toPairs(object: Object | Array<*>): NestedArray<any>;
-    toPairsIn(object: Object): NestedArray<any>;
+    toPairs(object: Object | Array<*>): Array<[string, any]>;
+    toPairsIn(object: Object): Array<[string, any]>;
     transform(
       iteratee: OIteratee<*>
     ): ((accumulator: any) => (collection: Object | Array<any>) => any) &

--- a/definitions/npm/lodash_v4.x.x/flow_v0.47.x-v0.54.x/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.47.x-v0.54.x/test_lodash-v4.x.x.js
@@ -29,6 +29,8 @@ import defaultTo from 'lodash/defaultTo';
 import tap from 'lodash/tap';
 import thru from 'lodash/thru';
 import times from 'lodash/times';
+import toPairs from "lodash/toPairs";
+import toPairsIn from "lodash/toPairsIn";
 import flatMap from 'lodash/flatMap';
 
 /**
@@ -399,3 +401,10 @@ noop('a', 2, [], null);
 (noop: (number, string) => void);
 // $ExpectError functions are contravariant in return types
 (noop: (string) => string);
+
+/**
+ * _.toPairs / _.toPairsIn
+ */
+var pairs: [string, number][];
+pairs = toPairs({ a: 12, b: 100 });
+pairs = toPairsIn({ a: 12, b: 100 });

--- a/definitions/npm/lodash_v4.x.x/flow_v0.55.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.55.x-/lodash_v4.x.x.js
@@ -880,9 +880,9 @@ declare module "lodash" {
     defaults(object?: ?Object, ...sources?: Array<Object>): Object;
     defaultsDeep(object?: ?Object, ...sources?: Array<Object>): Object;
     // alias for _.toPairs
-    entries(object?: ?Object): NestedArray<any>;
+    entries(object?: ?Object): Array<[string, any]>;
     // alias for _.toPairsIn
-    entriesIn(object?: ?Object): NestedArray<any>;
+    entriesIn(object?: ?Object): Array<[string, any]>;
     // alias for _.assignIn
     extend<A, B>(a: A, b: B): A & B;
     extend<A, B, C>(a: A, b: B, c: C): A & B & C;
@@ -1046,8 +1046,8 @@ declare module "lodash" {
       value: any,
       customizer?: (nsValue: any, key: string, nsObject: T) => any
     ): Object;
-    toPairs(object?: ?Object | Array<*>): NestedArray<any>;
-    toPairsIn(object?: ?Object): NestedArray<any>;
+    toPairs(object?: ?Object | Array<*>): Array<[string, any]>;
+    toPairsIn(object?: ?Object): Array<[string, any]>;
     transform(
       collection: Object | Array<any>,
       iteratee?: OIteratee<*>,
@@ -2454,9 +2454,9 @@ declare module "lodash/fp" {
     defaultsDeep(source: Object, object: Object): Object;
     defaultsDeepAll(objects: Array<Object>): Object;
     // alias for _.toPairs
-    entries(object: Object): NestedArray<any>;
+    entries(object: Object): Array<[string, any]>;
     // alias for _.toPairsIn
-    entriesIn(object: Object): NestedArray<any>;
+    entriesIn(object: Object): Array<[string, any]>;
     // alias for _.assignIn
     extend<A, B>(a: A): (b: B) => A & B;
     extend<A, B>(a: A, b: B): A & B;
@@ -2711,8 +2711,8 @@ declare module "lodash/fp" {
       value: any,
       object: T
     ): Object;
-    toPairs(object: Object | Array<*>): NestedArray<any>;
-    toPairsIn(object: Object): NestedArray<any>;
+    toPairs(object: Object | Array<*>): Array<[string, any]>;
+    toPairsIn(object: Object): Array<[string, any]>;
     transform(
       iteratee: OIteratee<*>
     ): ((accumulator: any) => (collection: Object | Array<any>) => any) &

--- a/definitions/npm/lodash_v4.x.x/flow_v0.55.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.55.x-/test_lodash-v4.x.x.js
@@ -28,6 +28,8 @@ import sortedLastIndexBy from "lodash/sortedLastIndexBy";
 import tap from "lodash/tap";
 import thru from "lodash/thru";
 import times from "lodash/times";
+import toPairs from "lodash/toPairs";
+import toPairsIn from "lodash/toPairsIn";
 import unionBy from "lodash/unionBy";
 import uniqBy from "lodash/uniqBy";
 import xorBy from "lodash/xorBy";
@@ -412,3 +414,10 @@ memoized = memoize(() => {});
 var debounced: (a: number) => string = debounce((a: number) => "foo");
 // $ExpectError debounce retains type information
 debounced = debounce(() => {});
+
+/**
+ * _.toPairs / _.toPairsIn
+ */
+var pairs: [string, number][];
+pairs = toPairs({ a: 12, b: 100 });
+pairs = toPairsIn({ a: 12, b: 100 });


### PR DESCRIPTION
Fixes #656 
Replaces #1629 

`_.toPairs` takes an object and returns an array of key-value tuples ([docs](https://lodash.com/docs/4.17.4#toPairs)). 

The old libdef defined the return value as `NestedArray<T> = Array<Array<T>>`, which is too strict because an object can have non-string values (the key will always be string type). 

``` js 
var o = {
  a: 12, 
  b: 100,
};

// This fails, because Flow expects pairs to be [string][]
var pairs: [string, number][] = _.toPairs(o); // => [['a', 12], ['b', 100]]
```

All credit to @ZhangYiJiang