### PR TITLE
Nock: Allow array for matching request body

### DIFF
--- a/definitions/npm/nock_v9.x.x/flow_v0.31.x-/nock_v9.x.x.js
+++ b/definitions/npm/nock_v9.x.x/flow_v0.31.x-/nock_v9.x.x.js
@@ -4,8 +4,9 @@ declare type $npm$nock$Path = string | RegExp | ((url: string) => boolean);
 declare type $npm$nock$Parameter =
   | string
   | RegExp
+  | Array<mixed>
   | Object
-  | ((body: Object) => boolean);
+  | ((body: Object | Array<mixed>) => boolean);
 
 declare type $npm$nock$RecordedCall = {
   scope: string,


### PR DESCRIPTION
Nock will match a JSON array:

```javascript
nock("http://example.com").post("/foo", [{ some: "thing" }, {some: "thing else"}]);
```

However, the type for the second parameter is currently limited to `string | RegExp | Object | (Object => boolean)`, so this isn't being allowed by Flow.