### PR TITLE
Copy v6 react-i18next to v7

### DIFF
--- a/cli/src/lib/npm/__tests__/npmLibDefs-test.js
+++ b/cli/src/lib/npm/__tests__/npmLibDefs-test.js
@@ -300,6 +300,7 @@ describe('npmLibDefs', () => {
   describe('findNpmLibDef', () => {
     describe('when no cached libDefs found', () => {
       it('returns null', async () => {
+        jest.setTimeout(10000);
         const pkgName = 'jest-test-npm-package';
         const pkgVersion = 'v1.0.0';
         const flowVersion = {kind: 'all'};

--- a/definitions/npm/react-i18next_v7.x.x/flow_v0.53.x-/react-i18next_v7.x.x.js
+++ b/definitions/npm/react-i18next_v7.x.x/flow_v0.53.x-/react-i18next_v7.x.x.js
@@ -1,0 +1,82 @@
+declare module "react-i18next" {
+  declare type TFunction = (key?: ?string, data?: ?Object) => string;
+
+  declare type TranslatorProps = {
+    t: TFunction,
+    i18nLoadedAt: Date,
+    i18n: Object
+  };
+
+  declare type Translator<OP, P> = (
+    component: React$ComponentType<P>
+  ) => Class<React$Component<OP, *>>;
+
+  declare type TranslateOptions = $Shape<{
+    wait: boolean,
+    nsMode: "default" | "fallback",
+    bindi18n: false | string,
+    bindStore: false | string,
+    withRef: boolean,
+    translateFuncName: string,
+    i18n: Object,
+    usePureComponent: boolean
+  }>;
+
+  declare function translate<OP, P>(
+    namespaces?: string | Array<string> | ((OP) => string | Array<string>),
+    options?: TranslateOptions
+  ): Translator<OP, P>;
+
+  declare type I18nProps = {
+    i18n?: Object,
+    ns?: string | Array<string>,
+    children: (t: TFunction, { i18n: Object, t: TFunction }) => React$Node,
+    initialI18nStore?: Object,
+    initialLanguage?: string
+  };
+  declare var I18n: React$ComponentType<I18nProps>;
+
+  declare type InterpolateProps = {
+    className?: string,
+    dangerouslySetInnerHTMLPartElement?: string,
+    i18n?: Object,
+    i18nKey?: string,
+    options?: Object,
+    parent?: string,
+    style?: Object,
+    t?: TFunction,
+    useDangerouslySetInnerHTML?: boolean
+  };
+  declare var Interpolate: React$ComponentType<InterpolateProps>;
+
+  declare type TransProps = {
+    count?: number,
+    parent?: string,
+    i18n?: Object,
+    i18nKey?: string,
+    t?: TFunction
+  };
+  declare var Trans: React$ComponentType<TransProps>;
+
+  declare type ProviderProps = { i18n: Object, children: React$Element<*> };
+  declare var I18nextProvider: React$ComponentType<ProviderProps>;
+
+  declare type NamespacesProps = {
+    components: Array<React$ComponentType<*>>,
+    i18n: { loadNamespaces: Function }
+  };
+  declare function loadNamespaces(props: NamespacesProps): Promise<void>;
+
+  declare var reactI18nextModule: {
+    type: "3rdParty",
+    init: (instance: Object) => void
+  };
+
+  declare function setDefaults(options: TranslateOptions): void;
+
+  declare function getDefaults(): TranslateOptions;
+
+  declare function getI18n(): Object;
+
+  declare function setI18n(instance: Object): void;
+}

--- a/definitions/npm/react-i18next_v7.x.x/test_react-i18next_v7.x.x.js
+++ b/definitions/npm/react-i18next_v7.x.x/test_react-i18next_v7.x.x.js
@@ -10,7 +10,6 @@ import {
   Trans,
   setDefaults,
   reactI18nextModule,
-  defaultOptions,
   getDefaults,
   getI18n,
   setI18n
@@ -61,7 +60,12 @@ class FlowErrorClassComp extends React.Component<Props> {
 }
 
 // passing
+const namspaces: Array<string> = ['namespace1', 'namespace2']
 translate();
+translate(namspaces)
+translate('namespace1')
+const funcTranslator: Translator<OwnProps, Props> = translate(({ s }: OwnProps) => s)
+const funcTranslatorArray: Translator<OwnProps, Props> = translate(({ s }: OwnProps) => [s])
 // $ExpectError - wrong argument type
 translate({});
 
@@ -137,16 +141,6 @@ reactI18nextModule.init(i18n);
 reactI18nextModule.type;
 // $ExpectError - no field property on reactI18nextModule
 reactI18nextModule.field;
-
-// passing
-defaultOptions.wait;
-defaultOptions.withRef;
-defaultOptions.bindI18n;
-defaultOptions.bindStore;
-defaultOptions.translateFuncName;
-defaultOptions.nsMode;
-// $ExpectError - no field property on defaultOptions
-defaultOptions.field;
 
 // passing
 setDefaults({ wait: true });


### PR DESCRIPTION
Mostly, this is just copying over the v6 files to v7 for react-i18next. The only breaking change in that release was to, by default, not render a parent tag around the output of the Trans component. Since the parent prop was being set to a default before, the types didn't change any.

A couple of minor updates were added that I modified the types to handle as well:
1. Add function namespace argument to translate HOC (https://github.com/i18next/react-i18next/commit/28a841b7598855a9049d6d07dbd6d10467b9a5a8)
2. Add usePureComponent to TranslateOptions (https://github.com/i18next/react-i18next/commit/39e9468bd4a716757564176257958c088fa9c22c)
