### PR TITLE
Add Jest support for using class and function as test name in describe() and test()

### DIFF
--- a/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/jest_v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/jest_v22.x.x.js
@@ -107,6 +107,12 @@ type JestPromiseType = {
 };
 
 /**
+ * Jest allows functions and classes to be used as test names in test() and
+ * describe()
+ */
+type JestTestName = string | Function;
+
+/**
  *  Plugin: jest-enzyme
  */
 type EnzymeMatchersType = {
@@ -441,17 +447,17 @@ declare var describe: {
   /**
    * Creates a block that groups together several related tests in one "test suite"
    */
-  (name: string, fn: Function): void,
+  (name: JestTestName, fn: Function): void,
 
   /**
    * Only run this describe block
    */
-  only(name: string, fn: Function): void,
+  only(name: JestTestName, fn: Function): void,
 
   /**
    * Skip running this describe block
    */
-  skip(name: string, fn: Function): void
+  skip(name: JestTestName, fn: Function): void
 };
 
 /** An individual test unit */
@@ -459,33 +465,33 @@ declare var it: {
   /**
    * An individual test unit
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    */
-  (name: string, fn?: Function): ?Promise<void>,
+  (name: JestTestName, fn?: Function): ?Promise<void>,
   /**
    * Only run this test
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    */
-  only(name: string, fn?: Function): ?Promise<void>,
+  only(name: JestTestName, fn?: Function): ?Promise<void>,
   /**
    * Skip running this test
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    */
-  skip(name: string, fn?: Function): ?Promise<void>,
+  skip(name: JestTestName, fn?: Function): ?Promise<void>,
   /**
    * Run the test concurrently
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    */
-  concurrent(name: string, fn?: Function): ?Promise<void>
+  concurrent(name: JestTestName, fn?: Function): ?Promise<void>
 };
-declare function fit(name: string, fn: Function): ?Promise<void>;
+declare function fit(name: JestTestName, fn: Function): ?Promise<void>;
 /** An individual test unit */
 declare var test: typeof it;
 /** A disabled group of tests */

--- a/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/test_jest-v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/test_jest-v22.x.x.js
@@ -34,11 +34,24 @@ expect("someVal").toHaveBeeenCalledWith("a");
 // $ExpectError property `fn` not found in Array
 mockFn.mock.calls.fn();
 
+class AClass {}
+function aFunction() {}
+
 describe("name", () => {});
+describe(AClass, () => {});
+describe(aFunction, () => {});
+
 describe.only("name", () => {});
+describe.only(AClass, () => {});
+describe.only(aFunction, () => {});
+
 describe.skip("name", () => {});
+describe.skip(AClass, () => {});
+describe.skip(aFunction, () => {});
 
 test("test", () => expect("foo").toMatchSnapshot());
+test(AClass, () => expect("foo").toMatchSnapshot());
+test(aFunction, () => expect("foo").toMatchSnapshot());
 test.only("test", () => expect("foo").toMatchSnapshot());
 test.skip("test", () => expect("foo").toMatchSnapshot());
 

--- a/definitions/npm/jest_v22.x.x/flow_v0.39.x-/jest_v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.39.x-/jest_v22.x.x.js
@@ -111,6 +111,12 @@ type JestPromiseType = {
 };
 
 /**
+ * Jest allows functions and classes to be used as test names in test() and
+ * describe()
+ */
+type JestTestName = string | Function;
+
+/**
  *  Plugin: jest-enzyme
  */
 type EnzymeMatchersType = {
@@ -459,17 +465,17 @@ declare var describe: {
   /**
    * Creates a block that groups together several related tests in one "test suite"
    */
-  (name: string, fn: () => void): void,
+  (name: JestTestName, fn: () => void): void,
 
   /**
    * Only run this describe block
    */
-  only(name: string, fn: () => void): void,
+  only(name: JestTestName, fn: () => void): void,
 
   /**
    * Skip running this describe block
    */
-  skip(name: string, fn: () => void): void
+  skip(name: JestTestName, fn: () => void): void
 };
 
 /** An individual test unit */
@@ -477,54 +483,54 @@ declare var it: {
   /**
    * An individual test unit
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
   (
-    name: string,
+    name: JestTestName,
     fn?: (done: () => void) => ?Promise<mixed>,
     timeout?: number
   ): void,
   /**
    * Only run this test
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
   only(
-    name: string,
+    name: JestTestName,
     fn?: (done: () => void) => ?Promise<mixed>,
     timeout?: number
   ): void,
   /**
    * Skip running this test
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
   skip(
-    name: string,
+    name: JestTestName,
     fn?: (done: () => void) => ?Promise<mixed>,
     timeout?: number
   ): void,
   /**
    * Run the test concurrently
    *
-   * @param {string} Name of Test
+   * @param {JestTestName} Name of Test
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
   concurrent(
-    name: string,
+    name: JestTestName,
     fn?: (done: () => void) => ?Promise<mixed>,
     timeout?: number
   ): void
 };
 declare function fit(
-  name: string,
+  name: JestTestName,
   fn: (done: () => void) => ?Promise<mixed>,
   timeout?: number
 ): void;

--- a/definitions/npm/jest_v22.x.x/flow_v0.39.x-/test_jest-v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.39.x-/test_jest-v22.x.x.js
@@ -75,11 +75,24 @@ expect("someVal").toHaveBeeenCalledWith("a");
 // $ExpectError property `fn` not found in Array
 mockFn.mock.calls.fn();
 
+class AClass {}
+function aFunction() {}
+
 describe("name", () => {});
+describe(AClass, () => {});
+describe(aFunction, () => {});
+
 describe.only("name", () => {});
+describe.only(AClass, () => {});
+describe.only(aFunction, () => {});
+
 describe.skip("name", () => {});
+describe.skip(AClass, () => {});
+describe.skip(aFunction, () => {});
 
 test("test", () => expect("foo").toMatchSnapshot());
+test(AClass, () => expect("foo").toMatchSnapshot());
+test(aFunction, () => expect("foo").toMatchSnapshot());
 test.only("test", () => expect("foo").toMatchSnapshot());
 test.skip("test", () => expect("foo").toMatchSnapshot());
 


### PR DESCRIPTION
Jest 22.0.5 adds support for using functions and classes as test names (https://github.com/facebook/jest/pull/5154) - https://github.com/facebook/jest/blob/master/CHANGELOG.md#features-6 

This PR adds that to the Jest libdef for v22.x.x 