### PR TITLE
Allow a .exe extension so binaries are not deleted on windows 

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -266,7 +266,7 @@ async function getOrderedFlowBinVersions(
   return _flowBinVersionPromise;
 }
 
-const flowNameRegex = /^flow-v[0-9]+.[0-9]+.[0-9]+$/;
+const flowNameRegex = /^flow-v[0-9]+.[0-9]+.[0-9]+(\.exe)?$/;
 /**
  * flow filename should be `flow-vx.x.x`
  * @param {string} name


### PR DESCRIPTION
(before running tests)
Fixes #1976 