### PR TITLE
Fix type of redis.setex

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -20,7 +20,7 @@ declare module "redis" {
     hdel: (topic: string, key: string) => number;
     get: (key: string, (Error | null, string | null) => void) => void;
     set: (key: string, value: string, cb?: (error: Error | null) => void) => void;
-    setex: (key: string, timeout: string | number, value: string, callback?: (error: ?Error, result: ?string) => void) => void;
+    setex: (key: string, timeout: number, value: string, callback?: (error: ?Error, result: ?string) => void) => void;
     ttl: (key: string, callback: (error: ?Error, ttl: ?number) => void) => void;
     del: (keys: Array<string>, cb?: (Error | null) => void) => void;
     mget: (keys: Array<string>, (Error | null, Array<string | null>) => void) => void;

--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
@@ -36,6 +36,13 @@ client.set('some-key');
 // $ExpectError
 client.set('some-key', { foo: 'bar' });
 
+client.setex('some-key', 12345, 'value');
+client.setex('some-key', 12345, 'value', (error) => {
+  if (error !== null) console.error(error);
+});
+// $ExpectError
+client.setx('somekey', 'value');
+
 client.del(['key1', 'key2', 'key3']);
 client.del(['key1', 'key2', 'key3'], (error) => {
   if (error) console.error(error);


### PR DESCRIPTION
`seconds` in `SETEX key seconds value` is expected to be a number and not a string.
See https://redis.io/commands/setex

In `setex('my-key', '5', 'my-value')`, the Redis client for JavaScript will apparently parse `5` as a number, but allowing both string and number for the `seconds` argument may not be the best thing to do if we want to limit side-effects/unexpected behaviors through using strict types.