### PR TITLE
Allow passing null to onNavigationStateChange prop

### DIFF
--- a/definitions/npm/react-navigation_v1.x.x/flow_v0.60.x-/react-navigation_v1.x.x.js
+++ b/definitions/npm/react-navigation_v1.x.x/flow_v0.60.x-/react-navigation_v1.x.x.js
@@ -578,7 +578,7 @@ declare module 'react-navigation' {
 
   declare export type NavigationContainerProps<S: {}, O: {}> = $Shape<{
     uriPrefix?: string | RegExp,
-    onNavigationStateChange?: (
+    onNavigationStateChange?: ?(
       NavigationState,
       NavigationState,
       NavigationAction


### PR DESCRIPTION
As seen here: https://github.com/react-navigation/react-navigation/issues/360#issuecomment-296690849, we need to be able to pass `null` to turn off logging.