### PR TITLE
Fix redis' lpush() type definition

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -3,7 +3,7 @@ declare module "redis" {
   declare class RedisClient extends events$EventEmitter mixins RedisClientPromisified {
     hmset: (key: string, map: any, callback: (?Error) => void) => void;
     rpush: (key: string, value: string, callback: (?Error) => void) => void;
-    lpush: (key: string, value: any) => number;
+    lpush: (key: string, value: any, callback?: (?Error, number) => void) => void;
     lrem: (
       topic: string,
       cursor: number,

--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
@@ -25,3 +25,15 @@ client.hmset("some-key", { key1: "value1" }, err =>
 client.rpush("some-list", "some-value", err =>
   console.log("rpush error:", err)
 );
+
+client.lpush("key", "value", (err, newLength) => {
+  if (err) {
+    console.log(`lpush error: ${err.message}`);
+  }
+  console.log(`New length: ${newLength}`);
+});
+client.lpush("key", "value");
+// $EXpectError
+client.lpush("key");
+// $EXpectError
+client.lpush("key", { foo: 'bar' });


### PR DESCRIPTION
From the [documentation](https://github.com/NodeRedis/node_redis/tree/009479537eb920d2c34045026a55d31febd1edd7):

> Note that the API is entirely asynchronous. To get data back from the server, you'll need to use a callback.

Demonstration:

```js
'use strict';

const redis = require('redis');

const client = redis.createClient({
  host: '127.0.0.1',
  port: 6379
});
client.on('error', (error) => {
  console.error(error);
  process.exit(1);
});

client.lpush('key', 'value', (error, listLength) => {
  console.log(`1. error: ${error}`);
  console.log(`1. listLength: ${listLength}`);
});

client.lpush('key', (error, listLength) => {
  console.log(`2. error: ${error}`);
  console.log(`2. listLength: ${listLength}`);
});
```

The code above outputs the following:

```
1. error: null
1. listLength: 1
2. error: ReplyError: ERR wrong number of arguments for 'lpush' command
2. listLength: undefined
```