### PR TITLE
Add query-string_v5.1.x definitions

### DIFF
--- a/definitions/npm/query-string_v5.1.x/flow_v0.32.x-/query-string_v5.1.x.js
+++ b/definitions/npm/query-string_v5.1.x/flow_v0.32.x-/query-string_v5.1.x.js
@@ -1,0 +1,19 @@
+declare module 'query-string' {
+  declare type ArrayFormat = 'none' | 'bracket' | 'index'
+  declare type ParseOptions = {|
+    arrayFormat?: ArrayFormat,
+  |}
+
+  declare type StringifyOptions = {|
+    arrayFormat?: ArrayFormat,
+    encode?: boolean,
+    strict?: boolean,
+  |}
+
+  declare module.exports: {
+    extract(str: string): string,
+    parse(str: string, opts?: ParseOptions): Object,
+    parseUrl(str: string, opts?: ParseOptions): { url: string, query: Object },
+    stringify(obj: Object, opts?: StringifyOptions): string,
+  }
+}

--- a/definitions/npm/query-string_v5.1.x/test_query-string_v5.1.x.js
+++ b/definitions/npm/query-string_v5.1.x/test_query-string_v5.1.x.js
@@ -1,0 +1,39 @@
+// @flow
+
+import { extract, parse, stringify, parseUrl } from "query-string";
+
+extract("?test");
+
+// $ExpectError: should be a string
+extract({});
+
+parse("test");
+
+parse("test", { arrayFormat: "bracket" });
+
+// $ExpectError: strict is not a parse option
+parse("test", { strict: true });
+
+// $ExpectError: should be a string
+parse({ test: null });
+
+stringify({ test: null });
+
+stringify({ test: null }, { strict: true });
+
+// $ExpectError: should be an object
+stringify("test");
+
+// $ExpectError: true is not a stringify option
+stringify({ test: null }, { test: true });
+
+
+parseUrl("test");
+
+parseUrl("test", { arrayFormat: "bracket" });
+
+// $ExpectError: strict is not a parse option
+parseUrl("test", { strict: true });
+
+// $ExpectError: should be a string
+parseUrl({ test: null });


### PR DESCRIPTION
Same as 5.0.x, but they added `parseUrl`