### PR TITLE
Add type for redis.llen()

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -15,6 +15,7 @@ declare module "redis" {
       cursor2: number,
       (error: Error | null, entries: Array<string>) => void
     ) => boolean;
+    llen: (key: string, (error: Error | null, length: number) => void) => boolean;
     hset: (topic: string, key: string, value: string) => number;
     hget: (topic: string, key: string, value: string) => string | void;
     hgetall: (topic: string, key: string) => Array<string> | void;

--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
@@ -75,6 +75,14 @@ client.lrange("key", 0, 5, (error, entries) => {
   console.log(entries.join(','));
 });
 
+client.llen('key', (error, length) => {
+  if (error !== null) {
+    console.error(error);
+    return;
+  }
+  console.log(length);
+});
+
 client.mget(["key1", "key2"], (error, entries) => {
   if (error === null) {
     console.log('Error!');


### PR DESCRIPTION
Reference: https://redis.io/commands/llen

Demonstration:

```js
'use strict';

const redis = require('redis');
const client = redis.createClient();

const returned = client.llen('key', (error, length) => {
  console.log('error', error);
  console.log('length', length);
});
console.log('returned', returned);
```

Outputs

```
returned false
error null
length 0
```