### PR TITLE
Fix enzyme debug method optional parameter

### DIFF
--- a/definitions/npm/enzyme_v2.3.x/flow_v0.25.x-v0.27.x/enzyme_v2.3.x.js
+++ b/definitions/npm/enzyme_v2.3.x/flow_v0.25.x-v0.27.x/enzyme_v2.3.x.js
@@ -52,7 +52,7 @@ declare module "enzyme" {
     setContext(context: Object): this;
     instance(): React$Component<any, any, any>;
     update(): this;
-    debug(): string;
+    debug(options?: Object): string;
     type(): string | Function | null;
     name(): string;
     forEach(fn: (node: this, index: number) => mixed): this;

--- a/definitions/npm/enzyme_v2.3.x/flow_v0.28.x-v0.52.x/enzyme_v2.3.x.js
+++ b/definitions/npm/enzyme_v2.3.x/flow_v0.28.x-v0.52.x/enzyme_v2.3.x.js
@@ -53,7 +53,7 @@ declare module "enzyme" {
     setContext(context: Object): this,
     instance(): React$Component<*, *, *>,
     update(): this,
-    debug(): string,
+    debug(options?: Object): string,
     type(): string | Function | null,
     name(): string,
     forEach(fn: (node: this, index: number) => mixed): this,

--- a/definitions/npm/enzyme_v2.3.x/flow_v0.53.x-/enzyme_v2.3.x.js
+++ b/definitions/npm/enzyme_v2.3.x/flow_v0.53.x-/enzyme_v2.3.x.js
@@ -55,7 +55,7 @@ declare module "enzyme" {
     setContext(context: Object): this,
     instance(): React.Component<*, *>,
     update(): this,
-    debug(): string,
+    debug(options?: Object): string,
     type(): string | Function | null,
     name(): string,
     forEach(fn: (node: this, index: number) => mixed): this,

--- a/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/enzyme_v3.x.x.js
+++ b/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/enzyme_v3.x.x.js
@@ -56,7 +56,7 @@ declare module "enzyme" {
     setContext(context: Object): this,
     instance(): React.Component<*, *>,
     update(): this,
-    debug(): string,
+    debug(options?: Object): string,
     type(): string | Function | null,
     name(): string,
     forEach(fn: (node: this, index: number) => mixed): this,


### PR DESCRIPTION
Hi,

although the [documentation](http://airbnb.io/enzyme/docs/api/ShallowWrapper/debug.html) does not showcase it the `debug` method actually accept an [optional `options` parameter](https://github.com/airbnb/enzyme/blob/master/packages/enzyme/src/ShallowWrapper.js#L1141).

This is causing errors in libs like [enzyme-matchers](https://github.com/FormidableLabs/enzyme-matchers/blob/master/packages/enzyme-matchers/src/assertions/toMatchElement.js#L26-L27).

```
Error: node_modules/enzyme-matchers/lib/assertions/toMatchElement.js.flow:27
 27:   const expected = expectedWrapper.debug(options);
                                              ^^^^^^^ unused function argument
   56:     debug(): string;
           ^^^^^^^^^^^^^^^ function type expects no arguments. See lib: flow-typed/npm/enzyme_v2.3.x.js:56

```



