### PR TITLE
fix Options type for meow_v4

### DIFF
--- a/definitions/npm/meow_v4.x.x/flow_v0.54.x-/meow_v4.x.x.js
+++ b/definitions/npm/meow_v4.x.x/flow_v0.54.x-/meow_v4.x.x.js
@@ -12,7 +12,7 @@ declare module "meow" {
     [key: string]: MinimistOption
   };
 
-  declare type Options = string | Array<string> | {|
+  declare type Options = {|
     description?: string | boolean,
     help?: string | boolean,
     version?: string | boolean,


### PR DESCRIPTION
Now that the exported function has two different signatures, `Options` should always be the config object.