### PR TITLE
Remove from enzyme_v3 getNodes() and define alternatives where applicable

### DIFF
--- a/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/enzyme_v3.x.x.js
+++ b/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/enzyme_v3.x.x.js
@@ -40,7 +40,6 @@ declare module "enzyme" {
     text(): string,
     html(): string,
     get(index: number): React.Node,
-    getNodes(): Array<React.Node>,
     getDOMNode(): HTMLElement | HTMLInputElement,
     at(index: number): this,
     first(): this,
@@ -90,7 +89,9 @@ declare module "enzyme" {
       options?: ?Object
     ): ShallowWrapper,
     equals(node: React.Node): boolean,
-    shallow(options?: { context?: Object }): ShallowWrapper
+    shallow(options?: { context?: Object }): ShallowWrapper,
+    getElement(): React.Node,
+    getElements(): Array<React.Node>
   }
 
   declare function shallow(

--- a/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/test_enzyme-v3.x.js
+++ b/definitions/npm/enzyme_v3.x.x/flow_v0.53.x-/test_enzyme-v3.x.js
@@ -48,6 +48,15 @@ shallowWrapper.find("someSelector");
 shallowWrapper.prop("foo");
 shallowWrapper.props().foo;
 
+// shallow's getNode(s) was replaced by getElement(s) in enzyme v3
+// $ExpectError
+shallowWrapper.getNode();
+// $ExpectError
+shallowWrapper.getNodes();
+
+shallowWrapper.getElement();
+shallowWrapper.getElements();
+
 (mount(<div />).map(node => true): Array<boolean>);
 
 (mount(<div />).reduce((acc: number, node, i) => i + 1): Array<number>);
@@ -56,6 +65,13 @@ shallowWrapper.props().foo;
 (mount(<div />).reduce((acc, node, i) => i + 1, 0): Array<number>);
 // $ExpectError
 (mount(<div />).reduce((acc, node, i) => i + 1, 0): Array<boolean>);
+
+
+// mount's getNode(s) were removed in enzyme v3
+// $ExpectError
+mount(<div />).getNode();
+// $ExpectError
+mount(<div />).getNodes();
 
 // Cheerio
 render(<div />).contents();


### PR DESCRIPTION
The enzyme_v3 libdef is missing some changes that happened after enzyme upgraded from v2 -> v3.

To quote the migration guide of enzyme:

> With shallow, .getNode() should be replaced with getElement()
> With mount, .getNode() should not be used. .instance() does what it used to.

This PR implements the following:

* `shallow()`
  * `getNode()` was replaced by `getElement()`
  * `getNodes()` was replaced by `getElements()`
* `mount()`
  * `getNode()` was removed
  * `getNodes()` was removed

Sources:

[The original commit with initial changes](https://github.com/airbnb/enzyme/commit/568ce8961ecbc55f26359cbfca35ea0300f4cb9f#diff-00a0c52d2a0eac5ec0025c1d32767a95L174)
[The current source-code printing errors for the removed methods](https://github.com/airbnb/enzyme/blob/master/packages/enzyme/src/ReactWrapper.js)
[The migration-guide v2 -> v3](https://github.com/airbnb/enzyme/blob/master/docs/guides/migration-from-2-to-3.md)