### PR TITLE
Fix Jest libdef to include new method #advanceTimersByTime.

### DIFF
--- a/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/jest_v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.25.x-v0.38.x/jest_v22.x.x.js
@@ -388,6 +388,13 @@ type JestObjectType = {
    * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
    * or setInterval() and setImmediate()).
    */
+  advanceTimersByTime(msToRun: number): void,
+  /**
+   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+   * or setInterval() and setImmediate()).
+   *
+   * Renamed to `advanceTimersByTime`.
+   */
   runTimersToTime(msToRun: number): void,
   /**
    * Executes only the macro-tasks that are currently pending (i.e., only the

--- a/definitions/npm/jest_v22.x.x/flow_v0.39.x-/jest_v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.39.x-/jest_v22.x.x.js
@@ -396,6 +396,13 @@ type JestObjectType = {
    * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
    * or setInterval() and setImmediate()).
    */
+  advanceTimersByTime(msToRun: number): void,
+  /**
+   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+   * or setInterval() and setImmediate()).
+   *
+   * Renamed to `advanceTimersByTime`.
+   */
   runTimersToTime(msToRun: number): void,
   /**
    * Executes only the macro-tasks that are currently pending (i.e., only the


### PR DESCRIPTION
Fixes regression in Jest libdef tests introduced by #1981, which didn't include that new method in the actual npm libdef. And because those files weren't changed, the jest tests weren't run.