### PR TITLE
Add definitions for jest v22.x.x

### DIFF
--- a/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/jest_v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/jest_v22.x.x.js
@@ -1,0 +1,539 @@
+type JestMockFn = {
+  (...args: Array<any>): any,
+  /**
+   * An object for introspecting mock calls
+   */
+  mock: {
+    /**
+     * An array that represents all calls that have been made into this mock
+     * function. Each call is represented by an array of arguments that were
+     * passed during the call.
+     */
+    calls: Array<Array<any>>,
+    /**
+     * An array that contains all the object instances that have been
+     * instantiated from this mock function.
+     */
+    instances: mixed
+  },
+  /**
+   * Resets all information stored in the mockFn.mock.calls and
+   * mockFn.mock.instances arrays. Often this is useful when you want to clean
+   * up a mock's usage data between two assertions.
+   */
+  mockClear(): Function,
+  /**
+   * Resets all information stored in the mock. This is useful when you want to
+   * completely restore a mock back to its initial state.
+   */
+  mockReset(): Function,
+  /**
+   * Removes the mock and restores the initial implementation. This is useful
+   * when you want to mock functions in certain test cases and restore the
+   * original implementation in others. Beware that mockFn.mockRestore only
+   * works when mock was created with jest.spyOn. Thus you have to take care of
+   * restoration yourself when manually assigning jest.fn().
+   */
+  mockRestore(): Function,
+  /**
+   * Accepts a function that should be used as the implementation of the mock.
+   * The mock itself will still record all calls that go into and instances
+   * that come from itself -- the only difference is that the implementation
+   * will also be executed when the mock is called.
+   */
+  mockImplementation(fn: Function): JestMockFn,
+  /**
+   * Accepts a function that will be used as an implementation of the mock for
+   * one call to the mocked function. Can be chained so that multiple function
+   * calls produce different results.
+   */
+  mockImplementationOnce(fn: Function): JestMockFn,
+  /**
+   * Just a simple sugar function for returning `this`
+   */
+  mockReturnThis(): void,
+  /**
+   * Deprecated: use jest.fn(() => value) instead
+   */
+  mockReturnValue(value: any): JestMockFn,
+  /**
+   * Sugar for only returning a value once inside your mock
+   */
+  mockReturnValueOnce(value: any): JestMockFn
+};
+
+type JestAsymmetricEqualityType = {
+  /**
+   * A custom Jasmine equality tester
+   */
+  asymmetricMatch(value: mixed): boolean
+};
+
+type JestCallsType = {
+  allArgs(): mixed,
+  all(): mixed,
+  any(): boolean,
+  count(): number,
+  first(): mixed,
+  mostRecent(): mixed,
+  reset(): void
+};
+
+type JestClockType = {
+  install(): void,
+  mockDate(date: Date): void,
+  tick(milliseconds?: number): void,
+  uninstall(): void
+};
+
+type JestMatcherResult = {
+  message?: string | (() => string),
+  pass: boolean
+};
+
+type JestMatcher = (actual: any, expected: any) => JestMatcherResult;
+
+type JestPromiseType = {
+  /**
+   * Use rejects to unwrap the reason of a rejected promise so any other
+   * matcher can be chained. If the promise is fulfilled the assertion fails.
+   */
+  rejects: JestExpectType,
+  /**
+   * Use resolves to unwrap the value of a fulfilled promise so any other
+   * matcher can be chained. If the promise is rejected the assertion fails.
+   */
+  resolves: JestExpectType
+};
+
+/**
+ *  Plugin: jest-enzyme
+ */
+type EnzymeMatchersType = {
+  toBeChecked(): void,
+  toBeDisabled(): void,
+  toBeEmpty(): void,
+  toBePresent(): void,
+  toContainReact(element: React$Element<any>): void,
+  toHaveClassName(className: string): void,
+  toHaveHTML(html: string): void,
+  toHaveProp(propKey: string, propValue?: any): void,
+  toHaveRef(refName: string): void,
+  toHaveState(stateKey: string, stateValue?: any): void,
+  toHaveStyle(styleKey: string, styleValue?: any): void,
+  toHaveTagName(tagName: string): void,
+  toHaveText(text: string): void,
+  toIncludeText(text: string): void,
+  toHaveValue(value: any): void,
+  toMatchElement(element: React$Element<any>): void,
+  toMatchSelector(selector: string): void
+};
+
+type JestExpectType = {
+  not: JestExpectType & EnzymeMatchersType,
+  /**
+   * If you have a mock function, you can use .lastCalledWith to test what
+   * arguments it was last called with.
+   */
+  lastCalledWith(...args: Array<any>): void,
+  /**
+   * toBe just checks that a value is what you expect. It uses === to check
+   * strict equality.
+   */
+  toBe(value: any): void,
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toBeCalled(): void,
+  /**
+   * Use .toBeCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toBeCalledWith(...args: Array<any>): void,
+  /**
+   * Using exact equality with floating point numbers is a bad idea. Rounding
+   * means that intuitive things fail.
+   */
+  toBeCloseTo(num: number, delta: any): void,
+  /**
+   * Use .toBeDefined to check that a variable is not undefined.
+   */
+  toBeDefined(): void,
+  /**
+   * Use .toBeFalsy when you don't care what a value is, you just want to
+   * ensure a value is false in a boolean context.
+   */
+  toBeFalsy(): void,
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThan.
+   */
+  toBeGreaterThan(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThanOrEqual.
+   */
+  toBeGreaterThanOrEqual(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeLessThan.
+   */
+  toBeLessThan(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeLessThanOrEqual.
+   */
+  toBeLessThanOrEqual(number: number): void,
+  /**
+   * Use .toBeInstanceOf(Class) to check that an object is an instance of a
+   * class.
+   */
+  toBeInstanceOf(cls: Class<*>): void,
+  /**
+   * .toBeNull() is the same as .toBe(null) but the error messages are a bit
+   * nicer.
+   */
+  toBeNull(): void,
+  /**
+   * Use .toBeTruthy when you don't care what a value is, you just want to
+   * ensure a value is true in a boolean context.
+   */
+  toBeTruthy(): void,
+  /**
+   * Use .toBeUndefined to check that a variable is undefined.
+   */
+  toBeUndefined(): void,
+  /**
+   * Use .toContain when you want to check that an item is in a list. For
+   * testing the items in the list, this uses ===, a strict equality check.
+   */
+  toContain(item: any): void,
+  /**
+   * Use .toContainEqual when you want to check that an item is in a list. For
+   * testing the items in the list, this matcher recursively checks the
+   * equality of all fields, rather than checking for object identity.
+   */
+  toContainEqual(item: any): void,
+  /**
+   * Use .toEqual when you want to check that two objects have the same value.
+   * This matcher recursively checks the equality of all fields, rather than
+   * checking for object identity.
+   */
+  toEqual(value: any): void,
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toHaveBeenCalled(): void,
+  /**
+   * Use .toHaveBeenCalledTimes to ensure that a mock function got called exact
+   * number of times.
+   */
+  toHaveBeenCalledTimes(number: number): void,
+  /**
+   * Use .toHaveBeenCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toHaveBeenCalledWith(...args: Array<any>): void,
+  /**
+   * Use .toHaveBeenLastCalledWith to ensure that a mock function was last called
+   * with specific arguments.
+   */
+  toHaveBeenLastCalledWith(...args: Array<any>): void,
+  /**
+   * Check that an object has a .length property and it is set to a certain
+   * numeric value.
+   */
+  toHaveLength(number: number): void,
+  /**
+   *
+   */
+  toHaveProperty(propPath: string, value?: any): void,
+  /**
+   * Use .toMatch to check that a string matches a regular expression or string.
+   */
+  toMatch(regexpOrString: RegExp | string): void,
+  /**
+   * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
+   */
+  toMatchObject(object: Object | Array<Object>): void,
+  /**
+   * This ensures that a React component matches the most recent snapshot.
+   */
+  toMatchSnapshot(name?: string): void,
+  /**
+   * Use .toThrow to test that a function throws when it is called.
+   * If you want to test that a specific error gets thrown, you can provide an
+   * argument to toThrow. The argument can be a string for the error message,
+   * a class for the error, or a regex that should match the error.
+   *
+   * Alias: .toThrowError
+   */
+  toThrow(message?: string | Error | RegExp): void,
+  toThrowError(message?: string | Error | RegExp): void,
+  /**
+   * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
+   * matching the most recent snapshot when it is called.
+   */
+  toThrowErrorMatchingSnapshot(): void
+};
+
+type JestObjectType = {
+  /**
+   *  Disables automatic mocking in the module loader.
+   *
+   *  After this method is called, all `require()`s will return the real
+   *  versions of each module (rather than a mocked version).
+   */
+  disableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of disableAutomock
+   */
+  autoMockOff(): JestObjectType,
+  /**
+   * Enables automatic mocking in the module loader.
+   */
+  enableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of enableAutomock
+   */
+  autoMockOn(): JestObjectType,
+  /**
+   * Clears the mock.calls and mock.instances properties of all mocks.
+   * Equivalent to calling .mockClear() on every mocked function.
+   */
+  clearAllMocks(): JestObjectType,
+  /**
+   * Resets the state of all mocks. Equivalent to calling .mockReset() on every
+   * mocked function.
+   */
+  resetAllMocks(): JestObjectType,
+  /**
+   * Removes any pending timers from the timer system.
+   */
+  clearAllTimers(): void,
+  /**
+   * The same as `mock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  doMock(moduleName: string, moduleFactory?: any): JestObjectType,
+  /**
+   * The same as `unmock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  dontMock(moduleName: string): JestObjectType,
+  /**
+   * Returns a new, unused mock function. Optionally takes a mock
+   * implementation.
+   */
+  fn(implementation?: Function): JestMockFn,
+  /**
+   * Determines if the given function is a mocked function.
+   */
+  isMockFunction(fn: Function): boolean,
+  /**
+   * Given the name of a module, use the automatic mocking system to generate a
+   * mocked version of the module for you.
+   */
+  genMockFromModule(moduleName: string): any,
+  /**
+   * Mocks a module with an auto-mocked version when it is being required.
+   *
+   * The second argument can be used to specify an explicit module factory that
+   * is being run instead of using Jest's automocking feature.
+   *
+   * The third argument can be used to create virtual mocks -- mocks of modules
+   * that don't exist anywhere in the system.
+   */
+  mock(
+    moduleName: string,
+    moduleFactory?: any,
+    options?: Object
+  ): JestObjectType,
+  /**
+   * Returns the actual module instead of a mock, bypassing all checks on
+   * whether the module should receive a mock implementation or not.
+   */
+  requireActual(moduleName: string): any,
+  /**
+   * Returns a mock module instead of the actual module, bypassing all checks
+   * on whether the module should be required normally or not.
+   */
+  requireMock(moduleName: string): any,
+  /**
+   * Resets the module registry - the cache of all required modules. This is
+   * useful to isolate modules where local state might conflict between tests.
+   */
+  resetModules(): JestObjectType,
+  /**
+   * Exhausts the micro-task queue (usually interfaced in node via
+   * process.nextTick).
+   */
+  runAllTicks(): void,
+  /**
+   * Exhausts the macro-task queue (i.e., all tasks queued by setTimeout(),
+   * setInterval(), and setImmediate()).
+   */
+  runAllTimers(): void,
+  /**
+   * Exhausts all tasks queued by setImmediate().
+   */
+  runAllImmediates(): void,
+  /**
+   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+   * or setInterval() and setImmediate()).
+   */
+  runTimersToTime(msToRun: number): void,
+  /**
+   * Executes only the macro-tasks that are currently pending (i.e., only the
+   * tasks that have been queued by setTimeout() or setInterval() up to this
+   * point)
+   */
+  runOnlyPendingTimers(): void,
+  /**
+   * Explicitly supplies the mock object that the module system should return
+   * for the specified module. Note: It is recommended to use jest.mock()
+   * instead.
+   */
+  setMock(moduleName: string, moduleExports: any): JestObjectType,
+  /**
+   * Indicates that the module system should never return a mocked version of
+   * the specified module from require() (e.g. that it should always return the
+   * real module).
+   */
+  unmock(moduleName: string): JestObjectType,
+  /**
+   * Instructs Jest to use fake versions of the standard timer functions
+   * (setTimeout, setInterval, clearTimeout, clearInterval, nextTick,
+   * setImmediate and clearImmediate).
+   */
+  useFakeTimers(): JestObjectType,
+  /**
+   * Instructs Jest to use the real versions of the standard timer functions.
+   */
+  useRealTimers(): JestObjectType,
+  /**
+   * Creates a mock function similar to jest.fn but also tracks calls to
+   * object[methodName].
+   */
+  spyOn(object: Object, methodName: string): JestMockFn,
+  /**
+   * Set the default timeout interval for tests and before/after hooks in milliseconds.
+   * Note: The default timeout interval is 5 seconds if this method is not called.
+   */
+  setTimeout(timeout: number): JestObjectType
+};
+
+type JestSpyType = {
+  calls: JestCallsType
+};
+
+/** Runs this function after every test inside this context */
+declare function afterEach(fn: Function): void;
+/** Runs this function before every test inside this context */
+declare function beforeEach(fn: Function): void;
+/** Runs this function after all tests have finished inside this context */
+declare function afterAll(fn: Function): void;
+/** Runs this function before any tests have started inside this context */
+declare function beforeAll(fn: Function): void;
+
+/** A context for grouping tests together */
+declare var describe: {
+  /**
+   * Creates a block that groups together several related tests in one "test suite"
+   */
+  (name: string, fn: Function): void,
+
+  /**
+   * Only run this describe block
+   */
+  only(name: string, fn: Function): void,
+
+  /**
+   * Skip running this describe block
+   */
+  skip(name: string, fn: Function): void
+};
+
+/** An individual test unit */
+declare var it: {
+  /**
+   * An individual test unit
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   */
+  (name: string, fn?: Function): ?Promise<void>,
+  /**
+   * Only run this test
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   */
+  only(name: string, fn?: Function): ?Promise<void>,
+  /**
+   * Skip running this test
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   */
+  skip(name: string, fn?: Function): ?Promise<void>,
+  /**
+   * Run the test concurrently
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   */
+  concurrent(name: string, fn?: Function): ?Promise<void>
+};
+declare function fit(name: string, fn: Function): ?Promise<void>;
+/** An individual test unit */
+declare var test: typeof it;
+/** A disabled group of tests */
+declare var xdescribe: typeof describe;
+/** A focused group of tests */
+declare var fdescribe: typeof describe;
+/** A disabled individual test */
+declare var xit: typeof it;
+/** A disabled individual test */
+declare var xtest: typeof it;
+
+/** The expect function is used every time you want to test a value */
+declare var expect: {
+  /** The object that you want to make assertions against */
+  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType,
+  /** Add additional Jasmine matchers to Jest's roster */
+  extend(matchers: { [name: string]: JestMatcher }): void,
+  /** Add a module that formats application-specific data structures. */
+  addSnapshotSerializer(serializer: (input: Object) => string): void,
+  assertions(expectedAssertions: number): void,
+  hasAssertions(): void,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): void,
+  arrayContaining(value: Array<mixed>): void,
+  objectContaining(value: Object): void,
+  /** Matches any received string that contains the exact expected string. */
+  stringContaining(value: string): void,
+  stringMatching(value: string | RegExp): void
+};
+
+// TODO handle return type
+// http://jasmine.github.io/2.4/introduction.html#section-Spies
+declare function spyOn(value: mixed, method: string): Object;
+
+/** Holds all functions related to manipulating test runner */
+declare var jest: JestObjectType;
+
+/**
+ * The global Jasmine object, this is generally not exposed as the public API,
+ * using features inside here could break in later versions of Jest.
+ */
+declare var jasmine: {
+  DEFAULT_TIMEOUT_INTERVAL: number,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): void,
+  arrayContaining(value: Array<mixed>): void,
+  clock(): JestClockType,
+  createSpy(name: string): JestSpyType,
+  createSpyObj(
+    baseName: string,
+    methodNames: Array<string>
+  ): { [methodName: string]: JestSpyType },
+  objectContaining(value: Object): void,
+  stringMatching(value: string): void
+};

--- a/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/test_jest-v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/test_jest-v22.x.x.js
@@ -1,0 +1,209 @@
+/* @flow */
+/* eslint-disable */
+
+jest.autoMockOff();
+jest.clearAllMocks();
+jest.resetAllMocks();
+
+// $ExpectError property `atoMockOff` not found in object type
+jest.atoMockOff();
+
+const mockFn = jest.fn();
+mockFn.mock.calls.map(String).map(a => a + a);
+
+expect(1).toEqual(1);
+expect(true).toBe(true);
+expect(5).toBeGreaterThan(3);
+expect(5).toBeLessThan(8);
+expect("jester").toContain("jest");
+expect({ foo: "bar" }).toHaveProperty("foo");
+expect({ foo: "bar" }).toHaveProperty("foo", "bar");
+expect("foo").toMatchSnapshot("snapshot name");
+expect({ foo: "bar" }).toMatchObject({ baz: "qux" });
+expect("foobar").toMatch(/foo/);
+expect("foobar").toMatch("foo");
+
+mockFn("a");
+expect("someVal").toBeCalled();
+expect("someVal").toBeCalledWith("a");
+
+// $ExpectError property `toHaveBeeenCalledWith` not found in object type
+expect("someVal").toHaveBeeenCalledWith("a");
+
+// $ExpectError property `fn` not found in Array
+mockFn.mock.calls.fn();
+
+describe("name", () => {});
+describe.only("name", () => {});
+describe.skip("name", () => {});
+
+test("test", () => expect("foo").toMatchSnapshot());
+test.only("test", () => expect("foo").toMatchSnapshot());
+test.skip("test", () => expect("foo").toMatchSnapshot());
+
+// $ExpectError property `fonly` not found in object type
+test.fonly("test", () => expect("foo").toMatchSnapshot());
+
+xtest("test", () => {});
+
+// $ExpectError property `bar` not found in object type
+expect.bar();
+
+expect.extend({
+  blah(actual, expected) {
+    return {
+      message: () => "blah fail",
+      pass: false
+    };
+  }
+});
+
+expect.extend({
+  foo(actual, expected) {
+    // $ExpectError property `pass` not found in object literal
+    return {};
+  }
+});
+
+const err = new Error("err");
+expect(() => {
+  throw err;
+}).toThrowError("err");
+
+expect(() => {
+  throw err;
+}).toThrowError(/err/);
+
+expect(() => {
+  throw err;
+}).toThrowError(err);
+
+expect(() => {}).toThrow("err");
+expect(() => {}).toThrow(/err/);
+expect(() => {}).toThrow(err);
+
+// Test method chaining fixes
+jest.doMock("testModule1", () => {}).doMock("testModule2", () => {});
+
+jest.dontMock("testModule1").dontMock("testModule2");
+
+jest.resetModules().resetModules();
+
+jest.spyOn({}, "foo");
+
+jest.setTimeout(1000);
+
+expect.addSnapshotSerializer(JSON.stringify);
+expect.assertions(1);
+expect.hasAssertions();
+
+expect.anything();
+expect.any(Error);
+expect.objectContaining({
+  foo: "bar"
+});
+expect.arrayContaining(["red", "blue"]);
+expect.stringMatching("*this part*");
+
+test.concurrent("test", () => {});
+
+expect([1, 2, 3]).toHaveLength(3);
+
+(async () => {
+  await expect(Promise.reject("ok")).rejects.toBe("ok");
+  await expect(Promise.resolve("ok")).resolves.toBe("ok");
+})();
+
+/**
+ *  Plugin: jest-enzyme
+ */
+
+// $ExpectError
+import { shallow } from "enzyme";
+const Dummy = () => <div />;
+const wrapper = shallow(<Dummy />);
+
+expect(wrapper).toBeChecked();
+
+expect(wrapper).toBeDisabled();
+
+expect(wrapper).toBeEmpty();
+
+expect(wrapper).toBePresent();
+
+expect(wrapper).toContainReact(<Dummy />);
+// $ExpectError
+expect(wrapper).toContainReact();
+// $ExpectError
+expect(wrapper).toContainReact("string");
+
+expect(wrapper).toHaveClassName("class");
+// $ExpectError
+expect(wrapper).toHaveClassName();
+// $ExpectError
+expect(wrapper).toHaveClassName(true);
+
+expect(wrapper).toHaveHTML("<span>test</span>");
+// $ExpectError
+expect(wrapper).toHaveHTML();
+// $ExpectError
+expect(wrapper).toHaveHTML(true);
+
+expect(wrapper).toHaveProp("test");
+expect(wrapper).toHaveProp("test", "test");
+// $ExpectError
+expect(wrapper).toHaveProp();
+// $ExpectError
+expect(wrapper).toHaveProp(true);
+
+expect(wrapper).toHaveRef("test");
+// $ExpectError
+expect(wrapper).toHaveRef();
+// $ExpectError
+expect(wrapper).toHaveRef(true);
+
+expect(wrapper).toHaveState("test");
+expect(wrapper).toHaveState("test", "test");
+// $ExpectError
+expect(wrapper).toHaveState();
+// $ExpectError
+expect(wrapper).toHaveState(true);
+
+expect(wrapper).toHaveStyle("color");
+expect(wrapper).toHaveStyle("color", "#ccc");
+// $ExpectError
+expect(wrapper).toHaveStyle();
+// $ExpectError
+expect(wrapper).toHaveStyle(true);
+
+expect(wrapper).toHaveTagName("marquee");
+// $ExpectError
+expect(wrapper).toHaveTagName();
+// $ExpectError
+expect(wrapper).toHaveTagName(true);
+
+expect(wrapper).toHaveText("test");
+// $ExpectError
+expect(wrapper).toHaveText();
+// $ExpectError
+expect(wrapper).toHaveText(true);
+
+expect(wrapper).toIncludeText("test");
+// $ExpectError
+expect(wrapper).toIncludeText();
+// $ExpectError
+expect(wrapper).toIncludeText(true);
+
+expect(wrapper).toHaveValue("test");
+
+expect(wrapper).toMatchElement(<Dummy />);
+// $ExpectError
+expect(wrapper).toMatchElement();
+// $ExpectError
+expect(wrapper).toMatchElement(true);
+
+expect(wrapper).toMatchSelector("span");
+// $ExpectError
+expect(wrapper).toMatchSelector();
+// $ExpectError
+expect(wrapper).toMatchSelector(true);

--- a/definitions/npm/jest_v22.x.x/flow_v0.39.x-/jest_v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.39.x-/jest_v22.x.x.js
@@ -1,0 +1,581 @@
+type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
+  (...args: TArguments): TReturn,
+  /**
+   * An object for introspecting mock calls
+   */
+  mock: {
+    /**
+     * An array that represents all calls that have been made into this mock
+     * function. Each call is represented by an array of arguments that were
+     * passed during the call.
+     */
+    calls: Array<TArguments>,
+    /**
+     * An array that contains all the object instances that have been
+     * instantiated from this mock function.
+     */
+    instances: Array<TReturn>
+  },
+  /**
+   * Resets all information stored in the mockFn.mock.calls and
+   * mockFn.mock.instances arrays. Often this is useful when you want to clean
+   * up a mock's usage data between two assertions.
+   */
+  mockClear(): void,
+  /**
+   * Resets all information stored in the mock. This is useful when you want to
+   * completely restore a mock back to its initial state.
+   */
+  mockReset(): void,
+  /**
+   * Removes the mock and restores the initial implementation. This is useful
+   * when you want to mock functions in certain test cases and restore the
+   * original implementation in others. Beware that mockFn.mockRestore only
+   * works when mock was created with jest.spyOn. Thus you have to take care of
+   * restoration yourself when manually assigning jest.fn().
+   */
+  mockRestore(): void,
+  /**
+   * Accepts a function that should be used as the implementation of the mock.
+   * The mock itself will still record all calls that go into and instances
+   * that come from itself -- the only difference is that the implementation
+   * will also be executed when the mock is called.
+   */
+  mockImplementation(
+    fn: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Accepts a function that will be used as an implementation of the mock for
+   * one call to the mocked function. Can be chained so that multiple function
+   * calls produce different results.
+   */
+  mockImplementationOnce(
+    fn: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Just a simple sugar function for returning `this`
+   */
+  mockReturnThis(): void,
+  /**
+   * Deprecated: use jest.fn(() => value) instead
+   */
+  mockReturnValue(value: TReturn): JestMockFn<TArguments, TReturn>,
+  /**
+   * Sugar for only returning a value once inside your mock
+   */
+  mockReturnValueOnce(value: TReturn): JestMockFn<TArguments, TReturn>
+};
+
+type JestAsymmetricEqualityType = {
+  /**
+   * A custom Jasmine equality tester
+   */
+  asymmetricMatch(value: mixed): boolean
+};
+
+type JestCallsType = {
+  allArgs(): mixed,
+  all(): mixed,
+  any(): boolean,
+  count(): number,
+  first(): mixed,
+  mostRecent(): mixed,
+  reset(): void
+};
+
+type JestClockType = {
+  install(): void,
+  mockDate(date: Date): void,
+  tick(milliseconds?: number): void,
+  uninstall(): void
+};
+
+type JestMatcherResult = {
+  message?: string | (() => string),
+  pass: boolean
+};
+
+type JestMatcher = (actual: any, expected: any) => JestMatcherResult;
+
+type JestPromiseType = {
+  /**
+   * Use rejects to unwrap the reason of a rejected promise so any other
+   * matcher can be chained. If the promise is fulfilled the assertion fails.
+   */
+  rejects: JestExpectType,
+  /**
+   * Use resolves to unwrap the value of a fulfilled promise so any other
+   * matcher can be chained. If the promise is rejected the assertion fails.
+   */
+  resolves: JestExpectType
+};
+
+/**
+ *  Plugin: jest-enzyme
+ */
+type EnzymeMatchersType = {
+  toBeChecked(): void,
+  toBeDisabled(): void,
+  toBeEmpty(): void,
+  toBePresent(): void,
+  toContainReact(element: React$Element<any>): void,
+  toHaveClassName(className: string): void,
+  toHaveHTML(html: string): void,
+  toHaveProp(propKey: string, propValue?: any): void,
+  toHaveRef(refName: string): void,
+  toHaveState(stateKey: string, stateValue?: any): void,
+  toHaveStyle(styleKey: string, styleValue?: any): void,
+  toHaveTagName(tagName: string): void,
+  toHaveText(text: string): void,
+  toIncludeText(text: string): void,
+  toHaveValue(value: any): void,
+  toMatchElement(element: React$Element<any>): void,
+  toMatchSelector(selector: string): void
+};
+
+type JestExpectType = {
+  not: JestExpectType & EnzymeMatchersType,
+  /**
+   * If you have a mock function, you can use .lastCalledWith to test what
+   * arguments it was last called with.
+   */
+  lastCalledWith(...args: Array<any>): void,
+  /**
+   * toBe just checks that a value is what you expect. It uses === to check
+   * strict equality.
+   */
+  toBe(value: any): void,
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toBeCalled(): void,
+  /**
+   * Use .toBeCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toBeCalledWith(...args: Array<any>): void,
+  /**
+   * Using exact equality with floating point numbers is a bad idea. Rounding
+   * means that intuitive things fail.
+   */
+  toBeCloseTo(num: number, delta: any): void,
+  /**
+   * Use .toBeDefined to check that a variable is not undefined.
+   */
+  toBeDefined(): void,
+  /**
+   * Use .toBeFalsy when you don't care what a value is, you just want to
+   * ensure a value is false in a boolean context.
+   */
+  toBeFalsy(): void,
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThan.
+   */
+  toBeGreaterThan(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThanOrEqual.
+   */
+  toBeGreaterThanOrEqual(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeLessThan.
+   */
+  toBeLessThan(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeLessThanOrEqual.
+   */
+  toBeLessThanOrEqual(number: number): void,
+  /**
+   * Use .toBeInstanceOf(Class) to check that an object is an instance of a
+   * class.
+   */
+  toBeInstanceOf(cls: Class<*>): void,
+  /**
+   * .toBeNull() is the same as .toBe(null) but the error messages are a bit
+   * nicer.
+   */
+  toBeNull(): void,
+  /**
+   * Use .toBeTruthy when you don't care what a value is, you just want to
+   * ensure a value is true in a boolean context.
+   */
+  toBeTruthy(): void,
+  /**
+   * Use .toBeUndefined to check that a variable is undefined.
+   */
+  toBeUndefined(): void,
+  /**
+   * Use .toContain when you want to check that an item is in a list. For
+   * testing the items in the list, this uses ===, a strict equality check.
+   */
+  toContain(item: any): void,
+  /**
+   * Use .toContainEqual when you want to check that an item is in a list. For
+   * testing the items in the list, this matcher recursively checks the
+   * equality of all fields, rather than checking for object identity.
+   */
+  toContainEqual(item: any): void,
+  /**
+   * Use .toEqual when you want to check that two objects have the same value.
+   * This matcher recursively checks the equality of all fields, rather than
+   * checking for object identity.
+   */
+  toEqual(value: any): void,
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toHaveBeenCalled(): void,
+  /**
+   * Use .toHaveBeenCalledTimes to ensure that a mock function got called exact
+   * number of times.
+   */
+  toHaveBeenCalledTimes(number: number): void,
+  /**
+   * Use .toHaveBeenCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toHaveBeenCalledWith(...args: Array<any>): void,
+  /**
+   * Use .toHaveBeenLastCalledWith to ensure that a mock function was last called
+   * with specific arguments.
+   */
+  toHaveBeenLastCalledWith(...args: Array<any>): void,
+  /**
+   * Check that an object has a .length property and it is set to a certain
+   * numeric value.
+   */
+  toHaveLength(number: number): void,
+  /**
+   *
+   */
+  toHaveProperty(propPath: string, value?: any): void,
+  /**
+   * Use .toMatch to check that a string matches a regular expression or string.
+   */
+  toMatch(regexpOrString: RegExp | string): void,
+  /**
+   * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
+   */
+  toMatchObject(object: Object | Array<Object>): void,
+  /**
+   * This ensures that a React component matches the most recent snapshot.
+   */
+  toMatchSnapshot(name?: string): void,
+  /**
+   * Use .toThrow to test that a function throws when it is called.
+   * If you want to test that a specific error gets thrown, you can provide an
+   * argument to toThrow. The argument can be a string for the error message,
+   * a class for the error, or a regex that should match the error.
+   *
+   * Alias: .toThrowError
+   */
+  toThrow(message?: string | Error | Class<Error> | RegExp): void,
+  toThrowError(message?: string | Error | Class<Error> | RegExp): void,
+  /**
+   * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
+   * matching the most recent snapshot when it is called.
+   */
+  toThrowErrorMatchingSnapshot(): void
+};
+
+type JestObjectType = {
+  /**
+   *  Disables automatic mocking in the module loader.
+   *
+   *  After this method is called, all `require()`s will return the real
+   *  versions of each module (rather than a mocked version).
+   */
+  disableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of disableAutomock
+   */
+  autoMockOff(): JestObjectType,
+  /**
+   * Enables automatic mocking in the module loader.
+   */
+  enableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of enableAutomock
+   */
+  autoMockOn(): JestObjectType,
+  /**
+   * Clears the mock.calls and mock.instances properties of all mocks.
+   * Equivalent to calling .mockClear() on every mocked function.
+   */
+  clearAllMocks(): JestObjectType,
+  /**
+   * Resets the state of all mocks. Equivalent to calling .mockReset() on every
+   * mocked function.
+   */
+  resetAllMocks(): JestObjectType,
+  /**
+   * Removes any pending timers from the timer system.
+   */
+  clearAllTimers(): void,
+  /**
+   * The same as `mock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  doMock(moduleName: string, moduleFactory?: any): JestObjectType,
+  /**
+   * The same as `unmock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  dontMock(moduleName: string): JestObjectType,
+  /**
+   * Returns a new, unused mock function. Optionally takes a mock
+   * implementation.
+   */
+  fn<TArguments: $ReadOnlyArray<*>, TReturn>(
+    implementation?: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Determines if the given function is a mocked function.
+   */
+  isMockFunction(fn: Function): boolean,
+  /**
+   * Given the name of a module, use the automatic mocking system to generate a
+   * mocked version of the module for you.
+   */
+  genMockFromModule(moduleName: string): any,
+  /**
+   * Mocks a module with an auto-mocked version when it is being required.
+   *
+   * The second argument can be used to specify an explicit module factory that
+   * is being run instead of using Jest's automocking feature.
+   *
+   * The third argument can be used to create virtual mocks -- mocks of modules
+   * that don't exist anywhere in the system.
+   */
+  mock(
+    moduleName: string,
+    moduleFactory?: any,
+    options?: Object
+  ): JestObjectType,
+  /**
+   * Returns the actual module instead of a mock, bypassing all checks on
+   * whether the module should receive a mock implementation or not.
+   */
+  requireActual(moduleName: string): any,
+  /**
+   * Returns a mock module instead of the actual module, bypassing all checks
+   * on whether the module should be required normally or not.
+   */
+  requireMock(moduleName: string): any,
+  /**
+   * Resets the module registry - the cache of all required modules. This is
+   * useful to isolate modules where local state might conflict between tests.
+   */
+  resetModules(): JestObjectType,
+  /**
+   * Exhausts the micro-task queue (usually interfaced in node via
+   * process.nextTick).
+   */
+  runAllTicks(): void,
+  /**
+   * Exhausts the macro-task queue (i.e., all tasks queued by setTimeout(),
+   * setInterval(), and setImmediate()).
+   */
+  runAllTimers(): void,
+  /**
+   * Exhausts all tasks queued by setImmediate().
+   */
+  runAllImmediates(): void,
+  /**
+   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+   * or setInterval() and setImmediate()).
+   */
+  runTimersToTime(msToRun: number): void,
+  /**
+   * Executes only the macro-tasks that are currently pending (i.e., only the
+   * tasks that have been queued by setTimeout() or setInterval() up to this
+   * point)
+   */
+  runOnlyPendingTimers(): void,
+  /**
+   * Explicitly supplies the mock object that the module system should return
+   * for the specified module. Note: It is recommended to use jest.mock()
+   * instead.
+   */
+  setMock(moduleName: string, moduleExports: any): JestObjectType,
+  /**
+   * Indicates that the module system should never return a mocked version of
+   * the specified module from require() (e.g. that it should always return the
+   * real module).
+   */
+  unmock(moduleName: string): JestObjectType,
+  /**
+   * Instructs Jest to use fake versions of the standard timer functions
+   * (setTimeout, setInterval, clearTimeout, clearInterval, nextTick,
+   * setImmediate and clearImmediate).
+   */
+  useFakeTimers(): JestObjectType,
+  /**
+   * Instructs Jest to use the real versions of the standard timer functions.
+   */
+  useRealTimers(): JestObjectType,
+  /**
+   * Creates a mock function similar to jest.fn but also tracks calls to
+   * object[methodName].
+   */
+  spyOn(object: Object, methodName: string): JestMockFn<any, any>,
+  /**
+   * Set the default timeout interval for tests and before/after hooks in milliseconds.
+   * Note: The default timeout interval is 5 seconds if this method is not called.
+   */
+  setTimeout(timeout: number): JestObjectType
+};
+
+type JestSpyType = {
+  calls: JestCallsType
+};
+
+/** Runs this function after every test inside this context */
+declare function afterEach(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** Runs this function before every test inside this context */
+declare function beforeEach(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** Runs this function after all tests have finished inside this context */
+declare function afterAll(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** Runs this function before any tests have started inside this context */
+declare function beforeAll(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+
+/** A context for grouping tests together */
+declare var describe: {
+  /**
+   * Creates a block that groups together several related tests in one "test suite"
+   */
+  (name: string, fn: () => void): void,
+
+  /**
+   * Only run this describe block
+   */
+  only(name: string, fn: () => void): void,
+
+  /**
+   * Skip running this describe block
+   */
+  skip(name: string, fn: () => void): void
+};
+
+/** An individual test unit */
+declare var it: {
+  /**
+   * An individual test unit
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  (
+    name: string,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+  /**
+   * Only run this test
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  only(
+    name: string,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+  /**
+   * Skip running this test
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  skip(
+    name: string,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+  /**
+   * Run the test concurrently
+   *
+   * @param {string} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  concurrent(
+    name: string,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void
+};
+declare function fit(
+  name: string,
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** An individual test unit */
+declare var test: typeof it;
+/** A disabled group of tests */
+declare var xdescribe: typeof describe;
+/** A focused group of tests */
+declare var fdescribe: typeof describe;
+/** A disabled individual test */
+declare var xit: typeof it;
+/** A disabled individual test */
+declare var xtest: typeof it;
+
+/** The expect function is used every time you want to test a value */
+declare var expect: {
+  /** The object that you want to make assertions against */
+  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType,
+  /** Add additional Jasmine matchers to Jest's roster */
+  extend(matchers: { [name: string]: JestMatcher }): void,
+  /** Add a module that formats application-specific data structures. */
+  addSnapshotSerializer(serializer: (input: Object) => string): void,
+  assertions(expectedAssertions: number): void,
+  hasAssertions(): void,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): void,
+  arrayContaining(value: Array<mixed>): void,
+  objectContaining(value: Object): void,
+  /** Matches any received string that contains the exact expected string. */
+  stringContaining(value: string): void,
+  stringMatching(value: string | RegExp): void
+};
+
+// TODO handle return type
+// http://jasmine.github.io/2.4/introduction.html#section-Spies
+declare function spyOn(value: mixed, method: string): Object;
+
+/** Holds all functions related to manipulating test runner */
+declare var jest: JestObjectType;
+
+/**
+ * The global Jasmine object, this is generally not exposed as the public API,
+ * using features inside here could break in later versions of Jest.
+ */
+declare var jasmine: {
+  DEFAULT_TIMEOUT_INTERVAL: number,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): void,
+  arrayContaining(value: Array<mixed>): void,
+  clock(): JestClockType,
+  createSpy(name: string): JestSpyType,
+  createSpyObj(
+    baseName: string,
+    methodNames: Array<string>
+  ): { [methodName: string]: JestSpyType },
+  objectContaining(value: Object): void,
+  stringMatching(value: string): void
+};

--- a/definitions/npm/jest_v22.x.x/flow_v0.39.x-/test_jest-v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.39.x-/test_jest-v22.x.x.js
@@ -1,0 +1,287 @@
+/* @flow */
+/* eslint-disable */
+import * as React from "react";
+
+jest.autoMockOff();
+jest.clearAllMocks();
+jest.resetAllMocks();
+
+// $ExpectError property `atoMockOff` not found in object type
+jest.atoMockOff();
+
+const mockFn = jest.fn();
+mockFn.mock.calls.map(String).map(a => a + a);
+
+type Foo = {
+  doStuff: string => number
+};
+const foo: Foo = {
+  doStuff(str: string): number {
+    return 5;
+  }
+};
+foo.doStuff = jest.fn().mockImplementation(str => 10);
+foo.doStuff = jest.fn().mockImplementation(str => parseInt(str, 10));
+foo.doStuff = jest.fn().mockImplementation(str => str.indexOf("a"));
+// $ExpectError function `doesntExist` not found in string.
+foo.doStuff = jest.fn().mockImplementation(str => str.doesntExist());
+// $ExpectError Mock function expected to return number, not string.
+foo.doStuff = jest.fn().mockImplementation(str => "10");
+foo.doStuff = jest.fn().mockImplementationOnce(str => 10);
+foo.doStuff = jest.fn().mockImplementationOnce(str => parseInt(str, 10));
+foo.doStuff = jest.fn().mockImplementationOnce(str => str.indexOf("a"));
+// $ExpectError function `doesntExist` not found in string.
+foo.doStuff = jest.fn().mockImplementationOnce(str => str.doesntExist());
+// $ExpectError Mock function expected to return number, not string.
+foo.doStuff = jest.fn().mockImplementationOnce(str => "10");
+
+foo.doStuff = jest.fn().mockReturnValue(10);
+// $ExpectError Mock function expected to return number, not string.
+foo.doStuff = jest.fn().mockReturnValue("10");
+
+foo.doStuff = jest.fn().mockReturnValueOnce(10);
+// $ExpectError Mock function expected to return number, not string.
+foo.doStuff = jest.fn().mockReturnValueOnce("10");
+
+const mockedDoStuff = (foo.doStuff = jest.fn().mockImplementation(str => 10));
+mockedDoStuff.mock.calls[0][0].indexOf("a");
+// $ExpectError function `doesntExist` not found in string.
+mockedDoStuff.mock.calls[0][0].doesntExist("a");
+
+mockedDoStuff.mock.instances[0] > 5;
+// $ExpectError function `doesntExist` not found in number.
+mockedDoStuff.mock.instances[0].indexOf("a");
+
+expect(1).toEqual(1);
+expect(true).toBe(true);
+expect(5).toBeGreaterThan(3);
+expect(5).toBeLessThan(8);
+expect("jester").toContain("jest");
+expect({ foo: "bar" }).toHaveProperty("foo");
+expect({ foo: "bar" }).toHaveProperty("foo", "bar");
+expect("foo").toMatchSnapshot("snapshot name");
+expect({ foo: "bar" }).toMatchObject({ baz: "qux" });
+expect("foobar").toMatch(/foo/);
+expect("foobar").toMatch("foo");
+
+mockFn("a");
+expect("someVal").toBeCalled();
+expect("someVal").toBeCalledWith("a");
+
+// $ExpectError property `toHaveBeeenCalledWith` not found in object type
+expect("someVal").toHaveBeeenCalledWith("a");
+
+// $ExpectError property `fn` not found in Array
+mockFn.mock.calls.fn();
+
+describe("name", () => {});
+describe.only("name", () => {});
+describe.skip("name", () => {});
+
+test("test", () => expect("foo").toMatchSnapshot());
+test.only("test", () => expect("foo").toMatchSnapshot());
+test.skip("test", () => expect("foo").toMatchSnapshot());
+
+// $ExpectError property `fonly` not found in object type
+test.fonly("test", () => expect("foo").toMatchSnapshot());
+
+test("name", done => {
+  done();
+});
+test.only("name", done => {
+  done();
+});
+test.skip("name", done => {
+  done();
+});
+
+// $ExpectError tests should return void or Promise.
+test("name", () => 5);
+test("name", async () => {});
+test("name", () => new Promise((resolve, reject) => {}));
+// $ExpectError describe does not support Promises.
+describe("name", () => new Promise((resolve, reject) => {}));
+
+beforeEach(() => {});
+beforeEach(() => new Promise((resolve, reject) => {}));
+// $ExpectError Lifecycle methods should return void or Promise.
+beforeEach(() => 5);
+
+beforeAll(() => {});
+beforeAll(() => new Promise((resolve, reject) => {}));
+// $ExpectError Lifecycle methods should return void or Promise.
+beforeAll(() => 5);
+
+afterEach(() => {});
+afterEach(() => new Promise((resolve, reject) => {}));
+// $ExpectError Lifecycle methods should return void or Promise.
+afterEach(() => 5);
+
+afterAll(() => {});
+afterAll(() => new Promise((resolve, reject) => {}));
+// $ExpectError Lifecycle methods should return void or Promise.
+afterAll(() => 5);
+
+xtest("test", () => {});
+
+// $ExpectError property `bar` not found in object type
+expect.bar();
+
+expect.extend({
+  blah(actual, expected) {
+    return {
+      message: () => "blah fail",
+      pass: false
+    };
+  }
+});
+
+expect.extend({
+  foo(actual, expected) {
+    // $ExpectError property `pass` not found in object literal
+    return {};
+  }
+});
+
+const err = new Error("err");
+expect(() => {
+  throw err;
+}).toThrowError("err");
+
+expect(() => {
+  throw err;
+}).toThrowError(/err/);
+
+expect(() => {
+  throw err;
+}).toThrowError(err);
+
+expect(() => {}).toThrow("err");
+expect(() => {}).toThrow(/err/);
+expect(() => {}).toThrow(err);
+
+// Test method chaining fixes
+jest.doMock("testModule1", () => {}).doMock("testModule2", () => {});
+
+jest.dontMock("testModule1").dontMock("testModule2");
+
+jest.resetModules().resetModules();
+
+jest.spyOn({}, "foo");
+
+jest.setTimeout(1000);
+
+expect.addSnapshotSerializer(JSON.stringify);
+expect.assertions(1);
+expect.hasAssertions();
+
+expect.anything();
+expect.any(Error);
+expect.objectContaining({
+  foo: "bar"
+});
+expect.arrayContaining(["red", "blue"]);
+expect.stringMatching("*this part*");
+
+test.concurrent("test", () => {});
+
+expect([1, 2, 3]).toHaveLength(3);
+
+(async () => {
+  await expect(Promise.reject("ok")).rejects.toBe("ok");
+  await expect(Promise.resolve("ok")).resolves.toBe("ok");
+})();
+
+/**
+ *  Plugin: jest-enzyme
+ */
+
+// $ExpectError
+import { shallow } from "enzyme";
+const Dummy = () => <div />;
+const wrapper = shallow(<Dummy />);
+
+expect(wrapper).toBeChecked();
+
+expect(wrapper).toBeDisabled();
+
+expect(wrapper).toBeEmpty();
+
+expect(wrapper).toBePresent();
+
+expect(wrapper).toContainReact(<Dummy />);
+// $ExpectError
+expect(wrapper).toContainReact();
+// $ExpectError
+expect(wrapper).toContainReact("string");
+
+expect(wrapper).toHaveClassName("class");
+// $ExpectError
+expect(wrapper).toHaveClassName();
+// $ExpectError
+expect(wrapper).toHaveClassName(true);
+
+expect(wrapper).toHaveHTML("<span>test</span>");
+// $ExpectError
+expect(wrapper).toHaveHTML();
+// $ExpectError
+expect(wrapper).toHaveHTML(true);
+
+expect(wrapper).toHaveProp("test");
+expect(wrapper).toHaveProp("test", "test");
+// $ExpectError
+expect(wrapper).toHaveProp();
+// $ExpectError
+expect(wrapper).toHaveProp(true);
+
+expect(wrapper).toHaveRef("test");
+// $ExpectError
+expect(wrapper).toHaveRef();
+// $ExpectError
+expect(wrapper).toHaveRef(true);
+
+expect(wrapper).toHaveState("test");
+expect(wrapper).toHaveState("test", "test");
+// $ExpectError
+expect(wrapper).toHaveState();
+// $ExpectError
+expect(wrapper).toHaveState(true);
+
+expect(wrapper).toHaveStyle("color");
+expect(wrapper).toHaveStyle("color", "#ccc");
+// $ExpectError
+expect(wrapper).toHaveStyle();
+// $ExpectError
+expect(wrapper).toHaveStyle(true);
+
+expect(wrapper).toHaveTagName("marquee");
+// $ExpectError
+expect(wrapper).toHaveTagName();
+// $ExpectError
+expect(wrapper).toHaveTagName(true);
+
+expect(wrapper).toHaveText("test");
+// $ExpectError
+expect(wrapper).toHaveText();
+// $ExpectError
+expect(wrapper).toHaveText(true);
+
+expect(wrapper).toIncludeText("test");
+// $ExpectError
+expect(wrapper).toIncludeText();
+// $ExpectError
+expect(wrapper).toIncludeText(true);
+
+expect(wrapper).toHaveValue("test");
+
+expect(wrapper).toMatchElement(<Dummy />);
+// $ExpectError
+expect(wrapper).toMatchElement();
+// $ExpectError
+expect(wrapper).toMatchElement(true);
+
+expect(wrapper).toMatchSelector("span");
+// $ExpectError
+expect(wrapper).toMatchSelector();
+// $ExpectError
+expect(wrapper).toMatchSelector(true);


### PR DESCRIPTION
This PR adds definitions for jest v22. I did not found any relevant changes of the [release to the definition](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2200), so I blatantly  copied the jest 21 definition.