### PR TITLE
Only take the last commit to diff

### DIFF
--- a/cli/src/lib/git.js
+++ b/cli/src/lib/git.js
@@ -75,7 +75,7 @@ export async function getDiff() {
       // We are probably already on master, so compare to the last commit.
       const {stdout: headDiff} = await child_process.spawnP(gitPath, [
         'diff',
-        'HEAD~2',
+        'HEAD~1',
         '--name-only',
       ]);
       stdout = headDiff;


### PR DESCRIPTION
Only compare to parent, not grand parent. Not sure why it's previously been ~2.
You can try `git diff HEAD~2 --name-only` and `git diff HEAD~1 --name-only` in master to see that the first one actually returns names for two last merged libdefs instead of one.

Noticed this behaviour here: https://github.com/flowtype/flow-typed/pull/1919 See the travis output where unrelated libdefs fails: https://travis-ci.org/flowtype/flow-typed/jobs/350025576