### PR TITLE
[react-redux] Add default export

### DIFF
--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
@@ -3,12 +3,12 @@ import type { Dispatch, Store } from "redux";
 declare module "react-redux" {
   import type { ComponentType, ElementConfig } from 'react';
 
-  declare export class Provider<S, A> extends React$Component<{
+  declare class Provider<S, A> extends React$Component<{
     store: Store<S, A>,
     children?: any
   }> {}
 
-  declare export function createProvider(
+  declare function createProvider(
     storeKey?: string,
     subKey?: string
   ): Provider<*, *>;
@@ -50,43 +50,43 @@ declare module "react-redux" {
 
   declare type OmitDispatch<Component> = $Diff<Component, {dispatch: Dispatch<*>}>;
 
-  declare export function connect<Com: ComponentType<*>, DP: Object, RSP: Object>(
+  declare function connect<Com: ComponentType<*>, DP: Object, RSP: Object>(
     mapStateToProps: MapStateToProps<DP, RSP>,
     mapDispatchToProps?: null
   ): (component: Com) => ComponentType<$Diff<OmitDispatch<ElementConfig<Com>>, RSP> & DP>;
 
-  declare export function connect<Com: ComponentType<*>>(
+  declare function connect<Com: ComponentType<*>>(
     mapStateToProps?: null,
     mapDispatchToProps?: null
   ): (component: Com) => ComponentType<OmitDispatch<ElementConfig<Com>>>;
 
-  declare export function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object>(
+  declare function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object>(
     mapStateToProps: MapStateToProps<SP, RSP>,
     mapDispatchToProps: MapDispatchToProps<A, DP, RDP>
   ): (component: Com) => ComponentType<$Diff<$Diff<ElementConfig<Com>, RSP>, RDP> & SP & DP>;
 
-  declare export function connect<Com: ComponentType<*>, A, OP: Object, DP: Object,PR: Object>(
+  declare function connect<Com: ComponentType<*>, A, OP: Object, DP: Object,PR: Object>(
     mapStateToProps?: null,
     mapDispatchToProps: MapDispatchToProps<A, OP, DP>
   ): (Com) => ComponentType<$Diff<ElementConfig<Com>, DP> & OP>;
 
-  declare export function connect<Com: ComponentType<*>, MDP: Object>(
+  declare function connect<Com: ComponentType<*>, MDP: Object>(
     mapStateToProps?: null,
     mapDispatchToProps: MDP
   ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, MDP>>;
 
-  declare export function connect<Com: ComponentType<*>, SP: Object, RSP: Object, MDP: Object>(
+  declare function connect<Com: ComponentType<*>, SP: Object, RSP: Object, MDP: Object>(
     mapStateToProps: MapStateToProps<SP, RSP>,
     mapDispatchToPRops: MDP
   ): (component: Com) => ComponentType<$Diff<$Diff<ElementConfig<Com>, RSP>, MDP> & SP>;
 
-  declare export function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
+  declare function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
     mapStateToProps: MapStateToProps<SP, RSP>,
     mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
     mergeProps: MergeProps<RSP, RDP, MP, RMP>
   ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP>;
 
-  declare export function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
+  declare function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
     mapStateToProps: ?MapStateToProps<SP, RSP>,
     mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
     mergeProps: ?MergeProps<RSP, RDP, MP, RMP>,

--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
@@ -3,12 +3,12 @@ import type { Dispatch, Store } from "redux";
 declare module "react-redux" {
   import type { ComponentType, ElementConfig } from 'react';
 
-  declare class Provider<S, A> extends React$Component<{
+  declare export class Provider<S, A> extends React$Component<{
     store: Store<S, A>,
     children?: any
   }> {}
 
-  declare function createProvider(
+  declare export function createProvider(
     storeKey?: string,
     subKey?: string
   ): Provider<*, *>;
@@ -50,46 +50,52 @@ declare module "react-redux" {
 
   declare type OmitDispatch<Component> = $Diff<Component, {dispatch: Dispatch<*>}>;
 
-  declare function connect<Com: ComponentType<*>, DP: Object, RSP: Object>(
+  declare export function connect<Com: ComponentType<*>, DP: Object, RSP: Object>(
     mapStateToProps: MapStateToProps<DP, RSP>,
     mapDispatchToProps?: null
   ): (component: Com) => ComponentType<$Diff<OmitDispatch<ElementConfig<Com>>, RSP> & DP>;
 
-  declare function connect<Com: ComponentType<*>>(
+  declare export function connect<Com: ComponentType<*>>(
     mapStateToProps?: null,
     mapDispatchToProps?: null
   ): (component: Com) => ComponentType<OmitDispatch<ElementConfig<Com>>>;
 
-  declare function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object>(
+  declare export function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object>(
     mapStateToProps: MapStateToProps<SP, RSP>,
     mapDispatchToProps: MapDispatchToProps<A, DP, RDP>
   ): (component: Com) => ComponentType<$Diff<$Diff<ElementConfig<Com>, RSP>, RDP> & SP & DP>;
 
-  declare function connect<Com: ComponentType<*>, A, OP: Object, DP: Object,PR: Object>(
+  declare export function connect<Com: ComponentType<*>, A, OP: Object, DP: Object,PR: Object>(
     mapStateToProps?: null,
     mapDispatchToProps: MapDispatchToProps<A, OP, DP>
   ): (Com) => ComponentType<$Diff<ElementConfig<Com>, DP> & OP>;
 
-  declare function connect<Com: ComponentType<*>, MDP: Object>(
+  declare export function connect<Com: ComponentType<*>, MDP: Object>(
     mapStateToProps?: null,
     mapDispatchToProps: MDP
   ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, MDP>>;
 
-  declare function connect<Com: ComponentType<*>, SP: Object, RSP: Object, MDP: Object>(
+  declare export function connect<Com: ComponentType<*>, SP: Object, RSP: Object, MDP: Object>(
     mapStateToProps: MapStateToProps<SP, RSP>,
     mapDispatchToPRops: MDP
   ): (component: Com) => ComponentType<$Diff<$Diff<ElementConfig<Com>, RSP>, MDP> & SP>;
 
-  declare function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
+  declare export function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
     mapStateToProps: MapStateToProps<SP, RSP>,
     mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
     mergeProps: MergeProps<RSP, RDP, MP, RMP>
   ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP>;
 
-  declare function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
+  declare export function connect<Com: ComponentType<*>, A, DP: Object, SP: Object, RSP: Object, RDP: Object, MP: Object, RMP: Object>(
     mapStateToProps: ?MapStateToProps<SP, RSP>,
     mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
     mergeProps: ?MergeProps<RSP, RDP, MP, RMP>,
     options: ConnectOptions<*, SP & DP & MP, RSP, RMP>
   ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP>;
+
+  declare export default {
+    Provider: typeof Provider,
+    createProvider: typeof createProvider,
+    connect: typeof connect,
+  };
 }


### PR DESCRIPTION
Avoiding any `export` declarations means that all declared modules are available as properties on the default export. The version of this libdef before the [revamp](https://github.com/flowtype/flow-typed/pull/1731) didn't have any `export` keywords, presumably for that reason.

Why not use named imports, you say? I have a specific case where I can't use named imports: the new module support in Node.js 9.3 can't handle named imports on commonjs modules. And since I'm not able to use the ESM version of `react-redux` because it relies on a named import from `react` (which doesn't have an ESM version), I have to use the commonjs version.

Regardless: as `react-redux` does indeed have a default export, the libdef should be declared accordingly.