### PR TITLE
Set cache directory with arguments of install and update commands

### DIFF
--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -119,8 +119,9 @@ export async function run(args: Args) {
   }
 
   if (args.cacheDir) {
-    console.log('• Setting cache dir', args.cacheDir);
-    setCustomCacheDir(path.resolve(args.cacheDir));
+    const cacheDir = path.resolve(args.cacheDir);
+    console.log('• Setting cache dir', cacheDir);
+    setCustomCacheDir(cacheDir);
   }
 
   const npmLibDefResult = await installNpmLibDefs({

--- a/cli/src/commands/install.js
+++ b/cli/src/commands/install.js
@@ -27,7 +27,10 @@ import {
   getPackageJsonDependencies,
 } from '../lib/npm/npmProjectUtils';
 
-import {getCacheRepoDir} from '../lib/cacheRepoUtils';
+import {
+  getCacheRepoDir,
+  _setCustomCacheDir as setCustomCacheDir,
+} from '../lib/cacheRepoUtils';
 
 import {getRangeLowerBound} from '../lib/semver';
 
@@ -48,6 +51,7 @@ export type Args = {
   skip: boolean,
   verbose: boolean,
   libdefDir?: string,
+  cacheDir?: string,
   packageDir?: string,
   ignoreDeps?: Array<string>,
   rootDir?: string,
@@ -74,6 +78,13 @@ export function setup(yargs: Yargs) {
     libdefDir: {
       alias: 'l',
       describe: 'Use a custom directory to install libdefs',
+      type: 'string',
+      demand: false,
+    },
+    cacheDir: {
+      alias: 'c',
+      describe:
+        'Directory (absolute or relative path, ~ is not supported) to store cache of libdefs',
       type: 'string',
       demand: false,
     },
@@ -105,6 +116,11 @@ export async function run(args: Args) {
   const coreLibDefResult = await installCoreLibDefs();
   if (coreLibDefResult !== 0) {
     return coreLibDefResult;
+  }
+
+  if (args.cacheDir) {
+    console.log('• Setting cache dir', args.cacheDir);
+    setCustomCacheDir(path.resolve(args.cacheDir));
   }
 
   const npmLibDefResult = await installNpmLibDefs({

--- a/cli/src/commands/update-cache.js
+++ b/cli/src/commands/update-cache.js
@@ -1,43 +1,44 @@
 // @flow
 
-import {updateCacheRepo} from '../lib/libDefs';
-
-import type {Argv} from 'yargs';
 import typeof Yargs from 'yargs';
+import {
+  _setCustomCacheDir as setCustomCacheDir,
+  ensureCacheRepo,
+} from '../lib/cacheRepoUtils';
+import {path} from '../lib/node';
 
 export const name = 'update-cache';
 export const description = 'Update the flow-typed definitions cache';
 
+export type Args = {
+  cacheDir?: string,
+};
 export function setup(yargs: Yargs) {
   return yargs.usage(`$0 ${name} - ${description}`).options({
-    debug: {
-      describe: 'Enable verbose messages for the update procedure',
-      alias: 'd',
-      type: 'boolean',
+    cacheDir: {
+      alias: 'c',
+      describe:
+        'Directory (absolute or relative path, ~ is not supported) to store cache of libdefs',
+      type: 'string',
       demand: false,
     },
   });
 }
 
-export async function run(argv: Argv): Promise<number> {
+export async function run(args: Args): Promise<number> {
   try {
-    let verbose;
-
-    if (argv.debug) {
-      verbose = process.stdout;
+    if (args.cacheDir) {
+      console.log('• Setting cache dir', args.cacheDir);
+      setCustomCacheDir(path.resolve(args.cacheDir));
     }
 
     console.log('Updating flow-typed definitions...');
-    await updateCacheRepo(verbose);
+    await ensureCacheRepo();
 
     console.log('Definitions update successful!');
     return 0;
   } catch (e) {
     console.error(`Update failed: ${e.message}`);
-
-    if (argv.debug) {
-      console.error(e);
-    }
 
     return 1;
   }

--- a/cli/src/commands/update-cache.js
+++ b/cli/src/commands/update-cache.js
@@ -28,8 +28,9 @@ export function setup(yargs: Yargs) {
 export async function run(args: Args): Promise<number> {
   try {
     if (args.cacheDir) {
-      console.log('• Setting cache dir', args.cacheDir);
-      setCustomCacheDir(path.resolve(args.cacheDir));
+      const cacheDir = path.resolve(args.cacheDir);
+      console.log('• Setting cache dir', cacheDir);
+      setCustomCacheDir(cacheDir);
     }
 
     console.log('Updating flow-typed definitions...');


### PR DESCRIPTION
Allows to specify path to cache directory with cli argument `cacheDir`. Useful for CI tools like travis.