### PR TITLE
Add type definitions for react-intl-with-message-id_v2.x.x

### DIFF
--- a/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.25.x-v0.52.x/react-intl-with-data-message-id_v2.x.x.js
+++ b/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.25.x-v0.52.x/react-intl-with-data-message-id_v2.x.x.js
@@ -1,0 +1,217 @@
+/**
+ * Original implementation of this file by @marudor at https://github.com/marudor/flowInterfaces
+ * Copied here based on intention to merge with flow-typed expressed here:
+ * https://github.com/marudor/flowInterfaces/issues/6
+ */
+import React from "react";
+
+// Mostly from https://github.com/yahoo/react-intl/wiki/API#react-intl-with-data-message-id-api
+
+type LocaleData = {
+  locale: string,
+  [key: string]: any
+};
+
+type MessageDescriptor = {
+  id: string,
+  description?: string,
+  defaultMessage?: string
+};
+
+type MessageDescriptorMap = { [key: string]: MessageDescriptor };
+
+type IntlConfig = {
+  locale: string,
+  formats: Object,
+  messages: { [id: string]: string },
+
+  defaultLocale: string,
+  defaultFormats: Object
+};
+
+type IntlFormat = {
+  formatDate: (value: any, options?: Object) => string,
+  formatTime: (value: any, options?: Object) => string,
+  formatRelative: (value: any, options?: Object) => string,
+  formatNumber: (value: any, options?: Object) => string,
+  formatPlural: (value: any, options?: Object) => string,
+  formatMessage: (
+    messageDescriptor: MessageDescriptor,
+    values?: Object
+  ) => string,
+  formatHTMLMessage: (
+    messageDescriptor: MessageDescriptor,
+    values?: Object
+  ) => string
+};
+
+type $IntlShape = IntlConfig & IntlFormat & { now: () => number };
+
+type DateTimeFormatOptions = {
+  localeMatcher?: "best fit" | "lookup",
+  formatMatcher?: "basic" | "best fit",
+
+  timeZone?: string,
+  hour12?: boolean,
+
+  weekday?: "narrow" | "short" | "long",
+  era?: "narrow" | "short" | "long",
+  year?: "numeric" | "2-digit",
+  month?: "numeric" | "2-digit" | "narrow" | "short" | "long",
+  day?: "numeric" | "2-digit",
+  hour?: "numeric" | "2-digit",
+  minute?: "numeric" | "2-digit",
+  second?: "numeric" | "2-digit",
+  timeZoneName?: "short" | "long"
+};
+
+type RelativeFormatOptions = {
+  style: "best fit" | "numeric",
+  units: "second" | "minute" | "hour" | "day" | "month" | "year"
+};
+
+type NumberFormatOptions = {
+  localeMatcher?: "best fit" | "lookup",
+
+  style?: "decimal" | "currency" | "percent",
+
+  currency?: string,
+  currencyDisplay?: "symbol" | "code" | "name",
+
+  useGrouping?: boolean,
+
+  minimumIntegerDigits?: number,
+  minimumFractionDigits?: number,
+  maximumFractionDigits?: number,
+  minimumSignificantDigits?: number,
+  maximumSignificantDigits?: number
+};
+
+type PluralFormatOptions = {
+  style: "cardinal" | "ordinal"
+};
+
+type PluralCategoryString = "zero" | "one" | "two" | "few" | "many" | "other";
+
+type $DateParseable = number | string | Date;
+
+declare module "react-intl-with-data-message-id" {
+  // PropType checker
+  declare function intlShape(
+    props: Object,
+    propName: string,
+    componentName: string
+  ): void;
+  declare function addLocaleData(data: LocaleData | Array<LocaleData>): void;
+  declare function defineMessages<T: { [key: string]: MessageDescriptor }>(
+    messageDescriptors: T
+  ): T;
+  declare function injectIntl(
+    WrappedComponent: ReactClass<*>,
+    options?: {
+      intlPropName?: string,
+      withRef?: boolean
+    }
+  ): ReactClass<*>;
+  declare function formatMessage(
+    messageDescriptor: MessageDescriptor,
+    values?: Object
+  ): string;
+  declare function formatHTMLMessage(
+    messageDescriptor: MessageDescriptor,
+    values?: Object
+  ): string;
+  declare function formatDate(
+    value: any,
+    options?: DateTimeFormatOptions & { format: string }
+  ): string;
+  declare function formatTime(
+    value: any,
+    options?: DateTimeFormatOptions & { format: string }
+  ): string;
+  declare function formatRelative(
+    value: any,
+    options?: RelativeFormatOptions & { format: string, now: any }
+  ): string;
+  declare function formatNumber(
+    value: any,
+    options?: NumberFormatOptions & { format: string }
+  ): string;
+  declare function formatPlural(
+    value: any,
+    options?: PluralFormatOptions
+  ): PluralCategoryString;
+
+  declare class FormattedMessage extends React.Component<
+    void,
+    MessageDescriptor & {
+      values?: Object,
+      tagName?: string
+    },
+    void
+  > {}
+  declare class FormattedHTMLMessage extends React.Component<
+    void,
+    DateTimeFormatOptions & {
+      values?: Object,
+      tagName?: string
+    },
+    void
+  > {}
+  declare class FormattedDate extends React.Component<
+    void,
+    DateTimeFormatOptions & {
+      value: $DateParseable,
+      format?: string
+    },
+    void
+  > {}
+  declare class FormattedTime extends React.Component<
+    void,
+    DateTimeFormatOptions & {
+      value: $DateParseable,
+      format?: string
+    },
+    void
+  > {}
+  declare class FormattedRelative extends React.Component<
+    void,
+    RelativeFormatOptions & {
+      value: $DateParseable,
+      format?: string,
+      updateInterval?: number,
+      initialNow?: $DateParseable
+    },
+    void
+  > {}
+  declare class FormattedNumber extends React.Component<
+    void,
+    NumberFormatOptions & {
+      value: number | string,
+      format?: string
+    },
+    void
+  > {}
+  declare class FormattedPlural extends React.Component<
+    void,
+    PluralFormatOptions & {
+      value: number | string,
+      other: React.Component,
+      zero?: React.Component,
+      one?: React.Component,
+      two?: React.Component,
+      few?: React.Component,
+      many?: React.Component
+    },
+    void
+  > {}
+  declare class IntlProvider extends React.Component<
+    void,
+    IntlConfig & {
+      children: React.Component,
+      initialNow?: $DateParseable
+    },
+    void
+  > {}
+  declare type IntlShape = $IntlShape;
+}

