### PR TITLE
Add redisClient.mset() type for Redis

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -22,6 +22,7 @@ declare module "redis" {
     set: (key: string, value: string, cb?: (error: Error | null) => void) => void;
     del: (...keys: Array<string>) => void;
     mget: (keys: Array<string>, (Error | null, Array<string | null>) => void) => void;
+    mset: (keysAndValues: Array<string>, cb?: (Error | null) => void) => void;
     rpoplpush: (source: string, destination: string) => string | void;
     publish: (topic: string, value: any) => void;
     subscribe: (topic: string) => void;

--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
@@ -54,3 +54,17 @@ client.mget(["key1", "key2"], (error, entries) => {
   }
   console.log(entries.join(','));
 });
+
+client.mset(["key1", "value1", "key2", "value"], (error) => {
+  if (error !== null) console.error(error);
+});
+client.mset(["key1", "value1", "key2", "value"]);
+// $ExpectError
+client.mset([
+  {
+    key: 'key1',
+    value: 'value1'
+  }
+], (error) => {
+  if (error !== null) console.error(error);
+});


### PR DESCRIPTION
Demonstration:

```js
const redis = require('redis');
const client = redis.createClient({ host: '127.0.0.1', port: 6379 });
client.mset(['key1', 'value1', 'key2', 'value2'], (error) => {
  console.log('Done. Error?', error); // Outputs "Done. Error? null"
  client.get('key1', console.log); // Outputs "null 'value1'"
  client.get('key2', console.log);  // Outputs "null 'value2'"
});
```

Official reference: https://redis.io/commands/mset