### PR TITLE
Allow any file type in first level definition folder

### DIFF
--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -27,7 +27,7 @@ export type LibDef = {|
   testFilePaths: Array<string>,
 |};
 
-export const TEST_FILE_NAME_RE = /(^test_.*\.js$)/;
+export const TEST_FILE_NAME_RE = /^test_.*\.js$/;
 
 const CACHE_DIR = path.join(os.homedir(), '.flow-typed');
 const CACHE_REPO_DIR = path.join(CACHE_DIR, 'repo');
@@ -368,7 +368,7 @@ export function parseRepoDirItem(
  */
 function validateTestFile(testFilePath) {
   const testFileName = path.basename(testFilePath);
-  return !TEST_FILE_NAME_RE.test(testFileName);
+  return TEST_FILE_NAME_RE.test(testFileName);
 }
 
 /**

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -27,7 +27,7 @@ export type LibDef = {|
   testFilePaths: Array<string>,
 |};
 
-export const TEST_FILE_NAME_RE = /(^test_.*\.js$|^.*\.md$)/;
+export const TEST_FILE_NAME_RE = /(^test_.*\.js$)/;
 
 const CACHE_DIR = path.join(os.homedir(), '.flow-typed');
 const CACHE_REPO_DIR = path.join(CACHE_DIR, 'repo');
@@ -238,11 +238,7 @@ async function parseLibDefsFromPkgDir(
         return;
       }
 
-      const isValidTestFile = validateTestFile(
-        pkgDirItemPath,
-        pkgDirItemContext,
-        validationErrs,
-      );
+      const isValidTestFile = validateTestFile(pkgDirItemPath);
 
       if (isValidTestFile) {
         commonTestFiles.push(pkgDirItemPath);
@@ -294,11 +290,7 @@ async function parseLibDefsFromPkgDir(
             return;
           }
 
-          const isValidTestFile = validateTestFile(
-            flowDirItemPath,
-            flowDirItemContext,
-            validationErrs,
-          );
+          const isValidTestFile = validateTestFile(flowDirItemPath);
 
           if (isValidTestFile) {
             testFilePaths.push(flowDirItemPath);
@@ -374,16 +366,9 @@ export function parseRepoDirItem(
 /**
  * Given a path to an assumed test file, ensure that it is named as expected.
  */
-function validateTestFile(testFilePath, context, validationErrs) {
+function validateTestFile(testFilePath) {
   const testFileName = path.basename(testFilePath);
-  if (!TEST_FILE_NAME_RE.test(testFileName)) {
-    const error =
-      'Malformed test file name! Test files must be formatted as test_(.*).js: ' +
-      testFileName;
-    validationError(context, error, validationErrs);
-    return false;
-  }
-  return true;
+  return !TEST_FILE_NAME_RE.test(testFileName);
 }
 
 /**

--- a/cli/src/lib/npm/__tests__/npmLibDefs-test.js
+++ b/cli/src/lib/npm/__tests__/npmLibDefs-test.js
@@ -146,23 +146,6 @@ describe('npmLibDefs', () => {
         'npm',
         'underscore_v1.x.x',
       );
-      const defsPromise1 = extractLibDefsFromNpmPkgDir(
-        UNDERSCORE_PATH,
-        null,
-        'underscore_v1.x.x',
-      );
-      let err = null;
-      try {
-        await defsPromise1;
-      } catch (e) {
-        err = e;
-      }
-      expect(err && err.message).toBe(
-        path.join('underscore_v1.x.x', 'asdf') +
-          ': Unexpected file name. This directory can ' +
-          'only contain test files or a libdef file named `underscore_v1.x.x.js`.',
-      );
-
       const errs = new Map();
       const defsPromise2 = extractLibDefsFromNpmPkgDir(
         UNDERSCORE_PATH,
@@ -172,13 +155,6 @@ describe('npmLibDefs', () => {
       );
       expect((await defsPromise2).length).toBe(2);
       expect([...errs.entries()]).toEqual([
-        [
-          path.join('underscore_v1.x.x', 'asdf'),
-          [
-            'Unexpected file name. This directory can only contain test files ' +
-              'or a libdef file named `underscore_v1.x.x.js`.',
-          ],
-        ],
         [
           'underscore_v1.x.x/asdfdir',
           ['Flow versions must start with `flow_`'],

--- a/cli/src/lib/npm/npmLibDefs.js
+++ b/cli/src/lib/npm/npmLibDefs.js
@@ -101,21 +101,8 @@ async function extractLibDefsFromNpmPkgDir(
 
     const pkgDirItemStat = fs.statSync(pkgDirItemPath);
     if (pkgDirItemStat.isFile()) {
-      if (path.extname(pkgDirItem) === '.swp') {
-        return;
-      }
-
       const isValidTestFile = TEST_FILE_NAME_RE.test(pkgDirItem);
-
-      if (isValidTestFile) {
-        commonTestFiles.push(pkgDirItemPath);
-        return;
-      }
-
-      const error =
-        `Unexpected file name. This directory can only contain test files ` +
-        `or a libdef file named ${'`' + libDefFileName + '`'}.`;
-      validationError(pkgDirItemContext, error, validationErrors);
+      if (isValidTestFile) commonTestFiles.push(pkgDirItemPath);
     } else if (pkgDirItemStat.isDirectory()) {
       const errCount = validationErrors == null ? 0 : validationErrors.size;
       const parsedFlowDir = parseFlowDirString(


### PR DESCRIPTION
No longer throws an error when there are non-test files and non-flow-version-range folders for first-level folders, ie: `definitions/npm/alasql_v1.x.x/`.

Also reverts the test file regex to only match and add test files.