### PR TITLE
fix(express): add optional Server return to listen method

### DIFF
--- a/definitions/npm/express_v4.16.x/flow_v0.32.x-/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.32.x-/express_v4.16.x.js
@@ -210,15 +210,15 @@ declare class express$Application extends express$Router mixins events$EventEmit
     hostname?: string,
     backlog?: number,
     callback?: (err?: ?Error) => mixed
-  ): Server;
+  ): ?Server;
   listen(
     port: number,
     hostname?: string,
     callback?: (err?: ?Error) => mixed
-  ): Server;
-  listen(port: number, callback?: (err?: ?Error) => mixed): Server;
-  listen(path: string, callback?: (err?: ?Error) => mixed): Server;
-  listen(handle: Object, callback?: (err?: ?Error) => mixed): Server;
+  ): ?Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): ?Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): ?Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?Server;
   disable(name: string): void;
   disabled(name: string): boolean;
   enable(name: string): express$Application;

--- a/definitions/npm/express_v4.16.x/flow_v0.32.x-/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.32.x-/express_v4.16.x.js
@@ -201,6 +201,14 @@ declare class express$Router extends express$Route {
   ) => void;
 }
 
+/*
+With flow-bin ^0.59, express app.listen() is deemed to return any and fails flow type coverage.
+Which is ironic because https://github.com/facebook/flow/blob/master/Changelog.md#misc-2 (release notes for 0.59)
+says "Improves typings for Node.js HTTP server listen() function."  See that?  IMPROVES!
+To work around this issue, we changed Server to ?Server here, so that our invocations of express.listen() will
+not be deemed to lack type coverage.
+*/
+
 declare class express$Application extends express$Router mixins events$EventEmitter {
   constructor(): void;
   locals: { [name: string]: mixed };

--- a/definitions/npm/express_v4.x.x/flow_v0.32.x-/express_v4.x.x.js
+++ b/definitions/npm/express_v4.x.x/flow_v0.32.x-/express_v4.x.x.js
@@ -167,11 +167,11 @@ declare class express$Application extends express$Router mixins events$EventEmit
   constructor(): void;
   locals: {[name: string]: mixed};
   mountpath: string;
-  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): Server;
-  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): Server;
-  listen(port: number, callback?: (err?: ?Error) => mixed): Server;
-  listen(path: string, callback?: (err?: ?Error) => mixed): Server;
-  listen(handle: Object, callback?: (err?: ?Error) => mixed): Server;
+  listen(port: number, hostname?: string, backlog?: number, callback?: (err?: ?Error) => mixed): ?Server;
+  listen(port: number, hostname?: string, callback?: (err?: ?Error) => mixed): ?Server;
+  listen(port: number, callback?: (err?: ?Error) => mixed): ?Server;
+  listen(path: string, callback?: (err?: ?Error) => mixed): ?Server;
+  listen(handle: Object, callback?: (err?: ?Error) => mixed): ?Server;
   disable(name: string): void;
   disabled(name: string): boolean;
   enable(name: string): express$Application;


### PR DESCRIPTION
This is a temporary fix for express typedefs to a known issue when declaring a class with overloaded methods (see more info here: https://github.com/facebook/flow/issues/4198). 

Since this issue has no fix in sight and causes coverage to fail reaching 100%, perhaps this seems an acceptable workaround?