### PR TITLE
Make handleActions use ReducerDefinition

### DIFF
--- a/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
+++ b/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
@@ -92,9 +92,7 @@ declare module "redux-actions" {
   ): Reducer<State, Action>;
 
   declare function handleActions<State, Action>(
-    reducers: {
-      [key: string]: Reducer<State, Action> | ReducerMap<State, Action>
-    },
+    reducers: ReducerDefinition<State, Action>,
     defaultState?: State
   ): Reducer<State, Action>;
 


### PR DESCRIPTION
In `handleAction()` the definition has already been changed to used the ReducerDefinition, now `handleActions()` should follow, too.

As far as I understand the code, this definition should also be able to handle nested reducers.