### PR TITLE
Add describe and it verbs as TDD building blocks for tests.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,112 +1,18 @@
-## Library Definition Best Practices
+# Library Definition Best Practices
 
 This is a set of best practices to keep in mind while writing a libdef. These
 best practices should also be considered when reviewing new libdefs or changes
 to existing libdefs.
 
-### tldr
+## tldr
 
-* [Avoid `any` when possible](#avoid-any-when-possible)
-* [Don't import types from other libdefs](#dont-import-types-from-other-libdefs)
-* [Always prefix global variables that aren't really meant to be global](#prefix-global-variables-that-arent-really-meant-to-be-global)
-
-##### Avoid `any` when possible
-
-Using the `any` type for a variable or interface results in the loss of type information as types pass through it. That means if a type passes through `any` before propogating on to other code, the `any` will potentially cause Flow to miss type errors!
-
-In many places it is better (but also stricter) to use the `mixed` type rather than the `any` type. The `mixed` type is safer in that it allows anything to flow in to it, but can never be used downstream without [dynamic type tests](https://flowtype.org/docs/dynamic-type-tests.html#_) that verify the type at runtime.
-
-Consider this code:
-
-```js
-const cache = new Map();
-function setCache(key: string, value: any) {
-  cache.set(key, value);
-}
-function getCache(key: string) {
-  cache.get(key);
-}
-
-setCache('foo', 42);
-var someString = getCache('foo'); // oops, 'foo' isn't a string!
-someString.length; // but because we used `any`, we don't know toerror here!
-```
-
-Because we've typed the values of the map as `any`, we open ourselves up to type errors:
-
-If, however, we had used `mixed` instead of `any`, Flow would ask us to verify that the type we got back from `getCache()` is in fact a `string` before using it as one:
-
-```js
-const cache = new Map();
-function setCache(key: string, value: mixed) {
-  cache.set(key, value);
-}
-function getCache(key: string) {
-  cache.get(key);
-}
-
-setCache('foo', 42);
-var someString = getCache('foo');
-if (typeof someString === 'string') {
-  someString.length;
-} else {
-  throw new Error('`foo` is unexpectedly something other than a string!');
-}
-```
-
-Because we used a dynamic type test in the second example, we've proved to Flow that the `mixed` result must be a string. If we hadn't done this, Flow would have given us an error reminding us that the value could be anything and it isn't safe to assume without checking first.
-
-There is sometimes a trade-off with using `mixed`, though. Using `mixed` means that if your variable ever does flow downstream, you'll always have to prove what kind of type it is (with a type test) before you can use it. Sometimes this is just too annoying and the risk involved with `any` is just worth the trade-off.
-
-In the case of library definitions, it is almost always better to use `mixed` for function and method parameters because the trade-off is hidden from users:
-
-```js
-declare function setCache(key: string, value: mixed): void;
-
-setCache('number', 42); // Ok
-setCache('string', 'asdf'); // Ok
-```
-
-It is also almost always ok to use `mixed` as the return type of a callback:
-
-```js
-declare function getUser(cb: (user: User) => mixed): void;
-getUser((user) => console.log('Got the user!'));
-```
-
-Using `mixed` in place of `any` for the return type of a function or the type of a variable is a judgement call, though. Return types and declared variables flow into users' programs, which means that users will have to prove the type of `mixed` before they can use them.
-
-##### Don't import types from other libdefs
-
-You might think it would be possible to import types from other libdefs, much the same way you do in your own code:
-
-```js
-import type { MyType } from 'some-module';
-declare module 'other-module' {
-  declare export function takesMyType(val: MyType): number;
-}
-```
-
-...but you would be wrong. Flow silently converts `MyType` to be typed `any`, and then sadness ensues.
-
-Currently it's not possible to safely import types from other libdefs when making your libdef. [Further discussion here](https://github.com/flowtype/flow-typed/issues/1857).
-
-##### Prefix global variables that aren't really meant to be global
-
-Right now we don't have a good way to write types inside `declare module {}` bodies that *aren't* exported. This problem is being worked on, but in the meantime the best option is to just put a declaration outside the `declare module {}` and reference it.
-
-Because this effectively creates a global type, please be sure to namespace these types with something like `$npm$ModuleName$`:
-
-```js
-type $npm$MyModule$Options = {
-  option1: number,
-  option2: string,
-};
-
-declare module "MyModule" {
-  declare function doStuff(options: $npm$MyModule$Options): void;
-}
-```
+* [Contributing to the definitions repository](#contributing-to-the-definitions-repository)
+* [Writing libdefs tips](#writing-libdefs-tips)
+  * [Avoid `any` when possible](#avoid-any-when-possible)
+  * [Don't import types from other libdefs](#dont-import-types-from-other-libdefs)
+  * [Always prefix global variables that aren't really meant to be global](#prefix-global-variables-that-arent-really-meant-to-be-global)
+* [Writing tests](#writing-tests)
+  * [Use `describe` and `it` blocks to limit scope](#use-describe-and-it-blocks-to-limit-scope)
 
 ## Contributing to the definitions repository
 
@@ -180,3 +86,123 @@ ever need to write a test for a particular version of Flow, you can put the
 You may also leave off the argument to run *all* tests (this takes a while). Please note that this test (and the one on Travis-CI) only will be able to run if the name of the repo folder is still "flow-typed".
 
 #### 6) Send a pull request
+
+You know how to do it.
+
+## Writing libdefs tips
+
+### Avoid `any` when possible
+
+Using the `any` type for a variable or interface results in the loss of type information as types pass through it. That means if a type passes through `any` before propogating on to other code, the `any` will potentially cause Flow to miss type errors!
+
+In many places it is better (but also stricter) to use the `mixed` type rather than the `any` type. The `mixed` type is safer in that it allows anything to flow in to it, but can never be used downstream without [dynamic type tests](https://flowtype.org/docs/dynamic-type-tests.html#_) that verify the type at runtime.
+
+Consider this code:
+
+```js
+const cache = new Map();
+function setCache(key: string, value: any) {
+  cache.set(key, value);
+}
+function getCache(key: string) {
+  cache.get(key);
+}
+
+setCache('foo', 42);
+var someString = getCache('foo'); // oops, 'foo' isn't a string!
+someString.length; // but because we used `any`, we don't know toerror here!
+```
+
+Because we've typed the values of the map as `any`, we open ourselves up to type errors:
+
+If, however, we had used `mixed` instead of `any`, Flow would ask us to verify that the type we got back from `getCache()` is in fact a `string` before using it as one:
+
+```js
+const cache = new Map();
+function setCache(key: string, value: mixed) {
+  cache.set(key, value);
+}
+function getCache(key: string) {
+  cache.get(key);
+}
+
+setCache('foo', 42);
+var someString = getCache('foo');
+if (typeof someString === 'string') {
+  someString.length;
+} else {
+  throw new Error('`foo` is unexpectedly something other than a string!');
+}
+```
+
+Because we used a dynamic type test in the second example, we've proved to Flow that the `mixed` result must be a string. If we hadn't done this, Flow would have given us an error reminding us that the value could be anything and it isn't safe to assume without checking first.
+
+There is sometimes a trade-off with using `mixed`, though. Using `mixed` means that if your variable ever does flow downstream, you'll always have to prove what kind of type it is (with a type test) before you can use it. Sometimes this is just too annoying and the risk involved with `any` is just worth the trade-off.
+
+In the case of library definitions, it is almost always better to use `mixed` for function and method parameters because the trade-off is hidden from users:
+
+```js
+declare function setCache(key: string, value: mixed): void;
+
+setCache('number', 42); // Ok
+setCache('string', 'asdf'); // Ok
+```
+
+It is also almost always ok to use `mixed` as the return type of a callback:
+
+```js
+declare function getUser(cb: (user: User) => mixed): void;
+getUser((user) => console.log('Got the user!'));
+```
+
+Using `mixed` in place of `any` for the return type of a function or the type of a variable is a judgement call, though. Return types and declared variables flow into users' programs, which means that users will have to prove the type of `mixed` before they can use them.
+
+### Don't import types from other libdefs
+
+You might think it would be possible to import types from other libdefs, much the same way you do in your own code:
+
+```js
+import type { MyType } from 'some-module';
+declare module 'other-module' {
+  declare export function takesMyType(val: MyType): number;
+}
+```
+
+...but you would be wrong. Flow silently converts `MyType` to be typed `any`, and then sadness ensues.
+
+Currently it's not possible to safely import types from other libdefs when making your libdef. [Further discussion here](https://github.com/flowtype/flow-typed/issues/1857).
+
+### Prefix global variables that aren't really meant to be global
+
+Right now we don't have a good way to write types inside `declare module {}` bodies that *aren't* exported. This problem is being worked on, but in the meantime the best option is to just put a declaration outside the `declare module {}` and reference it.
+
+Because this effectively creates a global type, please be sure to namespace these types with something like `$npm$ModuleName$`:
+
+```js
+type $npm$MyModule$Options = {
+  option1: number,
+  option2: string,
+};
+
+declare module "MyModule" {
+  declare function doStuff(options: $npm$MyModule$Options): void;
+}
+```
+
+## Writing tests
+
+### Use `describe` and `it` blocks to limit scope
+
+You can use `describe` and `it` verbs, much like you do in Mocha/Jest/whatever, to write descriptive tests and limit scope. These are available on the global scope, so you don't need to import anything. (Note that they don't actually run tests, they're just sugar to limit scope and emulate the TDD language with which we're all familiar).
+
+```js
+describe('#someFunction', () => {
+  it('should do something', () => {
+    const a: number = 1;
+  });
+
+  // you can also do type checks outside an it statement
+  //$ExpectError
+  const a: number = 'foo';
+})
+```

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -299,6 +299,7 @@ async function writeFlowConfig(testDirPath, libDefPath, includeWarnings) {
   const flowConfigData = [
     '[libs]',
     path.basename(libDefPath),
+    '../../../definitions/tdd_framework.js',
     '',
     '[options]',
     'suppress_comment=\\\\(.\\\\|\\n\\\\)*\\\\$ExpectError',

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
@@ -1,7 +1,6 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
 import _, { compose, pipe, curry, filter, find, repeat, zipWith } from "ramda";
-import { describe, it } from '../../../tdd_framework'
 
 const ns: Array<number> = [1, 2, 3, 4, 5];
 const ss: Array<string> = ["one", "two", "three", "four"];

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
@@ -1,6 +1,7 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
 import _, { compose, pipe, curry, filter, find, repeat, zipWith } from "ramda";
+import { describe, it } from '../../../tdd_framework'
 
 const ns: Array<number> = [1, 2, 3, 4, 5];
 const ss: Array<string> = ["one", "two", "three", "four"];
@@ -78,10 +79,18 @@ const dissocPathd4: { a: { b: string } } = _.dissocPath(["a", "c"])({
   a: { b: 1, c: 2 }
 });
 
-const o1 = { a: 1, b: 2, c: 3, d: 4 };
-const o2 = { a: 10, b: 20, c: 3, d: 40 };
-const ep: boolean = _.eqProps("a")(o1, o2);
-const ep2: boolean = _.eqProps("c", o1)(o2);
+describe('#eqProps', () => {
+  const o1 = { a: 1, b: 2, c: 3, d: 4 };
+  const o2 = { a: 10, b: 20, c: 3, d: 40 };
+
+  it('should do basic type checking', () => {
+    const ep: boolean = _.eqProps("a", o1, o2);
+  })
+
+  // curried versions
+  const ep: boolean = _.eqProps("a")(o1, o2);
+  const ep2: boolean = _.eqProps("c", o1)(o2);
+})
 
 const evolved1 = _.evolve(
   {

--- a/definitions/tdd_framework.js
+++ b/definitions/tdd_framework.js
@@ -1,0 +1,19 @@
+// @flow
+
+/**
+ * TDD language that can be imported into tests for more descriptive test writing and smaller scopes.
+ * Note that we don't actually run tests, these are simply present to mimic the TDD verbs we know and love.
+ *
+ * Usage:
+ *
+ *    describe('#someFunction', () => {
+ *      it('should do something', () => {
+ *        // test...
+ *      })
+ *
+ *      // you can also do type checks outside an it statement
+ *    })
+ *
+ */
+export const describe = (label: string, fn: (...any) => any): void => { fn() }
+export const it = (label: string, fn: (...any) => any): void => { fn() }

--- a/definitions/tdd_framework.js
+++ b/definitions/tdd_framework.js
@@ -1,7 +1,7 @@
 // @flow
 
 /**
- * TDD language that can be imported into tests for more descriptive test writing and smaller scopes.
+ * TDD language that can used in tests for more descriptive test writing and smaller scopes.
  * Note that we don't actually run tests, these are simply present to mimic the TDD verbs we know and love.
  *
  * Usage:
@@ -14,6 +14,8 @@
  *      // you can also do type checks outside an it statement
  *    })
  *
+ * It is set up such that you don't need to import these functions, you can just use them naturally as if they were
+ * available in the global scope.
  */
 export const describe = (label: string, fn: (...any) => any): void => { fn() }
 export const it = (label: string, fn: (...any) => any): void => { fn() }


### PR DESCRIPTION
Based on #1842. Adds `describe` and `it` as building blocks to test to allow for more familiar TDD test writing, reducing scope, and being more descriptive. Simple enough solution. I'm not wedded to it, but I wanted to see if it'd work out, and get people's feedback.