--- a/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.25.x-v0.52.x/test_react-intl-with-data-message-id_v2.x.x.js
+++ b/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.25.x-v0.52.x/test_react-intl-with-data-message-id_v2.x.x.js
@@ -1,0 +1,139 @@
+/* @flow */
+import React, { Component } from "react";
+import {
+  intlShape,
+  addLocaleData,
+  defineMessages,
+  injectIntl,
+  FormattedMessage,
+  FormattedHTMLMessage,
+  FormattedDate,
+  FormattedTime,
+  FormattedRelative,
+  FormattedNumber,
+  FormattedPlural,
+  IntlProvider
+} from "react-intl-with-data-message-id";
+import type { IntlShape } from "react-intl-with-data-message-id";
+
+intlShape({ foo: "bar" }, "propName", "TestComponentName");
+// $ExpectError number. This type is incompatible with void
+const result1: number = intlShape(
+  { foo: "bar" },
+  "propName",
+  "TestComponentName"
+);
+
+const localeData = {
+  locale: "fi",
+  testKey: { foo: "bar" },
+  testKey2: { baz: "buu" }
+};
+addLocaleData(localeData);
+// $ExpectError number. This type is incompatible with void
+const resultLocaleData: number = addLocaleData(localeData);
+
+const messages = {
+  messagekey1: {
+    id: "messageid1",
+    defaultMessage: "Nice default message",
+    description: "description field yeah"
+  },
+  messagekey2_foo: {
+    id: "messageid2_foo",
+    defaultMessage: "Nice default message for second translation id",
+    description: "description field yeah for second field"
+  }
+};
+const messageDescriptorMap = defineMessages(messages);
+// $ExpectError foo is undefined
+const messageDescriptorMap1 = defineMessages(messages).foo;
+// $ExpectError id and defaultMessage are required
+const messageDescriptorMap2 = defineMessages({ message: {} });
+// $ExpectError array. This type is incompatible with MessageDescriptorMap
+const messageDescriptorMap3: Array<string> = defineMessages(messages);
+// $ExpectError string. This type is incompatible with MessageDescriptorMap
+const messageDescriptorMap4: string = defineMessages(messages);
+
+class TestComponent extends Component {
+  render() {
+    return React.createElement("div", null, `Hello ppl`);
+  }
+}
+const InjectedTestComponent: ReactClass<*> = injectIntl(TestComponent);
+const InjectedTestComponentWithRef: ReactClass<*> = injectIntl(TestComponent, {
+  withRef: true
+});
+// $ExpectError void. This type is incompatible with ReactClass<*>
+const FailingInjectedTestComponent: void = injectIntl(TestComponent);
+
+const MessageComponent: ReactClass<*> = injectIntl(
+  (props: { intl: IntlShape }) => {
+    const { formatMessage } = props.intl;
+    return <div>{formatMessage(messageDescriptorMap.messagekey1)}</div>;
+  }
+);
+// const HTMLMessageComponent: ReactClass<
+//   *,
+// > = injectIntl((props: { intl: IntlShape }) => {
+//   const { formatHTMLMessage } = props.intl;
+//   return <div>{formatHTMLMessage(messageDescriptorMap.messagekey2)}</div>;
+// });
+const DateComponent: ReactClass<*> = injectIntl(
+  (props: { intl: IntlShape }) => {
+    const { formatDate } = props.intl;
+    return <div>{formatDate(new Date(1459832991883))}</div>;
+  }
+);
+const TimeComponent: ReactClass<*> = injectIntl(
+  (props: { intl: IntlShape }) => {
+    const { formatTime } = props.intl;
+    return <div>{formatTime(new Date(1459832991883))}</div>;
+  }
+);
+const RelativeComponent: ReactClass<*> = injectIntl(
+  (props: { intl: IntlShape }) => {
+    const { formatRelative } = props.intl;
+    return <div>{formatRelative(Date.now())}</div>;
+  }
+);
+const NumberComponent: ReactClass<*> = injectIntl(
+  (props: { intl: IntlShape }) => {
+    const { formatNumber } = props.intl;
+    return <div>{formatNumber(1000)}</div>;
+  }
+);
+const PluralComponent: ReactClass<*> = injectIntl(
+  (props: { intl: IntlShape }) => {
+    const { formatPlural } = props.intl;
+    return <div>{formatPlural(10, { one: "message", other: "messages" })}</div>;
+  }
+);
+
+// Components
+<FormattedMessage
+  id="test"
+  defaultMessage="test message"
+  description="this is description"
+/>;
+<FormattedMessage
+  id="test_plural"
+  defaultMessage={`Hello {name}, you have {numMessages, number} {numMessages, plural,
+    one {message}
+    other {messages}
+  }`}
+  description="Plural example"
+  values={{ name: <b>John Doe</b>, numMessages: 1 }}
+/>;
+<FormattedHTMLMessage
+  id="test"
+  defaultMessage="test message"
+  description="this is description"
+/>;
+<FormattedDate value={new Date(1459832991883)} />;
+
+<FormattedTime value={new Date(1459832991883)} />;
+<FormattedRelative value={Date.now()} />;
+<FormattedNumber value={1000} />;
+<FormattedPlural value={10} one="message" other="messages" />;
+<IntlProvider locale="en" />;

