### PR TITLE
Fix failing regression spec

### DIFF
--- a/cli/src/commands/__tests__/runTests-test.js
+++ b/cli/src/commands/__tests__/runTests-test.js
@@ -24,10 +24,8 @@ describe('run-tests (command)', () => {
     });
 
     it('console logs about unused suppression', async () => {
-      const expectedError = `// $ExpectError
-        ^^^^^^^^^^^^^^^ Error suppressing comment. Unused suppression`;
+      const expectedError = `Unused suppression comment.`;
       const calls = ((console.log: any): JestMockFn<*, *>).mock.calls;
-      // takes the last error message to make sure this does not break in future versions of Flow
       const lastErrorMsg = calls[calls.length - 1][1];
       expect(lastErrorMsg).toContain(expectedError);
     });


### PR DESCRIPTION
From the release notes in version 66: `Error message redesign to help you better debug typing issues in your programs.`