### PR TITLE
Adjust type definitions for react-intl-with-message-id_v2.x.x

### DIFF
--- a/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.25.x-v0.52.x/react-intl-with-data-message-id_v2.x.x.js
+++ b/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.25.x-v0.52.x/react-intl-with-data-message-id_v2.x.x.js
@@ -5,7 +5,7 @@
  */
 import React from "react";
 
-// Mostly from https://github.com/yahoo/react-intl/wiki/API#react-intl-with-data-message-id-api
+// Mostly from https://github.com/yahoo/react-intl/wiki/API#react-intl-api
 
 type LocaleData = {
   locale: string,
@@ -95,7 +95,7 @@ type PluralCategoryString = "zero" | "one" | "two" | "few" | "many" | "other";
 
 type $DateParseable = number | string | Date;
 
-declare module "react-intl-with-data-message-id" {
+declare module "react-intl" {
   // PropType checker
   declare function intlShape(
     props: Object,

--- a/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.53.x-v0.56.x/react-intl-with-data-message-id_v2.x.x.js
+++ b/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.53.x-v0.56.x/react-intl-with-data-message-id_v2.x.x.js
@@ -3,7 +3,7 @@
  * Copied here based on intention to merge with flow-typed expressed here:
  * https://github.com/marudor/flowInterfaces/issues/6
  */
-// Mostly from https://github.com/yahoo/react-intl/wiki/API#react-intl-with-data-message-id-api
+// Mostly from https://github.com/yahoo/react-intl/wiki/API#react-intl-api
 
 type $npm$ReactIntl$LocaleData = {
   locale: string,
@@ -107,7 +107,7 @@ type $npm$ReactIntl$PluralCategoryString =
 
 type $npm$ReactIntl$DateParseable = number | string | Date;
 
-declare module "react-intl-with-data-message-id" {
+declare module "react-intl" {
   // PropType checker
   declare function intlShape(
     props: Object,

--- a/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.57.x-/react-intl-with-data-message-id_v2.x.x.js
+++ b/definitions/npm/react-intl-with-data-message-id_v2.x.x/flow_v0.57.x-/react-intl-with-data-message-id_v2.x.x.js
@@ -3,7 +3,7 @@
  * Copied here based on intention to merge with flow-typed expressed here:
  * https://github.com/marudor/flowInterfaces/issues/6
  */
-// Mostly from https://github.com/yahoo/react-intl/wiki/API#react-intl-with-data-message-id-api
+// Mostly from https://github.com/yahoo/react-intl/wiki/API#react-intl-api
 
 import type { Element, ChildrenArray } from "react";
 
@@ -109,7 +109,7 @@ type $npm$ReactIntl$PluralCategoryString =
 
 type $npm$ReactIntl$DateParseable = number | string | Date;
 
-declare module "react-intl-with-data-message-id" {
+declare module "react-intl" {
   // PropType checker
   declare function intlShape(
     props: Object,


### PR DESCRIPTION
- renamed because enzyme-react-intl will not work in the project