### PR TITLE
fix inputRef type annotations for react-bootstrap

### DIFF
--- a/definitions/npm/react-bootstrap_v0.32.x/flow_v0.53.x-/react-bootstrap_v0.32.x.js
+++ b/definitions/npm/react-bootstrap_v0.32.x/flow_v0.53.x-/react-bootstrap_v0.32.x.js
@@ -1,5 +1,5 @@
 declare module "react-bootstrap" {
-  import type { Node, Element, Component } from 'react';
+  import type { Node, Element, Component, Ref } from 'react';
   declare type BsSize = 'lg' | 'large' | 'sm' | 'small';
   declare type BsStyle = 'lg' | 'large' | 'sm' | 'small' | 'xs' | 'xsmall';
   declare type ElementType = string;
@@ -175,7 +175,7 @@ declare module "react-bootstrap" {
     componentClass?: ElementType,
     type?: string,
     id?: string,
-    inputRef?: (ref: ?FormControl) => void, // TODO: double check ref
+    inputRef?: Ref<'input'>,
     bsSize?: BsSize,
     bsClass?: string,
   }> {
@@ -194,7 +194,7 @@ declare module "react-bootstrap" {
     disabled?: boolean,
     title?: string,
     validateState?: 'success' | 'warning' | 'error' | null,
-    inputRef?: (ref: ?Checkbox) => void, // TODO: double check ref
+    inputRef?: Ref<'input'>,
     bsClass?: string
   }> {}
 
@@ -203,7 +203,7 @@ declare module "react-bootstrap" {
     disabled?: boolean,
     title?: string,
     validateState?: 'success' | 'warning' | 'error' | null,
-    inputRef?: (ref: ?Radio) => void, // TODO: double check ref
+    inputRef?: Ref<'input'>,
     bsClass?: string
   }> {}
 

--- a/definitions/npm/react-bootstrap_v0.32.x/flow_v0.53.x-/test_react-bootstrap_v0.32.x.js
+++ b/definitions/npm/react-bootstrap_v0.32.x/flow_v0.53.x-/test_react-bootstrap_v0.32.x.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Dropdown, Overlay } from 'react-bootstrap';
+import { Dropdown, Overlay, FormControl, Checkbox, Radio } from 'react-bootstrap';
 
 
 // normal components works
@@ -8,3 +8,8 @@ import { Dropdown, Overlay } from 'react-bootstrap';
 
 // nested components works too
 (<Dropdown.Toggle></Dropdown.Toggle>: React.Node);
+
+// inputRefs gives HTMLInputElements
+(<FormControl inputRef={(ref) => {(ref: ?HTMLInputElement)}}/>: React.Node);
+(<Checkbox inputRef={(ref) => {(ref: ?HTMLInputElement)}} />: React.Node);
+(<Radio inputRef={(ref) => {(ref: ?HTMLInputElement)}} />: React.Node);


### PR DESCRIPTION
Better types for inputRefs. based on https://flow.org/en/docs/react/types/#toc-react-ref and https://flow.org/en/docs/react/types/#toc-react-elementref

Pointed out by @dperetti here: https://github.com/flowtype/flow-typed/pull/1889#issuecomment-370586750
fixes this: https://github.com/flowtype/flow-typed/issues/1917