### PR TITLE
Do not require component usage to type check in react-redux

### DIFF
--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
@@ -50,10 +50,12 @@ declare module "react-redux" {
 
   declare type OmitDispatch<Component> = $Diff<Component, {dispatch: Dispatch<*>}>;
 
-  declare export function connect<Com: ComponentType<*>, RS: Object, DP: Object, RSP: Object>(
-    mapStateToProps: MapStateToProps<RS, DP, RSP>,
+  declare export function connect<Com: ComponentType<*>,RS: Object, DP: Object, RSP: Object,
+    OMP: OmitDispatch<ElementConfig<Com>>,
+    CP: $Diff<OMP, RSP>>(
+    mapStateToProps: MapStateToProps<RS,DP, RSP>,
     mapDispatchToProps?: null
-  ): (component: Com) => ComponentType<$Diff<OmitDispatch<ElementConfig<Com>>, RSP> & DP>;
+  ): (component: Com) => ComponentType<CP & DP>;
 
   declare export function connect<Com: ComponentType<*>>(
     mapStateToProps?: null,

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
@@ -51,8 +51,13 @@ declare module "react-redux" {
 
   declare type OmitDispatch<Component> = $Diff<Component, {dispatch: Dispatch<*>}>;
 
-  declare export function connect<Com: ComponentType<*>, S: Object, DP: Object, RSP: Object,
-    CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>>(
+  declare export function connect<
+    Com: ComponentType<*>,
+    S: Object,
+    DP: Object,
+    RSP: Object,
+    CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>
+    >(
     mapStateToProps: MapStateToProps<S, DP, RSP>,
     mapDispatchToProps?: null
   ): (component: Com) => ComponentType<CP & DP>;
@@ -62,8 +67,16 @@ declare module "react-redux" {
     mapDispatchToProps?: null
   ): (component: Com) => ComponentType<OmitDispatch<ElementConfig<Com>>>;
 
-  declare export function connect<Com: ComponentType<*>, A, S: Object, DP: Object, SP: Object, RSP: Object, RDP: Object,
-    CP: $Diff<$Diff<ElementConfig<Com>, RSP>, RDP>>(
+  declare export function connect<
+    Com: ComponentType<*>,
+    A,
+    S: Object,
+    DP: Object,
+    SP: Object,
+    RSP: Object,
+    RDP: Object,
+    CP: $Diff<$Diff<ElementConfig<Com>, RSP>, RDP>
+    >(
     mapStateToProps: MapStateToProps<S, SP, RSP>,
     mapDispatchToProps: MapDispatchToProps<A, DP, RDP>
   ): (component: Com) => ComponentType<CP & SP & DP>;
@@ -88,20 +101,45 @@ declare module "react-redux" {
     mapDispatchToProps: MDP
   ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, MDP>>;
 
-  declare export function connect<Com: ComponentType<*>, S: Object, SP: Object, RSP: Object, MDP: Object,
-    CP: $Diff<ElementConfig<Com>, RSP>>(
+  declare export function connect<
+    Com: ComponentType<*>,
+    S: Object,
+    SP: Object,
+    RSP: Object,
+    MDP: Object,
+    CP: $Diff<ElementConfig<Com>, RSP>
+    >(
     mapStateToProps: MapStateToProps<S, SP, RSP>,
     mapDispatchToPRops: MDP
   ): (component: Com) => ComponentType<$Diff<CP, MDP> & SP>;
 
-  declare export function connect<Com: ComponentType<*>, A, S: Object, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object,
-    CP: $Diff<ElementConfig<Com>, RMP>>(
+  declare export function connect<
+    Com: ComponentType<*>,
+    A,
+    S: Object,
+    DP: Object,
+    SP: Object,
+    RSP: Object,
+    RDP: Object,
+    MP: Object,
+    RMP: Object,
+    CP: $Diff<ElementConfig<Com>, RMP>
+    >(
     mapStateToProps: MapStateToProps<S, SP, RSP>,
     mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
     mergeProps: MergeProps<RSP, RDP, MP, RMP>
   ): (component: Com) => ComponentType<CP & SP & DP & MP>;
 
-  declare export function connect<Com: ComponentType<*>, A, S: Object, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
+  declare export function connect<Com: ComponentType<*>,
+    A,
+    S: Object,
+    DP: Object,
+    SP: Object,
+    RSP: Object,
+    RDP: Object,
+    MP: Object,
+    RMP: Object
+    >(
     mapStateToProps: ?MapStateToProps<S, SP, RSP>,
     mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
     mergeProps: ?MergeProps<RSP, RDP, MP, RMP>,

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
@@ -25,6 +25,7 @@ declare module "react-redux" {
   RSP = Returned state props
   RDP = Returned dispatch props
   RMP = Returned merge props
+  CP = Props for returned component
   Com = React Component
   */
 
@@ -51,8 +52,7 @@ declare module "react-redux" {
   declare type OmitDispatch<Component> = $Diff<Component, {dispatch: Dispatch<*>}>;
 
   declare export function connect<Com: ComponentType<*>,RS: Object, DP: Object, RSP: Object,
-    OMP: OmitDispatch<ElementConfig<Com>>,
-    CP: $Diff<OMP, RSP>>(
+    CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>>(
     mapStateToProps: MapStateToProps<RS,DP, RSP>,
     mapDispatchToProps?: null
   ): (component: Com) => ComponentType<CP & DP>;
@@ -62,31 +62,44 @@ declare module "react-redux" {
     mapDispatchToProps?: null
   ): (component: Com) => ComponentType<OmitDispatch<ElementConfig<Com>>>;
 
-  declare export function connect<Com: ComponentType<*>, A, RS: Object, DP: Object, SP: Object, RSP: Object, RDP: Object>(
-    mapStateToProps: MapStateToProps<RS, SP, RSP>,
+  declare export function connect<Com: ComponentType<*>, A,RS: Object, DP: Object, SP: Object, RSP: Object, RDP: Object,
+    CP: $Diff<$Diff<ElementConfig<Com>, RSP>, RDP>>(
+    mapStateToProps: MapStateToProps<RS,SP, RSP>,
     mapDispatchToProps: MapDispatchToProps<A, DP, RDP>
-  ): (component: Com) => ComponentType<$Diff<$Diff<ElementConfig<Com>, RSP>, RDP> & SP & DP>;
+  ): (component: Com) => ComponentType<CP & SP & DP>;
 
-  declare export function connect<Com: ComponentType<*>, A, OP: Object, DP: Object,PR: Object>(
+  declare export function connect<
+    Com: ComponentType<*>,
+    A,
+    OP: Object,
+    DP: Object,
+    PR: Object,
+    CP: $Diff<ElementConfig<Com>, DP>
+    >(
     mapStateToProps?: null,
     mapDispatchToProps: MapDispatchToProps<A, OP, DP>
-  ): (Com) => ComponentType<$Diff<ElementConfig<Com>, DP> & OP>;
+  ): (Com) => ComponentType<CP & OP>;
 
-  declare export function connect<Com: ComponentType<*>, MDP: Object>(
+  declare export function connect<
+    Com: ComponentType<*>,
+    MDP: Object
+    >(
     mapStateToProps?: null,
     mapDispatchToProps: MDP
   ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, MDP>>;
 
-  declare export function connect<Com: ComponentType<*>, RS: Object, SP: Object, RSP: Object, MDP: Object>(
-    mapStateToProps: MapStateToProps<RS, SP, RSP>,
+  declare export function connect<Com: ComponentType<*>,RS: Object, SP: Object, RSP: Object, MDP: Object,
+    CP: $Diff<ElementConfig<Com>, RSP>>(
+    mapStateToProps: MapStateToProps<RS,SP, RSP>,
     mapDispatchToPRops: MDP
-  ): (component: Com) => ComponentType<$Diff<$Diff<ElementConfig<Com>, RSP>, MDP> & SP>;
+  ): (component: Com) => ComponentType<$Diff<CP, MDP> & SP>;
 
-  declare export function connect<Com: ComponentType<*>, A, RS: Object, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
-    mapStateToProps: MapStateToProps<RS, SP, RSP>,
+  declare export function connect<Com: ComponentType<*>, A,RS: Object, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object,
+    CP: $Diff<ElementConfig<Com>, RMP>>(
+    mapStateToProps: MapStateToProps<RS,SP, RSP>,
     mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
     mergeProps: MergeProps<RSP, RDP, MP, RMP>
-  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP>;
+  ): (component: Com) => ComponentType<CP & SP & DP & MP>;
 
   declare export function connect<Com: ComponentType<*>, A, RS: Object, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
     mapStateToProps: ?MapStateToProps<RS, SP, RSP>,

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
@@ -29,7 +29,7 @@ declare module "react-redux" {
   Com = React Component
   */
 
-  declare type MapStateToProps<RS: Object, SP: Object, RSP: Object> = (state: RS, props: SP) => RSP;
+  declare type MapStateToProps<S: Object, SP: Object, RSP: Object> = (state: S, props: SP) => RSP;
 
   declare type MapDispatchToProps<A, OP: Object, RDP: Object> = (dispatch: Dispatch<A>, ownProps: OP) => RDP;
 
@@ -51,9 +51,9 @@ declare module "react-redux" {
 
   declare type OmitDispatch<Component> = $Diff<Component, {dispatch: Dispatch<*>}>;
 
-  declare export function connect<Com: ComponentType<*>,RS: Object, DP: Object, RSP: Object,
+  declare export function connect<Com: ComponentType<*>, S: Object, DP: Object, RSP: Object,
     CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>>(
-    mapStateToProps: MapStateToProps<RS,DP, RSP>,
+    mapStateToProps: MapStateToProps<S, DP, RSP>,
     mapDispatchToProps?: null
   ): (component: Com) => ComponentType<CP & DP>;
 
@@ -62,9 +62,9 @@ declare module "react-redux" {
     mapDispatchToProps?: null
   ): (component: Com) => ComponentType<OmitDispatch<ElementConfig<Com>>>;
 
-  declare export function connect<Com: ComponentType<*>, A,RS: Object, DP: Object, SP: Object, RSP: Object, RDP: Object,
+  declare export function connect<Com: ComponentType<*>, A, S: Object, DP: Object, SP: Object, RSP: Object, RDP: Object,
     CP: $Diff<$Diff<ElementConfig<Com>, RSP>, RDP>>(
-    mapStateToProps: MapStateToProps<RS,SP, RSP>,
+    mapStateToProps: MapStateToProps<S, SP, RSP>,
     mapDispatchToProps: MapDispatchToProps<A, DP, RDP>
   ): (component: Com) => ComponentType<CP & SP & DP>;
 
@@ -88,24 +88,24 @@ declare module "react-redux" {
     mapDispatchToProps: MDP
   ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, MDP>>;
 
-  declare export function connect<Com: ComponentType<*>,RS: Object, SP: Object, RSP: Object, MDP: Object,
+  declare export function connect<Com: ComponentType<*>, S: Object, SP: Object, RSP: Object, MDP: Object,
     CP: $Diff<ElementConfig<Com>, RSP>>(
-    mapStateToProps: MapStateToProps<RS,SP, RSP>,
+    mapStateToProps: MapStateToProps<S, SP, RSP>,
     mapDispatchToPRops: MDP
   ): (component: Com) => ComponentType<$Diff<CP, MDP> & SP>;
 
-  declare export function connect<Com: ComponentType<*>, A,RS: Object, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object,
+  declare export function connect<Com: ComponentType<*>, A, S: Object, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object,
     CP: $Diff<ElementConfig<Com>, RMP>>(
-    mapStateToProps: MapStateToProps<RS,SP, RSP>,
+    mapStateToProps: MapStateToProps<S, SP, RSP>,
     mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
     mergeProps: MergeProps<RSP, RDP, MP, RMP>
   ): (component: Com) => ComponentType<CP & SP & DP & MP>;
 
-  declare export function connect<Com: ComponentType<*>, A, RS: Object, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
-    mapStateToProps: ?MapStateToProps<RS, SP, RSP>,
+  declare export function connect<Com: ComponentType<*>, A, S: Object, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
+    mapStateToProps: ?MapStateToProps<S, SP, RSP>,
     mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
     mergeProps: ?MergeProps<RSP, RDP, MP, RMP>,
-    options: ConnectOptions<*, SP & DP & MP, RSP, RMP>
+    options: ConnectOptions<S, SP & DP & MP, RSP, RMP>
   ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP>;
 
   declare export default {

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/test_connect.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/test_connect.js
@@ -39,7 +39,7 @@ function testPassingPropsToConnectedComponent() {
   connect(mapStateToProps)('');
 }
 
-function doesNotRequireDefinedComponentToTypeCheck() {
+function doesNotRequireDefinedComponentToTypeCheck1case() {
   type Props = {
     stringProp: string,
   };
@@ -54,6 +54,83 @@ function doesNotRequireDefinedComponentToTypeCheck() {
   });
 
   connect(mapStateToProps)(Component);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck2case() {
+  type Props = {
+    numProp: string,
+  };
+
+  const Component = ({ numProp }: Props) => {
+    return <span>{numProp}</span>;
+  };
+
+  const mapDispatchToProps = () => ({
+    // $ExpectError wrong type for numProp
+    numProp: false,
+  });
+
+  connect(null, mapDispatchToProps)(Component);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck3case() {
+  type Props = {
+    stringProp: string,
+    numProp: number
+  };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = (state: {}) => ({
+    // $ExpectError wrong type for stringProp
+    stringProp: false,
+  });
+
+  const mapDispatchToProps = () => ({
+    // $ExpectError wrong type for numProp
+    numProp: false,
+  });
+
+  connect(mapStateToProps, mapDispatchToProps)(Component);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck4case() {
+  type Props = {
+    stringProp: string,
+  };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = (state: {}) => ({
+    // $ExpectError wrong type for stringProp
+    stringProp: false,
+  });
+
+  connect(mapStateToProps, {})(Component);
+}
+
+function doesNotRequireDefinedComponentToTypeCheck5case() {
+  type Props = {
+    stringProp: string
+  };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = () => ({});
+  const mapDispatchToProps = () => ({});
+
+  const mergeProps = () => ({
+    // $ExpectError wrong type for stringProp
+    stringProp: true
+  });
+
+  connect(mapStateToProps, mapDispatchToProps, mergeProps)(Component);
 }
 
 function testExactProps() {

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/test_connect.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/test_connect.js
@@ -39,6 +39,23 @@ function testPassingPropsToConnectedComponent() {
   connect(mapStateToProps)('');
 }
 
+function doesNotRequireDefinedComponentToTypeCheck() {
+  type Props = {
+    stringProp: string,
+  };
+
+  const Component = ({ stringProp }: Props) => {
+    return <span>{stringProp}</span>;
+  };
+
+  const mapStateToProps = (state: {}) => ({
+    // $ExpectError wrong type for stringProp
+    stringProp: false,
+  });
+
+  connect(mapStateToProps)(Component);
+}
+
 function testExactProps() {
   type Props = {|
     forMapStateToProps: string,


### PR DESCRIPTION
Fixes issue where non-used components does not type check, see https://github.com/flowtype/flow-typed/issues/1946