### PR TITLE
proper support for toString in redux-actions

### DIFF
--- a/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
+++ b/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
@@ -26,28 +26,28 @@ declare module "redux-actions" {
   declare function createAction<T, P>(
     type: T,
     $?: empty // hack to force Flow to not use this signature when more than one argument is given
-  ): (payload: P, ...rest: any[]) => { type: T, payload: P, error?: boolean };
+  ): {(payload: P, ...rest: any[]): { type: T, payload: P, error?: boolean }, toString: () => T};
 
   declare function createAction<T, A, P>(
     type: T,
     payloadCreator: (...rest: A) => P,
     $?: empty
-  ): (...rest: A) => { type: T, payload: P, error?: boolean };
+  ): {(...rest: A): { type: T, payload: P, error?: boolean }, toString: () => T};
 
   declare function createAction<T, A, P, M>(
     type: T,
     payloadCreator: (...rest: A) => P,
     metaCreator: (...rest: A) => M
-  ): (...rest: A) => { type: T, payload: P, error?: boolean, meta: M };
+  ): {(...rest: A): { type: T, payload: P, error?: boolean, meta: M }, toString: () => T};
 
   declare function createAction<T, P, M>(
     type: T,
     payloadCreator: null | void,
     metaCreator: (payload: P, ...rest: any[]) => M
-  ): (
-    payload: P,
-    ...rest: any[]
-  ) => { type: T, payload: P, error?: boolean, meta: M };
+  ): {(
+      payload: P,
+      ...rest: any[]
+    ): { type: T, payload: P, error?: boolean, meta: M }, toString: () => T};
 
   // `createActions` is quite difficult to write a type for. Maybe try not to
   // use this one?

--- a/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/test_createAction.js
+++ b/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/test_createAction.js
@@ -25,6 +25,10 @@ function test_createAction() {
     // $ExpectError
     assert(a.payload, (x: number) => {});
   }
+
+  (action.toString(): 'INCREMENT');
+  // $ExpectError wrong type
+  (action.toString(): 'DECREMENT');
 }
 
 function test_createAction_givenPayloadType() {
@@ -46,6 +50,10 @@ function test_createAction_givenPayloadType() {
 
   // $ExpectError
   assert(a2.meta, (x: string) => {});
+
+  (action.toString(): 'INCREMENT');
+  // $ExpectError wrong type
+  (action.toString(): 'DECREMENT');
 }
 
 function test_createAction_withPayloadCreator() {
@@ -68,6 +76,10 @@ function test_createAction_withPayloadCreator() {
 
   // $ExpectError
   assert(a.payload, (x: string) => {});
+
+  (action.toString(): 'INCREMENT');
+  // $ExpectError wrong type
+  (action.toString(): 'DECREMENT');
 }
 
 function test_createAction_withPayloadCreatorAndMeta() {
@@ -78,6 +90,10 @@ function test_createAction_withPayloadCreatorAndMeta() {
 
   // $ExpectError
   assert(a.meta, (x: string) => {});
+
+  (action.toString(): 'INCREMENT');
+  // $ExpectError wrong type
+  (action.toString(): 'DECREMENT');
 }
 
 function test_createAction_withMeta() {
@@ -88,6 +104,10 @@ function test_createAction_withMeta() {
 
   // $ExpectError
   assert(a.meta, (x: string) => {});
+
+  (action.toString(): 'INCREMENT');
+  // $ExpectError wrong type
+  (action.toString(): 'DECREMENT');
 }
 
 // Helper to assert that the type of the first argument is compatible with the


### PR DESCRIPTION
see: https://github.com/redux-utilities/redux-actions/blob/master/src/createAction.js#L39
and: https://github.com/redux-utilities/redux-actions/issues/93

it's needed when creating reducers like:

```
import { createAction, handleActions } from 'redux-actions';
const addUpload = createAction('UPLOAD_TYPE');
export default handleActions(
  {
    [addUpload.toString()]: (state, action) => {
      const upload = action.payload;
    }
  })
```