### PR TITLE
Add renderStatic method to react-helmet-v5 lib def + update tests

### DIFF
--- a/definitions/npm/react-helmet_v5.x.x/flow_v0.53.x-/react-helmet_v5.x.x.js
+++ b/definitions/npm/react-helmet_v5.x.x/flow_v0.53.x-/react-helmet_v5.x.x.js
@@ -43,6 +43,7 @@ declare module 'react-helmet' {
 
     declare class Helmet extends React$Component<Props> {
       static rewind(): StateOnServer;
+      static renderStatic(): StateOnServer;
       static canUseDom(canUseDOM: boolean): void;
     }
 

--- a/definitions/npm/react-helmet_v5.x.x/test_react-helmet.js
+++ b/definitions/npm/react-helmet_v5.x.x/test_react-helmet.js
@@ -31,28 +31,30 @@ const fail = () => (
     <Helmet title={{}} />
 )
 
+// rewind and renderStatic are aliases
+const heads = [Helmet.rewind(), Helmet.renderStatic()];
 
-const head = Helmet.rewind();
+heads.forEach((head) => {
+  (head.htmlAttributes.toString(): string);
+  (head.title.toString(): string);
+  (head.base.toString(): string);
+  (head.meta.toString(): string);
+  (head.link.toString(): string);
+  (head.script.toString(): string);
+  (head.style.toString(): string);
 
-(head.htmlAttributes.toString(): string);
-(head.title.toString(): string);
-(head.base.toString(): string);
-(head.meta.toString(): string);
-(head.link.toString(): string);
-(head.script.toString(): string);
-(head.style.toString(): string);
-
-// $ExpectError
-(head.htmlAttributes.toString(): boolean);
-// $ExpectError
-(head.title.toString(): boolean);
-// $ExpectError
-(head.base.toString(): boolean);
-// $ExpectError
-(head.meta.toString(): boolean);
-// $ExpectError
-(head.link.toString(): boolean);
-// $ExpectError
-(head.script.toString(): boolean);
-// $ExpectError
-(head.style.toString(): boolean);
+  // $ExpectError
+  (head.htmlAttributes.toString(): boolean);
+  // $ExpectError
+  (head.title.toString(): boolean);
+  // $ExpectError
+  (head.base.toString(): boolean);
+  // $ExpectError
+  (head.meta.toString(): boolean);
+  // $ExpectError
+  (head.link.toString(): boolean);
+  // $ExpectError
+  (head.script.toString(): boolean);
+  // $ExpectError
+  (head.style.toString(): boolean);
+});


### PR DESCRIPTION
## Context
`react-helmet` supports the static method `renderStatic` as alias for `rewind` on the `Helmet` object. This is documented in their v5 release notes (https://github.com/nfl/react-helmet/releases/tag/5.0.0) and is used as the new default in their documentation as well (https://github.com/nfl/react-helmet).

The Flow definition, however, did not include this static method.

## What has been done?
- Added `renderStatic` as a static method on the `Helmet` object
- Updated tests; all tests that were previously only run on `Helmet.rewind()` are now run on both `Helmet.rewind()` and `Helmet.renderStatic()`