### PR TITLE
Fix type of redisClient.set()

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -19,7 +19,7 @@ declare module "redis" {
     hgetall: (topic: string, key: string) => Array<string> | void;
     hdel: (topic: string, key: string) => number;
     get: (key: string) => any;
-    set: (key: string, value: any) => void;
+    set: (key: string, value: string, cb?: (error: Error | null) => void) => void;
     del: (...keys: Array<string>) => void;
     rpoplpush: (source: string, destination: string) => string | void;
     publish: (topic: string, value: any) => void;

--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
@@ -19,6 +19,15 @@ redis.createClient('redis://localhost:6739')
 redis.createClient('redis://localhost:6739', options)
 redis.createClient(options)
 
+client.set('some-key', 'Some value');
+client.set('some-key', 'Some value', (error) => {
+  console.log('Error?', error);
+});
+// $ExpectError
+client.set('some-key');
+// $ExpectError
+client.set('some-key', { foo: 'bar' });
+
 client.hmset("some-key", { key1: "value1" }, err =>
   console.log("hmset error:", err)
 );


### PR DESCRIPTION
- The second argument must be a string (it used to be `any`)
- There is an option third argument which is a callback invoked when Redis is done saving the provided data

Example:

```js
const redis = require('redis');
const client = redis.createClient({ host: '127.0.0.1', port: 6379 });
client.set('some-key', 'Some value!', (error) => {
  console.log('Operation terminated!');
  console.log('Error?', error);
});

// Outputs:
// Operation terminated!
// Error? null
```