### PR TITLE
Fix the type for redis.lrange()

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -12,8 +12,9 @@ declare module "redis" {
     lrange: (
       topic: string,
       cursor: number,
-      cursor2: number
-    ) => Array<string> | void;
+      cursor2: number,
+      (error: Error | null, entries: Array<string>) => void
+    ) => boolean;
     hset: (topic: string, key: string, value: string) => number;
     hget: (topic: string, key: string, value: string) => string | void;
     hgetall: (topic: string, key: string) => Array<string> | void;
@@ -58,7 +59,7 @@ declare module "redis" {
       topic: string,
       cursor: number,
       cursor2: number
-    ) => Promise<Array<string>> | Promise<void>;
+    ) => Promise<Array<string>>;
     hsetAsync: (topic: string, key: string, value: string) => Promise<number>;
     hgetAsync: (topic: string, key: string) => Promise<string> | Promise<void>;
     hgetallAsync: (

--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
@@ -67,6 +67,14 @@ client.lpush("key");
 // $ExpectError
 client.lpush("key", { foo: 'bar' });
 
+client.lrange("key", 0, 5, (error, entries) => {
+  if (error !== null) {
+    console.error(error);
+    return;
+  }
+  console.log(entries.join(','));
+});
+
 client.mget(["key1", "key2"], (error, entries) => {
   if (error === null) {
     console.log('Error!');


### PR DESCRIPTION
Demonstration:

```js
'use strict';

const redis = require('redis');
const client = redis.createClient();

const returned = client.lrange('key', 0, 5, (error, entries) => {
  console.log('error', error);
  console.log('entries', entries);
});
console.log('returned', returned);
```

Output:

```
returned false
error null
entries []
```