### PR TITLE
Only mangle test file names when a name collision will occur.

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -132,10 +132,16 @@ async function getOrderedFlowBinVersions(
         apiPayload.forEach(rel => {
           // Temporary fix for https://github.com/facebook/flow/issues/5922
           if (rel.tag_name === 'v0.67.0') {
-            console.log('==========================================================================================')
-            console.log('We are tempoarily skipping v0.67.0 due to https://github.com/facebook/flow/issues/5922')
-            console.log('==========================================================================================')
-            return
+            console.log(
+              '==========================================================================================',
+            );
+            console.log(
+              'We are tempoarily skipping v0.67.0 due to https://github.com/facebook/flow/issues/5922',
+            );
+            console.log(
+              '==========================================================================================',
+            );
+            return;
           }
 
           // We only test against versions since 0.15.0 because it has proper
@@ -501,6 +507,7 @@ async function runTestGroup(
       testDirPath,
       path.basename(testGroup.libDefPath),
     );
+    const copiedFileNames = new Set();
     await P.all([
       P.all(
         testGroup.testFilePaths.map(async (filePath, idx) => {
@@ -509,7 +516,13 @@ async function runTestGroup(
           //
           // i.e. underscore/v1.x.x/test-underscore.js
           //      underscore/v1.x.x/flow-v0.22.x/test-underscore.js
-          const destBasename = idx + '-' + path.basename(filePath);
+          //
+          // Only mangles the name when there's a naming collision. Otherwise, uses the original.
+          const fileName = path.basename(filePath);
+          const destBasename = copiedFileNames.has(fileName)
+            ? `${idx}-${fileName}`
+            : fileName;
+          copiedFileNames.add(destBasename);
           await copyFile(filePath, path.join(testDirPath, destBasename));
         }),
       ),


### PR DESCRIPTION
Mostly closes #1331, by only mangling the test file name when a collision is going to occur. This probably covers 99% of use cases, and can re-visit the issue if we hit the edge cases.