### PR TITLE
libdef firebase: Add auth().setPersistence

### DIFF
--- a/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/firebase_v4.x.x.js
+++ b/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/firebase_v4.x.x.js
@@ -81,10 +81,12 @@ declare interface $npm$firebase$auth$ApplicationVerifier {
 }
 
 declare type $npm$firebase$auth$Auth$Persistence = {
-  LOCAL: 'local',
-  SESSION: 'session',
-  NONE: 'none',
+  +LOCAL: 'local',
+  +SESSION: 'session',
+  +NONE: 'none',
 }
+
+declare type $npm$firebase$auth$Auth$Persistence$Enum = $Values<$npm$firebase$auth$Auth$Persistence>
 
 declare class $npm$firebase$auth$Auth {
   static Persistence: $npm$firebase$auth$Auth$Persistence;
@@ -110,7 +112,7 @@ declare class $npm$firebase$auth$Auth {
     completed?: () => void
   ): () => void;
   sendPasswordResetEmail(email: string): Promise<void>;
-  setPersistence(persistence: 'local' | 'session' | 'none'): Promise<void>;
+  setPersistence(persistence: $npm$firebase$auth$Auth$Persistence$Enum): Promise<void>;
   signInAndRetrieveDataWithCredential(
     credential: $npm$firebase$auth$AuthCredential
   ): Promise<$npm$firebase$auth$UserCredential>;

--- a/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/firebase_v4.x.x.js
+++ b/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/firebase_v4.x.x.js
@@ -80,7 +80,14 @@ declare interface $npm$firebase$auth$ApplicationVerifier {
   verify(): Promise<string>;
 }
 
+declare type $npm$firebase$auth$Auth$Persistence = {
+  LOCAL: 'local',
+  SESSION: 'session',
+  NONE: 'none',
+}
+
 declare class $npm$firebase$auth$Auth {
+  static Persistence: $npm$firebase$auth$Auth$Persistence;
   app: $npm$firebase$App;
   currentUser: $npm$firebase$auth$User;
   applyActionCode(code: string): Promise<void>;
@@ -103,6 +110,7 @@ declare class $npm$firebase$auth$Auth {
     completed?: () => void
   ): () => void;
   sendPasswordResetEmail(email: string): Promise<void>;
+  setPersistence(persistence: 'local' | 'session' | 'none'): Promise<void>;
   signInAndRetrieveDataWithCredential(
     credential: $npm$firebase$auth$AuthCredential
   ): Promise<$npm$firebase$auth$UserCredential>;

--- a/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/test_firebase.js
+++ b/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/test_firebase.js
@@ -187,3 +187,9 @@ firebase
 
 // #23
 firebase.auth().setPersistence(firebase.auth.Auth.Persistence.SESSION);
+firebase.auth().setPersistence('local');
+
+// $ExpectError
+firebase.auth().setPersistence(firebase.auth.Auth.Persistence.FOO);
+// $ExpectError
+firebase.auth().setPersistence('foo');

--- a/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/test_firebase.js
+++ b/definitions/npm/firebase_v4.x.x/flow_v0.34.x-/test_firebase.js
@@ -184,3 +184,6 @@ firebase
       snp.foo;
     }
   })();
+
+// #23
+firebase.auth().setPersistence(firebase.auth.Auth.Persistence.SESSION);


### PR DESCRIPTION
Hi, first PR here. And thanks for all previous work!

[firebase.auth().setPersistence](https://firebase.google.com/docs/reference/js/firebase.auth.Auth#setPersistence) was missing in the firebase_v4.x.x libdef. But it's quite easy to add. So instead of opening an issue first I decided to implement it and send a PR. Hope that's okey!

Tests are added and passing.

Have a nice day!