### PR TITLE
Rxjs add missing definitions 'partition' and 'window*'

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
@@ -475,6 +475,11 @@ declare class rxjs$Observable<+T> {
 
   pairwise(): rxjs$Observable<[T, T]>;
 
+  partition(
+    predicate: (value: T, index?: number) => boolean,
+    thisArg: any
+  ): [rxjs$Observable<T>, rxjs$Observable<T>];
+
   publish(): rxjs$ConnectableObservable<T>;
 
   publishLast(): rxjs$ConnectableObservable<T>;

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
@@ -1039,6 +1039,21 @@ declare class rxjs$Observable<+T> {
     resultSelector: (...values: Array<any>) => A
   ): rxjs$Observable<A>;
 
+  window(
+    windowBoundaries: rxjs$Observable<any>
+  ): rxjs$Observable<rxjs$Observable<T>>;
+  windowCount(
+    windowSize: number,
+    startWindowEvery?: number
+  ): rxjs$Observable<rxjs$Observable<T>>;
+  windowToggle<A>(
+    openings: rxjs$Observable<A>,
+    closingSelector: (value: A) => rxjs$Observable<any>
+  ): rxjs$Observable<rxjs$Observable<T>>;
+  windowWhen(
+    closingSelector: () => rxjs$Observable<any>
+  ): rxjs$Observable<rxjs$Observable<T>>;
+
   withLatestFrom<A>(a: rxjs$Observable<A>): rxjs$Observable<[T, A]>;
 
   withLatestFrom<A, B>(

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -606,6 +606,11 @@ declare class rxjs$Observable<+T> {
 
   pairwise(): rxjs$Observable<[T, T]>;
 
+  partition(
+    predicate: (value: T, index: number) => boolean,
+    thisArg: any
+  ): [rxjs$Observable<T>, rxjs$Observable<T>];
+
   pipe(): rxjs$Observable<T>;
 
   pipe<A>(op1: rxjs$OperatorFunctionLast<T, A>): A;

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -1227,6 +1227,21 @@ declare class rxjs$Observable<+T> {
     resultSelector: (...values: Array<any>) => A
   ): rxjs$Observable<A>;
 
+  window(
+    windowBoundaries: rxjs$Observable<any>
+  ): rxjs$Observable<rxjs$Observable<T>>;
+  windowCount(
+    windowSize: number,
+    startWindowEvery?: number
+  ): rxjs$Observable<rxjs$Observable<T>>;
+  windowToggle<A>(
+    openings: rxjs$Observable<A>,
+    closingSelector: (value: A) => rxjs$Observable<any>
+  ): rxjs$Observable<rxjs$Observable<T>>;
+  windowWhen(
+    closingSelector: () => rxjs$Observable<any>
+  ): rxjs$Observable<rxjs$Observable<T>>;
+
   withLatestFrom<A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<[T, A]>;
 
   withLatestFrom<A, B>(

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -32,6 +32,9 @@ strings.elementAt(1, 5);
 (Observable.of(numbers, numbers).concatAll(): Observable<number>);
 
 // (numbers.pairwise(): Observable<Array<number>>);
+
+(numbers.partition(x => x % 2 === 0): [Observable<number>, Observable<number>]);
+
 (numbers.skipWhile(x => true): Observable<number>);
 
 // $ExpectError -- need the typecast or the error appears at the declaration site

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -145,6 +145,28 @@ const numberOrString: Observable<number | string> = numbers.concat(strings);
 // $ExpectError
 (Observable.of(2).startWith(1, "2", 3): Observable<number>);
 
+(numbers.window(Observable.interval(100)): Observable<Observable<number>>);
+// $ExpectError
+(numbers.window(Observable.interval(100)): Observable<Observable<string>>);
+
+(numbers.windowCount(3): Observable<Observable<number>>);
+(numbers.windowCount(2, 3): Observable<Observable<number>>);
+
+(numbers.windowToggle(
+  Observable.interval(100),
+  i => (i % 2 ? Observable.interval(500) : Observable.empty())
+): Observable<Observable<number>>);
+(numbers.windowToggle(
+  Observable.interval(100),
+  // $ExpectError
+  Observable.interval(500)
+): Observable<Observable<number>>);
+(numbers.windowWhen(() => Observable.interval(100)): Observable<
+  Observable<number>
+>);
+// $ExpectError
+(numbers.windowWhen(Observable.interval(100)): Observable<Observable<number>>);
+
 (numbers.withLatestFrom(strings): Observable<[number, string]>);
 // $ExpectError
 (numbers.withLatestFrom(numbers): Observable<[number, string]>);


### PR DESCRIPTION
http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-partition
http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-window
http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-windowCount
http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-windowToggle
http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-windowWhen