### PR TITLE
Fix `void` typo

### DIFF
--- a/definitions/npm/react-relay_v1.x.x/flow_v0.47.x-/react-relay_v1.x.x.js
+++ b/definitions/npm/react-relay_v1.x.x/flow_v0.47.x-/react-relay_v1.x.x.js
@@ -349,7 +349,7 @@ declare module "react-relay" {
     connectionConfig: ConnectionConfig
   ): TBase;
 
-  declare type Variable = string | void | number | Variables | void | Array<Variables>;
+  declare type Variable = string | number | Variables | void | null | Array<Variables>;
   declare export type Variables = { [string]: Variable } & {$call?: void};
   declare export type DataID = string;
 


### PR DESCRIPTION
Fix `void` typo introduced in #1796 