### PR TITLE
Update DOMOutputSpec to match prosemirror API

### DIFF
--- a/definitions/npm/prosemirror-model_v1.x.x/flow_v0.59.x-/prosemirror-model_v1.x.x.js
+++ b/definitions/npm/prosemirror-model_v1.x.x/flow_v0.59.x-/prosemirror-model_v1.x.x.js
@@ -432,8 +432,18 @@ declare module "prosemirror-model" {
     static fromSchema(schema: Schema): DOMSerializer
   }
 
-  // The real type of this is something like [string, Object, ...(DOMOutputSpec | 0)]
-  declare export type DOMOutputSpec = Array<
-    string | Object | DOMOutputSpec | 0
-  >;
+  declare type Attributes = { [string]: ?string }
+
+  declare export type DOMOutputSpec =
+    | string // node.text
+    | Element // document.createElement("div")
+    | [string] // ["br"]
+    // ["p", 0]
+    // ["img", node.attrs]
+    // ["div", ["hr"]]
+    | [string, 0 | Attributes | DOMOutputSpec | DOMOutputSpec[]]
+    // ["ul", { "data-tight": node.attrs.tight ? "true" : null }, 0]
+    // ["pre", node.attrs.params ? {"data-params": node.attrs.params} : {}, ["code", 0]]
+    // ["li", { "data-task": "true" }, [["input", {"type":"checkbox"}], 0]]
+    | [string, Attributes, 0 | DOMOutputSpec | DOMOutputSpec[]]
 }


### PR DESCRIPTION
Change `DOMOutputSpec` type so that it's more exact and also allows valid values that previous definition did not supported.

Here is the link to the verbal definition of this type http://prosemirror.net/docs/ref/#model.DOMOutputSpec