--- a/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.53.x-v0.56.x/react-intl-with-data-message-id_v2.x.x.js
+++ b/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.53.x-v0.56.x/react-intl-with-data-message-id_v2.x.x.js
@@ -1,0 +1,230 @@
+/**
+ * Original implementation of this file by @marudor at https://github.com/marudor/flowInterfaces
+ * Copied here based on intention to merge with flow-typed expressed here:
+ * https://github.com/marudor/flowInterfaces/issues/6
+ */
+// Mostly from https://github.com/yahoo/react-intl/wiki/API#react-intl-with-data-message-id-api
+
+type $npm$ReactIntl$LocaleData = {
+  locale: string,
+  [key: string]: any
+};
+
+type $npm$ReactIntl$MessageDescriptor = {
+  id: string,
+  description?: string,
+  defaultMessage?: string
+};
+
+type $npm$ReactIntl$IntlConfig = {
+  locale: string,
+  formats: Object,
+  messages: { [id: string]: string },
+
+  defaultLocale?: string,
+  defaultFormats?: Object
+};
+
+type $npm$ReactIntl$IntlProviderConfig = {
+  locale?: string,
+  formats?: Object,
+  messages?: { [id: string]: string },
+
+  defaultLocale?: string,
+  defaultFormats?: Object
+};
+
+type $npm$ReactIntl$IntlFormat = {
+  formatDate: (value: any, options?: Object) => string,
+  formatTime: (value: any, options?: Object) => string,
+  formatRelative: (value: any, options?: Object) => string,
+  formatNumber: (value: any, options?: Object) => string,
+  formatPlural: (value: any, options?: Object) => string,
+  formatMessage: (
+    messageDescriptor: $npm$ReactIntl$MessageDescriptor,
+    values?: Object
+  ) => string,
+  formatHTMLMessage: (
+    messageDescriptor: $npm$ReactIntl$MessageDescriptor,
+    values?: Object
+  ) => string
+};
+
+type $npm$ReactIntl$IntlShape = $npm$ReactIntl$IntlConfig &
+  $npm$ReactIntl$IntlFormat & { now: () => number };
+
+type $npm$ReactIntl$DateTimeFormatOptions = {
+  localeMatcher?: "best fit" | "lookup",
+  formatMatcher?: "basic" | "best fit",
+
+  timeZone?: string,
+  hour12?: boolean,
+
+  weekday?: "narrow" | "short" | "long",
+  era?: "narrow" | "short" | "long",
+  year?: "numeric" | "2-digit",
+  month?: "numeric" | "2-digit" | "narrow" | "short" | "long",
+  day?: "numeric" | "2-digit",
+  hour?: "numeric" | "2-digit",
+  minute?: "numeric" | "2-digit",
+  second?: "numeric" | "2-digit",
+  timeZoneName?: "short" | "long"
+};
+
+type $npm$ReactIntl$RelativeFormatOptions = {
+  style?: "best fit" | "numeric",
+  units?: "second" | "minute" | "hour" | "day" | "month" | "year"
+};
+
+type $npm$ReactIntl$NumberFormatOptions = {
+  localeMatcher?: "best fit" | "lookup",
+
+  style?: "decimal" | "currency" | "percent",
+
+  currency?: string,
+  currencyDisplay?: "symbol" | "code" | "name",
+
+  useGrouping?: boolean,
+
+  minimumIntegerDigits?: number,
+  minimumFractionDigits?: number,
+  maximumFractionDigits?: number,
+  minimumSignificantDigits?: number,
+  maximumSignificantDigits?: number
+};
+
+type $npm$ReactIntl$PluralFormatOptions = {
+  style?: "cardinal" | "ordinal"
+};
+
+type $npm$ReactIntl$PluralCategoryString =
+  | "zero"
+  | "one"
+  | "two"
+  | "few"
+  | "many"
+  | "other";
+
+type $npm$ReactIntl$DateParseable = number | string | Date;
+
+declare module "react-intl-with-data-message-id" {
+  // PropType checker
+  declare function intlShape(
+    props: Object,
+    propName: string,
+    componentName: string
+  ): void;
+  declare function addLocaleData(
+    data: $npm$ReactIntl$LocaleData | Array<$npm$ReactIntl$LocaleData>
+  ): void;
+  declare function defineMessages<
+    T: { [key: string]: $npm$ReactIntl$MessageDescriptor }
+  >(
+    messageDescriptors: T
+  ): T;
+  declare function injectIntl<Props: {}>(
+    WrappedComponent: React$ComponentType<
+      { intl: $npm$ReactIntl$IntlShape } & Props
+    >,
+    options?: {
+      intlPropName?: string,
+      withRef?: boolean
+    }
+  ): React$ComponentType<Props>;
+  declare function formatMessage(
+    messageDescriptor: $npm$ReactIntl$MessageDescriptor,
+    values?: Object
+  ): string;
+  declare function formatHTMLMessage(
+    messageDescriptor: $npm$ReactIntl$MessageDescriptor,
+    values?: Object
+  ): string;
+  declare function formatDate(
+    value: any,
+    options?: $npm$ReactIntl$DateTimeFormatOptions & { format: string }
+  ): string;
+  declare function formatTime(
+    value: any,
+    options?: $npm$ReactIntl$DateTimeFormatOptions & { format: string }
+  ): string;
+  declare function formatRelative(
+    value: any,
+    options?: $npm$ReactIntl$RelativeFormatOptions & {
+      format: string,
+      now: any
+    }
+  ): string;
+  declare function formatNumber(
+    value: any,
+    options?: $npm$ReactIntl$NumberFormatOptions & { format: string }
+  ): string;
+  declare function formatPlural(
+    value: any,
+    options?: $npm$ReactIntl$PluralFormatOptions
+  ): $npm$ReactIntl$PluralCategoryString;
+
+  declare class FormattedMessage extends React$Component<
+    $npm$ReactIntl$MessageDescriptor & {
+      values?: Object,
+      tagName?: string,
+      children?: (...formattedMessage: Array<React$Node>) => React$Node
+    }
+  > {}
+  declare class FormattedHTMLMessage extends React$Component<
+    $npm$ReactIntl$DateTimeFormatOptions & {
+      values?: Object,
+      tagName?: string,
+      children?: (...formattedMessage: Array<React$Node>) => React$Node
+    }
+  > {}
+  declare class FormattedDate extends React$Component<
+    $npm$ReactIntl$DateTimeFormatOptions & {
+      value: $npm$ReactIntl$DateParseable,
+      format?: string,
+      children?: (formattedDate: string) => React$Node
+    }
+  > {}
+  declare class FormattedTime extends React$Component<
+    $npm$ReactIntl$DateTimeFormatOptions & {
+      value: $npm$ReactIntl$DateParseable,
+      format?: string,
+      children?: (formattedDate: string) => React$Node
+    }
+  > {}
+  declare class FormattedRelative extends React$Component<
+    $npm$ReactIntl$RelativeFormatOptions & {
+      value: $npm$ReactIntl$DateParseable,
+      format?: string,
+      updateInterval?: number,
+      initialNow?: $npm$ReactIntl$DateParseable,
+      children?: (formattedDate: string) => React$Node
+    }
+  > {}
+  declare class FormattedNumber extends React$Component<
+    $npm$ReactIntl$NumberFormatOptions & {
+      value: number | string,
+      format?: string,
+      children?: (formattedNumber: string) => React$Node
+    }
+  > {}
+  declare class FormattedPlural extends React$Component<
+    $npm$ReactIntl$PluralFormatOptions & {
+      value: number | string,
+      other: React$Node,
+      zero?: React$Node,
+      one?: React$Node,
+      two?: React$Node,
+      few?: React$Node,
+      many?: React$Node,
+      children?: (formattedPlural: React$Node) => React$Node
+    }
+  > {}
+  declare class IntlProvider extends React$Component<
+    $npm$ReactIntl$IntlProviderConfig & {
+      children: React$Node,
+      initialNow?: $npm$ReactIntl$DateParseable
+    }
+  > {}
+  declare type IntlShape = $npm$ReactIntl$IntlShape;
+  declare type MessageDescriptor = $npm$ReactIntl$MessageDescriptor;
+}

