### PR TITLE
Update Props definitions for react-custom-scrollbars to reflect the library's definitions more closely

### DIFF
--- a/definitions/npm/react-custom-scrollbars_v4.2.x/flow_v0.54.x-/react-custom-scrollbars_v4.2.x.js
+++ b/definitions/npm/react-custom-scrollbars_v4.2.x/flow_v0.54.x-/react-custom-scrollbars_v4.2.x.js
@@ -29,8 +29,8 @@ declare module "react-custom-scrollbars" {
     thumbMinSize?: number,
     universal?: boolean,
     autoHeight?: boolean,
-    autoHeightMin?: number,
-    autoHeightMax?: number
+    autoHeightMin?: number | string,
+    autoHeightMax?: number | string
   };
 
   declare export default class Scrollbars extends React$Component<Props> {

--- a/definitions/npm/react-custom-scrollbars_v4.2.x/test_react-custom-scrollbars_v4.2.x.js
+++ b/definitions/npm/react-custom-scrollbars_v4.2.x/test_react-custom-scrollbars_v4.2.x.js
@@ -37,6 +37,7 @@ function GoodScrollBars() {
       autoHeightMax={30}
     />
   );
+}
 
 function GoodScrollBars2() {
   return (

--- a/definitions/npm/react-custom-scrollbars_v4.2.x/test_react-custom-scrollbars_v4.2.x.js
+++ b/definitions/npm/react-custom-scrollbars_v4.2.x/test_react-custom-scrollbars_v4.2.x.js
@@ -37,4 +37,30 @@ function GoodScrollBars() {
       autoHeightMax={30}
     />
   );
+
+function GoodScrollBars2() {
+  return (
+    <Scrollbars
+      onScroll={(event: SyntheticUIEvent<*>) => console.log(event)}
+      onScrollFrame={values => console.log(values)}
+      onScrollStart={() => console.log("start")}
+      onScrollStop={() => console.log("stop")}
+      onUpdate={values => console.log(values)}
+      renderView={() => null}
+      renderTrackHorizontal={() => null}
+      renderTrackVertical={() => null}
+      renderThumbHorizontal={() => null}
+      renderThumbVertical={() => null}
+      hideTracksWhenNotNeeded
+      autoHide
+      autoHideTimeout={300}
+      autoHideDuration={300}
+      thumbSize={10}
+      thumbMinSize={5}
+      universal
+      autoHeight
+      autoHeightMin={"20px"}
+      autoHeightMax={"30rem"}
+    />
+  );
 }


### PR DESCRIPTION
`autoHeightMin` and `autoHeightMax` now accept both `number` and `string` values, to reflect the actual library definitions (https://github.com/malte-wessel/react-custom-scrollbars/blob/b353cc4956d6154d6a100f34c3a6202c75434186/src/Scrollbars/index.js#L617-L624).