### PR TITLE
Add Ramda startsWith function

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
@@ -500,6 +500,7 @@ declare module ramda {
   >;
   declare var split: CurriedFunction2<RegExp | string, string, Array<string>>;
   declare var test: CurriedFunction2<RegExp, string, boolean>;
+  declare var startsWith: CurriedFunction2<string | Array<string>, string, boolean>;
   declare function toLower(a: string): string;
   declare function toString(a: any): string;
   declare function toUpper(a: string): string;


### PR DESCRIPTION
Added startsWith function as it was missing from the type definition. Here is the documentation.

Here is the reference within the ramda docs
http://ramdajs.com/docs/#startsWith

Here is the actual implementation within the Ramda Library
https://github.com/ramda/ramda/blob/v0.25.0/source/startsWith.js