### PR TITLE
Update the type for redis.del()

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -20,7 +20,7 @@ declare module "redis" {
     hdel: (topic: string, key: string) => number;
     get: (key: string) => any;
     set: (key: string, value: string, cb?: (error: Error | null) => void) => void;
-    del: (...keys: Array<string>) => void;
+    del: (keys: Array<string>, cb?: (Error | null) => void) => void;
     mget: (keys: Array<string>, (Error | null, Array<string | null>) => void) => void;
     mset: (keysAndValues: Array<string>, cb?: (Error | null) => void) => void;
     rpoplpush: (source: string, destination: string) => string | void;

--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
@@ -28,6 +28,11 @@ client.set('some-key');
 // $ExpectError
 client.set('some-key', { foo: 'bar' });
 
+client.del(['key1', 'key2', 'key3']);
+client.del(['key1', 'key2', 'key3'], (error) => {
+  if (error) console.error(error);
+});
+
 client.hmset("some-key", { key1: "value1" }, err =>
   console.log("hmset error:", err)
 );


### PR DESCRIPTION
`redisClient.del()` can be used in two ways:

```js
redisClient.del('key1', 'key2', 'key3', optionalCallback);
```

and

```js
redisClient.del(['key1', 'key2', 'key3'], optionalCallback);
```

The way it is currently typed allows the first form only, but doesn't allow the optional callback. I could not think of a way to type it so it would allow both forms while providing decent safety.
I decided to update the current type definition so it allows the second form, since I think it is the strictest and therefore the safest one. With these changes, we won't be able to use the first form anymore but we will be able to use the optional callback, which is something much more important in my opinion.

*Please note that suggestions are definitely welcome!*


Demonstration:

```js
const redis = require('redis');
const client = redis.createClient();
client.mset(['one', '1', 'two', '2', 'three', '3'], (error) => {
  if (error) {
    console.error(error);
    return;
  }
  client.mget(['one', 'two', 'three'], (error, values) => {
    if (error) {
      console.error(error);
      return;
    }
    console.log(values);  // outputs "'1', '2', '3'"
    client.del(['one', 'two', 'three'], (error) => {
      if (error) {
        console.error(error);
        return;
      }
      client.mget(['one', 'two', 'three'], (error, values) => {
        if (error) {
          console.error(error);
          return;
        }
        console.log(values); // outputs "null, null, null"
      });
    });
  });
});
```