### PR TITLE
correct react routers Prompt component type

### DIFF
--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.53.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.53.x-/react-router-dom_v4.x.x.js
@@ -115,7 +115,7 @@ declare module "react-router-dom" {
   }> {}
 
   declare export class Prompt extends React$Component<{
-    message: string | ((location: Location) => string | true),
+    message: string | ((location: Location) => string | boolean),
     when?: boolean
   }> {}
 


### PR DESCRIPTION
since `history` version 4.0.0-1 not only true but also false is allowed as a parameter for `block()`
see release note https://github.com/ReactTraining/history/blob/master/CHANGES.md#v400-1

therefore it is also allowed as the message parameter for the Prompt Component