### PR TITLE
Corrected Redux v3.x.x createStore and Reducer definitions

### DIFF
--- a/definitions/npm/redux_v3.x.x/flow_v0.25.x-v0.27.x/redux_v3.x.x.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.25.x-v0.27.x/redux_v3.x.x.js
@@ -2,7 +2,7 @@ declare module "redux" {
   declare type State = any;
   declare type Action = Object;
   declare type AsyncAction = any;
-  declare type Reducer<S, A> = (state: S, action: A) => S;
+  declare type Reducer<S, A> = (state: S | void, action: A) => S;
   declare type BaseDispatch = (a: Action) => Action;
   declare type Dispatch = (a: Action | AsyncAction) => any;
   declare type ActionCreator = (...args: any) => Action | AsyncAction;

--- a/definitions/npm/redux_v3.x.x/flow_v0.28.x-v0.32.x/redux_v3.x.x.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.28.x-v0.32.x/redux_v3.x.x.js
@@ -22,7 +22,7 @@ declare module 'redux' {
     replaceReducer(nextReducer: Reducer<S, A>): void
   };
 
-  declare type Reducer<S, A> = (state: S, action: A) => S;
+  declare type Reducer<S, A> = (state: S | void, action: A) => S;
 
   declare type Middleware<S, A> =
     (api: MiddlewareAPI<S, A>) =>
@@ -36,7 +36,7 @@ declare module 'redux' {
   declare type StoreEnhancer<S, A> = (next: StoreCreator<S, A>) => StoreCreator<S, A>;
 
   declare function createStore<S, A>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A>): Store<S, A>;
-  declare function createStore<S, A>(reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A>): Store<S, A>;
+  declare function createStore<S, A>(reducer: Reducer<S, A>, preloadedState?: S, enhancer?: StoreEnhancer<S, A>): Store<S, A>;
 
   declare function applyMiddleware<S, A>(...middlewares: Array<Middleware<S, A>>): StoreEnhancer<S, A>;
 

--- a/definitions/npm/redux_v3.x.x/flow_v0.28.x-v0.32.x/test_applyMiddleware.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.28.x-v0.32.x/test_applyMiddleware.js
@@ -5,7 +5,7 @@ import { applyMiddleware, createStore } from 'redux'
 type State = Array<number>;
 type Action = { type: 'A' };
 type Store = ReduxStore<State, Action>;
-const reducer = (state: State, action: Action): State => state
+const reducer = (state: State = [], action: Action): State => state
 
 //
 // applyMiddleware API

--- a/definitions/npm/redux_v3.x.x/flow_v0.28.x-v0.32.x/test_createStore.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.28.x-v0.32.x/test_createStore.js
@@ -5,7 +5,7 @@ import { createStore } from 'redux'
 type State = Array<number>;
 type Action = { type: 'A' };
 type Store = ReduxStore<State, Action>;
-const reducer = (state: State, action: Action): State => state
+const reducer = (state: State = [], action: Action): State => state
 
 //
 // createStore API
@@ -24,6 +24,7 @@ const store6: Store = createStore(reducer, [1]);
 const store7: Store = createStore(reducer, [1], 'wrong'); // wrong enhancer
 declare var myEnhancer: StoreEnhancer<State, Action>;
 const store8: Store = createStore(reducer, [1], myEnhancer);
+const store9: Store = createStore(reducer, undefined, myEnhancer);
 
 //
 // store members

--- a/definitions/npm/redux_v3.x.x/flow_v0.33.x-v0.54.x/redux_v3.x.x.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.33.x-v0.54.x/redux_v3.x.x.js
@@ -24,7 +24,7 @@ declare module 'redux' {
     replaceReducer(nextReducer: Reducer<S, A>): void
   };
 
-  declare export type Reducer<S, A> = (state: S, action: A) => S;
+  declare export type Reducer<S, A> = (state: S | void, action: A) => S;
 
   declare export type CombinedReducer<S, A> = (state: $Shape<S> & {} | void, action: A) => S;
 
@@ -40,7 +40,7 @@ declare module 'redux' {
   declare export type StoreEnhancer<S, A, D = Dispatch<A>> = (next: StoreCreator<S, A, D>) => StoreCreator<S, A, D>;
 
   declare export function createStore<S, A, D>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
-  declare export function createStore<S, A, D>(reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+  declare export function createStore<S, A, D>(reducer: Reducer<S, A>, preloadedState?: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
 
   declare export function applyMiddleware<S, A, D>(...middlewares: Array<Middleware<S, A, D>>): StoreEnhancer<S, A, D>;
 

--- a/definitions/npm/redux_v3.x.x/flow_v0.33.x-v0.54.x/test_applyMiddleware.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.33.x-v0.54.x/test_applyMiddleware.js
@@ -5,7 +5,7 @@ import { applyMiddleware, createStore } from 'redux'
 type State = Array<number>;
 type Action = { type: 'A' };
 type Store = ReduxStore<State, Action>;
-const reducer = (state: State, action: Action): State => state
+const reducer = (state: State = [], action: Action): State => state
 
 //
 // applyMiddleware API

--- a/definitions/npm/redux_v3.x.x/flow_v0.33.x-v0.54.x/test_createStore.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.33.x-v0.54.x/test_createStore.js
@@ -5,7 +5,7 @@ import { createStore } from 'redux'
 type State = Array<number>;
 type Action = { type: 'A' };
 type Store = ReduxStore<State, Action>;
-const reducer = (state: State, action: Action): State => state
+const reducer = (state: State = [], action: Action): State => state
 
 //
 // createStore API
@@ -24,6 +24,7 @@ const store6: Store = createStore(reducer, [1]);
 const store7: Store = createStore(reducer, [1], 'wrong'); // wrong enhancer
 declare var myEnhancer: StoreEnhancer<State, Action>;
 const store8: Store = createStore(reducer, [1], myEnhancer);
+const store9: Store = createStore(reducer, undefined, myEnhancer);
 
 //
 // store members

--- a/definitions/npm/redux_v3.x.x/flow_v0.33.x-v0.54.x/test_custom_dispatch.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.33.x-v0.54.x/test_custom_dispatch.js
@@ -7,7 +7,7 @@ type Action = { type: 'A' };
 type Thunk = (dispatch: Dispatch, getState: () => State) => void;
 type Dispatch = DispatchAPI<Action | Thunk>;
 type Store = ReduxStore<State, Action, Dispatch>;
-const reducer = (state: State, action: Action): State => state
+const reducer = (state: State = [], action: Action): State => state
 
 //
 // applyMiddleware interaction with createStore

--- a/definitions/npm/redux_v3.x.x/flow_v0.55.x-/redux_v3.x.x.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.55.x-/redux_v3.x.x.js
@@ -24,7 +24,7 @@ declare module 'redux' {
     replaceReducer(nextReducer: Reducer<S, A>): void
   };
 
-  declare export type Reducer<S, A> = (state: S, action: A) => S;
+  declare export type Reducer<S, A> = (state: S | void, action: A) => S;
 
   declare export type CombinedReducer<S, A> = (state: $Shape<S> & {} | void, action: A) => S;
 
@@ -40,7 +40,7 @@ declare module 'redux' {
   declare export type StoreEnhancer<S, A, D = Dispatch<A>> = (next: StoreCreator<S, A, D>) => StoreCreator<S, A, D>;
 
   declare export function createStore<S, A, D>(reducer: Reducer<S, A>, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
-  declare export function createStore<S, A, D>(reducer: Reducer<S, A>, preloadedState: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
+  declare export function createStore<S, A, D>(reducer: Reducer<S, A>, preloadedState?: S, enhancer?: StoreEnhancer<S, A, D>): Store<S, A, D>;
 
   declare export function applyMiddleware<S, A, D>(...middlewares: Array<Middleware<S, A, D>>): StoreEnhancer<S, A, D>;
 

--- a/definitions/npm/redux_v3.x.x/flow_v0.55.x-/test_applyMiddleware.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.55.x-/test_applyMiddleware.js
@@ -5,7 +5,7 @@ import { applyMiddleware, createStore } from 'redux'
 type State = Array<number>;
 type Action = { type: 'A' };
 type Store = ReduxStore<State, Action>;
-const reducer = (state: State, action: Action): State => state
+const reducer = (state: State = [], action: Action): State => state
 
 //
 // applyMiddleware API

--- a/definitions/npm/redux_v3.x.x/flow_v0.55.x-/test_combineReducers.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.55.x-/test_combineReducers.js
@@ -18,11 +18,13 @@ type State = {
 // combineReducers API
 //
 
-function reducerName(name: string, action: Action): string {
+const initialName = 'initialName'
+function reducerName(name: string = initialName, action: Action): string {
   return name
 }
 
-function reducerAge(age: number, action: Action): number {
+const initialAge = 0
+function reducerAge(age: number = initialAge, action: Action): number {
   return age
 }
 

--- a/definitions/npm/redux_v3.x.x/flow_v0.55.x-/test_createStore.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.55.x-/test_createStore.js
@@ -5,7 +5,7 @@ import { createStore } from 'redux'
 type State = Array<number>;
 type Action = { type: 'A' };
 type Store = ReduxStore<State, Action>;
-const reducer = (state: State, action: Action): State => state
+const reducer = (state: State = [], action: Action): State => state
 
 //
 // createStore API
@@ -24,6 +24,7 @@ const store6: Store = createStore(reducer, [1]);
 const store7: Store = createStore(reducer, [1], 'wrong'); // wrong enhancer
 declare var myEnhancer: StoreEnhancer<State, Action>;
 const store8: Store = createStore(reducer, [1], myEnhancer);
+const store9: Store = createStore(reducer, undefined, myEnhancer);
 
 //
 // store members

--- a/definitions/npm/redux_v3.x.x/flow_v0.55.x-/test_custom_dispatch.js
+++ b/definitions/npm/redux_v3.x.x/flow_v0.55.x-/test_custom_dispatch.js
@@ -7,7 +7,7 @@ type Action = { type: 'A' };
 type Thunk = (dispatch: Dispatch, getState: () => State) => void;
 type Dispatch = DispatchAPI<Action | Thunk>;
 type Store = ReduxStore<State, Action, Dispatch>;
-const reducer = (state: State, action: Action): State => state
+const reducer = (state: State = [], action: Action): State => state
 
 //
 // applyMiddleware interaction with createStore


### PR DESCRIPTION
Closes #1397 

The two definitions go hand-in-hand, as `createStore` takes a `Reducer` as a parameter and has side-effects specifically surrounding how that `Reducer` will be called. 

# `createStore` type proof

As described in the official [documentation](https://github.com/reactjs/redux/blob/master/docs/api/createStore.md), `createStore`'s `preloadedState` is optional.

# `Reducer` type proof

`createStore`'s `preloadedState` is optional (possibly `undefined`/`void`), as above, it is sent directly to a `Reducer`, specifically the `reducer` provided in the same `createStore` call. Redux is a small library so this can be verified in a straight-forward fashion by visual code inspection, as follows:

1. `reducer` and `preloadedState` are set as `currentReducer` and `currentState` respectively:

    https://github.com/reactjs/redux/blob/v3.7.2/src/createStore.js#L57


2. `currentReducer` called with `currentState` (inside `dispatch(<some action>)`):

    https://github.com/reactjs/redux/blob/v3.7.2/src/createStore.js#L170
