### PR TITLE
Fix type of Knex$Transaction.rollback

### DIFF
--- a/definitions/npm/knex_v0.13.x/flow_v0.38.x-/knex_v0.13.x.js
+++ b/definitions/npm/knex_v0.13.x/flow_v0.38.x-/knex_v0.13.x.js
@@ -1,7 +1,7 @@
 declare class Knex$Transaction<R>
   mixins Knex$QueryBuilder<R>, events$EventEmitter, Promise<R> {
   commit(connection?: any, value?: any): Promise<R>;
-  rollback(): Promise<R>;
+  rollback(?Error): Promise<R>;
   savepoint(connection?: any): Promise<R>;
 }
 

--- a/definitions/npm/knex_v0.13.x/test_knex-v0.13.js
+++ b/definitions/npm/knex_v0.13.x/test_knex-v0.13.js
@@ -69,6 +69,11 @@ knex
   .then(function(result) {})
   .catch(function(err) {});
 
+knex
+  .transaction(function(trx) {
+    trx.rollback();
+  });
+
 /**
  * knex is also an event emitter,
  * See : http://knexjs.org/#Interfaces-Events


### PR DESCRIPTION
# Demo

```js
'use strict';

const knex = require('knex');

const db = knex({
  client: 'mysql',
  connection: {
    host: '127.0.0.1',
    port: 3306,
    user: 'root',
    password: 'root',
    database: 'test-transaction'
  }
});

db.transaction((trx) => {
  return trx.rollback();
})
.then((...args) => {
  console.log('then()', args);
})
.catch((error) => {
  console.error('catch()', error);
});
```

Outputs

```
catch() Error: Transaction rejected with non-error: undefined
  <stack trace>
```

However, passing an Error object to `trx.rollback()` such as

```js
'use strict';

const knex = require('knex');

const db = knex({
  client: 'mysql',
  connection: {
    host: '127.0.0.1',
    port: 3306,
    user: 'root',
    password: 'root',
    database: 'test-transaction'
  }
});

db.transaction((trx) => {
  return trx.rollback(new Error('Something went wrong'));
})
.then((...args) => {
  console.log('then()', args);
})
.catch((error) => {
  console.error('catch()', error);
});
```

gives us the following output:

```
catch() Error: Something went wrong
  <stack trace>
```