### PR TITLE
Add 'ready' function to bee-queue_v1.x.x

### DIFF
--- a/definitions/npm/bee-queue_v1.x.x/flow_v0.25.0-/bee-queue_v1.x.x.js
+++ b/definitions/npm/bee-queue_v1.x.x/flow_v0.25.0-/bee-queue_v1.x.x.js
@@ -62,6 +62,8 @@ declare class BeeQueue$Queue extends events$EventEmitter {
   paused: boolean,
   process(handler: BeeQueue$Handler): void,
   process(concurrency: number, handler: BeeQueue$Handler): void,
+	ready(): Promise<*>,
+	ready(cb: function): void,
   removeJob(jobId: number): Promise<*>,
   removeJob(jobId: number, callback: (err: ?Error) => void): void,
   settings: {}


### PR DESCRIPTION
Hello! I was using flow-typed with bee-queue and I noticed that it didn't have the `ready` function defined, so I added it locally and the problem was fixed.

Thought it might be useful for others to add it on the remote as well!