### PR TITLE
fix(redis): fix hgetall result type

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -3,7 +3,7 @@ declare module "redis" {
   declare class RedisClient extends events$EventEmitter mixins RedisClientPromisified {
     hmset: (
       key: string,
-      map: any,
+      map: {[key: string]: string},
       callback?: (error: ?Error) => void
     ) => void;
     rpush: (
@@ -46,7 +46,7 @@ declare module "redis" {
     ) => void;
     hgetall: (
       topic: string,
-      callback: (error: ?Error, result: ?Array<string>) => void
+      callback: (error: ?Error, result: ?{[key: string]: string}) => void
     ) => void;
     hdel: (
       topic: string,
@@ -109,7 +109,7 @@ declare module "redis" {
   declare class RedisClientPromisified extends RedisClient {
     hmsetAsync: (
       key: string,
-      map: any,
+      map: {[key: string]: string},
       callback: (?Error) => void
     ) => Promise<void>;
     rpushAsync: (
@@ -138,7 +138,7 @@ declare module "redis" {
     hgetAsync: (topic: string, key: string) => Promise<string> | Promise<void>;
     hgetallAsync: (
       topic: string,
-    ) => Promise<Array<string>> | Promise<void>;
+    ) => Promise<{[key: string]: string}> | Promise<void>;
     hdelAsync: (topic: string, key: string) => Promise<number>;
     getAsync: (key: string) => Promise<any>;
     setAsync: (key: string, value: any) => Promise<void>;

--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
@@ -115,6 +115,6 @@ client.flushall((error) => {
   if (error !== null) console.error(error);
 });
 
-client.hgetall("key", (error: ?Error, result: ?Array<string>) => {})
+client.hgetall("key", (error: ?Error, result: ?{[key: string]: string}) => {})
 // $ExpectError
-client.hgetall("key", "bad extra argument in past type defs", (error: ?Error, result: ?Array<string>) => {})
+client.hgetall("key", "bad extra argument in past type defs", (error: ?Error, result: ?{[key: string]: string}) => {})


### PR DESCRIPTION
Argh, I didn't notice the section in the docs about how the client's `hgetall` builds an object out of the returned key-value pair array