### PR TITLE
Generate lodash/fp per file exports

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -4435,3 +4435,1539 @@ declare module "lodash/toPath" {
 declare module "lodash/uniqueId" {
   declare module.exports: $PropertyType<$Exports<"lodash">, "uniqueId">;
 }
+
+declare module "lodash/fp/chunk" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "chunk">;
+}
+
+declare module "lodash/fp/compact" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "compact">;
+}
+
+declare module "lodash/fp/concat" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "concat">;
+}
+
+declare module "lodash/fp/difference" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "difference">;
+}
+
+declare module "lodash/fp/differenceBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "differenceBy">;
+}
+
+declare module "lodash/fp/differenceWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "differenceWith">;
+}
+
+declare module "lodash/fp/drop" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "drop">;
+}
+
+declare module "lodash/fp/dropLast" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "dropLast">;
+}
+
+declare module "lodash/fp/dropRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "dropRight">;
+}
+
+declare module "lodash/fp/dropRightWhile" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "dropRightWhile">;
+}
+
+declare module "lodash/fp/dropWhile" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "dropWhile">;
+}
+
+declare module "lodash/fp/dropLastWhile" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "dropLastWhile">;
+}
+
+declare module "lodash/fp/fill" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "fill">;
+}
+
+declare module "lodash/fp/findIndex" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findIndex">;
+}
+
+declare module "lodash/fp/findIndexFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findIndexFrom">;
+}
+
+declare module "lodash/fp/findLastIndex" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findLastIndex">;
+}
+
+declare module "lodash/fp/findLastIndexFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findLastIndexFrom">;
+}
+
+declare module "lodash/fp/first" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "first">;
+}
+
+declare module "lodash/fp/flatten" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flatten">;
+}
+
+declare module "lodash/fp/unnest" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unnest">;
+}
+
+declare module "lodash/fp/flattenDeep" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flattenDeep">;
+}
+
+declare module "lodash/fp/flattenDepth" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flattenDepth">;
+}
+
+declare module "lodash/fp/fromPairs" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "fromPairs">;
+}
+
+declare module "lodash/fp/head" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "head">;
+}
+
+declare module "lodash/fp/indexOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "indexOf">;
+}
+
+declare module "lodash/fp/indexOfFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "indexOfFrom">;
+}
+
+declare module "lodash/fp/initial" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "initial">;
+}
+
+declare module "lodash/fp/init" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "init">;
+}
+
+declare module "lodash/fp/intersection" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "intersection">;
+}
+
+declare module "lodash/fp/intersectionBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "intersectionBy">;
+}
+
+declare module "lodash/fp/intersectionWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "intersectionWith">;
+}
+
+declare module "lodash/fp/join" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "join">;
+}
+
+declare module "lodash/fp/last" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "last">;
+}
+
+declare module "lodash/fp/lastIndexOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "lastIndexOf">;
+}
+
+declare module "lodash/fp/lastIndexOfFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "lastIndexOfFrom">;
+}
+
+declare module "lodash/fp/nth" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "nth">;
+}
+
+declare module "lodash/fp/pull" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pull">;
+}
+
+declare module "lodash/fp/pullAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pullAll">;
+}
+
+declare module "lodash/fp/pullAllBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pullAllBy">;
+}
+
+declare module "lodash/fp/pullAllWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pullAllWith">;
+}
+
+declare module "lodash/fp/pullAt" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pullAt">;
+}
+
+declare module "lodash/fp/remove" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "remove">;
+}
+
+declare module "lodash/fp/reverse" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "reverse">;
+}
+
+declare module "lodash/fp/slice" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "slice">;
+}
+
+declare module "lodash/fp/sortedIndex" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedIndex">;
+}
+
+declare module "lodash/fp/sortedIndexBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedIndexBy">;
+}
+
+declare module "lodash/fp/sortedIndexOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedIndexOf">;
+}
+
+declare module "lodash/fp/sortedLastIndex" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedLastIndex">;
+}
+
+declare module "lodash/fp/sortedLastIndexBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedLastIndexBy">;
+}
+
+declare module "lodash/fp/sortedLastIndexOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedLastIndexOf">;
+}
+
+declare module "lodash/fp/sortedUniq" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedUniq">;
+}
+
+declare module "lodash/fp/sortedUniqBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortedUniqBy">;
+}
+
+declare module "lodash/fp/tail" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "tail">;
+}
+
+declare module "lodash/fp/take" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "take">;
+}
+
+declare module "lodash/fp/takeRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "takeRight">;
+}
+
+declare module "lodash/fp/takeLast" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "takeLast">;
+}
+
+declare module "lodash/fp/takeRightWhile" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "takeRightWhile">;
+}
+
+declare module "lodash/fp/takeLastWhile" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "takeLastWhile">;
+}
+
+declare module "lodash/fp/takeWhile" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "takeWhile">;
+}
+
+declare module "lodash/fp/union" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "union">;
+}
+
+declare module "lodash/fp/unionBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unionBy">;
+}
+
+declare module "lodash/fp/unionWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unionWith">;
+}
+
+declare module "lodash/fp/uniq" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "uniq">;
+}
+
+declare module "lodash/fp/uniqBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "uniqBy">;
+}
+
+declare module "lodash/fp/uniqWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "uniqWith">;
+}
+
+declare module "lodash/fp/unzip" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unzip">;
+}
+
+declare module "lodash/fp/unzipWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unzipWith">;
+}
+
+declare module "lodash/fp/without" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "without">;
+}
+
+declare module "lodash/fp/xor" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "xor">;
+}
+
+declare module "lodash/fp/symmetricDifference" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "symmetricDifference">;
+}
+
+declare module "lodash/fp/xorBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "xorBy">;
+}
+
+declare module "lodash/fp/symmetricDifferenceBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "symmetricDifferenceBy">;
+}
+
+declare module "lodash/fp/xorWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "xorWith">;
+}
+
+declare module "lodash/fp/symmetricDifferenceWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "symmetricDifferenceWith">;
+}
+
+declare module "lodash/fp/zip" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "zip">;
+}
+
+declare module "lodash/fp/zipAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "zipAll">;
+}
+
+declare module "lodash/fp/zipObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "zipObject">;
+}
+
+declare module "lodash/fp/zipObj" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "zipObj">;
+}
+
+declare module "lodash/fp/zipObjectDeep" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "zipObjectDeep">;
+}
+
+declare module "lodash/fp/zipWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "zipWith">;
+}
+
+declare module "lodash/fp/countBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "countBy">;
+}
+
+declare module "lodash/fp/each" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "each">;
+}
+
+declare module "lodash/fp/eachRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "eachRight">;
+}
+
+declare module "lodash/fp/every" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "every">;
+}
+
+declare module "lodash/fp/all" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "all">;
+}
+
+declare module "lodash/fp/filter" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "filter">;
+}
+
+declare module "lodash/fp/find" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "find">;
+}
+
+declare module "lodash/fp/findFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findFrom">;
+}
+
+declare module "lodash/fp/findLast" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findLast">;
+}
+
+declare module "lodash/fp/findLastFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findLastFrom">;
+}
+
+declare module "lodash/fp/flatMap" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flatMap">;
+}
+
+declare module "lodash/fp/flatMapDeep" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flatMapDeep">;
+}
+
+declare module "lodash/fp/flatMapDepth" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flatMapDepth">;
+}
+
+declare module "lodash/fp/forEach" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "forEach">;
+}
+
+declare module "lodash/fp/forEachRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "forEachRight">;
+}
+
+declare module "lodash/fp/groupBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "groupBy">;
+}
+
+declare module "lodash/fp/includes" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "includes">;
+}
+
+declare module "lodash/fp/contains" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "contains">;
+}
+
+declare module "lodash/fp/includesFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "includesFrom">;
+}
+
+declare module "lodash/fp/invokeMap" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "invokeMap">;
+}
+
+declare module "lodash/fp/invokeArgsMap" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "invokeArgsMap">;
+}
+
+declare module "lodash/fp/keyBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "keyBy">;
+}
+
+declare module "lodash/fp/indexBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "indexBy">;
+}
+
+declare module "lodash/fp/map" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "map">;
+}
+
+declare module "lodash/fp/pluck" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pluck">;
+}
+
+declare module "lodash/fp/orderBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "orderBy">;
+}
+
+declare module "lodash/fp/partition" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "partition">;
+}
+
+declare module "lodash/fp/reduce" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "reduce">;
+}
+
+declare module "lodash/fp/reduceRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "reduceRight">;
+}
+
+declare module "lodash/fp/reject" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "reject">;
+}
+
+declare module "lodash/fp/sample" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sample">;
+}
+
+declare module "lodash/fp/sampleSize" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sampleSize">;
+}
+
+declare module "lodash/fp/shuffle" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "shuffle">;
+}
+
+declare module "lodash/fp/size" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "size">;
+}
+
+declare module "lodash/fp/some" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "some">;
+}
+
+declare module "lodash/fp/any" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "any">;
+}
+
+declare module "lodash/fp/sortBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sortBy">;
+}
+
+declare module "lodash/fp/now" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "now">;
+}
+
+declare module "lodash/fp/after" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "after">;
+}
+
+declare module "lodash/fp/ary" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "ary">;
+}
+
+declare module "lodash/fp/nAry" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "nAry">;
+}
+
+declare module "lodash/fp/before" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "before">;
+}
+
+declare module "lodash/fp/bind" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "bind">;
+}
+
+declare module "lodash/fp/bindKey" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "bindKey">;
+}
+
+declare module "lodash/fp/curry" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "curry">;
+}
+
+declare module "lodash/fp/curryN" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "curryN">;
+}
+
+declare module "lodash/fp/curryRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "curryRight">;
+}
+
+declare module "lodash/fp/curryRightN" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "curryRightN">;
+}
+
+declare module "lodash/fp/debounce" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "debounce">;
+}
+
+declare module "lodash/fp/defer" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "defer">;
+}
+
+declare module "lodash/fp/delay" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "delay">;
+}
+
+declare module "lodash/fp/flip" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flip">;
+}
+
+declare module "lodash/fp/memoize" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "memoize">;
+}
+
+declare module "lodash/fp/negate" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "negate">;
+}
+
+declare module "lodash/fp/complement" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "complement">;
+}
+
+declare module "lodash/fp/once" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "once">;
+}
+
+declare module "lodash/fp/overArgs" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "overArgs">;
+}
+
+declare module "lodash/fp/useWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "useWith">;
+}
+
+declare module "lodash/fp/partial" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "partial">;
+}
+
+declare module "lodash/fp/partialRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "partialRight">;
+}
+
+declare module "lodash/fp/rearg" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "rearg">;
+}
+
+declare module "lodash/fp/rest" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "rest">;
+}
+
+declare module "lodash/fp/unapply" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unapply">;
+}
+
+declare module "lodash/fp/restFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "restFrom">;
+}
+
+declare module "lodash/fp/spread" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "spread">;
+}
+
+declare module "lodash/fp/apply" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "apply">;
+}
+
+declare module "lodash/fp/spreadFrom" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "spreadFrom">;
+}
+
+declare module "lodash/fp/throttle" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "throttle">;
+}
+
+declare module "lodash/fp/unary" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unary">;
+}
+
+declare module "lodash/fp/wrap" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "wrap">;
+}
+
+declare module "lodash/fp/castArray" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "castArray">;
+}
+
+declare module "lodash/fp/clone" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "clone">;
+}
+
+declare module "lodash/fp/cloneDeep" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "cloneDeep">;
+}
+
+declare module "lodash/fp/cloneDeepWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "cloneDeepWith">;
+}
+
+declare module "lodash/fp/cloneWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "cloneWith">;
+}
+
+declare module "lodash/fp/conformsTo" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "conformsTo">;
+}
+
+declare module "lodash/fp/where" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "where">;
+}
+
+declare module "lodash/fp/conforms" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "conforms">;
+}
+
+declare module "lodash/fp/eq" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "eq">;
+}
+
+declare module "lodash/fp/identical" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "identical">;
+}
+
+declare module "lodash/fp/gt" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "gt">;
+}
+
+declare module "lodash/fp/gte" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "gte">;
+}
+
+declare module "lodash/fp/isArguments" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isArguments">;
+}
+
+declare module "lodash/fp/isArray" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isArray">;
+}
+
+declare module "lodash/fp/isArrayBuffer" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isArrayBuffer">;
+}
+
+declare module "lodash/fp/isArrayLike" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isArrayLike">;
+}
+
+declare module "lodash/fp/isArrayLikeObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isArrayLikeObject">;
+}
+
+declare module "lodash/fp/isBoolean" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isBoolean">;
+}
+
+declare module "lodash/fp/isBuffer" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isBuffer">;
+}
+
+declare module "lodash/fp/isDate" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isDate">;
+}
+
+declare module "lodash/fp/isElement" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isElement">;
+}
+
+declare module "lodash/fp/isEmpty" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isEmpty">;
+}
+
+declare module "lodash/fp/isEqual" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isEqual">;
+}
+
+declare module "lodash/fp/equals" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "equals">;
+}
+
+declare module "lodash/fp/isEqualWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isEqualWith">;
+}
+
+declare module "lodash/fp/isError" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isError">;
+}
+
+declare module "lodash/fp/isFinite" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isFinite">;
+}
+
+declare module "lodash/fp/isFunction" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isFunction">;
+}
+
+declare module "lodash/fp/isInteger" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isInteger">;
+}
+
+declare module "lodash/fp/isLength" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isLength">;
+}
+
+declare module "lodash/fp/isMap" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isMap">;
+}
+
+declare module "lodash/fp/isMatch" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isMatch">;
+}
+
+declare module "lodash/fp/whereEq" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "whereEq">;
+}
+
+declare module "lodash/fp/isMatchWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isMatchWith">;
+}
+
+declare module "lodash/fp/isNaN" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isNaN">;
+}
+
+declare module "lodash/fp/isNative" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isNative">;
+}
+
+declare module "lodash/fp/isNil" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isNil">;
+}
+
+declare module "lodash/fp/isNull" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isNull">;
+}
+
+declare module "lodash/fp/isNumber" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isNumber">;
+}
+
+declare module "lodash/fp/isObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isObject">;
+}
+
+declare module "lodash/fp/isObjectLike" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isObjectLike">;
+}
+
+declare module "lodash/fp/isPlainObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isPlainObject">;
+}
+
+declare module "lodash/fp/isRegExp" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isRegExp">;
+}
+
+declare module "lodash/fp/isSafeInteger" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isSafeInteger">;
+}
+
+declare module "lodash/fp/isSet" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isSet">;
+}
+
+declare module "lodash/fp/isString" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isString">;
+}
+
+declare module "lodash/fp/isSymbol" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isSymbol">;
+}
+
+declare module "lodash/fp/isTypedArray" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isTypedArray">;
+}
+
+declare module "lodash/fp/isUndefined" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isUndefined">;
+}
+
+declare module "lodash/fp/isWeakMap" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isWeakMap">;
+}
+
+declare module "lodash/fp/isWeakSet" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "isWeakSet">;
+}
+
+declare module "lodash/fp/lt" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "lt">;
+}
+
+declare module "lodash/fp/lte" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "lte">;
+}
+
+declare module "lodash/fp/toArray" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toArray">;
+}
+
+declare module "lodash/fp/toFinite" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toFinite">;
+}
+
+declare module "lodash/fp/toInteger" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toInteger">;
+}
+
+declare module "lodash/fp/toLength" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toLength">;
+}
+
+declare module "lodash/fp/toNumber" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toNumber">;
+}
+
+declare module "lodash/fp/toPlainObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toPlainObject">;
+}
+
+declare module "lodash/fp/toSafeInteger" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toSafeInteger">;
+}
+
+declare module "lodash/fp/toString" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toString">;
+}
+
+declare module "lodash/fp/add" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "add">;
+}
+
+declare module "lodash/fp/ceil" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "ceil">;
+}
+
+declare module "lodash/fp/divide" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "divide">;
+}
+
+declare module "lodash/fp/floor" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "floor">;
+}
+
+declare module "lodash/fp/max" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "max">;
+}
+
+declare module "lodash/fp/maxBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "maxBy">;
+}
+
+declare module "lodash/fp/mean" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "mean">;
+}
+
+declare module "lodash/fp/meanBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "meanBy">;
+}
+
+declare module "lodash/fp/min" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "min">;
+}
+
+declare module "lodash/fp/minBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "minBy">;
+}
+
+declare module "lodash/fp/multiply" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "multiply">;
+}
+
+declare module "lodash/fp/round" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "round">;
+}
+
+declare module "lodash/fp/subtract" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "subtract">;
+}
+
+declare module "lodash/fp/sum" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sum">;
+}
+
+declare module "lodash/fp/sumBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "sumBy">;
+}
+
+declare module "lodash/fp/clamp" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "clamp">;
+}
+
+declare module "lodash/fp/inRange" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "inRange">;
+}
+
+declare module "lodash/fp/random" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "random">;
+}
+
+declare module "lodash/fp/assign" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assign">;
+}
+
+declare module "lodash/fp/assignAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assignAll">;
+}
+
+declare module "lodash/fp/assignInAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assignInAll">;
+}
+
+declare module "lodash/fp/extendAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "extendAll">;
+}
+
+declare module "lodash/fp/assignIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assignIn">;
+}
+
+declare module "lodash/fp/assignInWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assignInWith">;
+}
+
+declare module "lodash/fp/assignWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assignWith">;
+}
+
+declare module "lodash/fp/assignInAllWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assignInAllWith">;
+}
+
+declare module "lodash/fp/extendAllWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "extendAllWith">;
+}
+
+declare module "lodash/fp/assignAllWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assignAllWith">;
+}
+
+declare module "lodash/fp/at" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "at">;
+}
+
+declare module "lodash/fp/props" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "props">;
+}
+
+declare module "lodash/fp/paths" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "paths">;
+}
+
+declare module "lodash/fp/create" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "create">;
+}
+
+declare module "lodash/fp/defaults" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "defaults">;
+}
+
+declare module "lodash/fp/defaultsAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "defaultsAll">;
+}
+
+declare module "lodash/fp/defaultsDeep" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "defaultsDeep">;
+}
+
+declare module "lodash/fp/defaultsDeepAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "defaultsDeepAll">;
+}
+
+declare module "lodash/fp/entries" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "entries">;
+}
+
+declare module "lodash/fp/entriesIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "entriesIn">;
+}
+
+declare module "lodash/fp/extend" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "extend">;
+}
+
+declare module "lodash/fp/extendWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "extendWith">;
+}
+
+declare module "lodash/fp/findKey" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findKey">;
+}
+
+declare module "lodash/fp/findLastKey" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "findLastKey">;
+}
+
+declare module "lodash/fp/forIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "forIn">;
+}
+
+declare module "lodash/fp/forInRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "forInRight">;
+}
+
+declare module "lodash/fp/forOwn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "forOwn">;
+}
+
+declare module "lodash/fp/forOwnRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "forOwnRight">;
+}
+
+declare module "lodash/fp/functions" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "functions">;
+}
+
+declare module "lodash/fp/functionsIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "functionsIn">;
+}
+
+declare module "lodash/fp/get" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "get">;
+}
+
+declare module "lodash/fp/prop" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "prop">;
+}
+
+declare module "lodash/fp/path" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "path">;
+}
+
+declare module "lodash/fp/getOr" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "getOr">;
+}
+
+declare module "lodash/fp/propOr" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "propOr">;
+}
+
+declare module "lodash/fp/pathOr" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pathOr">;
+}
+
+declare module "lodash/fp/has" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "has">;
+}
+
+declare module "lodash/fp/hasIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "hasIn">;
+}
+
+declare module "lodash/fp/invert" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "invert">;
+}
+
+declare module "lodash/fp/invertObj" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "invertObj">;
+}
+
+declare module "lodash/fp/invertBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "invertBy">;
+}
+
+declare module "lodash/fp/invoke" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "invoke">;
+}
+
+declare module "lodash/fp/invokeArgs" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "invokeArgs">;
+}
+
+declare module "lodash/fp/keys" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "keys">;
+}
+
+declare module "lodash/fp/keysIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "keysIn">;
+}
+
+declare module "lodash/fp/mapKeys" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "mapKeys">;
+}
+
+declare module "lodash/fp/mapValues" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "mapValues">;
+}
+
+declare module "lodash/fp/merge" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "merge">;
+}
+
+declare module "lodash/fp/mergeAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "mergeAll">;
+}
+
+declare module "lodash/fp/mergeWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "mergeWith">;
+}
+
+declare module "lodash/fp/mergeAllWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "mergeAllWith">;
+}
+
+declare module "lodash/fp/omit" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "omit">;
+}
+
+declare module "lodash/fp/omitAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "omitAll">;
+}
+
+declare module "lodash/fp/omitBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "omitBy">;
+}
+
+declare module "lodash/fp/pick" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pick">;
+}
+
+declare module "lodash/fp/pickAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pickAll">;
+}
+
+declare module "lodash/fp/pickBy" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pickBy">;
+}
+
+declare module "lodash/fp/result" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "result">;
+}
+
+declare module "lodash/fp/set" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "set">;
+}
+
+declare module "lodash/fp/assoc" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assoc">;
+}
+
+declare module "lodash/fp/assocPath" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "assocPath">;
+}
+
+declare module "lodash/fp/setWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "setWith">;
+}
+
+declare module "lodash/fp/toPairs" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toPairs">;
+}
+
+declare module "lodash/fp/toPairsIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toPairsIn">;
+}
+
+declare module "lodash/fp/transform" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "transform">;
+}
+
+declare module "lodash/fp/unset" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unset">;
+}
+
+declare module "lodash/fp/dissoc" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "dissoc">;
+}
+
+declare module "lodash/fp/dissocPath" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "dissocPath">;
+}
+
+declare module "lodash/fp/update" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "update">;
+}
+
+declare module "lodash/fp/updateWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "updateWith">;
+}
+
+declare module "lodash/fp/values" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "values">;
+}
+
+declare module "lodash/fp/valuesIn" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "valuesIn">;
+}
+
+declare module "lodash/fp/tap" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "tap">;
+}
+
+declare module "lodash/fp/thru" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "thru">;
+}
+
+declare module "lodash/fp/camelCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "camelCase">;
+}
+
+declare module "lodash/fp/capitalize" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "capitalize">;
+}
+
+declare module "lodash/fp/deburr" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "deburr">;
+}
+
+declare module "lodash/fp/endsWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "endsWith">;
+}
+
+declare module "lodash/fp/escape" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "escape">;
+}
+
+declare module "lodash/fp/escapeRegExp" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "escapeRegExp">;
+}
+
+declare module "lodash/fp/kebabCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "kebabCase">;
+}
+
+declare module "lodash/fp/lowerCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "lowerCase">;
+}
+
+declare module "lodash/fp/lowerFirst" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "lowerFirst">;
+}
+
+declare module "lodash/fp/pad" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pad">;
+}
+
+declare module "lodash/fp/padChars" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "padChars">;
+}
+
+declare module "lodash/fp/padEnd" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "padEnd">;
+}
+
+declare module "lodash/fp/padCharsEnd" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "padCharsEnd">;
+}
+
+declare module "lodash/fp/padStart" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "padStart">;
+}
+
+declare module "lodash/fp/padCharsStart" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "padCharsStart">;
+}
+
+declare module "lodash/fp/parseInt" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "parseInt">;
+}
+
+declare module "lodash/fp/repeat" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "repeat">;
+}
+
+declare module "lodash/fp/replace" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "replace">;
+}
+
+declare module "lodash/fp/snakeCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "snakeCase">;
+}
+
+declare module "lodash/fp/split" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "split">;
+}
+
+declare module "lodash/fp/startCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "startCase">;
+}
+
+declare module "lodash/fp/startsWith" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "startsWith">;
+}
+
+declare module "lodash/fp/template" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "template">;
+}
+
+declare module "lodash/fp/toLower" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toLower">;
+}
+
+declare module "lodash/fp/toUpper" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toUpper">;
+}
+
+declare module "lodash/fp/trim" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "trim">;
+}
+
+declare module "lodash/fp/trimChars" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "trimChars">;
+}
+
+declare module "lodash/fp/trimEnd" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "trimEnd">;
+}
+
+declare module "lodash/fp/trimCharsEnd" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "trimCharsEnd">;
+}
+
+declare module "lodash/fp/trimStart" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "trimStart">;
+}
+
+declare module "lodash/fp/trimCharsStart" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "trimCharsStart">;
+}
+
+declare module "lodash/fp/truncate" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "truncate">;
+}
+
+declare module "lodash/fp/unescape" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "unescape">;
+}
+
+declare module "lodash/fp/upperCase" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "upperCase">;
+}
+
+declare module "lodash/fp/upperFirst" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "upperFirst">;
+}
+
+declare module "lodash/fp/words" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "words">;
+}
+
+declare module "lodash/fp/attempt" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "attempt">;
+}
+
+declare module "lodash/fp/bindAll" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "bindAll">;
+}
+
+declare module "lodash/fp/cond" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "cond">;
+}
+
+declare module "lodash/fp/constant" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "constant">;
+}
+
+declare module "lodash/fp/always" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "always">;
+}
+
+declare module "lodash/fp/defaultTo" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "defaultTo">;
+}
+
+declare module "lodash/fp/flow" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flow">;
+}
+
+declare module "lodash/fp/pipe" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pipe">;
+}
+
+declare module "lodash/fp/flowRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "flowRight">;
+}
+
+declare module "lodash/fp/compose" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "compose">;
+}
+
+declare module "lodash/fp/identity" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "identity">;
+}
+
+declare module "lodash/fp/iteratee" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "iteratee">;
+}
+
+declare module "lodash/fp/matches" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "matches">;
+}
+
+declare module "lodash/fp/matchesProperty" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "matchesProperty">;
+}
+
+declare module "lodash/fp/propEq" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "propEq">;
+}
+
+declare module "lodash/fp/pathEq" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "pathEq">;
+}
+
+declare module "lodash/fp/method" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "method">;
+}
+
+declare module "lodash/fp/methodOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "methodOf">;
+}
+
+declare module "lodash/fp/mixin" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "mixin">;
+}
+
+declare module "lodash/fp/noConflict" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "noConflict">;
+}
+
+declare module "lodash/fp/noop" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "noop">;
+}
+
+declare module "lodash/fp/nthArg" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "nthArg">;
+}
+
+declare module "lodash/fp/over" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "over">;
+}
+
+declare module "lodash/fp/juxt" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "juxt">;
+}
+
+declare module "lodash/fp/overEvery" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "overEvery">;
+}
+
+declare module "lodash/fp/allPass" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "allPass">;
+}
+
+declare module "lodash/fp/overSome" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "overSome">;
+}
+
+declare module "lodash/fp/anyPass" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "anyPass">;
+}
+
+declare module "lodash/fp/property" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "property">;
+}
+
+declare module "lodash/fp/propertyOf" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "propertyOf">;
+}
+
+declare module "lodash/fp/range" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "range">;
+}
+
+declare module "lodash/fp/rangeStep" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "rangeStep">;
+}
+
+declare module "lodash/fp/rangeRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "rangeRight">;
+}
+
+declare module "lodash/fp/rangeStepRight" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "rangeStepRight">;
+}
+
+declare module "lodash/fp/runInContext" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "runInContext">;
+}
+
+declare module "lodash/fp/stubArray" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "stubArray">;
+}
+
+declare module "lodash/fp/stubFalse" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "stubFalse">;
+}
+
+declare module "lodash/fp/F" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "F">;
+}
+
+declare module "lodash/fp/stubObject" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "stubObject">;
+}
+
+declare module "lodash/fp/stubString" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "stubString">;
+}
+
+declare module "lodash/fp/stubTrue" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "stubTrue">;
+}
+
+declare module "lodash/fp/T" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "T">;
+}
+
+declare module "lodash/fp/times" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "times">;
+}
+
+declare module "lodash/fp/toPath" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "toPath">;
+}
+
+declare module "lodash/fp/uniqueId" {
+  declare module.exports: $PropertyType<$Exports<"lodash/fp">, "uniqueId">;
+}

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
@@ -1,59 +1,95 @@
 // @flow
