### PR TITLE
Add option to provide cache folder path in Environment property

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ a short grace period during a libdef installation, but sometimes it is useful to
 do this update manually. Use this command if you want to download the most
 recent definitions into the cache for yourself.
 
+It is possible to specify a folder where cache will be stored, it could be useful
+for CI build tools such as Travis to allow it keep cache folder between builds.
+To specify cache folder define Environment property `FLOW_TYPED_CACHE_DIR`.
+By default `$(HOME)/.flow-typed` will be used.
+
 ## Active Maintenance Team
 
 [![Andrew Smith](https://github.com/andrewsouthpaw.png?size=100)](https://github.com/andrewsouthpaw) | [![Georges-Antoine Assi](https://github.com/gantoine.png?size=100)](https://github.com/gantoine) | [![Ville Saukkonen](https://github.com/villesau.png?size=100)](https://github.com/villesau)

--- a/cli/src/lib/libDefs.js
+++ b/cli/src/lib/libDefs.js
@@ -29,7 +29,9 @@ export type LibDef = {|
 
 export const TEST_FILE_NAME_RE = /^test_.*\.js$/;
 
-const CACHE_DIR = path.join(os.homedir(), '.flow-typed');
+const CACHE_DIR = !!process.env.FLOW_TYPED_CACHE_DIR
+  ? process.env.FLOW_TYPED_CACHE_DIR
+  : path.join(os.homedir(), '.flow-typed');
 const CACHE_REPO_DIR = path.join(CACHE_DIR, 'repo');
 const GIT_REPO_DIR = path.join(__dirname, '..', '..', '..');
 


### PR DESCRIPTION
This options is quite useful in CI build tools like Travis to keep cache stashed between builds.