--- a/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.53.x-v0.56.x/test_react-intl-with-data-message-id_v2.x.x.js
+++ b/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.53.x-v0.56.x/test_react-intl-with-data-message-id_v2.x.x.js
@@ -1,0 +1,188 @@
+/* @flow */
+import * as React from "react";
+import {
+  intlShape,
+  addLocaleData,
+  defineMessages,
+  injectIntl,
+  FormattedMessage,
+  FormattedHTMLMessage,
+  FormattedDate,
+  FormattedTime,
+  FormattedRelative,
+  FormattedNumber,
+  FormattedPlural,
+  IntlProvider
+} from "react-intl-with-data-message-id";
+import type { IntlShape, MessageDescriptor } from "react-intl-with-data-message-id";
+
+intlShape({ foo: "bar" }, "propName", "TestComponentName");
+// $ExpectError number. This type is incompatible with void
+const result1: number = intlShape(
+  { foo: "bar" },
+  "propName",
+  "TestComponentName"
+);
+
+const localeData = {
+  locale: "fi",
+  testKey: { foo: "bar" },
+  testKey2: { baz: "buu" }
+};
+addLocaleData(localeData);
+// $ExpectError number. This type is incompatible with void
+const resultLocaleData: number = addLocaleData(localeData);
+
+const messages = {
+  messagekey1: {
+    id: "messageid1",
+    defaultMessage: "Nice default message",
+    description: "description field yeah"
+  },
+  messagekey2_foo: {
+    id: "messageid2_foo",
+    defaultMessage: "Nice default message for second translation id",
+    description: "description field yeah for second field"
+  },
+  messagekey3: {
+    id: "messageid3"
+  }
+};
+const messageDescriptorMap = defineMessages(messages);
+// $ExpectError foo is undefined
+const messageDescriptorMap1 = defineMessages(messages).foo;
+// $ExpectError id and defaultMessage are required
+const messageDescriptorMap2 = defineMessages({ message: {} });
+// $ExpectError array. This type is incompatible with MessageDescriptorMap
+const messageDescriptorMap3: Array<string> = defineMessages(messages);
+// $ExpectError string. This type is incompatible with MessageDescriptorMap
+const messageDescriptorMap4: string = defineMessages(messages);
+const msg1:MessageDescriptor = messageDescriptorMap.messagekey1;
+const msg2:MessageDescriptor = messageDescriptorMap.messagekey2_foo;
+const msg3:MessageDescriptor = messageDescriptorMap.messagekey3;
+
+class TestComponent extends React.Component<{ name: string, intl: IntlShape }> {
+  render() {
+    return React.createElement("div", {}, `Hello ${this.props.name}`);
+  }
+}
+
+const InjectedTestComponent: React.ComponentType<{ name: string }> = injectIntl(
+  TestComponent
+);
+
+const InjectedTestComponentWithRef: React.ComponentType<{
+  name: string
+}> = injectIntl(TestComponent, {
+  withRef: true
+});
+
+// $ExpectError This type is incompatible
+const BadPropsComponent: React.ComponentType<{ name: number }> = injectIntl(
+  TestComponent
+);
+
+// $ExpectError This type is incompatible
+const ExtraPropsComponent: React.ComponentType<{ foo: number }> = injectIntl(
+  TestComponent
+);
+
+// $ExpectError void. This type is incompatible
+const FailingInjectedTestComponent: void = injectIntl(TestComponent);
+
+const MessageComponent: React.ComponentType<{}> = injectIntl(
+  (props: { intl: IntlShape }) => {
+    const { formatMessage } = props.intl;
+    return (
+      <div>
+        {formatMessage(messageDescriptorMap.messagekey1)}
+      </div>
+    );
+  }
+);
+// const HTMLMessageComponent: React.ComponentType<
+//   *,
+// > = injectIntl((props: { intl: IntlShape }) => {
+//   const { formatHTMLMessage } = props.intl;
+//   return <div>{formatHTMLMessage(messageDescriptorMap.messagekey2)}</div>;
+// });
+const DateComponent: React.ComponentType<
+  *
+> = injectIntl((props: { intl: IntlShape }) => {
+  const { formatDate } = props.intl;
+  return (
+    <div>
+      {formatDate(new Date(1459832991883))}
+    </div>
+  );
+});
+const TimeComponent: React.ComponentType<
+  *
+> = injectIntl((props: { intl: IntlShape }) => {
+  const { formatTime } = props.intl;
+  return (
+    <div>
+      {formatTime(new Date(1459832991883))}
+    </div>
+  );
+});
+const RelativeComponent: React.ComponentType<
+  *
+> = injectIntl((props: { intl: IntlShape }) => {
+  const { formatRelative } = props.intl;
+  return (
+    <div>
+      {formatRelative(Date.now())}
+    </div>
+  );
+});
+const NumberComponent: React.ComponentType<
+  *
+> = injectIntl((props: { intl: IntlShape }) => {
+  const { formatNumber } = props.intl;
+  return (
+    <div>
+      {formatNumber(1000)}
+    </div>
+  );
+});
+const PluralComponent: React.ComponentType<
+  *
+> = injectIntl((props: { intl: IntlShape }) => {
+  const { formatPlural } = props.intl;
+  return (
+    <div>
+      {formatPlural(10, { one: "message", other: "messages" })}
+    </div>
+  );
+});
+
+// Components
+<FormattedMessage
+  id="test"
+  defaultMessage="test message"
+  description="this is description"
+/>;
+<FormattedMessage
+  id="test_plural"
+  defaultMessage={`Hello {name}, you have {numMessages, number} {numMessages, plural,
+    one {message}
+    other {messages}
+  }`}
+  description="Plural example"
+  values={{ name: <b>John Doe</b>, numMessages: 1 }}
+/>;
+<FormattedHTMLMessage
+  id="test"
+  defaultMessage="test message"
+  description="this is description"
+/>;
+<FormattedDate value={new Date(1459832991883)} />;
+
+<FormattedTime value={new Date(1459832991883)} />;
+<FormattedRelative value={Date.now()} />;
+<FormattedNumber value={1000} />;
+<FormattedPlural value={10} one="message" other="messages" />;
+<IntlProvider locale="en">
+  <div />
+</IntlProvider>;