-import _ from 'lodash/fp';
 
-_.filter('x', [{x: 1}, {x: 2}]);
-_.filter('x')([{x: 1}, {x: 2}]);
-_.filter('x', {a: {x: 1}, b: {x: 2}});
-_.filter('x')({a: {x: 1}, b: {x: 2}});
-_.filter((v: {y?: number}) => v.y)({a: {x: 1}, b: {x: 2}})[0].x;
+import assignIn from 'lodash/fp/assignIn';
+import extend from 'lodash/fp/extend';
+import sortedLastIndexBy from 'lodash/fp/sortedLastIndexBy';
+import sortedIndexBy from 'lodash/fp/sortedIndexBy';
+import range from 'lodash/fp/range';
+import isEqual from 'lodash/fp/isEqual';
+import clone from 'lodash/fp/clone';
+import uniqBy from 'lodash/fp/uniqBy';
+import unionBy from 'lodash/fp/unionBy';
+import pullAllBy from 'lodash/fp/pullAllBy';
+import map from 'lodash/fp/map';
+import keyBy from 'lodash/fp/keyBy';
+import getOr from 'lodash/fp/getOr';
+import get from 'lodash/fp/get';
+import intersectionBy from 'lodash/fp/intersectionBy';
+import groupBy from 'lodash/fp/groupBy';
+import findFrom from 'lodash/fp/findFrom';
+import find from 'lodash/fp/find';
+import differenceBy from 'lodash/fp/differenceBy';
+import countBy from 'lodash/fp/countBy';
+import attempt from 'lodash/fp/attempt';
+import filter from 'lodash/fp/filter';
+import xorBy from 'lodash/fp/xorBy';
+import zip from 'lodash/fp/zip';
+import isString from 'lodash/fp/isString';
+import concat from 'lodash/fp/concat';
+import first from 'lodash/fp/first';
+import conformsTo from 'lodash/fp/conformsTo';
+import defaultTo from 'lodash/fp/defaultTo';
+import tap from 'lodash/fp/tap';
+import thru from 'lodash/fp/thru';
+import times from 'lodash/fp/times';
+import flatMap from 'lodash/fp/flatMap';
+import noop from 'lodash/fp/noop';
+import pipe from 'lodash/fp/pipe';
+import compose from 'lodash/fp/compose';
+
+filter('x', [{x: 1}, {x: 2}]);
+filter('x')([{x: 1}, {x: 2}]);
+filter('x', {a: {x: 1}, b: {x: 2}});
+filter('x')({a: {x: 1}, b: {x: 2}});
+filter((v: {y?: number}) => v.y)({a: {x: 1}, b: {x: 2}})[0].x;
 // $ExpectError
