### PR TITLE
Update material-ui_v1 types

### DIFF
--- a/definitions/npm/material-ui_v1.x.x/flow_v0.61.x-/material-ui_v1.x.x.js
+++ b/definitions/npm/material-ui_v1.x.x/flow_v0.61.x-/material-ui_v1.x.x.js
@@ -1,5 +1,6 @@
 declare module "material-ui/AppBar/AppBar" {
-  declare type Color = "inherit" | "primary" | "accent" | "default";
+  declare type Color = "inherit" | "primary" | "secondary" | "default";
+  declare type Position = "fixed" | "absolute" | "sticky" | "static";
 
   declare module.exports: React$ComponentType<{
     children?: React$Node,
@@ -60,7 +61,7 @@ declare module "material-ui/BottomNavigation/BottomNavigation" {
   }>;
 }
 
-declare module "material-ui/BottomNavigation/BottomNavigationButton" {
+declare module "material-ui/BottomNavigation/BottomNavigationAction" {
   declare module.exports: React$ComponentType<{
     className?: string,
     classes?: Object,
@@ -76,20 +77,15 @@ declare module "material-ui/BottomNavigation/BottomNavigationButton" {
 
 declare module "material-ui/BottomNavigation" {
   declare module.exports: {
-    BottomNavigationButton: $Exports<
-      "material-ui/BottomNavigation/BottomNavigationButton"
+    BottomNavigationAction: $Exports<
+      "material-ui/BottomNavigation/BottomNavigationAction"
     >,
     default: $Exports<"material-ui/BottomNavigation/BottomNavigation">
   };
 }
 
 declare module "material-ui/Button/Button" {
-  declare type Color =
-    | "default"
-    | "inherit"
-    | "primary"
-    | "accent"
-    | "contrast";
+  declare type Color = "default" | "inherit" | "primary" | "secondary";
 
   declare module.exports: React$ComponentType<{
     children: React$Node,
@@ -364,7 +360,7 @@ declare module "material-ui/Dialog/Dialog" {
     TransitionCallback,
     TransitionDuration
   } from "material-ui/internal/transition";
-  declare type MaxWidth = "xs" | "sm" | "md";
+  declare type MaxWidth = "xs" | "sm" | "md" | false;
 
   declare module.exports: React$ComponentType<{
     children?: React$Node,
@@ -1309,11 +1305,12 @@ declare module "material-ui/Select/Select" {
 
   declare module.exports: React$ComponentType<{
     autoWidth?: boolean,
-    children: $ReadOnlyArray<ChildrenArray<*>>,
+    children: ChildrenArray<*>,
     classes?: Object,
     displayEmpty?: boolean,
     input?: React$Element<any>,
     native?: boolean,
+    onChange?: (event: Object, child: Object) => void,
     multiple?: boolean,
     MenuProps?: Object,
     renderValue?: Function,
@@ -1648,9 +1645,17 @@ declare module "material-ui/styles/withStyles" {
   declare module.exports: (
     stylesOrCreator: Object,
     options?: Options
-  ) => <Props: {}>(
+  ) => <
+    OwnProps: {},
+    Props: $Supertype<
+      OwnProps & {
+        classes: { +[string]: string },
+        innerRef: React$Ref<React$ElementType>
+      }
+    >
+  >(
     Component: React$ComponentType<Props>
-  ) => React$ComponentType<Props>;
+  ) => React$ComponentType<OwnProps>;
 }
 
 declare module "material-ui/styles/withTheme" {
@@ -1910,7 +1915,7 @@ declare module "material-ui/Tabs/Tabs" {
     fullWidth?: boolean,
     indicatorClassName?: string,
     indicatorColor?: IndicatorColor,
-    onChange: Function,
+    onChange?: (event: SyntheticEvent<>, value: any) => void,
     scrollable?: boolean,
     scrollButtons?: ScrollButtons,
     TabScrollButton?: React$ComponentType<*>,
@@ -2269,9 +2274,9 @@ declare module "material-ui/BottomNavigation/BottomNavigation.js" {
     "material-ui/BottomNavigation/BottomNavigation"
   >;
 }
-declare module "material-ui/BottomNavigation/BottomNavigationButton.js" {
+declare module "material-ui/BottomNavigation/BottomNavigationAction.js" {
   declare module.exports: $Exports<
-    "material-ui/BottomNavigation/BottomNavigationButton"
+    "material-ui/BottomNavigation/BottomNavigationAction"
   >;
 }
 declare module "material-ui/BottomNavigation/index.js" {


### PR DESCRIPTION
There have been some API changes in the material-ui 1.x branch: https://material-ui-next.com/

This PR is not a comprehensive set of updates to bring all of the components' types up to date. It only updates a few specific props on some components.