### PR TITLE
Replace `any` by `mixed` in express_v4.x.x.js

### DIFF
--- a/definitions/npm/express_v4.16.x/flow_v0.32.x-/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.32.x-/express_v4.16.x.js
@@ -18,7 +18,7 @@ declare type express$RequestParams = {
 
 declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
   baseUrl: string;
-  body: any;
+  body: mixed;
   cookies: { [cookie: string]: string };
   connection: Socket;
   fresh: boolean;

--- a/definitions/npm/express_v4.x.x/flow_v0.32.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.32.x-/express_v4.x.x.js
@@ -18,7 +18,7 @@ declare type express$RequestParams = {
 
 declare class express$Request extends http$IncomingMessage mixins express$RequestResponseBase {
   baseUrl: string;
-  body: any;
+  body: mixed;
   cookies: {[cookie: string]: string};
   connection: Socket;
   fresh: boolean;


### PR DESCRIPTION
Using `any` will effectively disable the type checker anywhere you use the `req.body` property, which is dangerous. By declaring it as a `mixed` type, it allows you to use it, but you'll have to make sure that any assumptions you make about its contents are checked first, which is the way to go.