### PR TITLE
Reorder lodash/fp _.includes() type definitions

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -2115,10 +2115,10 @@ declare module "lodash/fp" {
       iteratee: ValueOnlyIteratee<T>,
       collection: Array<T> | { [id: any]: T }
     ): { [key: V]: Array<T> };
-    includes(value: string): (str: string) => boolean;
-    includes(value: string, str: string): boolean;
     includes<T>(value: T): (collection: Array<T> | { [id: any]: T }) => boolean;
     includes<T>(value: T, collection: Array<T> | { [id: any]: T }): boolean;
+    includes(value: string): (str: string) => boolean;
+    includes(value: string, str: string): boolean;
     contains(value: string): (str: string) => boolean;
     contains(value: string, str: string): boolean;
     contains<T>(value: T): (collection: Array<T> | { [id: any]: T }) => boolean;

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
@@ -36,6 +36,7 @@ import flatMap from 'lodash/fp/flatMap';
 import noop from 'lodash/fp/noop';
 import pipe from 'lodash/fp/pipe';
 import compose from 'lodash/fp/compose';
+import includes from 'lodash/fp/includes';
 
 filter('x', [{x: 1}, {x: 2}]);
 filter('x')([{x: 1}, {x: 2}]);
@@ -436,3 +437,8 @@ const bc = (b: string) => ({b});
 const cd = (c: {b: string}) => [c.b];
 const pipedResult: string[] = pipe(ab, bc, cd)(1);
 const composedResult: string[] = compose(cd, bc, ab)(1);
+
+/**
+ * includes
+ */
+includes("test")({ a: "test2", b: "test" });


### PR DESCRIPTION
This enables the use case of `_.includes("string")(objectWithStringValues)`