### PR TITLE
Fix the redis.get() type

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -18,7 +18,7 @@ declare module "redis" {
     hget: (topic: string, key: string, value: string) => string | void;
     hgetall: (topic: string, key: string) => Array<string> | void;
     hdel: (topic: string, key: string) => number;
-    get: (key: string) => any;
+    get: (key: string, (Error | null, string | null) => void) => void;
     set: (key: string, value: string, cb?: (error: Error | null) => void) => void;
     del: (...keys: Array<string>) => void;
     mget: (keys: Array<string>, (Error | null, Array<string | null>) => void) => void;

--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
@@ -19,6 +19,14 @@ redis.createClient('redis://localhost:6739')
 redis.createClient('redis://localhost:6739', options)
 redis.createClient(options)
 
+client.get('some-key', (error, value) => {
+  if (error !== null) {
+    console.error(error)
+    return;
+  }
+  console.log(value);
+});
+
 client.set('some-key', 'Some value');
 client.set('some-key', 'Some value', (error) => {
   console.log('Error?', error);


### PR DESCRIPTION
Demonstration:


```js
const redis = require('redis');
const client = redis.createClient();
client.set('foo', 1, (error) => {
  if (error !== null) {
    console.error(error);
    return;
  }
  console.log(client.get('foo')); // outputs "true"
  client.get('foo', (error, value) => {
    console.log(error, value, typeof(value)); // outputs "null '1' 'string'"
  });
});
```