### PR TITLE
Correct type signature for AxiosXHRConfigBase.maxRetries

### DIFF
--- a/definitions/npm/axios_v0.13.x/flow_v0.25.x-/axios_v0.13.x.js
+++ b/definitions/npm/axios_v0.13.x/flow_v0.25.x-/axios_v0.13.x.js
@@ -1,22 +1,28 @@
-declare module 'axios' {
+declare module "axios" {
   declare interface AxiosXHRConfigBase<T> {
     adapter?: <T>(config: AxiosXHRConfig<T>) => Promise<AxiosXHR<T>>;
     auth?: {
-        username: string,
-        password: string
+      username: string,
+      password: string
     };
-    baseURL?: string,
+    baseURL?: string;
     progress?: (progressEvent: Event) => void | mixed;
     maxContentLength?: number;
-    maxRedirects?: 5,
+    maxRedirects?: 5;
     headers?: Object;
     params?: Object;
     paramsSerializer?: (params: Object) => string;
-    responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
+    responseType?:
+      | "arraybuffer"
+      | "blob"
+      | "document"
+      | "json"
+      | "text"
+      | "stream";
     transformResponse?: Array<<U>(data: T) => U>;
-    transformRequest?: Array<<U>(data: T) => U|Array<<U>(data: T) => U>>;
+    transformRequest?: Array<<U>(data: T) => U | Array<<U>(data: T) => U>>;
     timeout?: number;
-    validateStatus?: (status: number) => boolean,
+    validateStatus?: (status: number) => boolean;
     withCredentials?: boolean;
     xsrfCookieName?: string;
     xsrfHeaderName?: string;
@@ -35,39 +41,56 @@ declare module 'axios' {
     data: T;
     headers: Object;
     status: number;
-    statusText: string,
-    request: http$ClientRequest | XMLHttpRequest
+    statusText: string;
+    request: http$ClientRequest | XMLHttpRequest;
   }
   declare type $AxiosXHR<T> = $AxiosXHR<T>;
   declare class AxiosInterceptorIdent extends String {}
   declare class AxiosRequestInterceptor<T> {
     use(
-      successHandler: ?(response: AxiosXHRConfig<T>) => Promise<AxiosXHRConfig<*>> | AxiosXHRConfig<*>,
-      errorHandler: ?(error: mixed) => mixed,
+      successHandler: ?(
+        response: AxiosXHRConfig<T>
+      ) => Promise<AxiosXHRConfig<*>> | AxiosXHRConfig<*>,
+      errorHandler: ?(error: mixed) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
   declare class AxiosResponseInterceptor<T> {
     use(
       successHandler: ?(response: AxiosXHR<T>) => mixed,
-      errorHandler: ?(error: mixed) => mixed,
+      errorHandler: ?(error: mixed) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
   declare type AxiosPromise<T> = Promise<AxiosXHR<T>>;
   declare class Axios {
     constructor<T>(config?: AxiosXHRConfigBase<T>): void;
-    $call: <T>(config: AxiosXHRConfig<T> | string, config?: AxiosXHRConfig<T>) => AxiosPromise<T>;
+    $call: <T>(
+      config: AxiosXHRConfig<T> | string,
+      config?: AxiosXHRConfig<T>
+    ) => AxiosPromise<T>;
     request<T>(config: AxiosXHRConfig<T>): AxiosPromise<T>;
     delete<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
     get<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
     head<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    post<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    put<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    patch<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
+    post<T>(
+      url: string,
+      data?: mixed,
+      config?: AxiosXHRConfigBase<T>
+    ): AxiosPromise<T>;
+    put<T>(
+      url: string,
+      data?: mixed,
+      config?: AxiosXHRConfigBase<T>
+    ): AxiosPromise<T>;
+    patch<T>(
+      url: string,
+      data?: mixed,
+      config?: AxiosXHRConfigBase<T>
+    ): AxiosPromise<T>;
     interceptors: {
       request: AxiosRequestInterceptor<mixed>,
-      response: AxiosResponseInterceptor<mixed>,
+      response: AxiosResponseInterceptor<mixed>
     };
   }
 
@@ -80,10 +103,10 @@ declare module 'axios' {
   declare type $AxiosError<T> = AxiosError<T>;
 
   declare interface AxiosExport extends Axios {
-      Axios: typeof Axios;
-      create(config?: AxiosXHRConfigBase<any>): Axios;
-      all: typeof Promise.all;
-      spread(callback: Function): (arr: Array<any>) => Function
+    Axios: typeof Axios;
+    create(config?: AxiosXHRConfigBase<any>): Axios;
+    all: typeof Promise.all;
+    spread(callback: Function): (arr: Array<any>) => Function;
   }
   declare module.exports: AxiosExport;
 }

--- a/definitions/npm/axios_v0.13.x/flow_v0.25.x-/axios_v0.13.x.js
+++ b/definitions/npm/axios_v0.13.x/flow_v0.25.x-/axios_v0.13.x.js
@@ -8,7 +8,7 @@ declare module "axios" {
     baseURL?: string;
     progress?: (progressEvent: Event) => void | mixed;
     maxContentLength?: number;
-    maxRedirects?: 5;
+    maxRedirects?: number;
     headers?: Object;
     params?: Object;
     paramsSerializer?: (params: Object) => string;

--- a/definitions/npm/axios_v0.15.x/flow_v0.25.x-/axios_v0.15.x.js
+++ b/definitions/npm/axios_v0.15.x/flow_v0.25.x-/axios_v0.15.x.js
@@ -33,7 +33,7 @@ declare module "axios" {
     httpAgent?: mixed; // Missing the type in the core flow node libdef
     httpsAgent?: mixed; // Missing the type in the core flow node libdef
     maxContentLength?: number;
-    maxRedirects?: 5;
+    maxRedirects?: number;
     params?: Object;
     paramsSerializer?: (params: Object) => string;
     progress?: (progressEvent: Event) => void | mixed;

--- a/definitions/npm/axios_v0.15.x/flow_v0.25.x-/axios_v0.15.x.js
+++ b/definitions/npm/axios_v0.15.x/flow_v0.25.x-/axios_v0.15.x.js
@@ -1,4 +1,4 @@
-declare module 'axios' {
+declare module "axios" {
   declare interface ProxyConfig {
     host: string;
     port: number;
@@ -27,22 +27,28 @@ declare module 'axios' {
       username: string,
       password: string
     };
-    baseURL?: string,
+    baseURL?: string;
     cancelToken?: CancelToken;
     headers?: Object;
     httpAgent?: mixed; // Missing the type in the core flow node libdef
     httpsAgent?: mixed; // Missing the type in the core flow node libdef
     maxContentLength?: number;
-    maxRedirects?: 5,
+    maxRedirects?: 5;
     params?: Object;
     paramsSerializer?: (params: Object) => string;
     progress?: (progressEvent: Event) => void | mixed;
     proxy?: ProxyConfig;
-    responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
+    responseType?:
+      | "arraybuffer"
+      | "blob"
+      | "document"
+      | "json"
+      | "text"
+      | "stream";
     timeout?: number;
-    transformRequest?: Array<<U>(data: T) => U|Array<<U>(data: T) => U>>;
+    transformRequest?: Array<<U>(data: T) => U | Array<<U>(data: T) => U>>;
     transformResponse?: Array<<U>(data: T) => U>;
-    validateStatus?: (status: number) => boolean,
+    validateStatus?: (status: number) => boolean;
     withCredentials?: boolean;
     xsrfCookieName?: string;
     xsrfHeaderName?: string;
@@ -59,39 +65,56 @@ declare module 'axios' {
     data: T;
     headers: Object;
     status: number;
-    statusText: string,
-    request: http$ClientRequest | XMLHttpRequest
+    statusText: string;
+    request: http$ClientRequest | XMLHttpRequest;
   }
   declare type $AxiosXHR<T> = $AxiosXHR<T>;
   declare class AxiosInterceptorIdent extends String {}
   declare class AxiosRequestInterceptor<T> {
     use(
-      successHandler: ?(response: AxiosXHRConfig<T>) => Promise<AxiosXHRConfig<*>> | AxiosXHRConfig<*>,
-      errorHandler: ?(error: mixed) => mixed,
+      successHandler: ?(
+        response: AxiosXHRConfig<T>
+      ) => Promise<AxiosXHRConfig<*>> | AxiosXHRConfig<*>,
+      errorHandler: ?(error: mixed) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
   declare class AxiosResponseInterceptor<T> {
     use(
       successHandler: ?(response: AxiosXHR<T>) => mixed,
-      errorHandler: ?(error: mixed) => mixed,
+      errorHandler: ?(error: mixed) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
   declare type AxiosPromise<T> = Promise<AxiosXHR<T>>;
   declare class Axios {
     constructor<T>(config?: AxiosXHRConfigBase<T>): void;
-    $call: <T>(config: AxiosXHRConfig<T> | string, config?: AxiosXHRConfig<T>) => AxiosPromise<T>;
+    $call: <T>(
+      config: AxiosXHRConfig<T> | string,
+      config?: AxiosXHRConfig<T>
+    ) => AxiosPromise<T>;
     request<T>(config: AxiosXHRConfig<T>): AxiosPromise<T>;
     delete<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
     get<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
     head<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    post<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    put<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    patch<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
+    post<T>(
+      url: string,
+      data?: mixed,
+      config?: AxiosXHRConfigBase<T>
+    ): AxiosPromise<T>;
+    put<T>(
+      url: string,
+      data?: mixed,
+      config?: AxiosXHRConfigBase<T>
+    ): AxiosPromise<T>;
+    patch<T>(
+      url: string,
+      data?: mixed,
+      config?: AxiosXHRConfigBase<T>
+    ): AxiosPromise<T>;
     interceptors: {
       request: AxiosRequestInterceptor<mixed>,
-      response: AxiosResponseInterceptor<mixed>,
+      response: AxiosResponseInterceptor<mixed>
     };
     defaults: AxiosXHRConfig<*> & { headers: Object };
   }
@@ -111,7 +134,7 @@ declare module 'axios' {
     isCancel(value: any): boolean;
     create(config?: AxiosXHRConfigBase<any>): Axios;
     all: typeof Promise.all;
-    spread(callback: Function): (arr: Array<any>) => Function
+    spread(callback: Function): (arr: Array<any>) => Function;
   }
   declare module.exports: AxiosExport;
 }

--- a/definitions/npm/axios_v0.15.x/flow_v0.25.x-/axios_v0.15.x.js
+++ b/definitions/npm/axios_v0.15.x/flow_v0.25.x-/axios_v0.15.x.js
@@ -38,13 +38,7 @@ declare module "axios" {
     paramsSerializer?: (params: Object) => string;
     progress?: (progressEvent: Event) => void | mixed;
     proxy?: ProxyConfig;
-    responseType?:
-      | "arraybuffer"
-      | "blob"
-      | "document"
-      | "json"
-      | "text"
-      | "stream";
+    responseType?: "arraybuffer" | "blob" | "document" | "json" | "text" | "stream";
     timeout?: number;
     transformRequest?: Array<<U>(data: T) => U | Array<<U>(data: T) => U>>;
     transformResponse?: Array<<U>(data: T) => U>;

--- a/definitions/npm/axios_v0.16.x/flow_v0.25.x-/axios_v0.16.x.js
+++ b/definitions/npm/axios_v0.16.x/flow_v0.25.x-/axios_v0.16.x.js
@@ -33,7 +33,7 @@ declare module "axios" {
     httpAgent?: mixed; // Missing the type in the core flow node libdef
     httpsAgent?: mixed; // Missing the type in the core flow node libdef
     maxContentLength?: number;
-    maxRedirects?: 5;
+    maxRedirects?: number;
     params?: Object;
     paramsSerializer?: (params: Object) => string;
     progress?: (progressEvent: Event) => void | mixed;

--- a/definitions/npm/axios_v0.16.x/flow_v0.25.x-/axios_v0.16.x.js
+++ b/definitions/npm/axios_v0.16.x/flow_v0.25.x-/axios_v0.16.x.js
@@ -38,13 +38,7 @@ declare module "axios" {
     paramsSerializer?: (params: Object) => string;
     progress?: (progressEvent: Event) => void | mixed;
     proxy?: ProxyConfig;
-    responseType?:
-      | "arraybuffer"
-      | "blob"
-      | "document"
-      | "json"
-      | "text"
-      | "stream";
+    responseType?: "arraybuffer" | "blob" | "document" | "json" | "text" | "stream";
     timeout?: number;
     transformRequest?: Array<<U>(data: T) => U | Array<<U>(data: T) => U>>;
     transformResponse?: Array<<U>(data: T) => U>;

--- a/definitions/npm/axios_v0.16.x/flow_v0.25.x-/axios_v0.16.x.js
+++ b/definitions/npm/axios_v0.16.x/flow_v0.25.x-/axios_v0.16.x.js
@@ -1,4 +1,4 @@
-declare module 'axios' {
+declare module "axios" {
   declare interface ProxyConfig {
     host: string;
     port: number;
@@ -27,22 +27,28 @@ declare module 'axios' {
       username: string,
       password: string
     };
-    baseURL?: string,
+    baseURL?: string;
     cancelToken?: CancelToken;
     headers?: Object;
     httpAgent?: mixed; // Missing the type in the core flow node libdef
     httpsAgent?: mixed; // Missing the type in the core flow node libdef
     maxContentLength?: number;
-    maxRedirects?: 5,
+    maxRedirects?: 5;
     params?: Object;
     paramsSerializer?: (params: Object) => string;
     progress?: (progressEvent: Event) => void | mixed;
     proxy?: ProxyConfig;
-    responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
+    responseType?:
+      | "arraybuffer"
+      | "blob"
+      | "document"
+      | "json"
+      | "text"
+      | "stream";
     timeout?: number;
-    transformRequest?: Array<<U>(data: T) => U|Array<<U>(data: T) => U>>;
+    transformRequest?: Array<<U>(data: T) => U | Array<<U>(data: T) => U>>;
     transformResponse?: Array<<U>(data: T) => U>;
-    validateStatus?: (status: number) => boolean,
+    validateStatus?: (status: number) => boolean;
     withCredentials?: boolean;
     xsrfCookieName?: string;
     xsrfHeaderName?: string;
@@ -59,39 +65,56 @@ declare module 'axios' {
     data: T;
     headers?: Object;
     status: number;
-    statusText: string,
-    request: http$ClientRequest | XMLHttpRequest
+    statusText: string;
+    request: http$ClientRequest | XMLHttpRequest;
   }
   declare type $AxiosXHR<T> = AxiosXHR<T>;
   declare class AxiosInterceptorIdent extends String {}
   declare class AxiosRequestInterceptor<T> {
     use(
-      successHandler: ?(response: AxiosXHRConfig<T>) => Promise<AxiosXHRConfig<*>> | AxiosXHRConfig<*>,
-      errorHandler: ?(error: mixed) => mixed,
+      successHandler: ?(
+        response: AxiosXHRConfig<T>
+      ) => Promise<AxiosXHRConfig<*>> | AxiosXHRConfig<*>,
+      errorHandler: ?(error: mixed) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
   declare class AxiosResponseInterceptor<T> {
     use(
       successHandler: ?(response: AxiosXHR<T>) => mixed,
-      errorHandler: ?(error: $AxiosError<any>) => mixed,
+      errorHandler: ?(error: $AxiosError<any>) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
   declare type AxiosPromise<T> = Promise<AxiosXHR<T>>;
   declare class Axios {
     constructor<T>(config?: AxiosXHRConfigBase<T>): void;
-    $call: <T>(config: AxiosXHRConfig<T> | string, config?: AxiosXHRConfig<T>) => AxiosPromise<T>;
+    $call: <T>(
+      config: AxiosXHRConfig<T> | string,
+      config?: AxiosXHRConfig<T>
+    ) => AxiosPromise<T>;
     request<T>(config: AxiosXHRConfig<T>): AxiosPromise<T>;
     delete<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
     get<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
     head<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    post<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    put<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    patch<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
+    post<T>(
+      url: string,
+      data?: mixed,
+      config?: AxiosXHRConfigBase<T>
+    ): AxiosPromise<T>;
+    put<T>(
+      url: string,
+      data?: mixed,
+      config?: AxiosXHRConfigBase<T>
+    ): AxiosPromise<T>;
+    patch<T>(
+      url: string,
+      data?: mixed,
+      config?: AxiosXHRConfigBase<T>
+    ): AxiosPromise<T>;
     interceptors: {
       request: AxiosRequestInterceptor<mixed>,
-      response: AxiosResponseInterceptor<mixed>,
+      response: AxiosResponseInterceptor<mixed>
     };
     defaults: AxiosXHRConfig<*> & { headers: Object };
   }
@@ -111,7 +134,7 @@ declare module 'axios' {
     isCancel(value: any): boolean;
     create(config?: AxiosXHRConfigBase<any>): Axios;
     all: typeof Promise.all;
-    spread(callback: Function): (arr: Array<any>) => Function
+    spread(callback: Function): (arr: Array<any>) => Function;
   }
   declare module.exports: AxiosExport;
 }

--- a/definitions/npm/axios_v0.17.x/flow_v0.25.x-/axios_v0.17.x.js
+++ b/definitions/npm/axios_v0.17.x/flow_v0.25.x-/axios_v0.17.x.js
@@ -33,7 +33,7 @@ declare module "axios" {
     httpAgent?: mixed; // Missing the type in the core flow node libdef
     httpsAgent?: mixed; // Missing the type in the core flow node libdef
     maxContentLength?: number;
-    maxRedirects?: 5;
+    maxRedirects?: number;
     params?: Object;
     paramsSerializer?: (params: Object) => string;
     progress?: (progressEvent: Event) => void | mixed;

--- a/definitions/npm/axios_v0.17.x/flow_v0.25.x-/axios_v0.17.x.js
+++ b/definitions/npm/axios_v0.17.x/flow_v0.25.x-/axios_v0.17.x.js
@@ -38,13 +38,7 @@ declare module "axios" {
     paramsSerializer?: (params: Object) => string;
     progress?: (progressEvent: Event) => void | mixed;
     proxy?: ProxyConfig | false;
-    responseType?:
-      | "arraybuffer"
-      | "blob"
-      | "document"
-      | "json"
-      | "text"
-      | "stream";
+    responseType?: "arraybuffer" | "blob" | "document" | "json" | "text" | "stream";
     timeout?: number;
     transformRequest?: Array<<U>(data: T) => U | Array<<U>(data: T) => U>>;
     transformResponse?: Array<<U>(data: T) => U>;

--- a/definitions/npm/axios_v0.17.x/flow_v0.25.x-/axios_v0.17.x.js
+++ b/definitions/npm/axios_v0.17.x/flow_v0.25.x-/axios_v0.17.x.js
@@ -1,4 +1,4 @@
-declare module 'axios' {
+declare module "axios" {
   declare interface ProxyConfig {
     host: string;
     port: number;
@@ -27,22 +27,28 @@ declare module 'axios' {
       username: string,
       password: string
     };
-    baseURL?: string,
+    baseURL?: string;
     cancelToken?: CancelToken;
     headers?: Object;
     httpAgent?: mixed; // Missing the type in the core flow node libdef
     httpsAgent?: mixed; // Missing the type in the core flow node libdef
     maxContentLength?: number;
-    maxRedirects?: 5,
+    maxRedirects?: 5;
     params?: Object;
     paramsSerializer?: (params: Object) => string;
     progress?: (progressEvent: Event) => void | mixed;
     proxy?: ProxyConfig | false;
-    responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
+    responseType?:
+      | "arraybuffer"
+      | "blob"
+      | "document"
+      | "json"
+      | "text"
+      | "stream";
     timeout?: number;
-    transformRequest?: Array<<U>(data: T) => U|Array<<U>(data: T) => U>>;
+    transformRequest?: Array<<U>(data: T) => U | Array<<U>(data: T) => U>>;
     transformResponse?: Array<<U>(data: T) => U>;
-    validateStatus?: (status: number) => boolean,
+    validateStatus?: (status: number) => boolean;
     withCredentials?: boolean;
     xsrfCookieName?: string;
     xsrfHeaderName?: string;
@@ -59,39 +65,56 @@ declare module 'axios' {
     data: T;
     headers?: Object;
     status: number;
-    statusText: string,
-    request: http$ClientRequest | XMLHttpRequest
+    statusText: string;
+    request: http$ClientRequest | XMLHttpRequest;
   }
   declare type $AxiosXHR<T> = AxiosXHR<T>;
   declare class AxiosInterceptorIdent extends String {}
   declare class AxiosRequestInterceptor<T> {
     use(
-      successHandler: ?(response: AxiosXHRConfig<T>) => Promise<AxiosXHRConfig<*>> | AxiosXHRConfig<*>,
-      errorHandler: ?(error: mixed) => mixed,
+      successHandler: ?(
+        response: AxiosXHRConfig<T>
+      ) => Promise<AxiosXHRConfig<*>> | AxiosXHRConfig<*>,
+      errorHandler: ?(error: mixed) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
   declare class AxiosResponseInterceptor<T> {
     use(
       successHandler: ?(response: AxiosXHR<T>) => mixed,
-      errorHandler: ?(error: $AxiosError<any>) => mixed,
+      errorHandler: ?(error: $AxiosError<any>) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
   declare type AxiosPromise<T> = Promise<AxiosXHR<T>>;
   declare class Axios {
     constructor<T>(config?: AxiosXHRConfigBase<T>): void;
-    $call: <T>(config: AxiosXHRConfig<T> | string, config?: AxiosXHRConfig<T>) => AxiosPromise<T>;
+    $call: <T>(
+      config: AxiosXHRConfig<T> | string,
+      config?: AxiosXHRConfig<T>
+    ) => AxiosPromise<T>;
     request<T>(config: AxiosXHRConfig<T>): AxiosPromise<T>;
     delete<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
     get<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
     head<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    post<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    put<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    patch<T>(url: string, data?: mixed, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
+    post<T>(
+      url: string,
+      data?: mixed,
+      config?: AxiosXHRConfigBase<T>
+    ): AxiosPromise<T>;
+    put<T>(
+      url: string,
+      data?: mixed,
+      config?: AxiosXHRConfigBase<T>
+    ): AxiosPromise<T>;
+    patch<T>(
+      url: string,
+      data?: mixed,
+      config?: AxiosXHRConfigBase<T>
+    ): AxiosPromise<T>;
     interceptors: {
       request: AxiosRequestInterceptor<mixed>,
-      response: AxiosResponseInterceptor<mixed>,
+      response: AxiosResponseInterceptor<mixed>
     };
     defaults: AxiosXHRConfig<*> & { headers: Object };
   }
@@ -111,7 +134,7 @@ declare module 'axios' {
     isCancel(value: any): boolean;
     create(config?: AxiosXHRConfigBase<any>): Axios;
     all: typeof Promise.all;
-    spread(callback: Function): (arr: Array<any>) => Function
+    spread(callback: Function): (arr: Array<any>) => Function;
   }
   declare module.exports: AxiosExport;
 }


### PR DESCRIPTION
It seems the default value from axios' documentaiton made it into the type definitions. The correct type for `maxRetries` is number, but it had a literal 5. 

```typescript
138:     create(config?: AxiosXHRConfigBase<any>): Axios;
                         ^^^^^^^^^^^^^^^^^^^^^^^ AxiosXHRConfigBase. See lib: flow-typed/npm/axios_v0.17.x.js:138
  Property `maxRedirects` is incompatible:
     13:   maxRedirects: 0,
                         ^ number. Expected number literal `5`, got `0` instead
     39:     maxRedirects?: 5;
                            ^ number literal `5`. See lib: flow-typed/npm/axios_v0.17.x.js:39