### PR TITLE
Add response type to axios libdef

### DIFF
--- a/definitions/npm/axios_v0.18.x/flow_v0.25.x-/axios_v0.18.x.js
+++ b/definitions/npm/axios_v0.18.x/flow_v0.25.x-/axios_v0.18.x.js
@@ -28,8 +28,8 @@ declare module "axios" {
     reason?: Cancel;
     throwIfRequested(): void;
   }
-  declare interface AxiosXHRConfigBase<T> {
-    adapter?: <T>(config: AxiosXHRConfig<T>) => Promise<AxiosXHR<T>>;
+  declare interface AxiosXHRConfigBase<T,R = T> {
+    adapter?: <T,R>(config: AxiosXHRConfig<T,R>) => Promise<AxiosXHR<T,R>>;
     auth?: {
       username: string,
       password: string
@@ -54,93 +54,93 @@ declare module "axios" {
       | "stream";
     timeout?: number;
     transformRequest?: AxiosTransformer<T> | Array<AxiosTransformer<T>>;
-    transformResponse?: AxiosTransformer<T> | Array<AxiosTransformer<T>>;
+    transformResponse?: AxiosTransformer<R> | Array<AxiosTransformer<R>>;
     validateStatus?: (status: number) => boolean;
     withCredentials?: boolean;
     xsrfCookieName?: string;
     xsrfHeaderName?: string;
   }
-  declare type $AxiosXHRConfigBase<T> = AxiosXHRConfigBase<T>;
-  declare interface AxiosXHRConfig<T> extends AxiosXHRConfigBase<T> {
+  declare type $AxiosXHRConfigBase<T,R = T> = AxiosXHRConfigBase<T,R>;
+  declare interface AxiosXHRConfig<T,R = T> extends AxiosXHRConfigBase<T,R> {
     data?: T;
     method?: string;
     url: string;
   }
-  declare type $AxiosXHRConfig<T> = AxiosXHRConfig<T>;
-  declare class AxiosXHR<T> {
-    config: AxiosXHRConfig<T>;
-    data: T;
+  declare type $AxiosXHRConfig<T,R = T> = AxiosXHRConfig<T,R>;
+  declare class AxiosXHR<T,R = T> {
+    config: AxiosXHRConfig<T,R>;
+    data: R;
     headers?: Object;
     status: number;
     statusText: string;
     request: http$ClientRequest | XMLHttpRequest;
   }
-  declare type $AxiosXHR<T> = AxiosXHR<T>;
+  declare type $AxiosXHR<T,R = T> = AxiosXHR<T,R>;
   declare type AxiosInterceptorIdent = number;
-  declare class AxiosRequestInterceptor<T> {
+  declare class AxiosRequestInterceptor<T,R = T> {
     use(
       successHandler: ?(
-        response: AxiosXHRConfig<T>
-      ) => Promise<AxiosXHRConfig<*>> | AxiosXHRConfig<*>,
+        response: AxiosXHRConfig<T,R>
+      ) => Promise<AxiosXHRConfig<*,*>> | AxiosXHRConfig<*,*>,
       errorHandler: ?(error: mixed) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
-  declare class AxiosResponseInterceptor<T> {
+  declare class AxiosResponseInterceptor<T,R = T> {
     use(
-      successHandler: ?(response: AxiosXHR<T>) => mixed,
+      successHandler: ?(response: AxiosXHR<T,R>) => mixed,
       errorHandler: ?(error: $AxiosError<any>) => mixed
     ): AxiosInterceptorIdent;
     eject(ident: AxiosInterceptorIdent): void;
   }
-  declare type AxiosPromise<T> = Promise<AxiosXHR<T>>;
+  declare type AxiosPromise<T,R = T> = Promise<AxiosXHR<T,R>>;
   declare class Axios {
-    constructor<T>(config?: AxiosXHRConfigBase<T>): void;
-    $call: <T>(
-      config: AxiosXHRConfig<T> | string,
-      config?: AxiosXHRConfig<T>
-    ) => AxiosPromise<T>;
-    request<T>(config: AxiosXHRConfig<T>): AxiosPromise<T>;
-    delete<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    get<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    head<T>(url: string, config?: AxiosXHRConfigBase<T>): AxiosPromise<T>;
-    post<T>(
+    constructor<T,R>(config?: AxiosXHRConfigBase<T,R>): void;
+    $call: <T,R>(
+      config: AxiosXHRConfig<T,R> | string,
+      config?: AxiosXHRConfig<T,R>
+    ) => AxiosPromise<T,R>;
+    request<T,R>(config: AxiosXHRConfig<T,R>): AxiosPromise<T,R>;
+    delete<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;
+    get<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;
+    head<T,R>(url: string, config?: AxiosXHRConfigBase<T,R>): AxiosPromise<T,R>;
+    post<T,R>(
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T>
-    ): AxiosPromise<T>;
-    put<T>(
+      config?: AxiosXHRConfigBase<T,R>
+    ): AxiosPromise<T,R>;
+    put<T,R>(
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T>
-    ): AxiosPromise<T>;
-    patch<T>(
+      config?: AxiosXHRConfigBase<T,R>
+    ): AxiosPromise<T,R>;
+    patch<T,R>(
       url: string,
       data?: mixed,
-      config?: AxiosXHRConfigBase<T>
-    ): AxiosPromise<T>;
+      config?: AxiosXHRConfigBase<T,R>
+    ): AxiosPromise<T,R>;
     interceptors: {
       request: AxiosRequestInterceptor<mixed>,
       response: AxiosResponseInterceptor<mixed>
     };
-    defaults: { headers: Object } & AxiosXHRConfig<*>;
+    defaults: { headers: Object } & AxiosXHRConfig<*,*>;
   }
 
-  declare class AxiosError<T> extends Error {
-    config: AxiosXHRConfig<T>;
+  declare class AxiosError<T,R = T> extends Error {
+    config: AxiosXHRConfig<T,R>;
     request?: http$ClientRequest | XMLHttpRequest;
-    response?: AxiosXHR<T>;
+    response?: AxiosXHR<T,R>;
     code?: string;
   }
 
-  declare type $AxiosError<T> = AxiosError<T>;
+  declare type $AxiosError<T,R = T> = AxiosError<T,R>;
 
   declare interface AxiosExport extends Axios {
     Axios: typeof Axios;
     Cancel: Class<Cancel>;
     CancelToken: Class<CancelToken>;
     isCancel(value: any): boolean;
-    create(config?: AxiosXHRConfigBase<any>): Axios;
+    create(config?: AxiosXHRConfigBase<any, any>): Axios;
     all: typeof Promise.all;
     spread(callback: Function): (arr: Array<any>) => Function;
   }

--- a/definitions/npm/axios_v0.18.x/test_axios_v0.18.x.js
+++ b/definitions/npm/axios_v0.18.x/test_axios_v0.18.x.js
@@ -4,6 +4,7 @@ import type {
   $AxiosXHR,
   CancelTokenSource,
   Cancel,
+  AxiosPromise,
 } from 'axios';
 (axios.get('foo'): Promise<*>);
 (axios.post('bar', {}, {
@@ -87,13 +88,13 @@ axios.all([
     (a: string);
 })
 
-axios({ url: '/', method: 'post', data: { foo: 'bar' }})
-  .then(({ data }: $AxiosXHR<{ foo: string }, { bar: string }>) => {
-    // $ExpectError
-    data.foo;
-  })
+const promise1: AxiosPromise<{ foo: string }, { bar: string }> = axios({ url: '/', method: 'post', data: { foo: 'bar' }})
+promise1.then(({ data }) => {
+  // $ExpectError
+  data.foo;
+});
 
-  axios({ url: '/', method: 'post', data: { foo: 1 }})
-  .then(({ data }: $AxiosXHR<{ foo: number }>) => {
-    data.foo + 1;
-  })
+const promise2: AxiosPromise<{ foo: number }> = axios({ url: '/', method: 'post', data: { foo: 1 }})
+promise2.then(({ data }) => {
+  data.foo + 1;
+});

--- a/definitions/npm/axios_v0.18.x/test_axios_v0.18.x.js
+++ b/definitions/npm/axios_v0.18.x/test_axios_v0.18.x.js
@@ -86,3 +86,14 @@ axios.all([
     // $ExpectError
     (a: string);
 })
+
+axios({ url: '/', method: 'post', data: { foo: 'bar' }})
+  .then(({ data }: $AxiosXHR<{ foo: string }, { bar: string }>) => {
+    // $ExpectError
+    data.foo;
+  })
+
+  axios({ url: '/', method: 'post', data: { foo: 1 }})
+  .then(({ data }: $AxiosXHR<{ foo: number }>) => {
+    data.foo + 1;
+  })


### PR DESCRIPTION
This PR adds a separate response type to axios calls, earlier the definitions
used the same infered type for config.data and response.data. This has been mentioned in #1975 and #1539.

But hopefully this wont break backwards compatability since I added the
original type (T) as default for the new response type (R). Also verified by tests.

As of now I have only updated the 0.18.x-version. But the same issue is present in earlier versions as well. If you think I should update the old ones as well I'd be happy to do so.