### PR TITLE
Add redisClient.mget() type for Redis

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -21,6 +21,7 @@ declare module "redis" {
     get: (key: string) => any;
     set: (key: string, value: any) => void;
     del: (...keys: Array<string>) => void;
+    mget: (keys: Array<string>, (Error | null, Array<string | null>) => void) => void;
     rpoplpush: (source: string, destination: string) => string | void;
     publish: (topic: string, value: any) => void;
     subscribe: (topic: string) => void;

--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
@@ -37,3 +37,11 @@ client.lpush("key", "value");
 client.lpush("key");
 // $EXpectError
 client.lpush("key", { foo: 'bar' });
+
+client.mget(["key1", "key2"], (error, entries) => {
+  if (error === null) {
+    console.log('Error!');
+    return;
+  }
+  console.log(entries.join(','));
+});


### PR DESCRIPTION
Demonstration:

```js
const redis = require('redis');
const client = redis.createClient({ host: '127.0.0.1', port: 6379 });
client.set('key1', 'one', (error) => {
  if (error !== null) {
    console.error(error);
    return;
  }
  client.set('key2', 'two', (error) => {
    if (error !== null) {
      console.error(error);
      return;
    }
    client.mget(['key1', 'key2', 'unexisting-key'], console.log); // outputs "null [ 'one', 'two', null ]"
  });
});

```

Official reference: https://redis.io/commands/mget