### PR TITLE
Symbol for prop-type definitions

### DIFF
--- a/definitions/npm/prop-types_v15.x.x/flow_v0.41.x-/prop-types_v15.x.x.js
+++ b/definitions/npm/prop-types_v15.x.x/flow_v0.41.x-/prop-types_v15.x.x.js
@@ -11,6 +11,7 @@ declare module 'prop-types' {
   declare var number: React$PropType$Primitive<number>;
   declare var object: React$PropType$Primitive<Object>;
   declare var string: React$PropType$Primitive<string>;
+  declare var symbol: React$PropType$Primitive<Symbol>;
   declare var any: React$PropType$Primitive<any>;
   declare var arrayOf: React$PropType$ArrayOf;
   declare var element: React$PropType$Primitive<any>; /* TODO */


### PR DESCRIPTION
Update flow type definitions to include Symbol, so flow is able to recognize PropTypes.symbol.