### PR TITLE
R.indexOf accepts void type.

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/ramda_v0.x.x.js
@@ -640,9 +640,9 @@ declare module ramda {
     input: A
   ): R;
 
-  declare function indexOf<E>(x: E, xs: Array<E>): number;
+  declare function indexOf<E>(x: ?E, xs: Array<E>): number;
   declare function indexOf<E>(
-    x: E,
+    x: ?E,
     ...rest: Array<void>
   ): (xs: Array<E>) => number;
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_list.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-/test_ramda_v0.x.x_list.js
@@ -118,7 +118,6 @@ const str: string = "hello world";
 
   const ind: number = _.indexOf(1, ns);
   const ind1: number = _.indexOf(str)(ss);
-
   const ind2: { [key: string]: { [k: string]: number | string } } = _.indexBy(
     x => "s",
     os
@@ -126,6 +125,7 @@ const str: string = "hello world";
   const ind3: { [key: string]: { [k: string]: number | string } } = _.indexBy(
     x => "s"
   )(os);
+  const ind4: number = _.indexOf(null)(ss);
 
   const insxs: Array<number> = _.insert(1, 2, ns);
   const insxs2: Array<string> = _.insert(1, "2", ss);


### PR DESCRIPTION
Although undocumented, `R.indexOf` accepts `null` and `undefined` as search terms. It is actually useful to check for a void type inside an array, so I think loosening the definition in this case makes sense.

@LoganBarnett 