### PR TITLE
Add urlencoded Middleware to Express

### DIFF
--- a/definitions/npm/express_v4.16.x/flow_v0.32.x-/express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/flow_v0.32.x-/express_v4.16.x.js
@@ -263,6 +263,20 @@ declare type JsonOptions = {
   ) => mixed
 };
 
+declare type express$UrlEncodedOptions = {
+  extended?: boolean,
+  inflate?: boolean,
+  limit?: string | number,
+  parameterLimit?: number,
+  type?: string | Array<string> | ((req: express$Request) => boolean),
+  verify?: (
+    req: express$Request,
+    res: express$Response,
+    buf: Buffer,
+    encoding: string
+  ) => mixed,
+}
+
 declare module "express" {
   declare export type RouterOptions = express$RouterOptions;
   declare export type CookieOptions = express$CookieOptions;
@@ -277,6 +291,7 @@ declare module "express" {
     (): express$Application, // If you try to call like a function, it will use this signature
     json: (opts: ?JsonOptions) => express$Middleware,
     static: (root: string, options?: Object) => express$Middleware, // `static` property on the function
-    Router: typeof express$Router // `Router` property on the function
+    Router: typeof express$Router, // `Router` property on the function
+    urlencoded: (opts: ?express$UrlEncodedOptions) => express$Middleware,
   };
 }

--- a/definitions/npm/express_v4.16.x/test_express_v4.16.x.js
+++ b/definitions/npm/express_v4.16.x/test_express_v4.16.x.js
@@ -203,3 +203,42 @@ express.json({
   // $ExpectError
   type: req => 0
 });
+
+// https://expressjs.com/en/4x/api.html#express.urlencoded
+// body-parser based middleware for parsing urlencoded payloads
+
+// can be called with no args
+express.urlencoded();
+
+// urlencoded is a middleware
+app.use(express.urlencoded());
+
+// limit can be a string or number
+express.urlencoded({
+  limit: 100,
+});
+express.urlencoded({
+  limit: '100b',
+});
+express.urlencoded({
+  // $ExpectError
+  limit: false,
+});
+
+// type says it must be truthy, but intent is more clearly expressed as a bool.
+express.urlencoded({
+  // $ExpectError
+  type: req => 0
+});
+
+// type can be a string or array of strings
+express.urlencoded({
+  type: 'foo'
+});
+express.urlencoded({
+  type: ['foo', 'bar']
+});
+express.urlencoded({
+  // $ExpectError
+  type: [1 , 2]
+});


### PR DESCRIPTION
Updated the express_v4.16.x type definitions to include the urlencoded
middleware added in express v4.16.