-_.filter((v: {y: number}) => v.y)({a: {x: 1}, b: {x: 2}});
+filter((v: {y: number}) => v.y)({a: {x: 1}, b: {x: 2}});
 
 /**
- * _.attempt
+ * attempt
  */
-_.attempt(() => void 0)
-_.attempt(x => x)
-_.attempt((x, y, z) => {})
+attempt(() => void 0)
+attempt(x => x)
+attempt((x, y, z) => {})
 
 /**
- * _.countBy
+ * countBy
  */
-_.countBy(Math.floor, [6.1, 4.2, 6.3]);
-_.countBy('length', ['one', 'two', 'three']);
-_.countBy('length')(['one', 'two', 'three']);
-_.countBy('length')({one: 'one', two: 'two', three: 'three'});
-
-
-/**
- * _.differenceBy
- */
-_.differenceBy(Math.floor, [2.1, 1.2], [2.3, 3.4]);
-_.differenceBy('x', [{ 'x': 2 }, { 'x': 1 }], [{ 'x': 1 }]);
-_.differenceBy('x')([{ 'x': 2 }, { 'x': 1 }], [{ 'x': 1 }]);
+countBy(Math.floor, [6.1, 4.2, 6.3]);
+countBy('length', ['one', 'two', 'three']);
+countBy('length')(['one', 'two', 'three']);
+countBy('length')({one: 'one', two: 'two', three: 'three'});
 
 
 /**
- * _.find
+ * differenceBy
  */
