### PR TITLE
Rxjs fix signatures(withLatestFrom, combineLatest, zip)

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
@@ -1054,43 +1054,6 @@ declare class rxjs$Observable<+T> {
     closingSelector: () => rxjs$Observable<any>
   ): rxjs$Observable<rxjs$Observable<T>>;
 
-  withLatestFrom<A>(a: rxjs$Observable<A>): rxjs$Observable<[T, A]>;
-
-  withLatestFrom<A, B>(
-    a: rxjs$Observable<A>,
-    resultSelector: (a: A) => B
-  ): rxjs$Observable<B>;
-
-  withLatestFrom<A, B, C>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    resultSelector: (a: A, b: B) => C
-  ): rxjs$Observable<C>;
-
-  withLatestFrom<A, B, C, D>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    resultSelector: (a: A, b: B, c: C) => D
-  ): rxjs$Observable<D>;
-
-  withLatestFrom<A, B, C, D, E>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>,
-    resultSelector: (a: A, b: B, c: C, d: D) => E
-  ): rxjs$Observable<E>;
-
-  withLatestFrom<A, B, C, D, E, F>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>,
-    e: rxjs$Observable<E>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E) => F
-  ): rxjs$Observable<F>;
-
   withLatestFrom<A, B, C, D, E, F, G>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
@@ -1098,8 +1061,9 @@ declare class rxjs$Observable<+T> {
     d: rxjs$Observable<D>,
     e: rxjs$Observable<E>,
     f: rxjs$Observable<F>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F) => G
