### PR TITLE
Improve return values for pretty-error

### DIFF
--- a/definitions/npm/pretty-error_v2.x.x/flow_v0.25.x-/pretty-error_v2.x.x.js
+++ b/definitions/npm/pretty-error_v2.x.x/flow_v0.25.x-/pretty-error_v2.x.x.js
@@ -1,16 +1,16 @@
 declare module "pretty-error" {
   declare class PrettyError {
     static constructor(): PrettyError;
-    static start(): void;
-    alias(toBeAliased: string, alias: string): void;
-    appendStyle(style: Object): void;
-    render(error: Error): void;
-    skip(skipFn: (traceline: Object, lineNumber: number) => boolean): void;
-    skipNodeFiles(): void;
-    skipPackage(...packages: string[]): void;
-    skipPath(path: string): void;
-    start(): void;
-    withoutColors(): void;
+    static start(): PrettyError;
+    alias(toBeAliased: string, alias: string): this;
+    appendStyle(style: Object): this;
+    render(error: Error): string;
+    skip(skipFn: (traceline: Object, lineNumber: number) => boolean): this;
+    skipNodeFiles(): this;
+    skipPackage(...packages: string[]): this;
+    skipPath(path: string): this;
+    start(): this;
+    withoutColors(): this;
   }
   declare module.exports: Class<PrettyError>;
 }


### PR DESCRIPTION
render() returns a string, and most other functions return their own object to allow chaining.