### PR TITLE
Enhance the type of redisClient.lpush()

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -3,7 +3,7 @@ declare module "redis" {
   declare class RedisClient extends events$EventEmitter mixins RedisClientPromisified {
     hmset: (key: string, map: any, callback: (?Error) => void) => void;
     rpush: (key: string, value: string, callback: (?Error) => void) => void;
-    lpush: (key: string, value: any, callback?: (?Error, number) => void) => void;
+    lpush: (key: string, value: string, callback?: (?Error, number) => void) => void;
     lrem: (
       topic: string,
       cursor: number,

--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
@@ -33,7 +33,7 @@ client.lpush("key", "value", (err, newLength) => {
   console.log(`New length: ${newLength}`);
 });
 client.lpush("key", "value");
-// $EXpectError
+// $ExpectError
 client.lpush("key");
-// $EXpectError
+// $ExpectError
 client.lpush("key", { foo: 'bar' });


### PR DESCRIPTION
The second argument is expected to be a string (it used to be `any`).