### PR TITLE
flowtype/flow-typed#1760 Add root directory option to CLI

### DIFF
--- a/cli/src/commands/__tests__/install-test.js
+++ b/cli/src/commands/__tests__/install-test.js
@@ -265,10 +265,7 @@ describe('install (command)', () => {
 
         await Promise.all([mkdirp(FAKE_CACHE_REPO_DIR), mkdirp(FLOWTYPED_DIR)]);
 
-        await Promise.all([
-          copyDir(FIXTURE_FAKE_CACHE_REPO_DIR, FAKE_CACHE_REPO_DIR),
-          touchFile(path.join(FLOWPROJ_DIR, '.flowconfig')),
-        ]);
+        await copyDir(FIXTURE_FAKE_CACHE_REPO_DIR, FAKE_CACHE_REPO_DIR);
 
         await gitInit(FAKE_CACHE_REPO_DIR),
           await Promise.all([
@@ -295,6 +292,7 @@ describe('install (command)', () => {
       return fakeProjectEnv(async FLOWPROJ_DIR => {
         // Create some dependencies
         await Promise.all([
+          touchFile(path.join(FLOWPROJ_DIR, '.flowconfig')),
           writePkgJson(path.join(FLOWPROJ_DIR, 'package.json'), {
             name: 'test',
             devDependencies: {
@@ -347,6 +345,7 @@ describe('install (command)', () => {
       return fakeProjectEnv(async FLOWPROJ_DIR => {
         // Create some dependencies
         await Promise.all([
+          touchFile(path.join(FLOWPROJ_DIR, '.flowconfig')),
           writePkgJson(path.join(FLOWPROJ_DIR, 'package.json'), {
             name: 'test',
             devDependencies: {
@@ -405,6 +404,7 @@ describe('install (command)', () => {
       return fakeProjectEnv(async FLOWPROJ_DIR => {
         // Create some dependencies
         await Promise.all([
+          touchFile(path.join(FLOWPROJ_DIR, '.flowconfig')),
           writePkgJson(path.join(FLOWPROJ_DIR, 'package.json'), {
             name: 'test',
             devDependencies: {
@@ -444,6 +444,7 @@ describe('install (command)', () => {
       return fakeProjectEnv(async FLOWPROJ_DIR => {
         // Create some dependencies
         await Promise.all([
+          touchFile(path.join(FLOWPROJ_DIR, '.flowconfig')),
           writePkgJson(path.join(FLOWPROJ_DIR, 'package.json'), {
             name: 'test',
             devDependencies: {
@@ -476,6 +477,7 @@ describe('install (command)', () => {
       return fakeProjectEnv(async FLOWPROJ_DIR => {
         // Create some dependencies
         await Promise.all([
+          touchFile(path.join(FLOWPROJ_DIR, '.flowconfig')),
           writePkgJson(path.join(FLOWPROJ_DIR, 'package.json'), {
             name: 'test',
             devDependencies: {
@@ -520,6 +522,7 @@ describe('install (command)', () => {
       return fakeProjectEnv(async FLOWPROJ_DIR => {
         // Create some dependencies
         await Promise.all([
+          touchFile(path.join(FLOWPROJ_DIR, '.flowconfig')),
           writePkgJson(path.join(FLOWPROJ_DIR, 'package.json'), {
             name: 'test',
             devDependencies: {
@@ -572,6 +575,7 @@ describe('install (command)', () => {
       return fakeProjectEnv(async FLOWPROJ_DIR => {
         // Create some dependencies
         await Promise.all([
+          touchFile(path.join(FLOWPROJ_DIR, '.flowconfig')),
           writePkgJson(path.join(FLOWPROJ_DIR, 'package.json'), {
             name: 'test',
             devDependencies: {
@@ -625,6 +629,7 @@ describe('install (command)', () => {
       return fakeProjectEnv(async FLOWPROJ_DIR => {
         // Create some dependencies
         await Promise.all([
+          touchFile(path.join(FLOWPROJ_DIR, '.flowconfig')),
           writePkgJson(path.join(FLOWPROJ_DIR, 'package.json'), {
             name: 'test',
             dependencies: {
@@ -654,6 +659,50 @@ describe('install (command)', () => {
         expect(
           await fs.exists(
             path.join(FLOWPROJ_DIR, 'flow-typed', 'npm', 'foo_v1.x.x.js'),
+          ),
+        ).toEqual(true);
+      });
+    });
+
+    it('uses .flowconfig from specified root directory', () => {
+      return fakeProjectEnv(async FLOWPROJ_DIR => {
+        // Create some dependencies
+        await Promise.all([
+          mkdirp(path.join(FLOWPROJ_DIR, 'src')),
+          writePkgJson(path.join(FLOWPROJ_DIR, 'package.json'), {
+            name: 'test',
+            devDependencies: {
+              'flow-bin': '^0.43.0',
+            },
+            dependencies: {
+              foo: '1.2.3',
+            },
+          }),
+          mkdirp(path.join(FLOWPROJ_DIR, 'node_modules', 'foo')),
+          mkdirp(path.join(FLOWPROJ_DIR, 'node_modules', 'flow-bin')),
+        ]);
+
+        await touchFile(path.join(FLOWPROJ_DIR, 'src', '.flowconfig'));
+
+        // Run the install command
+        await run({
+          _: [],
+          overwrite: false,
+          verbose: false,
+          skip: false,
+          rootDir: path.join(FLOWPROJ_DIR, 'src'),
+        });
+
+        // Installs libdef
+        expect(
+          await fs.exists(
+            path.join(
+              FLOWPROJ_DIR,
+              'src',
+              'flow-typed',
+              'npm',
+              'foo_v1.x.x.js',
+            ),
           ),
         ).toEqual(true);
       });

--- a/cli/src/commands/create-stub.js
+++ b/cli/src/commands/create-stub.js
@@ -5,6 +5,7 @@ export const description = 'Create a libdef stub for an untyped npm package';
 
 import {createStub} from '../lib/stubUtils.js';
 import {findFlowRoot} from '../lib/flowProjectUtils.js';
+import {path} from '../lib/node';
 
 export function setup(yargs: Object) {
   return yargs
@@ -26,6 +27,11 @@ export function setup(yargs: Object) {
         type: 'string',
         demand: false,
       },
+      rootDir: {
+        alias: 'r',
+        describe: 'Directory of .flowconfig relative to node_modules',
+        type: 'string',
+      },
     })
     .example('$0 create-stub foo@^1.2.0')
     .example('$0 create-stub foo bar baz')
@@ -36,6 +42,7 @@ type Args = {
   overwrite: boolean,
   libdefDir?: string,
   _: Array<string>,
+  rootDir?: string,
 };
 
 function failWithMessage(message: string) {
@@ -50,9 +57,10 @@ export async function run(args: Args): Promise<number> {
     );
   }
   const packages = args._.slice(1);
+  const cwd = args.rootDir ? path.resolve(args.rootDir) : process.cwd();
 
   // Find the project root
-  const projectRoot = await findFlowRoot(process.cwd());
+  const projectRoot = await findFlowRoot(cwd);
   if (projectRoot == null) {
     return failWithMessage(
       `\nERROR: Unable to find a flow project in the current dir or any of ` +

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -50,6 +50,7 @@ export type Args = {
   libdefDir?: string,
   packageDir?: string,
   ignoreDeps?: Array<string>,
+  rootDir?: string,
 };
 export function setup(yargs: Yargs) {
   return yargs.usage(`$0 ${name} - ${description}`).options({
@@ -86,10 +87,15 @@ export function setup(yargs: Yargs) {
       describe: 'Dependency categories to ignore when installing definitions',
       type: 'array',
     },
+    rootDir: {
+      alias: 'r',
+      describe: 'Directory of .flowconfig relative to node_modules',
+      type: 'string',
+    },
   });
 }
 export async function run(args: Args) {
-  const cwd = process.cwd();
+  const cwd = args.rootDir ? path.resolve(args.rootDir) : process.cwd();
   const packageDir = args.packageDir ? path.resolve(args.packageDir) : cwd;
   const flowVersion = await determineFlowVersion(packageDir, args.flowVersion);
   const libdefDir = args.libdefDir || 'flow-typed';


### PR DESCRIPTION
* Adds `-rootDir` as an argument for install and create-stub for projects where `.flowconfig` is in a subdirectory relative to `node_modules`