-  ): rxjs$Observable<G>;
+    g: rxjs$Observable<G>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E, E, F, G]>;
 
   withLatestFrom<A, B, C, D, E, F, G, H>(
     a: rxjs$Observable<A>,
@@ -1109,8 +1073,95 @@ declare class rxjs$Observable<+T> {
     e: rxjs$Observable<E>,
     f: rxjs$Observable<F>,
     g: rxjs$Observable<G>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
   ): rxjs$Observable<H>;
+
+  withLatestFrom<A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E, F]>;
+
+  withLatestFrom<A, B, C, D, E, F, G>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F) => G
+  ): rxjs$Observable<G>;
+
+  withLatestFrom<A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E]>;
+
+  withLatestFrom<A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E) => F
+  ): rxjs$Observable<F>;
+
+  withLatestFrom<A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D]>;
+
+  withLatestFrom<A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D) => E
+  ): rxjs$Observable<E>;
+
+  withLatestFrom<A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C]>;
+
+  withLatestFrom<A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    resultSelector: (t: T, a: A, b: B, c: C) => D
+  ): rxjs$Observable<D>;
+
+  withLatestFrom<A, B>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    _: void
+  ): rxjs$Observable<[T, A, B]>;
+
+  withLatestFrom<A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    resultSelector: (t: T, a: A, b: B) => C
+  ): rxjs$Observable<C>;
+
+  withLatestFrom<A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<[T, A]>;
+
+  withLatestFrom<A, B>(
+    a: rxjs$Observable<A>,
+    resultSelector: (t: T, a: A) => B
+  ): rxjs$Observable<B>;
 
   static using<R: rxjs$ISubscription>(
     resourceFactory: () => ?R,

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
@@ -846,20 +846,23 @@ declare class rxjs$Observable<+T> {
 
   static zip<A, B>(
     a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>
+    b: rxjs$Observable<B>,
+    _: void
   ): rxjs$Observable<[A, B]>;
 
   static zip<A, B, C>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>
+    c: rxjs$Observable<C>,
+    _: void
   ): rxjs$Observable<[A, B, C]>;
 
   static zip<A, B, C, D>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
     c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>
+    d: rxjs$Observable<D>,
+    _: void
   ): rxjs$Observable<[A, B, C, D]>;
 
   static zip<A, B, C, D, E>(
@@ -867,7 +870,8 @@ declare class rxjs$Observable<+T> {
     b: rxjs$Observable<B>,
     c: rxjs$Observable<C>,
     d: rxjs$Observable<D>,
-    e: rxjs$Observable<E>
+    e: rxjs$Observable<E>,
+    _: void
   ): rxjs$Observable<[A, B, C, D, E]>;
 
   static zip<A, B, C, D, E, F>(
@@ -876,7 +880,8 @@ declare class rxjs$Observable<+T> {
     c: rxjs$Observable<C>,
     d: rxjs$Observable<D>,
     e: rxjs$Observable<E>,
-    f: rxjs$Observable<F>
+    f: rxjs$Observable<F>,
+    _: void
   ): rxjs$Observable<[A, B, C, D, E, F]>;
 
   static zip<A, B, C, D, E, F, G>(
@@ -886,7 +891,8 @@ declare class rxjs$Observable<+T> {
     d: rxjs$Observable<D>,
     e: rxjs$Observable<E>,
     f: rxjs$Observable<F>,
-    g: rxjs$Observable<G>
+    g: rxjs$Observable<G>,
+    _: void
   ): rxjs$Observable<[A, B, C, D, E, F, G]>;
 
   static zip<A, B, C, D, E, F, G, H>(
@@ -897,45 +903,9 @@ declare class rxjs$Observable<+T> {
     e: rxjs$Observable<E>,
     f: rxjs$Observable<F>,
     g: rxjs$Observable<G>,
-    h: rxjs$Observable<H>
+    h: rxjs$Observable<H>,
+    _: void
   ): rxjs$Observable<[A, B, C, D, E, F, G, H]>;
-
-  zip<A>(a: rxjs$Observable<A>): rxjs$Observable<[T, A]>;
-
-  zip<A, B>(
-    a: rxjs$Observable<A>,
-    resultSelector: (a: A) => B
-  ): rxjs$Observable<B>;
-
-  zip<A, B, C>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    resultSelector: (a: A, b: B) => C
-  ): rxjs$Observable<C>;
-
-  zip<A, B, C, D>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    resultSelector: (a: A, b: B, c: C) => D
-  ): rxjs$Observable<D>;
-
-  zip<A, B, C, D, E>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>,
-    resultSelector: (a: A, b: B, c: C, d: D) => E
-  ): rxjs$Observable<E>;
-
-  zip<A, B, C, D, E, F>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>,
-    e: rxjs$Observable<E>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E) => F
-  ): rxjs$Observable<F>;
 
   zip<A, B, C, D, E, F, G>(
     a: rxjs$Observable<A>,
@@ -944,8 +914,9 @@ declare class rxjs$Observable<+T> {
     d: rxjs$Observable<D>,
     e: rxjs$Observable<E>,
     f: rxjs$Observable<F>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F) => G
-  ): rxjs$Observable<G>;
+    g: rxjs$Observable<G>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E, E, F, G]>;
 
   zip<A, B, C, D, E, F, G, H>(
     a: rxjs$Observable<A>,
@@ -955,8 +926,95 @@ declare class rxjs$Observable<+T> {
     e: rxjs$Observable<E>,
     f: rxjs$Observable<F>,
     g: rxjs$Observable<G>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
   ): rxjs$Observable<H>;
+
+  zip<A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E, F]>;
+
+  zip<A, B, C, D, E, F, G>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F) => G
+  ): rxjs$Observable<G>;
+
+  zip<A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E]>;
+
+  zip<A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E) => F
+  ): rxjs$Observable<F>;
+
+  zip<A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D]>;
+
+  zip<A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D) => E
+  ): rxjs$Observable<E>;
+
+  zip<A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C]>;
+
+  zip<A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    resultSelector: (t: T, a: A, b: B, c: C) => D
+  ): rxjs$Observable<D>;
+
+  zip<A, B>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    _: void
+  ): rxjs$Observable<[T, A, B]>;
+
+  zip<A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    resultSelector: (t: T, a: A, b: B) => C
+  ): rxjs$Observable<C>;
+
+  zip<A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<[T, A]>;
+
+  zip<A, B>(
+    a: rxjs$Observable<A>,
+    resultSelector: (t: T, a: A) => B
+  ): rxjs$Observable<B>;
 
   static forkJoin<A, B>(
     a: rxjs$Observable<A>,

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
@@ -616,20 +616,23 @@ declare class rxjs$Observable<+T> {
 
   static combineLatest<A, B>(
     a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>
+    b: rxjs$Observable<B>,
+    _: void
   ): rxjs$Observable<[A, B]>;
 
   static combineLatest<A, B, C>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>
+    c: rxjs$Observable<C>,
+    _: void
   ): rxjs$Observable<[A, B, C]>;
 
   static combineLatest<A, B, C, D>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
     c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>
+    d: rxjs$Observable<D>,
+    _: void
   ): rxjs$Observable<[A, B, C, D]>;
 
   static combineLatest<A, B, C, D, E>(
@@ -637,7 +640,8 @@ declare class rxjs$Observable<+T> {
     b: rxjs$Observable<B>,
     c: rxjs$Observable<C>,
     d: rxjs$Observable<D>,
-    e: rxjs$Observable<E>
+    e: rxjs$Observable<E>,
+    _: void
   ): rxjs$Observable<[A, B, C, D, E]>;
 
   static combineLatest<A, B, C, D, E, F>(
@@ -646,7 +650,8 @@ declare class rxjs$Observable<+T> {
     c: rxjs$Observable<C>,
     d: rxjs$Observable<D>,
     e: rxjs$Observable<E>,
-    f: rxjs$Observable<F>
+    f: rxjs$Observable<F>,
+    _: void
   ): rxjs$Observable<[A, B, C, D, E, F]>;
 
   static combineLatest<A, B, C, D, E, F, G>(
@@ -656,7 +661,8 @@ declare class rxjs$Observable<+T> {
     d: rxjs$Observable<D>,
     e: rxjs$Observable<E>,
     f: rxjs$Observable<F>,
-    g: rxjs$Observable<G>
+    g: rxjs$Observable<G>,
+    _: void
   ): rxjs$Observable<[A, B, C, D, E, F, G]>;
 
   static combineLatest<A, B, C, D, E, F, G, H>(
@@ -667,45 +673,9 @@ declare class rxjs$Observable<+T> {
     e: rxjs$Observable<E>,
     f: rxjs$Observable<F>,
     g: rxjs$Observable<G>,
-    h: rxjs$Observable<H>
+    h: rxjs$Observable<H>,
+    _: void
   ): rxjs$Observable<[A, B, C, D, E, F, G, H]>;
-
-  combineLatest<A>(a: rxjs$Observable<A>): rxjs$Observable<[T, A]>;
-
-  combineLatest<A, B>(
-    a: rxjs$Observable<A>,
-    resultSelector: (a: A) => B
-  ): rxjs$Observable<B>;
-
-  combineLatest<A, B, C>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    resultSelector: (a: A, b: B) => C
-  ): rxjs$Observable<C>;
-
-  combineLatest<A, B, C, D>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    resultSelector: (a: A, b: B, c: C) => D
-  ): rxjs$Observable<D>;
-
-  combineLatest<A, B, C, D, E>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>,
-    resultSelector: (a: A, b: B, c: C, d: D) => E
-  ): rxjs$Observable<E>;
-
-  combineLatest<A, B, C, D, E, F>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>,
-    e: rxjs$Observable<E>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E) => F
-  ): rxjs$Observable<F>;
 
   combineLatest<A, B, C, D, E, F, G>(
     a: rxjs$Observable<A>,
@@ -714,8 +684,9 @@ declare class rxjs$Observable<+T> {
     d: rxjs$Observable<D>,
     e: rxjs$Observable<E>,
     f: rxjs$Observable<F>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F) => G
-  ): rxjs$Observable<G>;
+    g: rxjs$Observable<G>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E, E, F, G]>;
 
   combineLatest<A, B, C, D, E, F, G, H>(
     a: rxjs$Observable<A>,
@@ -725,8 +696,95 @@ declare class rxjs$Observable<+T> {
     e: rxjs$Observable<E>,
     f: rxjs$Observable<F>,
     g: rxjs$Observable<G>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
   ): rxjs$Observable<H>;
+
+  combineLatest<A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E, F]>;
+
+  combineLatest<A, B, C, D, E, F, G>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F) => G
+  ): rxjs$Observable<G>;
+
+  combineLatest<A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E]>;
+
+  combineLatest<A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E) => F
+  ): rxjs$Observable<F>;
+
+  combineLatest<A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D]>;
+
+  combineLatest<A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D) => E
+  ): rxjs$Observable<E>;
+
+  combineLatest<A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C]>;
+
+  combineLatest<A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    resultSelector: (t: T, a: A, b: B, c: C) => D
+  ): rxjs$Observable<D>;
+
+  combineLatest<A, B>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    _: void
+  ): rxjs$Observable<[T, A, B]>;
+
+  combineLatest<A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    resultSelector: (t: T, a: A, b: B) => C
+  ): rxjs$Observable<C>;
+
+  combineLatest<A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<[T, A]>;
+
+  combineLatest<A, B>(
+    a: rxjs$Observable<A>,
+    resultSelector: (t: T, a: A) => B
+  ): rxjs$Observable<B>;
 
   static zip<A, B>(
     a: rxjs$Observable<A>,

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -1081,53 +1081,6 @@ declare class rxjs$Observable<+T> {
     _: void
   ): rxjs$Observable<[A, B, C, D, E, F, G, H]>;
 
-  zip<A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<[T, A]>;
-
-  zip<A, B>(
-    a: rxjs$Observable<A>,
-    resultSelector: (a: A) => B
-  ): rxjs$Observable<B>;
-
-  zip<A, B, C>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    resultSelector: (a: A, b: B) => C
-  ): rxjs$Observable<C>;
-
-  zip<A, B, C, D>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    resultSelector: (a: A, b: B, c: C) => D
-  ): rxjs$Observable<D>;
-
-  zip<A, B, C, D, E>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>,
-    resultSelector: (a: A, b: B, c: C, d: D) => E
-  ): rxjs$Observable<E>;
-
-  zip<A, B, C, D, E, F>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>,
-    e: rxjs$Observable<E>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E) => F
-  ): rxjs$Observable<F>;
-
-  zip<A, B, C, D, E, F, G>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>,
-    e: rxjs$Observable<E>,
-    f: rxjs$Observable<F>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F) => G
-  ): rxjs$Observable<G>;
-
   zip<A, B, C, D, E, F, G, H>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
