### PR TITLE
Fix broken Ramda tests.

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
@@ -1599,16 +1599,16 @@ declare module ramda {
   declare function propOr<T, V, A: { [k: string]: V }>(
     or: T,
     ...rest: Array<void>
-  ): ((p: $Keys<A>, ...rest: Array<void>) => (o: A) => V | T) &
-    ((p: $Keys<A>, o: A) => V | T);
+  ): ((p: string, ...rest: Array<void>) => (o: A) => V | T) &
+    ((p: string, o: A) => V | T);
   declare function propOr<T, V, A: { [k: string]: V }>(
     or: T,
-    p: $Keys<A>,
+    p: string,
     ...rest: Array<void>
   ): (o: A) => V | T;
   declare function propOr<T, V, A: { [k: string]: V }>(
     or: T,
-    p: $Keys<A>,
+    p: string,
     o: A
   ): V | T;
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
@@ -187,9 +187,9 @@ const propAA: number = objA.a;
 //$ExpectError
 const om: Object = _.omit(["a", "d", "h"], { a: 1, b: 2, c: 3, d: 4 });
 
+const omap1 = _.omit(["a", "d", "h"], { a: 1, b: 2, c: 3, d: 4, h: 7 });
 //$ExpectError
-const om2 = _.omit(["a", "d", "h"]);
-const omap = om2({ a: 1, b: 2, c: 3, d: 4 });
+const omap2 = _.omit(["a", "d", "h"], { a: 1, b: 2, c: 3, d: 4 });
 
 const path1: Object | number = _.path(["a", "b"], { a: { b: 2 } });
 const path2: Object | number = _.path(["a", 1], { a: { "1": 2 } });
@@ -225,7 +225,6 @@ const alice = {
   age: 101
 };
 
-//$ExpectError
 const favoriteWithDefault = _.propOr("Ramda", "favoriteLibrary");
 const fav = favoriteWithDefault(alice);
 


### PR DESCRIPTION
[Review: @LoganBarnett ]

There were a couple tests that were breaking for some versions of flow, which are now fixed. Key changes:

- `omit` tests were rewritten to be more straightforward. The currying isn't always supported in all versions of flow, and I kind of don't care to fix the tests to make it so.
- `propOr` should not use `$Keys` for the prop input, since it shouldn't require that the prop exist on the object; that's the point of `propOr`.

This was done with minimal effort and not more restructuring of the tests, that will come later. I just want the build to work. 😀 