### PR TITLE
Fix redux-devtools-extension_v2.x.x.js

### DIFF
--- a/definitions/npm/redux-devtools-extension_v2.x.x/flow_v0.47.x-/redux-devtools-extension_v2.x.x.js
+++ b/definitions/npm/redux-devtools-extension_v2.x.x/flow_v0.47.x-/redux-devtools-extension_v2.x.x.js
@@ -93,7 +93,7 @@ declare function $npm$ReduxDevtoolsExtension$composeWithDevTools<A, B, C, D, E, 
   ab: A => B
 ): A => H;
 
-declare function $npm$ReduxDevtoolsExtension$devToolsEnhancer<S, A>(options: $npm$ReduxDevtoolsExtension$DevToolsOptions): StoreEnhancer<S, A>;
+declare function $npm$ReduxDevtoolsExtension$devToolsEnhancer<S, A>(options?: $npm$ReduxDevtoolsExtension$DevToolsOptions): StoreEnhancer<S, A>;
 
 declare module 'redux-devtools-extension' {
   declare export type DevToolsOptions = $npm$ReduxDevtoolsExtension$DevToolsOptions;

--- a/definitions/npm/redux-devtools-extension_v2.x.x/test_redux-devtools-extension_v2.x.x.js
+++ b/definitions/npm/redux-devtools-extension_v2.x.x/test_redux-devtools-extension_v2.x.x.js
@@ -81,6 +81,5 @@ const options2: OptionsLogProd = {
  */
 type SelfFn<A> = A => A;
 
-// $ExpectError
 enhancer();
 (enhancer(options1): SelfFn<*>);


### PR DESCRIPTION
`devToolsEnhancer`'s options argument is optional. See here for reference: https://github.com/zalmoxisus/redux-devtools-extension#13-use-redux-devtools-extension-package-from-npm