@@ -1136,8 +1089,106 @@ declare class rxjs$Observable<+T> {
     e: rxjs$Observable<E>,
     f: rxjs$Observable<F>,
     g: rxjs$Observable<G>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
   ): rxjs$Observable<H>;
+
+  zip<A, B, C, D, E, F, G>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F) => G
+  ): rxjs$Observable<G>;
+
+  zip<A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E) => F
+  ): rxjs$Observable<F>;
+
+  zip<A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D) => E
+  ): rxjs$Observable<E>;
+
+  zip<A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    resultSelector: (t: T, a: A, b: B, c: C) => D
+  ): rxjs$Observable<D>;
+
+  zip<A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    resultSelector: (t: T, a: A, b: B) => C
+  ): rxjs$Observable<C>;
+
+  zip<A, B>(
+    a: rxjs$Observable<A>,
+    resultSelector: (t: T, a: A) => B
+  ): rxjs$Observable<B>;
+
+  zip<A, B, C, D, E, F, G>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    g: rxjs$Observable<G>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E, E, F, G]>;
+
+  zip<A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E, F]>;
+
+  zip<A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E]>;
+
+  zip<A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D]>;
+
+  zip<A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C]>;
+
+  zip<A, B>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    _: void
+  ): rxjs$Observable<[T, A, B]>;
+
+  zip<A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<[T, A]>;
 
   static forkJoin<A, B>(
     a: rxjs$Observable<A>,

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -851,53 +851,6 @@ declare class rxjs$Observable<+T> {
     _: void
   ): rxjs$Observable<[A, B, C, D, E, F, G, H]>;
 
-  combineLatest<A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<[T, A]>;
-
-  combineLatest<A, B>(
-    a: rxjs$Observable<A>,
-    resultSelector: (a: A) => B
-  ): rxjs$Observable<B>;
-
-  combineLatest<A, B, C>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    resultSelector: (a: A, b: B) => C
-  ): rxjs$Observable<C>;
-
-  combineLatest<A, B, C, D>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    resultSelector: (a: A, b: B, c: C) => D
-  ): rxjs$Observable<D>;
-
-  combineLatest<A, B, C, D, E>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>,
-    resultSelector: (a: A, b: B, c: C, d: D) => E
-  ): rxjs$Observable<E>;
-
-  combineLatest<A, B, C, D, E, F>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>,
-    e: rxjs$Observable<E>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E) => F
-  ): rxjs$Observable<F>;
-
-  combineLatest<A, B, C, D, E, F, G>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>,
-    e: rxjs$Observable<E>,
-    f: rxjs$Observable<F>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F) => G
-  ): rxjs$Observable<G>;
-
   combineLatest<A, B, C, D, E, F, G, H>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
