### PR TITLE
react-navigation_v1.x.x: add Header.HEIGHT property

### DIFF
--- a/cli/src/commands/__tests__/runTests-test.js
+++ b/cli/src/commands/__tests__/runTests-test.js
@@ -24,7 +24,7 @@ describe('run-tests (command)', () => {
     });
 
     it('console logs about unused suppression', async () => {
-      const expectedError = `Unused suppression comment.`;
+      const expectedError = `Unused suppression`;
       const calls = ((console.log: any): JestMockFn<*, *>).mock.calls;
       const lastErrorMsg = calls[calls.length - 1][1];
       expect(lastErrorMsg).toContain(expectedError);

--- a/definitions/npm/react-navigation_v1.x.x/flow_v0.60.x-/react-navigation_v1.x.x.js
+++ b/definitions/npm/react-navigation_v1.x.x/flow_v0.60.x-/react-navigation_v1.x.x.js
@@ -949,9 +949,9 @@ declare module 'react-navigation' {
   };
   declare export var SafeAreaView: React$ComponentType<_SafeAreaViewProps>;
 
-  declare export var Header: React$ComponentType<HeaderProps> & {
-    HEIGHT: number
-  };
+  declare export class Header<P: HeaderProps, S> extends React$Component<P, S> {
+    static HEIGHT: number
+  }
 
   declare type _HeaderTitleProps = {
     children: React$Node,

--- a/definitions/npm/react-navigation_v1.x.x/flow_v0.60.x-/react-navigation_v1.x.x.js
+++ b/definitions/npm/react-navigation_v1.x.x/flow_v0.60.x-/react-navigation_v1.x.x.js
@@ -949,7 +949,9 @@ declare module 'react-navigation' {
   };
   declare export var SafeAreaView: React$ComponentType<_SafeAreaViewProps>;
 
-  declare export var Header: React$ComponentType<HeaderProps>;
+  declare export var Header: React$ComponentType<HeaderProps> & {
+    HEIGHT: number
+  };
 
   declare type _HeaderTitleProps = {
     children: React$Node,


### PR DESCRIPTION
The component Header in `react-navigation` has a static HEIGHT property that wasn't in the flow definition.