### PR TITLE
fix problems caused by callable object type in reselect

### DIFF
--- a/definitions/npm/reselect_v3.x.x/flow_v0.34.x-v0.46.x/reselect_v3.x.x.js
+++ b/definitions/npm/reselect_v3.x.x/flow_v0.34.x-v0.46.x/reselect_v3.x.x.js
@@ -1,7 +1,6 @@
 declare module "reselect" {
-  declare type Selector<TState, TProps, TResult> = {
-    (state: TState, props: TProps, ...rest: any[]): TResult
-  };
+  declare type Selector<TState, TProps, TResult> = 
+    (state: TState, props: TProps, ...rest: any[]) => TResult;
 
   declare type SelectorCreator = {
     <

--- a/definitions/npm/reselect_v3.x.x/flow_v0.47.x-/reselect_v3.x.x.js
+++ b/definitions/npm/reselect_v3.x.x/flow_v0.47.x-/reselect_v3.x.x.js
@@ -2,9 +2,8 @@
 // flow-typed version: b43dff3e0e/reselect_v3.x.x/flow_>=v0.28.x
 
 declare module "reselect" {
-  declare type Selector<-TState, TProps, TResult> = {
-    (state: TState, props: TProps, ...rest: any[]): TResult
-  };
+  declare type Selector<-TState, TProps, TResult> =
+    (state: TState, props: TProps, ...rest: any[]) => TResult
 
   declare type SelectorCreator = {
     <TState, TProps, TResult, T1>(


### PR DESCRIPTION
fix #824 
using a callable object type that doesn't have any other props on it is pointless and sometimes flow complains that an argument to one of my functions, which is supposed to be a `Selector`, should be an object.