### PR TITLE
fix(chai_v3.5.x.x): add missing aliases to ExpectChain

### DIFF
--- a/definitions/npm/chai_v3.5.x/flow_v0.25.0-/chai_v3.5.x.js
+++ b/definitions/npm/chai_v3.5.x/flow_v0.25.0-/chai_v3.5.x.js
@@ -32,8 +32,12 @@ declare module "chai" {
     equals: (value: T) => ExpectChain<T>,
 
     above: (value: T & number) => ExpectChain<T>,
+    greaterThan: (value: T & number) => ExpectChain<T>,
+    gt: (value: T & number) => ExpectChain<T>,
     least: (value: T & number) => ExpectChain<T>,
     below: (value: T & number) => ExpectChain<T>,
+    lessThan: (value: T & number) => ExpectChain<T>,
+    lt: (value: T & number) => ExpectChain<T>,
     most: (value: T & number) => ExpectChain<T>,
     within: (start: T & number, finish: T & number) => ExpectChain<T>,
 


### PR DESCRIPTION
`.gt`, `.greaterThan`, `.lt`, and `.lessThan`