### PR TITLE
Update next-routes_v1.x.x.js

### DIFF
--- a/definitions/npm/next-routes_v1.x.x/flow_v0.47.x-/next-routes_v1.x.x.js
+++ b/definitions/npm/next-routes_v1.x.x/flow_v0.47.x-/next-routes_v1.x.x.js
@@ -79,7 +79,7 @@ declare module 'next-routes' {
     add(route: Route | string): Routes;
     add(pattern: string, page: string): Routes;
     add(name: string, pattern: string, page: string): Routes;
-    getRequestHandler(app: Object, customHandler: (any) => any): Function;
+    getRequestHandler(app: Object, customHandler?: (any) => any): Function;
     pushRoute(
       route: string,
       params?: { [name: string]: string },


### PR DESCRIPTION
Make the second parameter of `getRequestHandler` optional.

### Reference

```js
// server.js
const next = require('next')
const routes = require('./routes')
const app = next({dev: process.env.NODE_ENV !== 'production'})
const handler = routes.getRequestHandler(app)
```

https://github.com/fridays/next-routes#on-the-server