### PR TITLE
Missing ramda definitions

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
@@ -1566,8 +1566,9 @@ declare module ramda {
 
   declare function over<T, V, U>(lens: Lens, x: (any) => mixed, val: V): U;
   declare function over<T, V, U>(
-    lens: Lens
-  ): (x: (any) => mixed) => (val: V) => U;
+    lens: Lens,
+    ...rest: Array<void>
+  ): ((x: (any) => mixed, ...rest: Array<void>) => (val: V) => U) & ((x: (any) => mixed, val: V) => U);
 
   declare function path<V>(
     p: Array<mixed>,
@@ -1691,7 +1692,10 @@ declare module ramda {
   ): Array<$ElementType<O, T>>;
 
   declare function set<T, V, U>(lens: Lens, x: T, val: V): U;
-  declare function set<T, V, U>(lens: Lens): (x: T) => (val: V) => U;
+  declare function set<T, V, U>(
+    lens: Lens,
+    ...rest: Array<void>
+  ): ((x: (any) => mixed, ...rest: Array<void>) => (val: V) => U) & ((x: (any) => mixed, val: V) => U);
 
   declare function toPairs<T, O: { [k: string]: T }>(
     o: O

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
@@ -500,9 +500,18 @@ declare module ramda {
   >;
   declare var split: CurriedFunction2<RegExp | string, string, Array<string>>;
   declare var test: CurriedFunction2<RegExp, string, boolean>;
-  declare var startsWith: CurriedFunction2<string | Array<string>, string, boolean>;
+  declare var startsWith: CurriedFunction2<
+    string | Array<string>,
+    string | Array<string>,
+    boolean
+  >;
+  declare var endsWith: CurriedFunction2<
+    string | Array<string>,
+    string | Array<string>,
+    boolean
+  >;
   declare function toLower(a: string): string;
-  declare function toString(a: any): string;
+  declare function toString(x: any): string;
   declare function toUpper(a: string): string;
   declare function trim(a: string): string;
 
@@ -873,7 +882,10 @@ declare module ramda {
     ...rest: Array<void>
   ): (xs: T) => T;
 
-  declare function sortWith<V, T: Array<V>>(fns: Array<(a: V, b: V) => number>, xs: T): T;
+  declare function sortWith<V, T: Array<V>>(
+    fns: Array<(a: V, b: V) => number>,
+    xs: T
+  ): T;
   declare function sortWith<V, T: Array<V>>(
     fns: Array<(a: V, b: V) => number>,
     ...rest: Array<void>
@@ -977,10 +989,6 @@ declare module ramda {
 
   declare function length<T>(xs: Array<T>): number;
 
-  declare function mergeAll(
-    objs: Array<{ [key: string]: any }>
-  ): { [key: string]: any };
-
   declare function reverse<T, V: Array<T> | string>(xs: V): V;
 
   declare type Reduce = (<A, B>(
@@ -1053,6 +1061,43 @@ declare module ramda {
   ): (xs: Array<B>) => A;
   declare function reduceRight<A, B>(
     fn: (elem: B, acc: A) => A,
+    init: A,
+    xs: Array<B>
+  ): A;
+
+  declare function reduceWhile<A, B>(
+    pred: (acc: A, curr: B) => boolean,
+    ...rest: Array<void>
+  ): ((
+    fn: (a: A, b: B) => A,
+    ...rest: Array<void>
+  ) => (
+    init: A,
+    ...rest: Array<void>
+  ) => (
+    xs: Array<B>
+  ) => A &
+    ((
+      fn: (a: A, b: B) => A,
+      ...rest: Array<void>
+    ) => (init: A, xs: Array<B>) => A)) &
+    ((
+      fn: (a: A, b: B) => A,
+      init: A,
+      ...rest: Array<void>
+    ) => (xs: Array<B>) => A) &
+    ((fn: (a: A, b: B) => A, init: A, xs: Array<B>) => A);
+
+  declare function reduceWhile<A, B>(
+    pred: (acc: A, curr: B) => boolean,
+    fn: (a: A, b: B) => A,
+    ...rest: Array<void>
+  ): ((init: A, ...rest: Array<void>) => (xs: Array<B>) => A) &
+    ((init: A, xs: Array<B>) => A);
+
+  declare function reduceWhile<A, B>(
+    fn: (acc: A, curr: B) => boolean,
+    fn: (a: A, b: B) => A,
     init: A,
     xs: Array<B>
   ): A;
@@ -1216,6 +1261,24 @@ declare module ramda {
 
   declare function identical<T>(x: T, ...rest: Array<void>): (y: T) => boolean;
   declare function identical<T>(x: T, y: T): boolean;
+
+  declare function innerJoin<A, B>(
+    pred: (a: A, b: B) => boolean,
+    ...rest: Array<void>
+  ): (
+    a: Array<A>,
+    ...rest: Array<void>
+  ) => (b: Array<B>) => Array<A> & ((a: Array<A>, b: Array<B>) => Array<A>);
+  declare function innerJoin<A, B>(
+    pred: (a: A, b: B) => boolean,
+    a: Array<A>,
+    ...rest: Array<void>
+  ): (b: Array<B>) => Array<A>;
+  declare function innerJoin<A, B>(
+    pred: (a: A, b: B) => boolean,
+    a: Array<A>,
+    b: Array<B>
+  ): Array<A>;
 
   declare function intersection<T>(x: Array<T>, y: Array<T>): Array<T>;
   declare function intersection<T>(x: Array<T>): (y: Array<T>) => Array<T>;
@@ -1399,12 +1462,21 @@ declare module ramda {
 
   declare function keys(o: Object): Array<string>;
 
-  /* TODO
-  lens
-  lensIndex
-  lensPath
-  lensProp
-  */
+  declare type Lens = <T, V>(x: T) => V;
+
+  declare function lens<T, U, V>(
+    getter: (s: T) => U,
+    setter: (a: U, s: T) => V
+  ): Lens;
+  declare function lens<T, U, V>(
+    getter: (s: T) => U
+  ): (setter: (a: U, s: T) => V) => Lens;
+
+  declare function lensIndex(n: number): Lens;
+
+  declare function lensPath(a: Array<string | number>): Lens;
+
+  declare function lensProp(str: string): Lens;
 
   declare function mapObjIndexed<A, B>(
     fn: (val: A, key: string, o: Object) => B,
@@ -1415,78 +1487,69 @@ declare module ramda {
     ...args: Array<void>
   ): (o: { [key: string]: A }) => { [key: string]: B };
 
-  declare function merge<A, B>(o1: A, ...rest: Array<void>): (o2: B) => A & B;
-  declare function merge<A, B>(o1: A, o2: B): A & B;
+  declare type Merge = (<A, B>(a: A, b: B) => A) &
+    (<A, B>(a: A, ...rest: Array<void>) => (b: B) => A);
+
+  declare var merge: Merge;
 
   declare function mergeAll<T>(
     os: Array<{ [k: string]: T }>
   ): { [k: string]: T };
 
-  declare function mergeWith<
-    T,
-    S,
-    R,
-    A: { [k: string]: T },
-    B: { [k: string]: S }
-  >(
-    fn: (v1: T, v2: S) => R
-  ): ((o1: A, ...rest: Array<void>) => (o2: B) => A & B) &
-    ((o1: A, o2: B) => A & B);
-  declare function mergeWith<
-    T,
-    S,
-    R,
-    A: { [k: string]: T },
-    B: { [k: string]: S }
-  >(
-    fn: (v1: T, v2: S) => R,
-    o1: A,
-    o2: B
-  ): A & B;
-  declare function mergeWith<
-    T,
-    S,
-    R,
-    A: { [k: string]: T },
-    B: { [k: string]: S }
-  >(
-    fn: (v1: T, v2: S) => R,
-    o1: A,
-    ...rest: Array<void>
-  ): (o2: B) => A & B;
+  declare var mergeDeepLeft: Merge;
 
-  declare function mergeWithKey<
-    T,
-    S,
-    R,
+  declare var mergeDeepRight: Merge;
+
+  declare type MergeWith = (<A: { [k: string]: T }, B: { [k: string]: T }, T>(
+    fn: (a: T, b: T) => T,
+    a: A,
+    b: B
+  ) => A & B) &
+    (<A, B, T>(
+      fn: (a: T, b: T) => T,
+      ...rest: Array<void>
+    ) => (a: A, ...rest: Array<void>) => (b: B) => A & B) &
+    (<A, B, T>(
+      fn: (a: T, b: T) => T,
+      ...rest: Array<void>
+    ) => (a: A, b: B) => A & B) &
+    (<A, B, T>(
+      fn: (a: T, b: T) => T,
+      a: A,
+      ...rest: Array<void>
+    ) => (b: B) => A & B);
+
+  declare type MergeWithKey = (<
+    S: string,
     A: { [k: string]: T },
-    B: { [k: string]: S }
+    B: { [k: string]: T },
+    T
   >(
-    fn: (key: $Keys<A & B>, v1: T, v2: S) => R
-  ): ((o1: A, ...rest: Array<void>) => (o2: B) => A & B) &
-    ((o1: A, o2: B) => A & B);
-  declare function mergeWithKey<
-    T,
-    S,
-    R,
-    A: { [k: string]: T },
-    B: { [k: string]: S }
-  >(
-    fn: (key: $Keys<A & B>, v1: T, v2: S) => R,
-    o1: A,
-    o2: B
-  ): A & B;
-  declare function mergeWithKey<
-    T,
-    S,
-    R,
-    A: { [k: string]: T },
-    B: { [k: string]: S }
-  >(
-    fn: (key: $Keys<A & B>, v1: T, v2: S) => R,
-    o1: A,
-    ...rest: Array<void>
-  ): (o2: B) => A & B;
+    fn: (s: S, a: T, b: T) => T,
+    a: A,
+    b: B
+  ) => A & B) &
+    (<S: string, A: { [k: string]: T }, B: { [k: string]: T }, T>(
+      fn: (s: S, a: T, b: T) => T,
+      ...rest: Array<void>
+    ) => (a: A, b: B) => A & B) &
+    (<S: string, A: { [k: string]: T }, B: { [k: string]: T }, T>(
+      fn: (s: S, a: T, b: T) => T,
+      ...rest: Array<void>
+    ) => (a: A, ...rest: Array<void>) => (b: B) => A & B) &
+    (<S: string, A: { [k: string]: T }, B: { [k: string]: T }, T>(
+      fn: (s: S, a: T, b: T) => T,
+      a: A,
+      ...rest: Array<void>
+    ) => (b: B) => A & B);
+
+  declare var mergeDeepWith: MergeWith;
+
+  declare var mergeDeepWithKey: MergeWithKey;
+
+  declare var mergeWith: MergeWith;
+
+  declare var mergeWithKey: MergeWithKey;
 
   declare function objOf<T>(
     key: string,
@@ -1500,7 +1563,10 @@ declare module ramda {
   ): (val: T) => Object;
   declare function omit<T: Object>(keys: Array<$Keys<T>>, val: T): Object;
 
-  // TODO over
+  declare function over<T, V, U>(lens: Lens, x: (any) => mixed, val: V): U;
+  declare function over<T, V, U>(
+    lens: Lens
+  ): (x: (any) => mixed) => (val: V) => U;
 
   declare function path<V>(
     p: Array<mixed>,
@@ -1623,7 +1689,8 @@ declare module ramda {
     o: O
   ): Array<$ElementType<O, T>>;
 
-  // TODO set
+  declare function set<T, V, U>(lens: Lens, x: T, val: V): U;
+  declare function set<T, V, U>(lens: Lens): (x: T) => (val: V) => U;
 
   declare function toPairs<T, O: { [k: string]: T }>(
     o: O
@@ -1654,7 +1721,8 @@ declare module ramda {
     o: $Shape<O & Q>
   ): boolean;
 
-  // TODO view
+  declare function view<T, V>(lens: Lens, val: T): V;
+  declare function view<T, V>(lens: Lens): (val: T) => V;
 
   // *Function
   declare var __: $npm$ramda$Placeholder;
@@ -1688,6 +1756,12 @@ declare module ramda {
   >(
     spec: T
   ): (...args: A) => NestedObject<S>;
+
+  declare function applyTo<A, B>(
+    a: A,
+    ...rest: Array<void>
+  ): (fn: (x: A) => B) => B;
+  declare function applyTo<A, B>(a: A, fn: (x: A) => B): B;
 
   declare function binary<T>(
     fn: (...args: Array<any>) => T
@@ -1766,12 +1840,32 @@ declare module ramda {
 
   declare function memoize<A, B, T: (...args: Array<A>) => B>(fn: T): T;
 
+  declare function memoizeWith<A, B>(
+    keyFn: (x: A) => string,
+    ...rest: Array<void>
+  ): (fn: (x: B) => B) => A;
+  declare function memoizeWith<A, B>(
+    keyFn: (x: A) => string,
+    fn: (x: B) => B
+  ): A;
+
   declare function nAry<T>(
     arity: number,
     fn: (...args: Array<any>) => T
   ): (...args: Array<any>) => T;
 
   declare function nthArg<T>(n: number): (...args: Array<T>) => T;
+
+  declare var o: (<A, B, C>(fn1: (b: B) => C, fn2: (a: A) => B, x: A) => C) &
+    (<A, B, C>(
+      fn1: (b: B) => C,
+      ...rest: void[]
+    ) => (fn2: (a: A) => B, ...rest: void[]) => (x: A) => C) &
+    (<A, B, C>(
+      fn1: (b: B) => C,
+      ...rest: void[]
+    ) => (fn2: (a: A) => B, x: A) => C) &
+    (<A, B, C>(fn1: (b: B) => C, fn2: (a: A) => B) => (x: A) => C);
 
   declare function of<T>(x: T): Array<T>;
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
@@ -1559,10 +1559,10 @@ declare module ramda {
   declare function objOf<T>(key: string, val: T): { [key: string]: T };
 
   declare function omit<T: Object>(
-    keys: Array<T>,
+    keys: Array<string>,
     ...rest: Array<void>
   ): (val: T) => Object;
-  declare function omit<T: Object>(keys: Array<T>, val: T): Object;
+  declare function omit<T: Object>(keys: Array<string>, val: T): Object;
 
   declare function over<T, V, U>(lens: Lens, x: (any) => mixed, val: V): U;
   declare function over<T, V, U>(

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
@@ -1487,8 +1487,8 @@ declare module ramda {
     ...args: Array<void>
   ): (o: { [key: string]: A }) => { [key: string]: B };
 
-  declare type Merge = (<A, B>(a: A, b: B) => A) &
-    (<A, B>(a: A, ...rest: Array<void>) => (b: B) => A);
+  declare type Merge = (<A, B>(a: A, b: B) => A & B) &
+    (<A, B>(a: A, ...rest: Array<void>) => (b: B) => A & B);
 
   declare var merge: Merge;
 
@@ -1498,7 +1498,8 @@ declare module ramda {
 
   declare var mergeDeepLeft: Merge;
 
-  declare var mergeDeepRight: Merge;
+  declare var mergeDeepRight: (<A, B>(a: A, b: B) => B & A) &
+  (<A, B>(a: A, ...rest: Array<void>) => (b: B) => B & A);
 
   declare type MergeWith = (<A: { [k: string]: T }, B: { [k: string]: T }, T>(
     fn: (a: T, b: T) => T,
@@ -1558,10 +1559,10 @@ declare module ramda {
   declare function objOf<T>(key: string, val: T): { [key: string]: T };
 
   declare function omit<T: Object>(
-    keys: Array<$Keys<T>>,
+    keys: Array<T>,
     ...rest: Array<void>
   ): (val: T) => Object;
-  declare function omit<T: Object>(keys: Array<$Keys<T>>, val: T): Object;
+  declare function omit<T: Object>(keys: Array<T>, val: T): Object;
 
   declare function over<T, V, U>(lens: Lens, x: (any) => mixed, val: V): U;
   declare function over<T, V, U>(

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
@@ -1499,7 +1499,7 @@ declare module ramda {
   declare var mergeDeepLeft: Merge;
 
   declare var mergeDeepRight: (<A, B>(a: A, b: B) => B & A) &
-  (<A, B>(a: A, ...rest: Array<void>) => (b: B) => B & A);
+    (<A, B>(a: A, ...rest: Array<void>) => (b: B) => B & A);
 
   declare type MergeWith = (<A: { [k: string]: T }, B: { [k: string]: T }, T>(
     fn: (a: T, b: T) => T,
@@ -1857,16 +1857,17 @@ declare module ramda {
 
   declare function nthArg<T>(n: number): (...args: Array<T>) => T;
 
-  declare var o: (<A, B, C>(fn1: (b: B) => C, fn2: (a: A) => B, x: A) => C) &
+  declare var o: (<A, B, C>(
+    fn1: (b: B) => C,
+    ...rest: void[]
+  ) => ((fn2: (a: A) => B, ...rest: void[]) => (x: A) => C) &
+    ((fn2: (a: A) => B, x: A) => C)) &
     (<A, B, C>(
       fn1: (b: B) => C,
+      fn2: (a: A) => B,
       ...rest: void[]
-    ) => (fn2: (a: A) => B, ...rest: void[]) => (x: A) => C) &
-    (<A, B, C>(
-      fn1: (b: B) => C,
-      ...rest: void[]
-    ) => (fn2: (a: A) => B, x: A) => C) &
-    (<A, B, C>(fn1: (b: B) => C, fn2: (a: A) => B) => (x: A) => C);
+    ) => (x: A) => C) &
+    (<A, B, C>(fn1: (b: B) => C, fn2: (a: A) => B, x: A) => C);
 
   declare function of<T>(x: T): Array<T>;
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_functions.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_functions.js
@@ -307,14 +307,25 @@ const stuffDone: number = doStuff("dd", 1, true, obb);
 const range = _.juxt([_.toString, Math.min, Math.max]);
 const ju: Array<number | string> = range(3, 4, 9, -3);
 
-let count = 0;
-const factorial = _.memoize(n => {
-  count += 1;
+let _memoize = 0;
+const _memoizeFactorial = _.memoize(n => {
+  _memoize += 1;
   return _.product(_.range(1, n + 1));
 });
-const mem: number = factorial(5);
+const mem: number = _memoizeFactorial(5);
+
+let _memoizeWith = 0;
+const _memoizeWithFactorial = _.memoizeWith(_.identity, n => {
+  _memoizeWith += 1;
+  return _.product(_.range(1, n + 1));
+});
+const memWith: number = _memoizeWithFactorial(5);
 
 const narg: string | number = _.nthArg(1)(1, "b", "c");
+
+const nameIs = ({ first, last }) => `The name's ${last}, ${first} ${last}`;
+const o1: string = _.o(_.toUpper, nameIs)({ first: "James", last: "Bond" });
+const oNum: number = _.o(_.multiply(10), _.add(10))(-4);
 
 const oof: Array<Array<number>> = _.of([42]);
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_functions.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_functions.js
@@ -53,6 +53,26 @@ const spec = {
 const getMetrics = _.applySpec(spec);
 const apspec: $Shape<R> = getMetrics(2, 2);
 
+const applyToResult1 = _.applyTo(5, value => {
+  (value: number);
+  // $ExpectError
+  (value: string);
+  return String(value)
+});
+(applyToResult1: string);
+// $ExpectError
+(applyToResult1: number);
+
+const applyToResult2 = _.applyTo(5)(value => {
+  (value: number);
+  // $ExpectError
+  (value: string);
+  return String(value)
+});
+(applyToResult2: string);
+// $ExpectError
+(applyToResult2: number);
+
 const cmp: (x: Object, y: Object) => number = _.comparator(
   (a, b) => a.age < b.age
 );

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_list.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_list.js
@@ -276,6 +276,10 @@ const str: string = "hello world";
   ];
   const names1: { [k: string]: Array<string> } = namesByGrade(students);
 
+  const isOdd = (acc, x) => x % 2 === 1;
+  const reduceWhile1: number = _.reduceWhile(isOdd, _.add, 0, [1, 3, 5, 60, 777, 800]);
+  const reduceWhile2: number = _.reduceWhile(isOdd, _.add, 111, [2, 4, 6]);
+
   const spl: Array<string> = _.split(/\./, "a.b.c.xyz.d");
 
   const spl1: [Array<number>, Array<number>] = _.splitAt(1, [1, 2, 3]);

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_list.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_list.js
@@ -53,6 +53,11 @@ const str: string = "hello world";
   const dropxs6: Array<number> = _.dropRepeatsWith(_.eqBy(Math.abs), ns);
   const dropxs7: Array<number> = _.dropWhile(x => x === 1, ns);
 
+  const endsWithxs: boolean = _.endsWith("a")("abc");
+  const endsWithxs1: boolean = _.endsWith("b", "abc");
+  const endsWithxs2: boolean = _.endsWith(["a"], ["a", "b", "c"]);
+  const endsWithxs3: boolean = _.endsWith(["b"], ["a", "b", "c"]);
+
   const findxs: ?{ [k: string]: number | string } = _.find(
     _.propEq("a", 2),
     os
@@ -296,6 +301,11 @@ const str: string = "hello world";
     return a - b;
   };
   const sortxs: Array<number> = _.sort(diff, [4, 2, 7, 5]);
+
+  const startsWithxs: boolean = _.startsWith("a")("abc");
+  const startsWithxs1: boolean = _.startsWith("b", "abc");
+  const startsWithxs2: boolean = _.startsWith(["a"], ["a", "b", "c"]);
+  const startsWithxs3: boolean = _.startsWith(["b"], ["a", "b", "c"]);
 
   const timesxs: Array<number> = _.times(_.identity, 5);
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
@@ -78,18 +78,15 @@ const dissocPathd4: { a: { b: string } } = _.dissocPath(["a", "c"])({
   a: { b: 1, c: 2 }
 });
 
-describe('#eqProps', () => {
-  const o1 = { a: 1, b: 2, c: 3, d: 4 };
-  const o2 = { a: 10, b: 20, c: 3, d: 40 };
 
-  it('should do basic type checking', () => {
-    const ep: boolean = _.eqProps("a", o1, o2);
-  })
+const o1 = { a: 1, b: 2, c: 3, d: 4 };
+const o2 = { a: 10, b: 20, c: 3, d: 40 };
 
-  // curried versions
-  const ep: boolean = _.eqProps("a")(o1, o2);
-  const ep2: boolean = _.eqProps("c", o1)(o2);
-})
+const ep: boolean = _.eqProps("a", o1, o2);
+
+// curried versions
+const epCurr: boolean = _.eqProps("a")(o1, o2);
+const ep2: boolean = _.eqProps("c", o1)(o2);
 
 const evolved1 = _.evolve(
   {
@@ -223,12 +220,9 @@ const objA = _.objOf("a", false);
 //$ExpectError
 const propAA: number = objA.a;
 
-//$ExpectError
 const om: Object = _.omit(["a", "d", "h"], { a: 1, b: 2, c: 3, d: 4 });
-
 const omap1 = _.omit(["a", "d", "h"], { a: 1, b: 2, c: 3, d: 4, h: 7 });
-//$ExpectError
-const omap2 = _.omit(["a", "d", "h"], { a: 1, b: 2, c: 3, d: 4 });
+const omap2 = _.omit(["a", "d", "h"])({ a: 1, b: 2, c: 3, d: 4 });
 
 const path1: Object | number = _.path(["a", "b"], { a: { b: 2 } });
 const path2: Object | number = _.path(["a", 1], { a: { "1": 2 } });

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
@@ -343,12 +343,17 @@ const xLensOver: Array<{ [k: string]: * }> = _.over(xLens, _.negate, dataObj);
 
 const xLensPathView: number = _.view(xLensPath, dataObj);
 const xLensPathSet: Array<{ [k: string]: * }> = _.set(xLensPath, 4, dataObj);
+const xLensPathSetCurr: Array<{ [k: string]: * }> = _.set(xLensPath, 4)(dataObj);
 const xLensPathOver: Array<{ [k: string]: * }> = _.over(xLensPath, _.negate, dataObj);
+const xLensPathOverCurr: Array<{ [k: string]: * }> = _.over(xLensPath)(_.negate)(dataObj);
 
 const xLensIndexView: number = _.view(xLensIndex, dataArr);
 const xLensIndexSet: Array<string> = _.set(xLensIndex, "test", dataArr);
+const xLensIndexSetCurr: Array<string> = _.set(xLensIndex)("test", dataArr);
 const xLensIndexOver: Array<string> = _.over(xLensIndex, _.concat("test"), dataArr);
+const xLensIndexOverCurr: Array<string> = _.over(xLensIndex, _.concat("test"))(dataArr);
 
 const xLensPropView: number = _.view(xLensProp, dataObj);
 const xLensPropSet: Array<{ [k: string]: * }> = _.set(xLensProp, 4, dataObj);
 const xLensPropOver: Array<{ [k: string]: * }> = _.over(xLensProp, _.negate, dataObj);
+const xLensPropOverCurr: Array<{ [k: string]: * }> = _.over(xLensProp)(_.negate, dataObj);

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
@@ -188,6 +188,21 @@ const mwithK = _.mergeWithKey(
 );
 const propB1: boolean = mwithK.b;
 
+const mDwith = _.mergeDeepWith(
+  _.concat,
+  { a: true, values: [10, 20] },
+  { b: true, values: [15, 35] }
+);
+const propmDwithB: boolean = mDwith.b;
+
+const concatValues = (k, l, r) => k == 'values' ? _.concat(l, r) : r
+const mDwithKey = _.mergeDeepWithKey(
+  concatValues,
+  { a: true, c: { thing: 'foo', values: [10, 20] }},
+  { b: true, c: { thing: 'bar', values: [15, 35] }}
+);
+const propmDwithKeyB: boolean = mDwithKey.b;
+
 const mDLeft = _.mergeDeepLeft(
   { a: true, values: [10, 20] },
   { b: true, values: [15, 35] }

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
@@ -330,12 +330,25 @@ const pred1 = _.whereEq({ a: 1, b: 2 });
 const win: boolean = pred1({ a: 1, d: 1 });
 
 const xLens = _.lens(_.prop('x'), _.assoc('x'));
+const xLensPath = _.lensPath(['y', 0, 'y']);
+const xLensIndex = _.lensIndex(0);
+const xLensProp = _.lensProp('x');
 
-const lensView: number = _.view(xLens, {x: 1, y: 2});
-const lensSetObj: Object = _.set(xLens, 4, {x: 1, y: 2});
-const lensSetObjX: 4 = lensSetObj.x;
+const dataObj = {x: 5, y: [{y: 2, z: 3}, {y: 4, z: 5}]};
+const dataArr = ['a', 'b', 'c'];
 
-const lensOverObj: Object = _.over(xLens, _.negate, {x: 1, y: 2});  //=> {x: -1, y: 2}
-const lensOverObjX: -1 = lensSetObj.x;
-const lensOverObjY: 2 = lensSetObj.y;
+const xLensView: number = _.view(xLens, dataObj);
+const xLensSet: Array<{ [k: string]: * }> = _.set(xLens, 4, dataObj);
+const xLensOver: Array<{ [k: string]: * }> = _.over(xLens, _.negate, dataObj);
 
+const xLensPathView: number = _.view(xLensPath, dataObj);
+const xLensPathSet: Array<{ [k: string]: * }> = _.set(xLensPath, 4, dataObj);
+const xLensPathOver: Array<{ [k: string]: * }> = _.over(xLensPath, _.negate, dataObj);
+
+const xLensIndexView: number = _.view(xLensIndex, dataArr);
+const xLensIndexSet: Array<string> = _.set(xLensIndex, "test", dataArr);
+const xLensIndexOver: Array<string> = _.over(xLensIndex, _.concat("test"), dataArr);
+
+const xLensPropView: number = _.view(xLensProp, dataObj);
+const xLensPropSet: Array<{ [k: string]: * }> = _.set(xLensProp, 4, dataObj);
+const xLensPropOver: Array<{ [k: string]: * }> = _.over(xLensProp, _.negate, dataObj);

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
@@ -188,6 +188,22 @@ const mwithK = _.mergeWithKey(
 );
 const propB1: boolean = mwithK.b;
 
+const mDLeft = _.mergeDeepLeft(
+  { a: true, values: [10, 20] },
+  { b: true, values: [15, 35] }
+);
+const propB2: boolean = mDLeft.a;
+const propB3: boolean = mDLeft.b;
+const propB4: 10 = mDLeft.values[0];
+
+const mDRight = _.mergeDeepRight(
+  { a: true, values: [10, 20] },
+  { b: true, values: [15, 35] }
+);
+const propB5: boolean = mDRight.a;
+const propB6: boolean = mDRight.b;
+const propB7: 15 = mDRight.values[0];
+
 const objA = _.objOf("a", false);
 //$ExpectError
 const propAA: number = objA.a;
@@ -289,7 +305,7 @@ const pred = _.where({
   b: _.complement(_.equals("bar")),
   c: (c: Object) => !!c,
   x: _.gt(10),
-  y: _.lt(20)
+  y: _.lt(20),
 });
 
 const w: boolean = pred({ a: "foo", b: "xxx", c: {}, x: 11, y: 19 });

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
@@ -313,3 +313,14 @@ const w: boolean = pred({ a: "foo", b: "xxx", c: {}, x: 11, y: 19 });
 const pred1 = _.whereEq({ a: 1, b: 2 });
 
 const win: boolean = pred1({ a: 1, d: 1 });
+
+const xLens = _.lens(_.prop('x'), _.assoc('x'));
+
+const lensView: number = _.view(xLens, {x: 1, y: 2});
+const lensSetObj: Object = _.set(xLens, 4, {x: 1, y: 2});
+const lensSetObjX: 4 = lensSetObj.x;
+
+const lensOverObj: Object = _.over(xLens, _.negate, {x: 1, y: 2});  //=> {x: -1, y: 2}
+const lensOverObjX: -1 = lensSetObj.x;
+const lensOverObjY: 2 = lensSetObj.y;
+

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_relation.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_relation.js
@@ -46,6 +46,16 @@ const _minBy: number = _.minBy(Math.abs, 2, 1);
 
 const _identical: boolean = _.identical(2, 1);
 
+const _innerJoin: Array<{ [k: string]: mixed }> = _.innerJoin(
+  (record, id) => record.id === id,
+  [{id: 824, name: 'Richie Furay'},
+   {id: 956, name: 'Dewey Martin'},
+   {id: 313, name: 'Bruce Palmer'},
+   {id: 456, name: 'Stephen Stills'},
+   {id: 177, name: 'Neil Young'}],
+  [177, 456, 999]
+);
+
 const inters: Array<number> = _.intersection(ns, ns);
 
 const interBy: Array<number> = _.intersectionWith(_.eqBy(Math.abs), ns, ns);


### PR DESCRIPTION
Fixes already broken unit tests, allow currying for some functions, and adding some missing ramda definitions, including:

- [x]  `endsWith `
- [x]  `reduceWhile `
- [x]  `innerJoin `
- [x]  `lens`
- [x]  `lensIndex`
- [x]  `lensPath`
- [x]  `lensProp`
- [x]  `view`
- [x]  `set`
- [x]  `over`
- [x]  `mergeDeepLeft`
- [x]  `mergeDeepRight`
- [x]  `mergeDeepWith`
- [x]  `mergeDeepWithKey`
- [x]  `memoizeWith `
- [x]  `applyTo`
- [x]  `o`