### PR TITLE
Fix - HTTP result type fixed in @sendgrid/mail_v6.x.x definition.

### DIFF
--- a/definitions/npm/@sendgrid/mail_v6.x.x/flow_v0.30.x-/mail_v6.x.x.js
+++ b/definitions/npm/@sendgrid/mail_v6.x.x/flow_v0.30.x-/mail_v6.x.x.js
@@ -131,7 +131,7 @@ declare module '@sendgrid/mail' {
   declare class MailService {
     setApiKey(apiKey: string): void;
     setSubstitutionWrappers(left: string, right: string): void;
-    send(data: MailData | MailData[], isMultiple?: boolean, cb?: (err: Error | ResponseError, result: [http$ClientRequest, {}]) => void): Promise<[http$ClientRequest, {}]>;
+    send(data: MailData | MailData[], isMultiple?: boolean, cb?: (err: Error | ResponseError, result: [http$ServerResponse, {}]) => void): Promise<[http$ServerResponse, {}]>;
   }
 
   declare export default MailService & { MailService: MailService };


### PR DESCRIPTION
Hello,

Small fix in `@sendgrid/mail_v6.x.x`.
Right result type is **http$ServerResponse**, not **http$ClientRequest**.

Have a nice day.

Regards, 
Dimitri