### PR TITLE
Improves error message when libdef not found for flow version

### DIFF
--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -339,7 +339,8 @@ async function installNpmLibDefs({
     // a stub if no libdef exists -- just inform them that one doesn't exist
     console.log(
       colors.red(
-        `!! No libdefs found in flow-typed for the explicitly requested libdefs. !!`,
+        `!! No flow@${flowVersionToSemver(flowVersion)}-compatible libdefs ` +
+          `found in flow-typed for the explicitly requested libdefs. !!`,
       ) +
         '\n' +
         '\n' +


### PR DESCRIPTION
* fixes #801 (it wasn't obvious that the problem may missing libdefs *for the given flow version*).

* brings message in line with elsewhere in same file:
  https://github.com/flowtype/flow-typed/blob/41bf41381b9b520e29804ad167145d268e3ff795/cli/src/commands/install.js#L383