### PR TITLE
Make options optional in helmet definition

### DIFF
--- a/definitions/npm/helmet_v3.x.x/flow_v0.38.x-/helmet_v3.x.x.js
+++ b/definitions/npm/helmet_v3.x.x/flow_v0.38.x-/helmet_v3.x.x.js
@@ -16,8 +16,8 @@ declare type helmet$HstsOptions = {
 }
 
 declare type helmet$HpkpOptions = {
-  maxAge?: number;
-  sha256s?: Array<string>;
+  maxAge: number;
+  sha256s: Array<string>;
   includeSubDomains?: boolean;
   reportUri?: string;
   reportOnly?: boolean;

--- a/definitions/npm/helmet_v3.x.x/flow_v0.38.x-/helmet_v3.x.x.js
+++ b/definitions/npm/helmet_v3.x.x/flow_v0.38.x-/helmet_v3.x.x.js
@@ -9,15 +9,15 @@ declare type helmet$ReferrerPolicyOptions = {
 }
 
 declare type helmet$HstsOptions = {
-  maxAge: number;
-  includeSubDomains: boolean;
-  preload: boolean;
+  maxAge?: number;
+  includeSubDomains?: boolean;
+  preload?: boolean;
   setIf?: (req: http$IncomingMessage, res: http$ServerResponse) => boolean;
 }
 
 declare type helmet$HpkpOptions = {
-  maxAge: number;
-  sha256s: Array<string>;
+  maxAge?: number;
+  sha256s?: Array<string>;
   includeSubDomains?: boolean;
   reportUri?: string;
   reportOnly?: boolean;


### PR DESCRIPTION
All these options are optional. The [helmet.hsts](https://github.com/helmetjs/helmet/blob/master/index.js#L62) function just exports the [hsts module](https://github.com/helmetjs/hsts/blob/master/index.js), which treats all options as optional.


