### PR TITLE
[lodash] Update difference* methods to accept $ReadOnlyArray<T>

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.55.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.55.x-/lodash_v4.x.x.js
@@ -212,13 +212,13 @@ declare module "lodash" {
     chunk<T>(array?: ?Array<T>, size?: ?number): Array<Array<T>>;
     compact<T, N: ?T>(array?: ?Array<N>): Array<T>;
     concat<T>(base?: ?Array<T>, ...elements: Array<any>): Array<T | any>;
-    difference<T>(array?: ?Array<T>, values?: ?Array<T>): Array<T>;
+    difference<T>(array?: ?$ReadOnlyArray<T>, values?: ?$ReadOnlyArray<T>): Array<T>;
     differenceBy<T>(
-      array?: ?Array<T>,
-      values?: ?Array<T>,
+      array?: ?$ReadOnlyArray<T>,
+      values?: ?$ReadOnlyArray<T>,
       iteratee?: ?ValueOnlyIteratee<T>
     ): T[];
-    differenceWith<T>(array?: ?T[], values?: ?T[], comparator?: ?Comparator<T>): T[];
+    differenceWith<T>(array?: ?$ReadOnlyArray<T>, values?: ?$ReadOnlyArray<T>, comparator?: ?Comparator<T>): T[];
     drop<T>(array?: ?Array<T>, n?: ?number): Array<T>;
     dropRight<T>(array?: ?Array<T>, n?: ?number): Array<T>;
     dropRightWhile<T>(array?: ?Array<T>, predicate?: ?Predicate<T>): Array<T>;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.55.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.55.x-/test_lodash-v4.x.x.js
@@ -7,6 +7,7 @@ import conformsTo from "lodash/conformsTo";
 import countBy from "lodash/countBy";
 import debounce from "lodash/debounce";
 import defaultTo from "lodash/defaultTo";
+import difference from "lodash/difference";
 import differenceBy from "lodash/differenceBy";
 import extend from "lodash/extend";
 import find from "lodash/find";
@@ -49,6 +50,11 @@ attempt((x, y, z) => {}, null, {}, []);
  */
 countBy([6.1, 4.2, 6.3], Math.floor);
 countBy(["one", "two", "three"], "length");
+
+/**
+ * _.difference
+ */
+difference((["a", "b"]: $ReadOnlyArray<string>), (["b"]: $ReadOnlyArray<string>));
 
 /**
  * _.differenceBy


### PR DESCRIPTION
This fixes part of the issue of #1099, making `_.difference`, `_.differenceBy`, and `_.differenceWith` accept `$ReadOnlyArray`.

Because `Array<T> <: $ReadOnlyArray<T>`, this allows immutable arrays to be used in non-mutating lodash functions.