### PR TITLE
Add load method to yamljs

### DIFF
--- a/definitions/npm/yamljs_v0.x.x/flow_v0.28.0-/yamljs_v0.x.x.js
+++ b/definitions/npm/yamljs_v0.x.x/flow_v0.28.0-/yamljs_v0.x.x.js
@@ -1,4 +1,5 @@
 declare module "yamljs" {
+  declare type Load = (path: string) => mixed;
   declare type Parse = (yaml: string) => mixed;
   declare type Stringify = (
     obj: mixed,
@@ -7,6 +8,7 @@ declare module "yamljs" {
   ) => string;
 
   declare export default {
+    load: Load,
     parse: Parse,
     stringify: Stringify
   }


### PR DESCRIPTION
Using "load" is a very common use-case and at the very least is needed in here to stop compile errors. 