@@ -906,8 +859,106 @@ declare class rxjs$Observable<+T> {
     e: rxjs$Observable<E>,
     f: rxjs$Observable<F>,
     g: rxjs$Observable<G>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
   ): rxjs$Observable<H>;
+
+  combineLatest<A, B, C, D, E, F, G>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F) => G
+  ): rxjs$Observable<G>;
+
+  combineLatest<A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E) => F
+  ): rxjs$Observable<F>;
+
+  combineLatest<A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D) => E
+  ): rxjs$Observable<E>;
+
+  combineLatest<A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    resultSelector: (t: T, a: A, b: B, c: C) => D
+  ): rxjs$Observable<D>;
+
+  combineLatest<A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    resultSelector: (t: T, a: A, b: B) => C
+  ): rxjs$Observable<C>;
+
+  combineLatest<A, B>(
+    a: rxjs$Observable<A>,
+    resultSelector: (t: T, a: A) => B
+  ): rxjs$Observable<B>;
+
+  combineLatest<A, B, C, D, E, F, G>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    g: rxjs$Observable<G>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E, E, F, G]>;
+
+  combineLatest<A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E, F]>;
+
+  combineLatest<A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E]>;
+
+  combineLatest<A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D]>;
+
+  combineLatest<A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C]>;
+
+  combineLatest<A, B>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    _: void
+  ): rxjs$Observable<[T, A, B]>;
+
+  combineLatest<A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<[T, A]>;
 
   static zip<A, B>(
     a: rxjs$Observable<A>,

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -1242,53 +1242,6 @@ declare class rxjs$Observable<+T> {
     closingSelector: () => rxjs$Observable<any>
   ): rxjs$Observable<rxjs$Observable<T>>;
 
-  withLatestFrom<A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<[T, A]>;
-
-  withLatestFrom<A, B>(
-    a: rxjs$Observable<A>,
-    resultSelector: (a: A) => B
-  ): rxjs$Observable<B>;
-
-  withLatestFrom<A, B, C>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    resultSelector: (a: A, b: B) => C
-  ): rxjs$Observable<C>;
-
-  withLatestFrom<A, B, C, D>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    resultSelector: (a: A, b: B, c: C) => D
-  ): rxjs$Observable<D>;
-
-  withLatestFrom<A, B, C, D, E>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>,
-    resultSelector: (a: A, b: B, c: C, d: D) => E
-  ): rxjs$Observable<E>;
-
-  withLatestFrom<A, B, C, D, E, F>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>,
-    e: rxjs$Observable<E>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E) => F
-  ): rxjs$Observable<F>;
-
-  withLatestFrom<A, B, C, D, E, F, G>(
-    a: rxjs$Observable<A>,
-    b: rxjs$Observable<B>,
-    c: rxjs$Observable<C>,
-    d: rxjs$Observable<D>,
-    e: rxjs$Observable<E>,
-    f: rxjs$Observable<F>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F) => G
-  ): rxjs$Observable<G>;
-
   withLatestFrom<A, B, C, D, E, F, G, H>(
     a: rxjs$Observable<A>,
     b: rxjs$Observable<B>,
@@ -1297,8 +1250,106 @@ declare class rxjs$Observable<+T> {
     e: rxjs$Observable<E>,
     f: rxjs$Observable<F>,
     g: rxjs$Observable<G>,
-    resultSelector: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F, g: G) => H
   ): rxjs$Observable<H>;
