### PR TITLE
redis_v2 .x.x - add ttl and setex definitions

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -20,6 +20,8 @@ declare module "redis" {
     hdel: (topic: string, key: string) => number;
     get: (key: string, (Error | null, string | null) => void) => void;
     set: (key: string, value: string, cb?: (error: Error | null) => void) => void;
+    setex: (key: string, timeout: string | number, value: string, callback?: (error: ?Error, result: ?string) => void) => void;
+    ttl: (key: string, callback: (error: ?Error, ttl: ?number) => void) => void;
     del: (keys: Array<string>, cb?: (Error | null) => void) => void;
     mget: (keys: Array<string>, (Error | null, Array<string | null>) => void) => void;
     mset: (keysAndValues: Array<string>, cb?: (Error | null) => void) => void;


### PR DESCRIPTION
- add `ttl(key, cb)` method https://redis.io/commands/ttl
- add `setex(key, timeout, value, cb)` method https://redis.io/commands/setex