-_.find(x => x * 1 == 3, [1, 2, 3]);
-_.findFrom(x => x == 2, 1, [1, 2, 3]);
+differenceBy(Math.floor, [2.1, 1.2], [2.3, 3.4]);
+differenceBy('x', [{ 'x': 2 }, { 'x': 1 }], [{ 'x': 1 }]);
+differenceBy('x')([{ 'x': 2 }, { 'x': 1 }], [{ 'x': 1 }]);
+
+
+/**
+ * find
+ */
+find(x => x * 1 == 3, [1, 2, 3]);
+findFrom(x => x == 2, 1, [1, 2, 3]);
 // $ExpectError number cannot be compared to string
-_.find(x => x == 'a', [1, 2, 3]);
+find(x => x == 'a', [1, 2, 3]);
 // $ExpectError number. This type is incompatible with function type.
-_.find(1, [1, 2, 3]);
+find(1, [1, 2, 3]);
 // $ExpectError property `y`. Property not found in object literal
-_.find(v => v.y == 3, [{x:1}, {x:2}, {x:3}]);
-_.find(v => v.x == 3, [{x:1}, {x:2}, {x:3}]);
-_.find((a: number, b: string) => a, {x: 1, y: 2});
-_.find({ x: 3 }, {x: 1, y: 2});
-_.find({ x: 3 })({x: 1, y: 2});
+find(v => v.y == 3, [{x:1}, {x:2}, {x:3}]);
+find(v => v.x == 3, [{x:1}, {x:2}, {x:3}]);
+find((a: number, b: string) => a, {x: 1, y: 2});
+find({ x: 3 }, {x: 1, y: 2});
+find({ x: 3 })({x: 1, y: 2});
 
 // $ExpectError undefined. This type is incompatible with object type.