+
+  withLatestFrom<A, B, C, D, E, F, G>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E, f: F) => G
+  ): rxjs$Observable<G>;
+
+  withLatestFrom<A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D, e: E) => F
+  ): rxjs$Observable<F>;
+
+  withLatestFrom<A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    resultSelector: (t: T, a: A, b: B, c: C, d: D) => E
+  ): rxjs$Observable<E>;
+
+  withLatestFrom<A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    resultSelector: (t: T, a: A, b: B, c: C) => D
+  ): rxjs$Observable<D>;
+
+  withLatestFrom<A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    resultSelector: (t: T, a: A, b: B) => C
+  ): rxjs$Observable<C>;
+
+  withLatestFrom<A, B>(
+    a: rxjs$Observable<A>,
+    resultSelector: (t: T, a: A) => B
+  ): rxjs$Observable<B>;
+
+  withLatestFrom<A, B, C, D, E, F, G>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    g: rxjs$Observable<G>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E, E, F, G]>;
+
+  withLatestFrom<A, B, C, D, E, F>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    f: rxjs$Observable<F>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E, F]>;
+
+  withLatestFrom<A, B, C, D, E>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    e: rxjs$Observable<E>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D, E]>;
+
+  withLatestFrom<A, B, C, D>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    d: rxjs$Observable<D>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C, D]>;
+
+  withLatestFrom<A, B, C>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    c: rxjs$Observable<C>,
+    _: void
+  ): rxjs$Observable<[T, A, B, C]>;
+
+  withLatestFrom<A, B>(
+    a: rxjs$Observable<A>,
+    b: rxjs$Observable<B>,
+    _: void
+  ): rxjs$Observable<[T, A, B]>;
+
+  withLatestFrom<A>(a: rxjs$Observable<A>, _: void): rxjs$Observable<[T, A]>;
 
   static using<R: rxjs$ISubscription>(
     resourceFactory: () => ?R,

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -171,6 +171,21 @@ const numberOrString: Observable<number | string> = numbers.concat(strings);
 // $ExpectError
 (numbers.withLatestFrom(numbers): Observable<[number, string]>);
 
+(numbers.withLatestFrom(strings, (a: number, b: string) => ({
+  a,
+  b
+})): Observable<{ a: number, b: string }>);
+
+(numbers.withLatestFrom(strings, strings): Observable<
+  [number, string, string]
+>);
+
+(numbers.withLatestFrom(
+  strings,
+  strings,
+  (a: number, b: string, c: string) => ({ a, b, c })
+): Observable<{ a: number, b: string, c: string }>);
+
 numbers.observeOn(Scheduler.async);
 // $ExpectError
 numbers.observeOn(null);

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -143,12 +143,39 @@ const zipped2: Observable<[number, string]> = Observable.zip(numbers, strings);
 
 const zipped3: Observable<[number]> = Observable.zip(numbers);
 
+(Observable.zip(numbers, strings, strings): Observable<
+  [number, string, string]
+>);
+
 // $ExpectError
 const zippedBad: Observable<{ n: number, s: string }> = Observable.zip(
   numbers,
   numbers,
   (n, s) => ({ n, s })
 );
+
+(Observable.zip(numbers, strings): Observable<[number, string]>);
+(Observable.zip(numbers, strings, (a: number, b: string) => ({
+  a,
+  b
+})): Observable<{ a: number, b: string }>);
+
+(numbers.zip(strings): Observable<[number, string]>);
+// $ExpectError
+(numbers.zip(numbers): Observable<[number, string]>);
+
+(numbers.zip(strings, (a: number, b: string) => ({
+  a,
+  b
+})): Observable<{ a: number, b: string }>);
+
+(numbers.zip(strings, strings): Observable<[number, string, string]>);
+
+(numbers.zip(strings, strings, (a: number, b: string, c: string) => ({
+  a,
+  b,
+  c
+})): Observable<{ a: number, b: string, c: string }>);
 
 // $ExpectError
 const bogusEmpty: Observable<string> = Observable.empty().concat(
@@ -196,6 +223,10 @@ const numberOrString: Observable<number | string> = numbers.concat(strings);
   a,
   b
 })): Observable<{ a: number, b: string }>);
