### PR TITLE
[temp] Change return type of callback to mixed for async functions.

### DIFF
--- a/definitions/npm/temp_v0.8.x/flow_v0.58.x-/temp_v0.8.x.js
+++ b/definitions/npm/temp_v0.8.x/flow_v0.58.x-/temp_v0.8.x.js
@@ -17,7 +17,7 @@ declare module 'temp' {
     // Functions
     mkdir(
       affixes?: Affixes,
-      callback?: (err: ?ErrnoError, dirPath: string) => void,
+      callback?: (err: ?ErrnoError, dirPath: string) => mixed,
     ): void;
     mkdirSync(affixes?: Affixes): string;
     open(
@@ -25,7 +25,7 @@ declare module 'temp' {
       callback?: (
         err: ?ErrnoError,
         info: {path: string, fd: ?number},
-      ) => void,
+      ) => mixed,
     ): void;
     openSync(affixes?: Affixes): {path: string, fd: ?number};
     path(rawAffixes?: Affixes, defaultPrefix?: string): string;
@@ -33,7 +33,7 @@ declare module 'temp' {
       callback?: (
         err: ?ErrnoError,
         info: {files: number, dirs?: number},
-      ) => void,
+      ) => mixed,
     ): void;
     cleanupSync(): {files: number, dirs: number};
     createWriteStream(affixes?: Affixes): stream$Writable;


### PR DESCRIPTION
Because the current return type is declared as `void`, Flow complains
when an `async` function is used in the callback because it returns a
`Promise`.