### PR TITLE
Add typing for return type of underscore's _.times

### DIFF
--- a/definitions/npm/underscore_v1.x.x/flow_v0.38.x-v0.49.x/test_underscore.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.38.x-v0.49.x/test_underscore.js
@@ -83,6 +83,11 @@ var identityIsString: string = _.identity('foo');
 // $ExpectError
 var identityIsNotString: string = _.identity(42);
 
+var timesString: Array<string> = _.times(3, (i) => `str${i}`);
+var timesNumber: Array<number> = _.times(3, (i) => i + 1);
+// $ExpectError
+var timesNumberError: Array<string> = _.times(3, (i) => i + 1);
+
 var toArrayString: Array<string> = _.toArray({foo: 'bar', baz: 'qux'});
 var toArrayNumber: Array<number> = _.toArray({foo: 4, bar: 2});
 // $ExpectError

--- a/definitions/npm/underscore_v1.x.x/flow_v0.38.x-v0.49.x/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.38.x-v0.49.x/underscore_v1.x.x.js
@@ -582,7 +582,7 @@ declare module "underscore" {
     identity<U>(value: U): U;
     constant<U>(value: U): () => U;
     noop(): void;
-    times(n: number, iteratee: Function, context?: mixed): void;
+    times<T>(n: number, iteratee: (index: number) => T, context?: mixed): Array<T>;
     random(min: number, max: number): number;
     // TODO: Is this right?
     mixin(object: Object): Underscore & Object;

--- a/definitions/npm/underscore_v1.x.x/flow_v0.50.x-/test_underscore.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.50.x-/test_underscore.js
@@ -85,8 +85,8 @@ _.union([1, 2, 3], [2, 30, 1], [1, 40, [1]]);
 _.union([1, 2, 3], 4)
 
 _.filter([1, 2, 3, 4, 5, 6], function(num: number): boolean { return num % 2 === 0; });
-_.filter([1, 2, 3, 4, 5, 6], function(num, index: number, as: number[]): boolean { 
-  return num % 2 == 0 || index === 7 || as.length > 3; 
+_.filter([1, 2, 3, 4, 5, 6], function(num, index: number, as: number[]): boolean {
+  return num % 2 == 0 || index === 7 || as.length > 3;
 });
 _.filter({name: 'foo', a: 'bar'}, function (val, key, obj): boolean {
   var testKey = key + 'foo';
@@ -118,6 +118,11 @@ _.bindAll({msg: 'hi', greet: function(){ return this.msg;}}, ['greet', 'toString
 var identityIsString: string = _.identity('foo');
 // $ExpectError
 var identityIsNotString: string = _.identity(42);
+
+var timesString: Array<string> = _.times(3, (i) => `str${i}`);
+var timesNumber: Array<number> = _.times(3, (i) => i + 1);
+// $ExpectError
+var timesNumberError: Array<string> = _.times(3, (i) => i + 1);
 
 var toArrayString: Array<string> = _.toArray({foo: 'bar', baz: 'qux'});
 var toArrayNumber: Array<number> = _.toArray({foo: 4, bar: 2});

--- a/definitions/npm/underscore_v1.x.x/flow_v0.50.x-/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.50.x-/underscore_v1.x.x.js
@@ -584,7 +584,7 @@ declare module "underscore" {
     identity<U>(value: U): U;
     constant<U>(value: U): () => U;
     noop(): void;
-    times(n: number, iteratee: Function, context?: mixed): void;
+    times<T>(n: number, iteratee: (index: number) => T, context?: mixed): Array<T>;
     random(min: number, max: number): number;
     // TODO: Is this right?
     mixin(object: Object): Underscore & Object;
@@ -612,7 +612,7 @@ declare module "underscore" {
     reduceRight<U>(iteratee: (memo: U, value: T, index?: number) => U, init: U): U;
     find(predicate: (value: T) => boolean): ?T;
     filter(predicate: (value: T) => boolean): Array<T>;
-    filter(predicate: {[string]: T}): Array<T>;    
+    filter(predicate: {[string]: T}): Array<T>;
     where(properties: Object): Array<T>;
     findWhere(properties: $Shape<T>): ?T;
     reject(predicate: (value: T) => boolean, context?: mixed): Array<T>;


### PR DESCRIPTION
There was a definition for `_.times`, but it didn't account for the fact that it can be used to build up an array with the return values of the iteratee. I tried to imitate the surrounding code style as much as possible, happy to make any additional changes as needed!