### PR TITLE
Add type definition for re-reselect

### DIFF
--- a/definitions/npm/re-reselect_v1.x.x/flow_v0.66.x-/re-reselect_v1.x.x.js
+++ b/definitions/npm/re-reselect_v1.x.x/flow_v0.66.x-/re-reselect_v1.x.x.js
@@ -1,0 +1,867 @@
+declare module "re-reselect" {
+  declare type Selector<-TState, TProps, TResult> =
+    (state: TState, props: TProps, ...rest: any[]) => TResult
+
+  declare type SelectorCreator<TState, TProps, TResult> =
+    ((state: TState, props: TProps) => string | number) => Selector<TState, TProps, TResult>
+
+
+  declare type CreateCachedSelector = {
+    <TState, TProps, TResult, T1>(
+      selector1: Selector<TState, TProps, T1>,
+      resultFunc: (arg1: T1) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1>(
+      selectors: [Selector<TState, TProps, T1>],
+      resultFunc: (arg1: T1) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      resultFunc: (arg1: T1, arg2: T2) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2>(
+      selectors: [Selector<TState, TProps, T1>, Selector<TState, TProps, T2>],
+      resultFunc: (arg1: T1, arg2: T2) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>
+      ],
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>
+      ],
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>
+      ],
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      selector14: Selector<TState, TProps, T14>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>,
+        Selector<TState, TProps, T14>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      selector14: Selector<TState, TProps, T14>,
+      selector15: Selector<TState, TProps, T15>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>,
+        Selector<TState, TProps, T14>,
+        Selector<TState, TProps, T15>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15,
+      T16
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      selector14: Selector<TState, TProps, T14>,
+      selector15: Selector<TState, TProps, T15>,
+      selector16: Selector<TState, TProps, T16>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15,
+        arg16: T16
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15,
+      T16
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>,
+        Selector<TState, TProps, T14>,
+        Selector<TState, TProps, T15>,
+        Selector<TState, TProps, T16>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15,
+        arg16: T16
+      ) => TResult
+    ): SelectorCreator<TState, TProps, TResult>
+  };
+
+  declare module.exports: CreateCachedSelector;
+}

--- a/definitions/npm/re-reselect_v1.x.x/test_re-reselect_1.x.x.js
+++ b/definitions/npm/re-reselect_v1.x.x/test_re-reselect_1.x.x.js
@@ -1,0 +1,101 @@
+/* @flow */
+import createCachedSelector from "re-reselect";
+
+// TEST: Should pass for 2 selectors given as arguments
+type State = {
+  x: number,
+  y: number
+};
+
+const test1Selector = createCachedSelector(
+  (state: State) => state.x,
+  (state: State) => state.y,
+  (x, y) => {
+    return x + y;
+  }
+)(() => 1)
+
+test1Selector({ x: 100, y: 200 });
+// $ExpectError invalid state
+test1Selector({ x: 100 });
+// END TEST
+
+// TEST: Should pass for 2 selectors given as array
+const test2Selector = createCachedSelector(
+  [(state: State) => state.x, (state: State) => state.y],
+  (x, y) => {
+    return x + y;
+  }
+)(() => 2)
+
+test2Selector({ x: 100, y: 200 });
+// $ExpectError invalid state
+test2Selector({ x: 100 });
+// END TEST
+
+// TEST: Should pass when selectors have additional Props argument
+type TestProps = {
+  x: number
+};
+
+const test3Selector = createCachedSelector(
+  (state: State, props: TestProps) => state.x + props.x,
+  (state: State, props: TestProps) => state.y + props.x,
+  (x, y) => {
+    return x + y;
+  }
+)((state, props) => props.x)
+
+test3Selector(
+  { x: 100, y: 200 },
+  { x: 10 }
+);
+// $ExpectError invalid state
+test3Selector({ x: 100 }, { x: 10 });
+// $ExpectError invalid props
+test3Selector({ x: 100, y: 200 }, { y: 10 });
+// END TEST
+
+// TEST: Should work when using another selector as functions
+{
+  const simpleSelector = (state: State): string => "foo";
+  const resultSelector = (arg: string): string => "foo";
+
+  const combinedSelector1 = createCachedSelector(simpleSelector, resultSelector)(() => 1);
+  const combinedSelector2: (state: State) => string = createCachedSelector(
+    combinedSelector1,
+    resultSelector
+  )(() => 2);
+
+  combinedSelector1({ x: 100, y: 200 })
+  // $ExpectError invalid state
+  combinedSelector1({ x: 100 })
+}
+// END TEST
+
+// TEST: Should work when using more complex selectors as functions
+{
+  const resultFunc = (param1: string, param2: number): number => 42;
+  const simpleSelector = (state: State): string => "foo";
+  const compoundSelector = createCachedSelector(simpleSelector, () => 42)(() => 1);
+  const selector = createCachedSelector(
+    simpleSelector,
+    compoundSelector,
+    resultFunc
+  )(() => 2);
+
+  const result: number = selector({ x: 42, y: 42 });
+  // $ExpectError invalid state
+  selector({ x: 42 });
+}
+// END TEST
+
+// TEST: Should validate parameters based on the return values of nested
+// selectors.
+createCachedSelector(
+  (state: State) => state.x,
+  (state: State) => state.y,
+  // $ExpectError first argument will be a number, not a string.
+  (x: string, y: number) => "foo"
+)
+// END TEST


### PR DESCRIPTION
`re-reselect` is a simple wrapper on top of `reselect` that adds the ability to have multiple caches per-selector when you provide it a cache key. This definition is copied and pasted from the definition for `reselect` and modified to support the additional function required to generate a cache key.

I hope to have followed the contribution guidelines correctly, please let me know if I didn't understand something correctly. A couple of notes regarding the guidelines:

1. There is an `any` value in here that is copied and pasted from reselect's definition. I wasn't quite confident enough to change it to something else.
2. I'd like for this to support more versions, but flow 0.65 and below didn't much care for the parts I added. So, the range for this is defined as `flow_v0.66.x-`.

Thanks and please let me know if there's anything I can do to make this more mergeable!