-var result: Object = _.find('active', users);
+var result: Object = find('active', users);
 
 /**
- * _.find examples from the official doc
+ * find examples from the official doc
  */
 var users = [
   { 'user': 'barney',  'age': 36, 'active': true },
@@ -61,84 +97,84 @@ var users = [
   { 'user': 'pebbles', 'age': 1,  'active': true }
 ];
 
-_.find(function(o) { return o.age < 40; }, users);
+find(function(o) { return o.age < 40; }, users);
 
-// The `_.matches` iteratee shorthand.
-_.find({ 'age': 1, 'active': true }, users);
+// The `matches` iteratee shorthand.
+find({ 'age': 1, 'active': true }, users);
 
-// The `_.matchesProperty` iteratee shorthand.
-_.find(['active', false], users);
+// The `matchesProperty` iteratee shorthand.
+find(['active', false], users);
 
-// The `_.property` iteratee shorthand.
-_.find('active', users);
+// The `property` iteratee shorthand.
+find('active', users);
 
 
 /**
- * _.groupBy
+ * groupBy
  */
-var numbersGroupedByMathFloor = _.groupBy(Math.floor, [6.1, 4.2, 6.3]);
+var numbersGroupedByMathFloor = groupBy(Math.floor, [6.1, 4.2, 6.3]);
 if (numbersGroupedByMathFloor[6]) {
   numbersGroupedByMathFloor[6][0] / numbersGroupedByMathFloor[6][1]
 }
-var stringsGroupedByLength = _.groupBy('length', ['one', 'two', 'three']);
+var stringsGroupedByLength = groupBy('length', ['one', 'two', 'three']);
 if (stringsGroupedByLength[3]) {
   stringsGroupedByLength[3][0].toLowerCase();
 }
 var numbersObj: {[key: string]: number} = {a: 6.1, b: 4.2, c: 6.3};
-var numbersGroupedByMathFloor2 = _.groupBy(Math.floor, numbersObj);
+var numbersGroupedByMathFloor2 = groupBy(Math.floor, numbersObj);
 if (numbersGroupedByMathFloor2[6]) {
   numbersGroupedByMathFloor2[6][0] / numbersGroupedByMathFloor2[6][1]
 }
 var stringObj: {[key: string]: string} = {a: 'one', b: 'two', c: 'three'};
-var stringsGroupedByLength2 = _.groupBy('length', stringObj);
+var stringsGroupedByLength2 = groupBy('length', stringObj);
 if (stringsGroupedByLength2[3]) {
   stringsGroupedByLength2[3][0].toLowerCase();
 }
 
 
 /**
- * _.intersectionBy
+ * intersectionBy
  */
-_.intersectionBy(Math.floor, [2.1, 1.2], [2.3, 3.4]);
-_.intersectionBy('x', [{ 'x': 1 }], [{ 'x': 2 }, { 'x': 1 }]);
+intersectionBy(Math.floor, [2.1, 1.2], [2.3, 3.4]);
+intersectionBy('x', [{ 'x': 1 }], [{ 'x': 2 }, { 'x': 1 }]);
 
 
 /**
- * _.get
+ * get
  */
 
 // Object — examples from lodash docs
 var exampleObjectForGetTest = { 'a': [{ 'b': { 'c': 3 } }] };
-_.get('a[0].b.c', exampleObjectForGetTest);
-_.get(['a', '0', 'b', 'c'], exampleObjectForGetTest);
-_.getOr('default', 'a.b.c', exampleObjectForGetTest);
+get('a[0].b.c', exampleObjectForGetTest);
+get(['a', '0', 'b', 'c'], exampleObjectForGetTest);
+getOr('default', 'a.b.c', exampleObjectForGetTest);
 
-// Array — not documented, but _.get does support arrays
-_.get('0', [1, 2, 3]);
-_.get('[1]', ['foo', 'bar', 'baz']);
-_.get('2', [{ a: 'foo' }, { b: 'bar' }, { c: 'baz' }]);
-_.get('3', [[1, 2], [3, 4], [5, 6], [7, 8]]);
-_.get('3')([[1, 2], [3, 4], [5, 6], [7, 8]]);
+// Array — not documented, but get does support arrays
+get('0', [1, 2, 3]);
+get('[1]', ['foo', 'bar', 'baz']);
+get('2', [{ a: 'foo' }, { b: 'bar' }, { c: 'baz' }]);
+get('3', [[1, 2], [3, 4], [5, 6], [7, 8]]);
+get('3')([[1, 2], [3, 4], [5, 6], [7, 8]]);
 
 // First argument must be string when looking for array items by index
 // $ExpectError number This type is incompatible with union: ?array type | string
-_.get(0, [1, 2, 3]);
+get(0, [1, 2, 3]);
 
 
 /**
- * _.keyBy
+ * keyBy
  */
-_.keyBy(function(o) {
+keyBy(function(o) {
   return String.fromCharCode(o.code);
 }, [
   { 'dir': 'left', 'code': 97 },
   { 'dir': 'right', 'code': 100 }
 ]);
-_.keyBy('dir', [
+keyBy('dir', [
   { 'dir': 'left', 'code': 97 },
   { 'dir': 'right', 'code': 100 }
 ]);
-_.keyBy('dir')([
+keyBy('dir')([
   { 'dir': 'left', 'code': 97 },
   { 'dir': 'right', 'code': 100 }
 ]);
@@ -154,158 +190,158 @@ var keyByTest_map: KeyByTest$ByNumber<KeyByTest$Record> = {
   [keyByTest_array[2].id]: keyByTest_array[2],
 }
 
-var keyByTest_map2: KeyByTest$ByNumberMaybe<KeyByTest$Record> = _.keyBy('id', keyByTest_map)
-var keyByTest_map3: KeyByTest$ByNumberMaybe<KeyByTest$Record> = _.keyBy('id')(keyByTest_map)
+var keyByTest_map2: KeyByTest$ByNumberMaybe<KeyByTest$Record> = keyBy('id', keyByTest_map)
+var keyByTest_map3: KeyByTest$ByNumberMaybe<KeyByTest$Record> = keyBy('id')(keyByTest_map)
 
 
 /**
- * _.map examples from the official doc
+ * map examples from the official doc
  */
 function square(n) {
   return n * n;
 }
 
-_.map(square, [4, 8]);
-_.map(square, { 'a': 4, 'b': 8 });
+map(square, [4, 8]);
+map(square, { 'a': 4, 'b': 8 });
 
 var users = [
   { 'user': 'barney' },
   { 'user': 'fred' }
 ];
 
-// The `_.property` iteratee shorthand.
-_.map('user', users);
+// The `property` iteratee shorthand.
+map('user', users);
 
 
 /**
- * _.pullAllBy
+ * pullAllBy
  */
-_.pullAllBy('x', [{ 'x': 1 }, { 'x': 3 }], [{ 'x': 1 }, { 'x': 2 }, { 'x': 3 }, { 'x': 1 }]);
-_.pullAllBy('x')([{ 'x': 1 }, { 'x': 3 }])([{ 'x': 1 }, { 'x': 2 }, { 'x': 3 }, { 'x': 1 }]);
+pullAllBy('x', [{ 'x': 1 }, { 'x': 3 }], [{ 'x': 1 }, { 'x': 2 }, { 'x': 3 }, { 'x': 1 }]);
+pullAllBy('x')([{ 'x': 1 }, { 'x': 3 }])([{ 'x': 1 }, { 'x': 2 }, { 'x': 3 }, { 'x': 1 }]);
 
 
 /**
- * _.unionBy
+ * unionBy
  */
-_.unionBy(Math.floor, [2.1], [1.2, 2.3]);
-_.unionBy('x', [{ 'x': 1 }], [{ 'x': 2 }, { 'x': 1 }]);
+unionBy(Math.floor, [2.1], [1.2, 2.3]);
+unionBy('x', [{ 'x': 1 }], [{ 'x': 2 }, { 'x': 1 }]);
 
 
 /**
- * _.uniqBy
+ * uniqBy
  */
-_.uniqBy(Math.floor, [2.1, 1.2, 2.3]);
-_.uniqBy('x', [{ 'x': 1 }, { 'x': 2 }, { 'x': 1 }]);
+uniqBy(Math.floor, [2.1, 1.2, 2.3]);
+uniqBy('x', [{ 'x': 1 }, { 'x': 2 }, { 'x': 1 }]);
 
 
 /**
- * _.clone
+ * clone
  */
-_.clone({a: 1}).a == 1;
+clone({a: 1}).a == 1;
 // $ExpectError property `b`. Property not found in object literal
-_.clone({a: 1}).b == 1
+clone({a: 1}).b == 1
 // $ExpectError number. This type is incompatible with function type.
-_.clone({a: 1}).a == 'c';
+clone({a: 1}).a == 'c';
 
 /**
- * _.isEqual
+ * isEqual
  */
-_.isEqual('a', 'b');
-_.isEqual({x: 1}, {y: 2});
-_.isEqual({x: 1})({y: 2});
+isEqual('a', 'b');
+isEqual({x: 1}, {y: 2});
+isEqual({x: 1})({y: 2});
 
 // $ExpectError function type expects no more than 2 arguments
-_.isEqual(1, 2, 3);
+isEqual(1, 2, 3);
 
 
 /**
- * _.range
+ * range
  */
-_.range(0, 10)[4] == 4
-_.range(0)(10)[4] == 4
+range(0, 10)[4] == 4
+range(0)(10)[4] == 4
 // $ExpectError string. This type is incompatible with number
-_.range(0, 'a');
+range(0, 'a');
 // $ExpectError string cannot be compared to number
-_.range(0, 10)[4] == 'a';
+range(0, 10)[4] == 'a';
 
 
 /**
- * _.sortedIndexBy
+ * sortedIndexBy
  */
-_.sortedIndexBy(function(o) { return o.x; }, { 'x': 4 }, [{ 'x': 4 }, { 'x': 5 }]);
-_.sortedIndexBy('x', { 'x': 4 }, [{ 'x': 4 }, { 'x': 5 }]);
-_.sortedIndexBy('x')({ 'x': 4 }, [{ 'x': 4 }, { 'x': 5 }]);
+sortedIndexBy(function(o) { return o.x; }, { 'x': 4 }, [{ 'x': 4 }, { 'x': 5 }]);
+sortedIndexBy('x', { 'x': 4 }, [{ 'x': 4 }, { 'x': 5 }]);
+sortedIndexBy('x')({ 'x': 4 }, [{ 'x': 4 }, { 'x': 5 }]);
 
 
 /**
- * _.sortedLastIndexBy
+ * sortedLastIndexBy
  */
-_.sortedLastIndexBy(function(o) { return o.x; }, { 'x': 4 }, [{ 'x': 4 }, { 'x': 5 }]);
-_.sortedLastIndexBy('x', { 'x': 4 }, [{ 'x': 4 }, { 'x': 5 }]);
+sortedLastIndexBy(function(o) { return o.x; }, { 'x': 4 }, [{ 'x': 4 }, { 'x': 5 }]);
+sortedLastIndexBy('x', { 'x': 4 }, [{ 'x': 4 }, { 'x': 5 }]);
 
 /**
- * _.extend
+ * extend
  */
-_.extend({a: 1}, {b: 2}).a
-_.extend({a: 1})({b: 2}).a
-_.extend({a: 1}, {b: 2}).b
+extend({a: 1}, {b: 2}).a
+extend({a: 1})({b: 2}).a
+extend({a: 1}, {b: 2}).b
 // $ExpectError property `c`. Property not found in object literal
-_.extend({a: 1}, {b: 2}).c
+extend({a: 1}, {b: 2}).c
 // $ExpectError property `c`. Poperty not found in object literal
-_.assignIn({a: 1}, {b: 2}).c
+assignIn({a: 1}, {b: 2}).c
 // $ExpectError property `c`. Poperty not found in object literal
-_.assignIn({a: 1})({b: 2}).c
+assignIn({a: 1})({b: 2}).c
 
 
 /**
- * _.xorBy
+ * xorBy
  */
-_.xorBy(Math.floor, [2.1, 1.2], [2.3, 3.4]);
-_.xorBy('x', [{ 'x': 1 }], [{ 'x': 2 }, { 'x': 1 }]);
+xorBy(Math.floor, [2.1, 1.2], [2.3, 3.4]);
+xorBy('x', [{ 'x': 1 }], [{ 'x': 2 }, { 'x': 1 }]);
 
 
 /**
- * _.zip
+ * zip
  */
-_.zip(['a', 'b', 'c'], ['d', 'e', 'f'])[0].length;
-_.zip(['a', 'b', 'c'], [1, 2, 3])[0].length;
-_.zip(['a', 'b', 'c'], [1, 2, 3])[0][0] + 'a'
-_.zip(['a', 'b', 'c'], [1, 2, 3])[0][1] * 10
+zip(['a', 'b', 'c'], ['d', 'e', 'f'])[0].length;
+zip(['a', 'b', 'c'], [1, 2, 3])[0].length;
+zip(['a', 'b', 'c'], [1, 2, 3])[0][0] + 'a'
+zip(['a', 'b', 'c'], [1, 2, 3])[0][1] * 10
 // $ExpectError `x` property not found in Array
-_.zip([{x:1}], [{x:2,y:1}])[0].x
+zip([{x:1}], [{x:2,y:1}])[0].x
 // $ExpectError `y` property not found in object literal
-_.zip([{x:1}], [{x:2,y:1}])[0][0].y
-_.zip([{x:1}], [{x:2,y:1}])[0][1].y
+zip([{x:1}], [{x:2,y:1}])[0][0].y
+zip([{x:1}], [{x:2,y:1}])[0][1].y
 // $ExpectError Flow could potentially catch this -- the tuple only has two elements.
-_.zip([{x:1}], [{x:2,y:1}])[0][2]
+zip([{x:1}], [{x:2,y:1}])[0][2]
 
 /**
- * _.isString
+ * isString
  */
 
 var boolTrue: true;
 var boolFalse: false;
 
-boolTrue  = _.isString('foo');
-boolFalse = _.isString(['']);
-boolFalse = _.isString({});
-boolFalse = _.isString(5);
-boolFalse = _.isString(function(f) { return f });
-boolFalse = _.isString();
-boolFalse = _.isString(true);
+boolTrue  = isString('foo');
+boolFalse = isString(['']);
+boolFalse = isString({});
+boolFalse = isString(5);
+boolFalse = isString(function(f) { return f });
+boolFalse = isString();
+boolFalse = isString(true);
 
 // $ExpectError
-boolFalse = _.isString('');
+boolFalse = isString('');
 // $ExpectError
-boolTrue = _.isString(undefined);
+boolTrue = isString(undefined);
 
 
 /**
- * _.find
+ * find
  */
-_.find(x => x == 1, [1, 2, 3]);
+find(x => x == 1, [1, 2, 3]);
 // $ExpectError number. This type is incompatible with function type.
-_.find(1, [1, 2, 3]);
+find(1, [1, 2, 3]);
 
 
 // Copy pasted tests from iflow-lodash
@@ -323,80 +359,80 @@ var directStrings : string[];
 var allNums : number[];
 var numsAndStrList : Array<number|string>;
 var mixedList : Array<mixed>;
-allNums = _.concat(nums, nums);
-numsAndStrList = _.concat(nums, '123');
-numsAndStrList = _.concat(nums)('123');
-numsAndStrList = _.concat(nums)(['123']);
-numsAndStrList = _.concat(nums, ['123', '456']);
-numsAndStrList = _.concat(nums, [1,2,3, '456']);
-mixedList = _.concat(nums, [[1,2,3], '456']);
-(_.concat(1, 2): number[]);
-(_.concat(1, [2]): number[]);
-(_.concat([1], [2]): number[]);
-(_.concat([1], 2): number[]);
+allNums = concat(nums, nums);
+numsAndStrList = concat(nums, '123');
+numsAndStrList = concat(nums)('123');
+numsAndStrList = concat(nums)(['123']);
+numsAndStrList = concat(nums, ['123', '456']);
+numsAndStrList = concat(nums, [1,2,3, '456']);
+mixedList = concat(nums, [[1,2,3], '456']);
+(concat(1, 2): number[]);
+(concat(1, [2]): number[]);
+(concat([1], [2]): number[]);
+(concat([1], 2): number[]);
 
 // Array#map, lodash.map, lodash#map
 nativeSquares = nums.map(function(num) {
   return num * num;
 });
-directSquares = _.map(function(num) {
+directSquares = map(function(num) {
   return num * num;
 }, nums);
 
-num = _.first(nums);
+num = first(nums);
 
 // return type of iterator is reflected in result and chain
 nativeStrings = nums.map(function(num) {
   return JSON.stringify(num);
 });
-directStrings = _.map(function(num) {
+directStrings = map(function(num) {
   return JSON.stringify(num);
 }, nums);
 
 var obj = {a:1, b:2};
-bool = _.conformsTo({
+bool = conformsTo({
   a: function(x:number) {
     return true;
   },
 }, obj);
 
-num = _.defaultTo(2, undefined);
-string = _.defaultTo('str', undefined);
-bool = _.defaultTo('str', true);
-string = _.defaultTo(true, 'str');
+num = defaultTo(2, undefined);
+string = defaultTo('str', undefined);
+bool = defaultTo('str', true);
+string = defaultTo(true, 'str');
 
-num = _.tap(function(n) { return false; }, 1);
-bool = _.thru(function(n) { return false; }, 1);
+num = tap(function(n) { return false; }, 1);
+bool = thru(function(n) { return false; }, 1);
 
 var timesNums: number[];
 
-timesNums = _.times((i: number) => i, 5);
-timesNums = _.times((i: number) => i)(5);
+timesNums = times((i: number) => i, 5);
+timesNums = times((i: number) => i)(5);
 // $ExpectError string. This type is incompatible with number
-var strings : string[] = _.times((i) => i, 5);
-timesNums = _.times(function(i: number) { return i + 1; }, 5);
+var strings : string[] = times((i) => i, 5);
+timesNums = times(function(i: number) { return i + 1; }, 5);
 // $ExpectError string. This type is incompatible with number
-timesNums = _.times(function(i: number) { return JSON.stringify(i); }, 5);
+timesNums = times(function(i: number) { return JSON.stringify(i); }, 5);
 
 // lodash.flatMap for collections and objects
 // this arrow function needs a type annotation due to a bug in flow
 // https://github.com/facebook/flow/issues/1948
-_.flatMap((n): number[] => [n, n], [1, 2, 3]);
-_.flatMap(n => [n, n], {a: 1, b: 2});
+flatMap((n): number[] => [n, n], [1, 2, 3]);
+flatMap(n => [n, n], {a: 1, b: 2});
 
 /**
- * _.noop
+ * noop
  */
-_.noop();
-_.noop(1);
-_.noop('a', 2, [], null);
-(_.noop: (string) => void);
-(_.noop: (number, string) => void);
+noop();
+noop(1);
+noop('a', 2, [], null);
+(noop: (string) => void);
+(noop: (number, string) => void);
 // $ExpectError functions are contravariant in return types
-(_.noop: (string) => string);
+(noop: (string) => string);
 
 const ab = (a: number) => `${a}`;
 const bc = (b: string) => ({b});
 const cd = (c: {b: string}) => [c.b];
-const pipedResult: string[] = _.pipe(ab, bc, cd)(1);
-const composedResult: string[] = _.compose(cd, bc, ab)(1);
+const pipedResult: string[] = pipe(ab, bc, cd)(1);
+const composedResult: string[] = compose(cd, bc, ab)(1);


### PR DESCRIPTION
Original motivation: https://github.com/flowtype/flow-typed/pull/1262#issuecomment-331303944

Initially, I've just copypasted `lodash/*` module declarations, but found that `lodash` and `lodash/fp` exports are actually different :C. So all new `lodash/fp/*` module declarations were generated based on `Lodash` class defined in `lodash/fp` module export. Also, I've reworked `lodash/fp` tests using per-file imports.