### PR TITLE
ramda: use `$Values` to represent the values function

### DIFF
--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/ramda_v0.x.x.js
@@ -1705,7 +1705,7 @@ declare module ramda {
     o: O
   ): Array<[string, T]>;
 
-  declare function values<T, O: { [k: string]: T }>(o: O): Array<T>;
+  declare function values<T>(o: T): Array<$Values<T>>;
 
   declare function valuesIn<T, O: { [k: string]: T }>(o: O): Array<T | any>;
 

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
@@ -1,5 +1,6 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
+import { describe, it } from 'flow-typed-test';
 import _, {
   compose,
   curry,
@@ -315,16 +316,16 @@ F.prototype.y = "Y";
 const f = new F();
 const topin = _.toPairsIn(f);
 
-// Test union behavior of an individual element
-{
-  const val = values({ a: 1, b: 2, c: true });
-  const val1: number | boolean = val[0];
-}
+describe('values', () => {
+  it('provides a union per element when the types of all values vary', () => {
+    const val = values({ a: 1, b: 2, c: true });
+    const val1: number | boolean = val[0];
+  })
 
-// Test from examples in docs: http://ramdajs.com/docs/#values
-{
-  const vs: Array<number> = values({a: 1, b: 2, c: 3})
-}
+  it('works with the example in the docs http://ramdajs.com/docs/#values', () => {
+    const vs: Array<number> = values({a: 1, b: 2, c: 3})
+  })
+})
 
 const pred = _.where({
   a: (a: string) => a === "foo",

--- a/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
+++ b/definitions/npm/ramda_v0.x.x/flow_v0.62.x-/test_ramda_v0.x.x_object.js
@@ -1,6 +1,15 @@
 /* @flow */
 /*eslint-disable no-undef, no-unused-vars, no-console*/
-import _, { compose, pipe, curry, filter, find, repeat, zipWith } from "ramda";
+import _, {
+  compose,
+  curry,
+  filter,
+  find,
+  pipe,
+  repeat,
+  values,
+  zipWith,
+} from "ramda";
 
 const ns: Array<number> = [1, 2, 3, 4, 5];
 const ss: Array<string> = ["one", "two", "three", "four"];
@@ -151,17 +160,17 @@ const inverted1: { [k: string]: string } = _.invertObj(raceResultsByFirstName);
 const ks: Array<string> = _.keys(raceResultsByFirstName);
 const ksi: Array<string> = _.keysIn(square);
 
-const values = { x: 1, y: 2, z: 3 };
+const xs = { x: 1, y: 2, z: 3 };
 const prependKeyAndDouble = (num, key, obj) => key + num * 2;
 
 const obI: { [k: string]: string } = _.mapObjIndexed(
   prependKeyAndDouble,
-  values
+  xs
 );
 //$ExpectError
 const obI2: { [k: string]: number } = _.mapObjIndexed(
   prependKeyAndDouble,
-  values
+  xs
 );
 
 const ob1 = { a: 1 };
@@ -306,8 +315,16 @@ F.prototype.y = "Y";
 const f = new F();
 const topin = _.toPairsIn(f);
 
-const val = _.values({ a: 1, b: 2, c: true });
-const val1: number | boolean = val[0];
+// Test union behavior of an individual element
+{
+  const val = values({ a: 1, b: 2, c: true });
+  const val1: number | boolean = val[0];
+}
+
+// Test from examples in docs: http://ramdajs.com/docs/#values
+{
+  const vs: Array<number> = values({a: 1, b: 2, c: 3})
+}
 
 const pred = _.where({
   a: (a: string) => a === "foo",


### PR DESCRIPTION
`values` in Ramda returns all of the values of an object. This is a natural fit for `$Values<T>`, which this PR changes the `values` definition to use.

There is a close cousin of `values` called `valuesIn`. It looks like the definition for `valuesIn` isn't even in the libdefs yet. I'm not terribly familiar with how differently we should type `valuesIn` so I'm leaving that out of this PR and it can be addressed in a future date.

This also begins using the new testing format per #1928.

@AndrewSouthpaw I'd totally forgotten about our discussion on #1534 but I think this is on the right track and not in conflict with anything we've talked about so far. Please correct me if I'm wrong though!