### PR TITLE
Improve react-dropzone definition

### DIFF
--- a/definitions/npm/react-dropzone_v4.x.x/flow_v0.53.x-/react-dropzone_v4.x.x.js
+++ b/definitions/npm/react-dropzone_v4.x.x/flow_v0.53.x-/react-dropzone_v4.x.x.js
@@ -8,6 +8,10 @@ declare module "react-dropzone" {
     isDragReject: boolean,
   }
 
+  declare type DropzoneFile = File & {
+    preview?: string;
+  }
+
   declare type DropzoneProps = {
     accept?: string,
     children?: React$Node | (ChildrenProps) => React$Node,
@@ -31,9 +35,9 @@ declare module "react-dropzone" {
     rejectStyle?: Object,
     disabledStyle?: Object,
     onClick?: (event: SyntheticMouseEvent<>) => mixed,
-    onDrop?: (acceptedFiles: Array<File>, rejectedFiles: Array<File>, event: SyntheticDragEvent<>) => mixed,
-    onDropAccepted?: (acceptedFiles: Array<File>, event: SyntheticDragEvent<>) => mixed,
-    onDropRejected?: (rejectedFiles: Array<File>, event: SyntheticDragEvent<>) => mixed,
+    onDrop?: (acceptedFiles: Array<DropzoneFile>, rejectedFiles: Array<DropzoneFile>, event: SyntheticDragEvent<>) => mixed,
+    onDropAccepted?: (acceptedFiles: Array<DropzoneFile>, event: SyntheticDragEvent<>) => mixed,
+    onDropRejected?: (rejectedFiles: Array<DropzoneFile>, event: SyntheticDragEvent<>) => mixed,
     onDragStart?: (event: SyntheticDragEvent<>) => mixed,
     onDragEnter?: (event: SyntheticDragEvent<>) => mixed,
     onDragOver?: (event: SyntheticDragEvent<>) => mixed,
@@ -41,5 +45,9 @@ declare module "react-dropzone" {
     onFileDialogCancel?: () => mixed,
   };
 
-  declare module.exports: React$ComponentType<DropzoneProps>;
+  declare class Dropzone extends React$Component<DropzoneProps> {
+    open(): void;
+  }
+
+  declare module.exports: typeof Dropzone;
 }

--- a/definitions/npm/react-dropzone_v4.x.x/test_react-dropzone_v4.x.x.js
+++ b/definitions/npm/react-dropzone_v4.x.x/test_react-dropzone_v4.x.x.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Dropzone, { type ChildrenProps } from "react-dropzone";
+import Dropzone, { type ChildrenProps, type DropzoneFile } from "react-dropzone";
 
 <Dropzone />;
 
@@ -29,14 +29,17 @@ import Dropzone, { type ChildrenProps } from "react-dropzone";
   rejectStyle={{ height: '80px' }}
   disabledStyle={{ height: '90px' }}
   onClick={(event: SyntheticMouseEvent<>) => {}}
-  onDrop={(acceptedFiles: Array<File>, rejectedFiles: Array<File>, event: SyntheticDragEvent<>) => {}}
-  onDropAccepted={(acceptedFiles: Array<File>, event: SyntheticDragEvent<>) => {}}
-  onDropRejected={(rejectedFiles: Array<File>, event: SyntheticDragEvent<>) => {}}
+  onDrop={(acceptedFiles: Array<DropzoneFile>, rejectedFiles: Array<DropzoneFile>, event: SyntheticDragEvent<>) => {}}
+  onDropAccepted={(acceptedFiles: Array<DropzoneFile>, event: SyntheticDragEvent<>) => {}}
+  onDropRejected={(rejectedFiles: Array<DropzoneFile>, event: SyntheticDragEvent<>) => {}}
   onDragStart={(event: SyntheticDragEvent<>) => {}}
   onDragEnter={(event: SyntheticDragEvent<>) => {}}
   onDragOver={(event: SyntheticDragEvent<>) => {}}
   onDragLeave={(event: SyntheticDragEvent<>) => {}}
   onFileDialogCancel={() => {}}
+  ref={(ref: ?Dropzone) => {
+    if (ref) ref.open();
+  }}
 >
   {
     ({
@@ -55,9 +58,9 @@ import Dropzone, { type ChildrenProps } from "react-dropzone";
 <Dropzone
   accept="image/jpeg, image/png, application/pdf"
   onClick={() => {}}
-  onDrop={(acceptedFiles: Array<File>) => {}}
-  onDropAccepted={(acceptedFiles: Array<File>) => {}}
-  onDropRejected={(rejectedFiles: Array<File>) => {}}
+  onDrop={(acceptedFiles: Array<DropzoneFile>) => {}}
+  onDropAccepted={(acceptedFiles: Array<DropzoneFile>) => {}}
+  onDropRejected={(rejectedFiles: Array<DropzoneFile>) => {}}
   onDragStart={() => {}}
   onDragEnter={() => {}}
   onDragOver={() => {}}


### PR DESCRIPTION
I improve react-dropzone definition for the following two points :)

First, react-dropzone has been added a `preview` field to `File` object.
FYI: 
* https://github.com/react-dropzone/react-dropzone/blob/v4.2.8/src/index.js#L165

Second, react-dropzone has a **public** instance method named `open` to invoke programmatically from ref.
FYI:
* https://react-dropzone.js.org/#opening-file-dialog-programmatically
* https://github.com/react-dropzone/react-dropzone/blob/v4.2.8/src/index.js#L265-L274