### PR TITLE
Cleanup runTests a bit

### DIFF
--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -471,9 +471,9 @@ async function removeTrashFromBinDir() {
 async function runTestGroup(
   repoDirPath: string,
   testGroup: TestGroup,
-  numberOfFlowVersions: number = 15,
-  errors = [],
+  orderedFlowVersions: Array<string>,
 ): Promise<Array<string>> {
+  const errors = [];
   // Some older versions of Flow choke on ">"/"<"/"="
   const testDirName = testGroup.id
     .replace(/\//g, '--')
@@ -491,15 +491,6 @@ async function runTestGroup(
 
   if (!await fs.exists(BIN_DIR)) {
     await fs.mkdir(BIN_DIR);
-  }
-
-  //Prepare bin folder to collect flow instances
-  await removeTrashFromBinDir();
-  let orderedFlowVersions;
-  try {
-    orderedFlowVersions = await getOrderedFlowBinVersions(numberOfFlowVersions);
-  } catch (e) {
-    orderedFlowVersions = await getCachedFlowBinVersions(numberOfFlowVersions);
   }
 
   try {
@@ -629,10 +620,23 @@ async function runTests(
     const results = new Map();
     while (testGroups.length > 0) {
       const testGroup = testGroups.shift();
+      //Prepare bin folder to collect flow instances
+      await removeTrashFromBinDir();
+      let orderedFlowVersions;
+      try {
+        orderedFlowVersions = await getOrderedFlowBinVersions(
+          numberOfFlowVersions,
+        );
+      } catch (e) {
+        orderedFlowVersions = await getCachedFlowBinVersions(
+          numberOfFlowVersions,
+        );
+      }
+
       const testGroupErrors = await runTestGroup(
         repoDirPath,
         testGroup,
-        numberOfFlowVersions,
+        orderedFlowVersions,
       );
       if (testGroupErrors.length > 0) {
         const errors = results.get(testGroup.id) || [];

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -99,7 +99,6 @@ async function getOrderedFlowBinVersions(
     _flowBinVersionPromise = (async function() {
       console.log('Fetching all Flow binaries...');
       const IS_WINDOWS = os.type() === 'Windows_NT';
-      const FLOW_BIN_VERSION_ORDER = [];
       const GH_CLIENT = gitHubClient();
       // We only test against the latest numberOfReleases Versions
       const QUERY_PAGE_SIZE = numberOfReleases;
@@ -125,7 +124,7 @@ async function getOrderedFlowBinVersions(
         );
       });
 
-      apiPayload
+      const FLOW_BIN_VERSION_ORDER = apiPayload
         .filter(rel => {
           // Temporary fix for https://github.com/facebook/flow/issues/5922
           if (rel.tag_name === 'v0.67.0') {
@@ -159,7 +158,7 @@ async function getOrderedFlowBinVersions(
           }
           return true;
         })
-        .forEach(rel => {
+        .map(rel => {
           // Find the binary zip in the list of assets
           const binZip = rel.assets
             .filter(({name}) => {
@@ -180,8 +179,8 @@ async function getOrderedFlowBinVersions(
             const version =
               rel.tag_name[0] === 'v' ? rel.tag_name : 'v' + rel.tag_name;
 
-            FLOW_BIN_VERSION_ORDER.push(version);
             binURLs.set(version, binZip[0]);
+            return version;
           }
         });
 

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -106,91 +106,84 @@ async function getOrderedFlowBinVersions(
       const OS_ARCH_FILTER_RE = new RegExp(`flow-${BIN_PLATFORM}`);
 
       let binURLs = new Map();
-      let apiPayload = null;
       let page = 0;
-      while (
-        apiPayload === null /* || apiPayload.length === QUERY_PAGE_SIZE*/
-      ) {
-        apiPayload = await new Promise((res, rej) => {
-          GH_CLIENT.releases.listReleases(
-            {
-              owner: 'facebook',
-              repo: 'flow',
-              page: page++,
-              per_page: QUERY_PAGE_SIZE,
-            },
-            (err, result) => {
-              if (err) {
-                rej(err);
-              } else {
-                res(result);
-              }
-            },
-          );
-        });
-
-        apiPayload
-          .filter(rel => {
-            // Temporary fix for https://github.com/facebook/flow/issues/5922
-            if (rel.tag_name === 'v0.67.0') {
-              console.log(
-                '==========================================================================================',
-              );
-              console.log(
-                'We are tempoarily skipping v0.67.0 due to https://github.com/facebook/flow/issues/5922',
-              );
-              console.log(
-                '==========================================================================================',
-              );
-              return false;
-            }
-
-            // We only test against versions since 0.15.0 because it has proper
-            // [ignore] fixes (which are necessary to run tests)
-            // Because Windows was only supported starting with version 0.30.0, we also skip version prior to that when running on windows.
-            if (semver.lt(rel.tag_name, IS_WINDOWS ? '0.30.0' : '0.15.0')) {
-              return false;
-            }
-
-            // Because flow 0.57 was broken before 0.57.3 on the Windows platform, we also skip those versions when running on windows.
-            if (
-              IS_WINDOWS &&
-              (semver.eq(rel.tag_name, '0.57.0') ||
-                semver.eq(rel.tag_name, '0.57.1') ||
-                semver.eq(rel.tag_name, '0.57.2'))
-            ) {
-              return false;
-            }
-            return true;
-          })
-          .forEach(rel => {
-            // Find the binary zip in the list of assets
-            const binZip = rel.assets
-              .filter(({name}) => {
-                return (
-                  OS_ARCH_FILTER_RE.test(name) && !/-latest.zip$/.test(name)
-                );
-              })
-              .map(asset => asset.browser_download_url);
-
-            if (binZip.length !== 1) {
-              throw new Error(
-                'Unexpected number of ' +
-                  BIN_PLATFORM +
-                  ' assets for flow-' +
-                  rel.tag_name +
-                  '! ' +
-                  JSON.stringify(binZip),
-              );
+      const apiPayload = await new Promise((res, rej) => {
+        GH_CLIENT.releases.listReleases(
+          {
+            owner: 'facebook',
+            repo: 'flow',
+            page: page++,
+            per_page: QUERY_PAGE_SIZE,
+          },
+          (err, result) => {
+            if (err) {
+              rej(err);
             } else {
-              const version =
-                rel.tag_name[0] === 'v' ? rel.tag_name : 'v' + rel.tag_name;
-
-              FLOW_BIN_VERSION_ORDER.push(version);
-              binURLs.set(version, binZip[0]);
+              res(result);
             }
-          });
-      }
+          },
+        );
+      });
+
+      apiPayload
+        .filter(rel => {
+          // Temporary fix for https://github.com/facebook/flow/issues/5922
+          if (rel.tag_name === 'v0.67.0') {
+            console.log(
+              '==========================================================================================',
+            );
+            console.log(
+              'We are tempoarily skipping v0.67.0 due to https://github.com/facebook/flow/issues/5922',
+            );
+            console.log(
+              '==========================================================================================',
+            );
+            return false;
+          }
+
+          // We only test against versions since 0.15.0 because it has proper
+          // [ignore] fixes (which are necessary to run tests)
+          // Because Windows was only supported starting with version 0.30.0, we also skip version prior to that when running on windows.
+          if (semver.lt(rel.tag_name, IS_WINDOWS ? '0.30.0' : '0.15.0')) {
+            return false;
+          }
+
+          // Because flow 0.57 was broken before 0.57.3 on the Windows platform, we also skip those versions when running on windows.
+          if (
+            IS_WINDOWS &&
+            (semver.eq(rel.tag_name, '0.57.0') ||
+              semver.eq(rel.tag_name, '0.57.1') ||
+              semver.eq(rel.tag_name, '0.57.2'))
+          ) {
+            return false;
+          }
+          return true;
+        })
+        .forEach(rel => {
+          // Find the binary zip in the list of assets
+          const binZip = rel.assets
+            .filter(({name}) => {
+              return OS_ARCH_FILTER_RE.test(name) && !/-latest.zip$/.test(name);
+            })
+            .map(asset => asset.browser_download_url);
+
+          if (binZip.length !== 1) {
+            throw new Error(
+              'Unexpected number of ' +
+                BIN_PLATFORM +
+                ' assets for flow-' +
+                rel.tag_name +
+                '! ' +
+                JSON.stringify(binZip),
+            );
+          } else {
+            const version =
+              rel.tag_name[0] === 'v' ? rel.tag_name : 'v' + rel.tag_name;
+
+            FLOW_BIN_VERSION_ORDER.push(version);
+            binURLs.set(version, binZip[0]);
+          }
+        });
 
       FLOW_BIN_VERSION_ORDER.sort((a, b) => {
         return semver.lt(a, b) ? -1 : 1;


### PR DESCRIPTION
This is handy if you are working on fixing libdefs for some specific flow version and don't want to be bothered about other versions while developing. `numberOfFlowVersions` already covers the main use case which is to run test suite against latest version of Flow though.

note that `?w=1` makes reviewing easier: https://github.com/flowtype/flow-typed/pull/1992/files?w=1

E: reverted last commit and now this contains only refactorings