### PR TITLE
react-bootstrap: OverlayTrigger trigger prop takes array of triggers, not any strings

### DIFF
--- a/definitions/npm/react-bootstrap_v0.32.x/flow_v0.53.x-/react-bootstrap_v0.32.x.js
+++ b/definitions/npm/react-bootstrap_v0.32.x/flow_v0.53.x-/react-bootstrap_v0.32.x.js
@@ -580,7 +580,7 @@ declare module "react-bootstrap" {
   }> {}
 
   declare export class OverlayTrigger extends React$Component<{
-    trigger?: TriggerType | Array<string>,
+    trigger?: TriggerType | Array<TriggerType>,
     delay?: number,
     delayShow?: number,
     delayHide?: number,


### PR DESCRIPTION
It's not an arbitrary string what it takes in array: https://react-bootstrap.github.io/components/tooltips/#overlays-trigger-props