### PR TITLE
Ramda#pathOr accepts numbers for path.

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/ramda_v0.x.x.js
@@ -1533,21 +1533,41 @@ declare module ramda {
   declare function path<V, A: null | void>(p: Array<string>, o: A): void;
   declare function path<V, A: mixed>(p: Array<string>, o: A): ?V;
 
-  declare function pathOr<T, V, A: NestedObject<V>>(
-    or: T,
-    ...rest: Array<void>
-  ): ((p: Array<string|number>, ...rest: Array<void>) => (o: ?A) => V | T) &
-    ((p: Array<string|number>, o: ?A) => V | T);
-  declare function pathOr<T, V, A: NestedObject<V>>(
-    or: T,
-    p: Array<string|number>,
-    ...rest: Array<void>
-  ): (o: ?A) => V | T;
-  declare function pathOr<T, V, A: NestedObject<V>>(
-    or: T,
-    p: Array<string|number>,
-    o: ?A
-  ): V | T;
+  declare type PathOr = (
+    <T, V, A: NestedObject<V>>(or: T) => (
+      (p: Array<string|number>) => (o: A) => V | T
+    ) & (
+      (p: Array<string|number>, o: A) => V | T
+    )
+  ) & (
+    <T, V, A: NestedObject<V>>(
+      or: T,
+      p: Array<string|number>
+    ) => (o: A) => V | T
+  ) & (
+    <T, V, A: NestedObject<V>>(
+      or: T,
+      p: Array<string|number>,
+      o: A
+    ) => V | T
+  );
+
+  // declare function pathOr<T, V, A: NestedObject<V>>(
+  //   or: T,
+  //   ...rest: Array<void>
+  // ): ((p: Array<string|number>, ...rest: Array<void>) => (o: ?A) => V | T) &
+  //   ((p: Array<string|number>, o: ?A) => V | T);
+  // declare function pathOr<T, V, A: NestedObject<V>>(
+  //   or: T,
+  //   p: Array<string|number>,
+  //   ...rest: Array<void>
+  // ): (o: ?A) => V | T;
+  // declare function pathOr<T, V, A: NestedObject<V>>(
+  //   or: T,
+  //   p: Array<string|number>,
+  //   o: ?A
+  // ): V | T;
+  declare var pathOr: PathOr;
 
   declare function pick<A>(
     keys: Array<string>,

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/ramda_v0.x.x.js
@@ -1533,24 +1533,18 @@ declare module ramda {
   declare function path<V, A: null | void>(p: Array<string>, o: A): void;
   declare function path<V, A: mixed>(p: Array<string>, o: A): ?V;
 
-  declare type PathOr = (
-    <T, V, A: NestedObject<V>>(or: T) => (
-      (p: Array<string|number>) => (o: A) => V | T
-    ) & (
-      (p: Array<string|number>, o: A) => V | T
+  declare type PathOr =
+    & (
+      <T, V, A: NestedObject<V>>(or: T) =>
+        & ((p: Array<string|number>) => (o: A) => V | T)
+        & ((p: Array<string|number>, o: A) => V | T)
     )
-  ) & (
-    <T, V, A: NestedObject<V>>(
-      or: T,
-      p: Array<string|number>
-    ) => (o: A) => V | T
-  ) & (
-    <T, V, A: NestedObject<V>>(
-      or: T,
-      p: Array<string|number>,
-      o: A
-    ) => V | T
-  );
+    & (
+      <T, V, A: NestedObject<V>>(or: T, p: Array<string|number>) => (o: A) => V | T
+    )
+    & (
+      <T, V, A: NestedObject<V>>(or: T, p: Array<string|number>, o: A ) => V | T
+    );
 
   // declare function pathOr<T, V, A: NestedObject<V>>(
   //   or: T,

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/ramda_v0.x.x.js
@@ -1546,21 +1546,6 @@ declare module ramda {
       <T, V, A: NestedObject<V>>(or: T, p: Array<string|number>, o: A ) => V | T
     );
 
-  // declare function pathOr<T, V, A: NestedObject<V>>(
-  //   or: T,
-  //   ...rest: Array<void>
-  // ): ((p: Array<string|number>, ...rest: Array<void>) => (o: ?A) => V | T) &
-  //   ((p: Array<string|number>, o: ?A) => V | T);
-  // declare function pathOr<T, V, A: NestedObject<V>>(
-  //   or: T,
-  //   p: Array<string|number>,
-  //   ...rest: Array<void>
-  // ): (o: ?A) => V | T;
-  // declare function pathOr<T, V, A: NestedObject<V>>(
-  //   or: T,
-  //   p: Array<string|number>,
-  //   o: ?A
-  // ): V | T;
   declare var pathOr: PathOr;
 
   declare function pick<A>(

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/ramda_v0.x.x.js
@@ -1536,16 +1536,16 @@ declare module ramda {
   declare function pathOr<T, V, A: NestedObject<V>>(
     or: T,
     ...rest: Array<void>
-  ): ((p: Array<string>, ...rest: Array<void>) => (o: ?A) => V | T) &
-    ((p: Array<string>, o: ?A) => V | T);
+  ): ((p: Array<string|number>, ...rest: Array<void>) => (o: ?A) => V | T) &
+    ((p: Array<string|number>, o: ?A) => V | T);
   declare function pathOr<T, V, A: NestedObject<V>>(
     or: T,
-    p: Array<string>,
+    p: Array<string|number>,
     ...rest: Array<void>
   ): (o: ?A) => V | T;
   declare function pathOr<T, V, A: NestedObject<V>>(
     or: T,
-    p: Array<string>,
+    p: Array<string|number>,
     o: ?A
   ): V | T;
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/test_ramda_v0.x.x_object.js
@@ -199,6 +199,9 @@ const path4: void = _.path(["a"], null);
 const pathOr: string | Object | number = _.pathOr("N/A", ["a", "b"], {
   a: { b: 2 }
 });
+const pathOr2: string | Object | number = _.pathOr("N/A", ["a", 1], {
+  a: { [1]: 2 }
+});
 
 const pck: Object = _.pick(["a", "d"], { a: 1, b: 2, c: 3, d: 4 });
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.49.x-v0.61.x/test_ramda_v0.x.x_object.js
@@ -196,12 +196,19 @@ const path2: Object | number = _.path(["a", 1], { a: { "1": 2 } });
 const path3: ?Object = _.path(["a", "b"], { c: { b: 2 } });
 const path4: void = _.path(["a"], null);
 
-const pathOr: string | Object | number = _.pathOr("N/A", ["a", "b"], {
-  a: { b: 2 }
-});
-const pathOr2: string | Object | number = _.pathOr("N/A", ["a", 1], {
-  a: { [1]: 2 }
-});
+{ // #pathOr
+  { // it should work with basic form
+    const pathOr: string | Object | number = _.pathOr("N/A", ["a", 1], {
+      a: { [1]: 2 }
+    });
+  }
+
+  { // it should work with curried versions
+    const pathOr2 = _.pathOr('N/A', ['a'])({ a: 1 })
+    const pathOr3 = _.pathOr('N/A')(['a'], { a: 1 })
+    const pathOr4 = _.pathOr('N/A')(['a'])({ a: 1 })
+  }
+}
 
 const pck: Object = _.pick(["a", "d"], { a: 1, b: 2, c: 3, d: 4 });
 


### PR DESCRIPTION
@LoganBarnett 

Per [the docs](http://ramdajs.com/docs/#pathOr). Also refactors the signature using the pattern

```
declare type Foo = ...
declare var foo = Foo
```

per discussion in #1615.

Also, tries out a different spacing structure to better illustrate the nesting of intersected functions, for better reading. I'd really like your opinion on this one, hopefully we could standardize. I like what you started with `Reduce`, and it's impossible for me to keep track of the nested parens.