### PR TITLE
Fix size function arguments

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.55.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.55.x-/lodash_v4.x.x.js
@@ -711,7 +711,7 @@ declare module "lodash" {
     sampleSize<V, T: Object>(object: T, n?: number): Array<V>;
     shuffle<T>(array: ?Array<T>): Array<T>;
     shuffle<V, T: Object>(object: T): Array<V>;
-    size(collection: Array<any> | Object): number;
+    size(collection: Array<any> | Object | string): number;
     some<T>(array: ?Array<T>, predicate?: Predicate<T>): boolean;
     some<T>(array: void | null, predicate?: ?Predicate<T>): false;
     some<A, T: { [id: string]: A }>(
@@ -2259,7 +2259,7 @@ declare module "lodash/fp" {
     ): (collection: Array<T> | { [id: any]: T }) => Array<T>;
     sampleSize<T>(n: number, collection: Array<T> | { [id: any]: T }): Array<T>;
     shuffle<T>(collection: Array<T> | { [id: any]: T }): Array<T>;
-    size(collection: Array<any> | Object): number;
+    size(collection: Array<any> | Object | string): number;
     some<T>(
       predicate: Predicate<T> | OPredicate<T>
     ): (collection: Array<T> | { [id: any]: T }) => boolean;


### PR DESCRIPTION
`size` function allows argument to be `string`: https://lodash.com/docs/4.17.4#size