### PR TITLE
Adding libdef for eventemitter3_v3.x.x

### DIFF
--- a/definitions/npm/eventemitter3_v3.x.x/flow_v0.25.x-/eventemitter3_v3.x.x.js
+++ b/definitions/npm/eventemitter3_v3.x.x/flow_v0.25.x-/eventemitter3_v3.x.x.js
@@ -1,0 +1,26 @@
+declare module 'eventemitter3' {
+  declare type ListenerFn = (...args: any[]) => void
+  declare class EventEmitter {
+    static constructor(): EventEmitter,
+    static prefixed: string | boolean,
+    eventNames(): (string | Symbol)[],
+    listeners(event: string | Symbol): ListenerFn[],
+    listenerCount(event: string | Symbol): number,
+    on(event: string | Symbol, listener: ListenerFn, context?: any): this,
+    addListener(event: string | Symbol, listener: ListenerFn, context?: any): this,
+    once(event: string | Symbol, listener: ListenerFn, context?: any): this,
+    removeAllListeners(event?: string | Symbol): this,
+    removeListener(event: string | Symbol, listener?: ListenerFn, context?: any, once?: boolean): this,
+    off(event: string | Symbol, listener?: ListenerFn, context?: any, once?: boolean): this,
+    emit(event: string, ...params?: any[]): this
+  }
+  declare module.exports: Class<EventEmitter>
+}
+
+// Filename aliases
+declare module 'eventemitter3/index' {
+  declare module.exports: $Exports<'eventemitter3'>
+}
+declare module 'eventemitter3/index.js' {
+  declare module.exports: $Exports<'eventemitter3'>
+}

--- a/definitions/npm/eventemitter3_v3.x.x/test_eventemitter3-v3.js
+++ b/definitions/npm/eventemitter3_v3.x.x/test_eventemitter3-v3.js
@@ -37,7 +37,7 @@ a.getMaxListeners();
 
 // appears in v3.x
 
-(a.listenerCount(): number);
+(a.listenerCount(Symbol(42)): number);
 
 // Breaks compatibility with v2.x
 // $ExpectError

--- a/definitions/npm/eventemitter3_v3.x.x/test_eventemitter3-v3.js
+++ b/definitions/npm/eventemitter3_v3.x.x/test_eventemitter3-v3.js
@@ -37,7 +37,7 @@ a.getMaxListeners();
 
 // appears in v3.x
 
-(a.listenerCount(): number)
+(a.listenerCount(): number);
 
 // Breaks compatibility with v2.x
 // $ExpectError

--- a/definitions/npm/eventemitter3_v3.x.x/test_eventemitter3-v3.js
+++ b/definitions/npm/eventemitter3_v3.x.x/test_eventemitter3-v3.js
@@ -1,0 +1,47 @@
+// @flow
+import EventEmitter from 'eventemitter3';
+import type { ListenerFn } from 'eventemitter3'
+
+class A extends EventEmitter { }
+
+const a: EventEmitter = new A();
+
+a.on('test', () => {});
+// $ExpectError
+a.on('test');
+
+a.off('test');
+// $ExpectError
+a.off();
+
+a.removeListener('test');
+// $ExpectError
+a.removeListener();
+
+a.once('test', () => {});
+// $ExpectError
+a.once('test');
+
+a.emit('test', 'something');
+a.emit('test');
+
+// a.emit(); Supposedly a bug in Flow, should expect an error here
+
+// $ExpectError
+a.setMaxListeners();
+
+// $ExpectError
+a.getMaxListeners();
+
+(a.listeners('emit'): ListenerFn[]);
+
+// appears in v3.x
+
+(a.listenerCount(): number)
+
+// Breaks compatibility with v2.x
+// $ExpectError
+(a.listeners('emit', true): boolean);
+
+// $ExpectError
+(a.listeners('emit', false): ListenerFn[]);


### PR DESCRIPTION
Adds a libdef for eventemitter3 v3.

There were some breaking changes, outlined [here](https://github.com/primus/eventemitter3/releases/tag/3.0.0). You can also look at thet [ts definitions](https://github.com/primus/eventemitter3/blob/master/index.d.ts) for reference.