--- a/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.57.x-/react-intl-with-data-message-id_v2.x.x.js
+++ b/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.57.x-/react-intl-with-data-message-id_v2.x.x.js
@@ -1,0 +1,262 @@
+/**
+ * Original implementation of this file by @marudor at https://github.com/marudor/flowInterfaces
+ * Copied here based on intention to merge with flow-typed expressed here:
+ * https://github.com/marudor/flowInterfaces/issues/6
+ */
+// Mostly from https://github.com/yahoo/react-intl/wiki/API#react-intl-with-data-message-id-api
+
+import type { Element, ChildrenArray } from "react";
+
+type $npm$ReactIntl$LocaleData = {
+  locale: string,
+  [key: string]: any
+};
+
+type $npm$ReactIntl$MessageDescriptor = {
+  id: string,
+  description?: string,
+  defaultMessage?: string
+};
+
+type $npm$ReactIntl$IntlConfig = {
+  locale: string,
+  formats: Object,
+  messages: { [id: string]: string },
+
+  defaultLocale?: string,
+  defaultFormats?: Object
+};
+
+type $npm$ReactIntl$IntlProviderConfig = {
+  locale?: string,
+  formats?: Object,
+  messages?: { [id: string]: string },
+
+  defaultLocale?: string,
+  defaultFormats?: Object
+};
+
+type $npm$ReactIntl$IntlFormat = {
+  formatDate: (value: any, options?: Object) => string,
+  formatTime: (value: any, options?: Object) => string,
+  formatRelative: (value: any, options?: Object) => string,
+  formatNumber: (value: any, options?: Object) => string,
+  formatPlural: (value: any, options?: Object) => string,
+  formatMessage: (
+    messageDescriptor: $npm$ReactIntl$MessageDescriptor,
+    values?: Object
+  ) => string,
+  formatHTMLMessage: (
+    messageDescriptor: $npm$ReactIntl$MessageDescriptor,
+    values?: Object
+  ) => string
+};
+
+type $npm$ReactIntl$IntlShape = $npm$ReactIntl$IntlConfig &
+  $npm$ReactIntl$IntlFormat & { now: () => number };
+
+type $npm$ReactIntl$DateTimeFormatOptions = {
+  localeMatcher?: "best fit" | "lookup",
+  formatMatcher?: "basic" | "best fit",
+
+  timeZone?: string,
+  hour12?: boolean,
+
+  weekday?: "narrow" | "short" | "long",
+  era?: "narrow" | "short" | "long",
+  year?: "numeric" | "2-digit",
+  month?: "numeric" | "2-digit" | "narrow" | "short" | "long",
+  day?: "numeric" | "2-digit",
+  hour?: "numeric" | "2-digit",
+  minute?: "numeric" | "2-digit",
+  second?: "numeric" | "2-digit",
+  timeZoneName?: "short" | "long"
+};
+
+type $npm$ReactIntl$RelativeFormatOptions = {
+  style?: "best fit" | "numeric",
+  units?: "second" | "minute" | "hour" | "day" | "month" | "year"
+};
+
+type $npm$ReactIntl$NumberFormatOptions = {
+  localeMatcher?: "best fit" | "lookup",
+
+  style?: "decimal" | "currency" | "percent",
+
+  currency?: string,
+  currencyDisplay?: "symbol" | "code" | "name",
+
+  useGrouping?: boolean,
+
+  minimumIntegerDigits?: number,
+  minimumFractionDigits?: number,
+  maximumFractionDigits?: number,
+  minimumSignificantDigits?: number,
+  maximumSignificantDigits?: number
+};
+
+type $npm$ReactIntl$PluralFormatOptions = {
+  style?: "cardinal" | "ordinal"
+};
+
+type $npm$ReactIntl$PluralCategoryString =
+  | "zero"
+  | "one"
+  | "two"
+  | "few"
+  | "many"
+  | "other";
+
+type $npm$ReactIntl$DateParseable = number | string | Date;
+
+declare module "react-intl-with-data-message-id" {
+  // PropType checker
+  declare function intlShape(
+    props: Object,
+    propName: string,
+    componentName: string
+  ): void;
+  declare function addLocaleData(
+    data: $npm$ReactIntl$LocaleData | Array<$npm$ReactIntl$LocaleData>
+  ): void;
+  declare function defineMessages<
+    T: { [key: string]: $npm$ReactIntl$MessageDescriptor }
+  >(
+    messageDescriptors: T
+  ): T;
+
+  declare type InjectIntlProvidedProps = {
+    intl: $npm$ReactIntl$IntlShape
+  }
+
+  declare type ComponentWithDefaultProps<DefaultProps: {}, Props: {}> =
+    | React$ComponentType<Props>
+    | React$StatelessFunctionalComponent<Props>
+    | ChildrenArray<void | null | boolean | string | number | Element<any>>;
+
+  declare type InjectIntlOtions = {
+    intlPropName?: string,
+    withRef?: boolean
+  }
+
+  declare class IntlInjectedComponent<TOwnProps, TDefaultProps> extends React$Component<TOwnProps> {
+    static WrappedComponent: Class<React$Component<TOwnProps & InjectIntlProvidedProps>>,
+    static defaultProps: TDefaultProps,
+    props: TOwnProps
+  }
+
+  declare type IntlInjectedComponentClass<TOwnProps, TDefaultProps: {} = {}> = Class<
+    IntlInjectedComponent<TOwnProps, TDefaultProps>
+  >;
+
+  declare function injectIntl<OriginalProps: InjectIntlProvidedProps, DefaultProps: {}>
+  (
+    component: ComponentWithDefaultProps<DefaultProps, OriginalProps>,
+    options?: InjectIntlOtions,
+  ):
+  IntlInjectedComponentClass<$Diff<OriginalProps, InjectIntlProvidedProps>, DefaultProps>
+
+  declare function injectIntl<OriginalProps: InjectIntlProvidedProps>
+  (
+    component: React$ComponentType<OriginalProps>,
+    options?: InjectIntlOtions,
+  ):
+  IntlInjectedComponentClass<$Diff<OriginalProps, InjectIntlProvidedProps>>;
+
+  declare function formatMessage(
+    messageDescriptor: $npm$ReactIntl$MessageDescriptor,
+    values?: Object
+  ): string;
+  declare function formatHTMLMessage(
+    messageDescriptor: $npm$ReactIntl$MessageDescriptor,
+    values?: Object
+  ): string;
+  declare function formatDate(
+    value: any,
+    options?: $npm$ReactIntl$DateTimeFormatOptions & { format: string }
+  ): string;
+  declare function formatTime(
+    value: any,
+    options?: $npm$ReactIntl$DateTimeFormatOptions & { format: string }
+  ): string;
+  declare function formatRelative(
+    value: any,
+    options?: $npm$ReactIntl$RelativeFormatOptions & {
+      format: string,
+      now: any
+    }
+  ): string;
+  declare function formatNumber(
+    value: any,
+    options?: $npm$ReactIntl$NumberFormatOptions & { format: string }
+  ): string;
+  declare function formatPlural(
+    value: any,
+    options?: $npm$ReactIntl$PluralFormatOptions
+  ): $npm$ReactIntl$PluralCategoryString;
+
+  declare class FormattedMessage extends React$Component<
+    $npm$ReactIntl$MessageDescriptor & {
+      values?: Object,
+      tagName?: string,
+      children?: (...formattedMessage: Array<React$Node>) => React$Node
+    }
+  > {}
+  declare class FormattedHTMLMessage extends React$Component<
+    $npm$ReactIntl$DateTimeFormatOptions & {
+      values?: Object,
+      tagName?: string,
+      children?: (...formattedMessage: Array<React$Node>) => React$Node
+    }
+  > {}
+  declare class FormattedDate extends React$Component<
+    $npm$ReactIntl$DateTimeFormatOptions & {
+      value: $npm$ReactIntl$DateParseable,
+      format?: string,
+      children?: (formattedDate: string) => React$Node
+    }
+  > {}
+  declare class FormattedTime extends React$Component<
+    $npm$ReactIntl$DateTimeFormatOptions & {
+      value: $npm$ReactIntl$DateParseable,
+      format?: string,
+      children?: (formattedDate: string) => React$Node
+    }
+  > {}
+  declare class FormattedRelative extends React$Component<
+    $npm$ReactIntl$RelativeFormatOptions & {
+      value: $npm$ReactIntl$DateParseable,
+      format?: string,
+      updateInterval?: number,
+      initialNow?: $npm$ReactIntl$DateParseable,
+      children?: (formattedDate: string) => React$Node
+    }
+  > {}
+  declare class FormattedNumber extends React$Component<
+    $npm$ReactIntl$NumberFormatOptions & {
+      value: number | string,
+      format?: string,
+      children?: (formattedNumber: string) => React$Node
+    }
+  > {}
+  declare class FormattedPlural extends React$Component<
+    $npm$ReactIntl$PluralFormatOptions & {
+      value: number | string,
+      other: React$Node,
+      zero?: React$Node,
+      one?: React$Node,
+      two?: React$Node,
+      few?: React$Node,
+      many?: React$Node,
+      children?: (formattedPlural: React$Node) => React$Node
+    }
+  > {}
+  declare class IntlProvider extends React$Component<
+    $npm$ReactIntl$IntlProviderConfig & {
+      children: React$Node,
+      initialNow?: $npm$ReactIntl$DateParseable
+    }
+  > {}
+  declare type IntlShape = $npm$ReactIntl$IntlShape;
+  declare type MessageDescriptor = $npm$ReactIntl$MessageDescriptor;
+}

