### PR TITLE
Redis: fix the type definition of lrem()

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -18,9 +18,9 @@ declare module "redis" {
     ) => void;
     lrem: (
       topic: string,
-      cursor: number,
+      count: number,
       value: string,
-      callback?: (error: ?Error, entries: ?Array<string>) => void
+      callback?: (error: ?Error, entries: number) => void
     ) => void;
     lrange: (
       topic: string,

--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/test_redis_v2.x.x.js
@@ -118,3 +118,10 @@ client.flushall((error) => {
 client.hgetall("key", (error: ?Error, result: ?{[key: string]: string}) => {})
 // $ExpectError
 client.hgetall("key", "bad extra argument in past type defs", (error: ?Error, result: ?{[key: string]: string}) => {})
+
+
+client.lrem('my-key', 5, 'value', (error: ?Error, count: number) => {});
+// $ExpectError
+client.lrem('my-key', 5, (error: ?Error, count: number) => {});
+// $ExpectError
+client.lrem('my-key', 5, 'value', (error: ?Error, result: string) => {});


### PR DESCRIPTION
Reference: https://redis.io/commands/lrem

Demo:

```js
'use strict';

const redis = require('redis');

const client = redis.createClient({
  host: '127.0.0.1',
  port: 6379
});

const listKey = 'my-list';
client.lpush(listKey, 'test', (error) => {
  if (error) {
    console.error(error);
    return;
  }
  client.lpush(listKey, 'test', (error) => {
    if (error) {
      console.error(error);
      return;
    }
    client.lrem(listKey, 1, 'test', (error, count) => {
      if (error) {
        console.error(error);
        return;
      }
      console.log(count, typeof(count)); // Output "1 'number'"
    });
  });
});
```