### PR TITLE
Add mockName type to jest mocked functions

### DIFF
--- a/cli/flow-typed/npm/jest_v22.x.x.js
+++ b/cli/flow-typed/npm/jest_v22.x.x.js
@@ -56,6 +56,11 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
     fn: (...args: TArguments) => TReturn,
   ): JestMockFn<TArguments, TReturn>,
   /**
+   * Accepts a string to use in test result output in place of "jest.fn()" to
+   * indicate which mock function is being referenced.
+   */
+  mockName(name: string): JestMockFn < TArguments, TReturn >,
+  /**
    * Just a simple sugar function for returning `this`
    */
   mockReturnThis(): void,

--- a/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/jest_v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/jest_v22.x.x.js
@@ -49,6 +49,11 @@ type JestMockFn = {
    */
   mockImplementationOnce(fn: Function): JestMockFn,
   /**
+   * Accepts a string to use in test result output in place of "jest.fn()" to
+   * indicate which mock function is being referenced.
+   */
+  mockName(name: string): JestMockFn,
+  /**
    * Just a simple sugar function for returning `this`
    */
   mockReturnThis(): void,

--- a/definitions/npm/jest_v22.x.x/flow_v0.39.x-/jest_v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.39.x-/jest_v22.x.x.js
@@ -53,6 +53,11 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
     fn: (...args: TArguments) => TReturn
   ): JestMockFn<TArguments, TReturn>,
   /**
+   * Accepts a string to use in test result output in place of "jest.fn()" to
+   * indicate which mock function is being referenced.
+   */
+  mockName(name: string): JestMockFn<TArguments, TReturn>,
+  /**
    * Just a simple sugar function for returning `this`
    */
   mockReturnThis(): void,

--- a/definitions/npm/jest_v22.x.x/flow_v0.39.x-/test_jest-v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.39.x-/test_jest-v22.x.x.js
@@ -44,6 +44,10 @@ foo.doStuff = jest.fn().mockReturnValueOnce(10);
 // $ExpectError Mock function expected to return number, not string.
 foo.doStuff = jest.fn().mockReturnValueOnce("10");
 
+foo.doStuff = jest.fn().mockName("10");
+// $ExpectError mockName expects a string, not a number
+foo.doStuff = jest.fn().mockName(10);
+
 const mockedDoStuff = (foo.doStuff = jest.fn().mockImplementation(str => 10));
 mockedDoStuff.mock.calls[0][0].indexOf("a");
 // $ExpectError function `doesntExist` not found in string.


### PR DESCRIPTION
mockName was added to jest mocked functions as of jest v22 but seems to be missing from the flow type definitions.