--- a/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.57.x-/test_react-intl-with-data-message-id_v2.x.x.js
+++ b/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.57.x-/test_react-intl-with-data-message-id_v2.x.x.js
@@ -1,0 +1,206 @@
+/* @flow */
+import * as React from "react";
+import {
+  intlShape,
+  addLocaleData,
+  defineMessages,
+  injectIntl,
+  FormattedMessage,
+  FormattedHTMLMessage,
+  FormattedDate,
+  FormattedTime,
+  FormattedRelative,
+  FormattedNumber,
+  FormattedPlural,
+  IntlProvider
+} from "react-intl-with-data-message-id";
+import type { IntlShape, MessageDescriptor, IntlInjectedComponentClass } from "react-intl-with-data-message-id";
+
+intlShape({ foo: "bar" }, "propName", "TestComponentName");
+// $ExpectError number. This type is incompatible with void
+const result1: number = intlShape(
+  { foo: "bar" },
+  "propName",
+  "TestComponentName"
+);
+
+const localeData = {
+  locale: "fi",
+  testKey: { foo: "bar" },
+  testKey2: { baz: "buu" }
+};
+addLocaleData(localeData);
+// $ExpectError number. This type is incompatible with void
+const resultLocaleData: number = addLocaleData(localeData);
+
+const messages = {
+  messagekey1: {
+    id: "messageid1",
+    defaultMessage: "Nice default message",
+    description: "description field yeah"
+  },
+  messagekey2_foo: {
+    id: "messageid2_foo",
+    defaultMessage: "Nice default message for second translation id",
+    description: "description field yeah for second field"
+  },
+  messagekey3: {
+    id: "messageid3"
+  }
+};
+const messageDescriptorMap = defineMessages(messages);
+// $ExpectError foo is undefined
+const messageDescriptorMap1 = defineMessages(messages).foo;
+// $ExpectError id and defaultMessage are required
+const messageDescriptorMap2 = defineMessages({ message: {} });
+// $ExpectError array. This type is incompatible with MessageDescriptorMap
+const messageDescriptorMap3: Array<string> = defineMessages(messages);
+// $ExpectError string. This type is incompatible with MessageDescriptorMap
+const messageDescriptorMap4: string = defineMessages(messages);
+const msg1:MessageDescriptor = messageDescriptorMap.messagekey1;
+const msg2:MessageDescriptor = messageDescriptorMap.messagekey2_foo;
+const msg3:MessageDescriptor = messageDescriptorMap.messagekey3;
+
+class TestComponent extends React.Component<{ name: string, intl: IntlShape }> {
+  render() {
+    return React.createElement("div", {}, `Hello ${this.props.name}`);
+  }
+}
+
+const InjectedTestComponent: React.ComponentType<{ name: string }> = injectIntl(
+  TestComponent
+);
+
+const InjectedTestComponentWithRef: React.ComponentType<{
+  name: string
+}> = injectIntl(TestComponent, {
+  withRef: true
+});
+
+// $ExpectError This type is incompatible
+const BadPropsComponent: React.ComponentType<{ name: number }> = injectIntl(
+  TestComponent
+);
+
+// $ExpectError This type is incompatible
+const ExtraPropsComponent: React.ComponentType<{ foo: number }> = injectIntl(
+  TestComponent
+);
+
+// $ExpectError void. This type is incompatible
+const FailingInjectedTestComponent: void = injectIntl(TestComponent);
+
+const MessageComponent: React.ComponentType<{}> = injectIntl(
+  (props: { intl: IntlShape }) => {
+    const { formatMessage } = props.intl;
+    return (
+      <div>
+        {formatMessage(messageDescriptorMap.messagekey1)}
+      </div>
+    );
+  }
+);
+
+type WithDefaultProps = {
+  defaultProp: number,
+  normalProp: number,
+};
+
+class TestComponentWithDefault extends React.Component<WithDefaultProps & { intl: IntlShape }> {
+  static defaultProps = { defaultProp: 1 };
+
+  render() {
+    return <div />
+  }
+}
+
+const InjectedTestComponentWithDefault
+  : IntlInjectedComponentClass<WithDefaultProps, { defaultProp: number }>
+  = injectIntl(TestComponentWithDefault);
+
+// const HTMLMessageComponent: React.ComponentType<
+//   *,
+// > = injectIntl((props: { intl: IntlShape }) => {
+//   const { formatHTMLMessage } = props.intl;
+//   return <div>{formatHTMLMessage(messageDescriptorMap.messagekey2)}</div>;
+// });
+const DateComponent: React.ComponentType<
+  *
+> = injectIntl((props: { intl: IntlShape }) => {
+  const { formatDate } = props.intl;
+  return (
+    <div>
+      {formatDate(new Date(1459832991883))}
+    </div>
+  );
+});
+const TimeComponent: React.ComponentType<
+  *
+> = injectIntl((props: { intl: IntlShape }) => {
+  const { formatTime } = props.intl;
+  return (
+    <div>
+      {formatTime(new Date(1459832991883))}
+    </div>
+  );
+});
+const RelativeComponent: React.ComponentType<
+  *
+> = injectIntl((props: { intl: IntlShape }) => {
+  const { formatRelative } = props.intl;
+  return (
+    <div>
+      {formatRelative(Date.now())}
+    </div>
+  );
+});
+const NumberComponent: React.ComponentType<
+  *
+> = injectIntl((props: { intl: IntlShape }) => {
+  const { formatNumber } = props.intl;
+  return (
+    <div>
+      {formatNumber(1000)}
+    </div>
+  );
+});
+const PluralComponent: React.ComponentType<
+  *
+> = injectIntl((props: { intl: IntlShape }) => {
+  const { formatPlural } = props.intl;
+  return (
+    <div>
+      {formatPlural(10, { one: "message", other: "messages" })}
+    </div>
+  );
+});
+
+// Components
+<FormattedMessage
+  id="test"
+  defaultMessage="test message"
+  description="this is description"
+/>;
+<FormattedMessage
+  id="test_plural"
+  defaultMessage={`Hello {name}, you have {numMessages, number} {numMessages, plural,
+    one {message}
+    other {messages}
+  }`}
+  description="Plural example"
+  values={{ name: <b>John Doe</b>, numMessages: 1 }}
+/>;
+<FormattedHTMLMessage
+  id="test"
+  defaultMessage="test message"
+  description="this is description"
+/>;
+<FormattedDate value={new Date(1459832991883)} />;
+
+<FormattedTime value={new Date(1459832991883)} />;
+<FormattedRelative value={Date.now()} />;
+<FormattedNumber value={1000} />;
+<FormattedPlural value={10} one="message" other="messages" />;
+<IntlProvider locale="en">
+  <div />
+</IntlProvider>;


### PR DESCRIPTION
Please, we are using react intl but we need to have `data-message-id` in the rendered `HTML` and we want to use types from `react-intl`.

I wanted to introduce change in `react-intl` but my issue is opened without attention for few months.
https://github.com/yahoo/react-intl/issues/1077 