+
+(numbers.withLatestFrom(strings, strings): Observable<
+  [number, string, string]
+>);
 
 (numbers.withLatestFrom(strings, strings): Observable<
   [number, string, string]

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -64,11 +64,32 @@ const combined2: Observable<[number, string]> = Observable.combineLatest(
 
 const combined3: Observable<[number]> = Observable.combineLatest(numbers);
 
+(Observable.combineLatest(numbers, strings, strings): Observable<
+  [number, string, string]
+>);
+
 const combinedBad: Observable<{
   n: number,
   s: string
   // $ExpectError
 }> = Observable.combineLatest(numbers, numbers, (n, s) => ({ n, s }));
+
+(numbers.combineLatest(strings): Observable<[number, string]>);
+// $ExpectError
+(numbers.combineLatest(numbers): Observable<[number, string]>);
+
+(numbers.combineLatest(strings, (a: number, b: string) => ({
+  a,
+  b
+})): Observable<{ a: number, b: string }>);
+
+(numbers.combineLatest(strings, strings): Observable<[number, string, string]>);
+
+(numbers.combineLatest(strings, strings, (a: number, b: string, c: string) => ({
+  a,
+  b,
+  c
+})): Observable<{ a: number, b: string, c: string }>);
 
 const forked: Observable<{ n: number, s: string }> = Observable.forkJoin(
   numbers,


### PR DESCRIPTION
http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-withLatestFrom
http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-combineLatest
http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#static-method-combineLatest
http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-zipProto
http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#static-method-zip

# The last argument is now properly optional
These operators receive a projection function as the last argument, and it is optional.
Under the previous signature, It's not optional in case of 2 or more Observables are given as arguments.

Actual behavior is described in document of `withLatestFrom`:
> Projection function for combining values together. Receives all values in order of the Observables passed, where the first parameter is a value from the source Observable. (e.g. a.withLatestFrom(b, c, (a1, b1, c1) => a1 + b1 + c1)). If this is not passed, arrays will be emitted on the output Observable.

It is the same for `combineLatest`, `zip` and static version of these operators.

# Fix projection function's argument signature
In operators as instance methods, projection function should receive the value from source Observable as the first argument, but ignored in previous signature.

from actual behavior:
```
declare class Observable<+T> {
  // ...
  withLatestFrom<A, B, C>(
    a: Observable<A>,
    b: Observable<B>,
    resultSelector: (t: T, a: A, b: B) => C
  ): Observable<C>;
}
```

previous signature:
```
declare class Observable<+T> {
  // ...
  withLatestFrom<A, B, C>(
    a: Observable<A>,
    b: Observable<B>,
    resultSelector: (a: A, b: B) => C //  source Observable's value is missing
  ): Observable<C>;
}
```

It is the same for instance method version of `combineLatest` and `zip`.