### PR TITLE
redux-connect toString is read-only

### DIFF
--- a/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
+++ b/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
@@ -26,19 +26,19 @@ declare module "redux-actions" {
   declare function createAction<T, P>(
     type: T,
     $?: empty // hack to force Flow to not use this signature when more than one argument is given
-  ): {(payload: P, ...rest: any[]): { type: T, payload: P, error?: boolean }, toString: () => T};
+  ): {(payload: P, ...rest: any[]): { type: T, payload: P, error?: boolean }, +toString: () => T};
 
   declare function createAction<T, A, P>(
     type: T,
     payloadCreator: (...rest: A) => P,
     $?: empty
-  ): {(...rest: A): { type: T, payload: P, error?: boolean }, toString: () => T};
+  ): {(...rest: A): { type: T, payload: P, error?: boolean }, +toString: () => T};
 
   declare function createAction<T, A, P, M>(
     type: T,
     payloadCreator: (...rest: A) => P,
     metaCreator: (...rest: A) => M
-  ): {(...rest: A): { type: T, payload: P, error?: boolean, meta: M }, toString: () => T};
+  ): {(...rest: A): { type: T, payload: P, error?: boolean, meta: M }, +toString: () => T};
 
   declare function createAction<T, P, M>(
     type: T,
@@ -47,7 +47,7 @@ declare module "redux-actions" {
   ): {(
       payload: P,
       ...rest: any[]
-    ): { type: T, payload: P, error?: boolean, meta: M }, toString: () => T};
+    ): { type: T, payload: P, error?: boolean, meta: M }, +toString: () => T};
 
   // `createActions` is quite difficult to write a type for. Maybe try not to
   // use this one?


### PR DESCRIPTION
When toString is read-only, this plays better together with "traditional" function types (there toString is read-only too)