### PR TITLE
Ramda: allows R.replace's 2nd argument to be a function

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
@@ -494,7 +494,7 @@ declare module ramda {
   declare var match: CurriedFunction2<RegExp, string, Array<string | void>>;
   declare var replace: CurriedFunction3<
     RegExp | string,
-    string,
+    string | ((substring: string, ...args: Array<any>) => string),
     string,
     string
   >;

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
@@ -494,7 +494,7 @@ declare module ramda {
   declare var match: CurriedFunction2<RegExp, string, Array<string | void>>;
   declare var replace: CurriedFunction3<
     RegExp | string,
-    string | ((substring: string, ...args: Array<any>) => string),
+    string | ((substring: string, ...args: Array<string>) => string),
     string,
     string
   >;


### PR DESCRIPTION
Just like String.prototype.replace, Ramda's replace can take either a string or a function that returns a string as the second argument.


Example:
```js
import { toLower, replace, compose } from 'ramda';

// point-free version
const camelize = compose(
  replace(/_(\w)/g, (_, x) => x.toUpperCase()),
  toLower,
);

// vanillajs version
const camelize2 = s => s.toLowerCase().replace(/_(\w)/g, (_, x) => x.toUpperCase())

const input = 'MY_UPPERCASE_STRING';

console.log(
  camelize(input), // => myUpperCaseString
  camelize2(input), // => myUpperCaseString
)

```