### PR TITLE
Add the type for redis.flushall()

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -24,6 +24,7 @@ declare module "redis" {
     mget: (keys: Array<string>, (Error | null, Array<string | null>) => void) => void;
     mset: (keysAndValues: Array<string>, cb?: (Error | null) => void) => void;
     rpoplpush: (source: string, destination: string) => string | void;
+    flushall: (cb?: (Error | null) => void) => void;
     publish: (topic: string, value: any) => void;
     subscribe: (topic: string) => void;
     unsubscribe: (topic: string) => void;

--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
@@ -68,3 +68,8 @@ client.mset([
 ], (error) => {
   if (error !== null) console.error(error);
 });
+
+client.flushall();
+client.flushall((error) => {
+  if (error !== null) console.error(error);
+});


### PR DESCRIPTION
Demonstration:

```js
const redis = require('redis');
const client = redis.createClient();
client.set('foo', 'bar', (error) => {
  if (error) {
    console.error(error);
    return;
  }
  client.flushall((error) => {
    if (error) {
      console.error(error);
      return;
    }
    client.get('foo', (error, value) => {
      if (error) {
        console.error(error);
        return;
      }
      console.log(value); // Outputs "null"
    });
  });
});
```

Reference: https://redis.io/commands/flushall