### PR TITLE
[react-navigation] fix typespec of init function on react-navigation

### DIFF
--- a/definitions/npm/react-navigation_v1.x.x/flow_v0.60.x-/react-navigation_v1.x.x.js
+++ b/definitions/npm/react-navigation_v1.x.x/flow_v0.60.x-/react-navigation_v1.x.x.js
@@ -753,7 +753,7 @@ declare module 'react-navigation' {
       toString: () => string,
     },
     init: {
-      (payload: { params?: NavigationParams }): NavigationInitAction,
+      (payload?: { params?: NavigationParams }): NavigationInitAction,
       toString: () => string,
     },
     navigate: {


### PR DESCRIPTION
https://github.com/react-navigation/react-navigation/blob/2bb91a6740e2f1ade012906dc03c972ba6375cc3/src/NavigationActions.js#L24

`init` do not required to pass `payload`