### PR TITLE
Support stateless in react css modules

### DIFF
--- a/definitions/npm/react-css-modules_v3.x.x/flow_v0.53.x-/react-css-modules_v3.x.x.js
+++ b/definitions/npm/react-css-modules_v3.x.x/flow_v0.53.x-/react-css-modules_v3.x.x.js
@@ -2,7 +2,7 @@
 import React from "react";
 
 declare module "react-css-modules" {
-  declare type StatelessComponent<P, S> = (props: P, state: S) => ?React$Element<any>;
+  declare type StatelessComponent<P, S> = (props: P, state: S) => React$Element<any>;
   declare module.exports: <P, S, C: React$Component<P, S>, X>(
     component: Class<C> | StatelessComponent<P, S>,
     styles: X,

--- a/definitions/npm/react-css-modules_v3.x.x/flow_v0.53.x-/react-css-modules_v3.x.x.js
+++ b/definitions/npm/react-css-modules_v3.x.x/flow_v0.53.x-/react-css-modules_v3.x.x.js
@@ -2,12 +2,13 @@
 import React from "react";
 
 declare module "react-css-modules" {
+  declare type StatelessComponent<P, S> = (props: P, state: S) => ?React$Element<any>;
   declare module.exports: <P, S, C: React$Component<P, S>, X>(
-    component: Class<C>,
+    component: Class<C> | StatelessComponent<P, S>,
     styles: X,
     options?: {|
       allowMultiple?: boolean,
-      errorWhenNotFound?: boolean
-    |}
+      errorWhenNotFound?: boolean,
+    |},
   ) => Class<React$Component<$Diff<P, { styles: X }>, S>>;
 }

--- a/definitions/npm/react-css-modules_v3.x.x/flow_v0.53.x-/test_react-css-modules-v3.js
+++ b/definitions/npm/react-css-modules_v3.x.x/flow_v0.53.x-/test_react-css-modules-v3.js
@@ -18,7 +18,7 @@ type Props = {};
 
 type State = {};
 
-const ExampleModule2 = (props: Props, state: State) => {
+const ExampleModule2 = (props: Props) => {
   return (<div>hoge</div>)
 }
 

--- a/definitions/npm/react-css-modules_v3.x.x/flow_v0.53.x-/test_react-css-modules-v3.js
+++ b/definitions/npm/react-css-modules_v3.x.x/flow_v0.53.x-/test_react-css-modules-v3.js
@@ -2,58 +2,90 @@
 
 import React, { Component } from 'react';
 import CSSModules from 'react-css-modules';
+import { describe, it } from 'flow-typed-test';
 
-const styles = { test: '123' };
+describe('React Component', () => {
+  const styles = { test: '123' };
 
-class ExampleModule extends Component<{
-  foo: string,
-  styles: typeof styles,
-}> {
-  render() {
-    return <div className={this.props.styles}>{this.props.foo}</div>;
+  class ExampleModule extends Component<{
+    foo: string,
+    styles: typeof styles,
+  }> {
+    render() {
+      return <div className={this.props.styles}>{this.props.foo}</div>;
+    }
   }
-}
+  
+  it('React Component can be declared', () => {
+    const ExampleCSSModules = CSSModules(ExampleModule, styles);
+    const ExampleCSSModules2 = CSSModules(ExampleModule, styles, { allowMultiple: true });
+    class Working extends Component<{}> {
+      render() {
+        return <ExampleCSSModules foo="bar" />;
+      }
+    }
+  });
+  
+  it('React Component can be undeclared', () => {
+    const ExampleCSSModules = CSSModules(ExampleModule, styles);
+    // $ExpectError invalid module option.
+    const BustedCSSModule = CSSModules(ExampleModule, styles, { wubbaLubba: 'dub-dub' });
+    
+    class Failure1 extends Component<{}> {
+      render() {
+    
+        // $ExpectError Missing prop `foo` will be caught.
+        return <ExampleCSSModules />;
+      }
+    }
+    
+    class Failure2 extends Component<{}> {
+      render() {
+    
+        // $ExpectError Unwrapped component won't be passed `styles`.
+        return <ExampleModule foo="bar" />;
+      }
+    }
+  });  
+});
 
-type Props = {};
+describe('Stateless Functional Component', () => {
+  const styles = { test: '123' };
+  type Props = {
+    foo: string,
+    styles: typeof styles,
+  };
+  type State = {};
 
-type State = {};
-
-const ExampleModule2 = (props: Props) => {
-  return (<div>hoge</div>)
-}
-
-const ExampleModule3 = (props: Props, state: State) => {
-  return (<div>hoge</div>)
-}
-
-const ExampleCSSModules = CSSModules(ExampleModule, styles);
-const ExampleCSSModules2 = CSSModules(ExampleModule, styles, { allowMultiple: true });
-const ExampleCSSModules3 = CSSModules(ExampleModule2, styles);
-const ExampleCSSModules4 = CSSModules(ExampleModule2, styles, { allowMultiple: true });
-const ExampleCSSModules5 = CSSModules(ExampleModule3, styles);
-const ExampleCSSModules6 = CSSModules(ExampleModule3, styles, { allowMultiple: true });
-
-// $ExpectError invalid module option.
-const BustedCSSModule = CSSModules(ExampleModule, styles, { wubbaLubba: 'dub-dub' });
-
-class Failure1 extends Component<{}> {
-  render() {
-
-    // $ExpectError Missing prop `foo` will be caught.
-    return <ExampleCSSModules />;
+  // Props and State
+  const StatelessComponent = (props: Props, state: State) => {
+    return (<div>hoge</div>)
   }
-}
-
-class Failure2 extends Component<{}> {
-  render() {
-
-    // $ExpectError Unwrapped component won't be passed `styles`.
-    return <ExampleModule foo="bar" />;
+  // Props only
+  const StatelessComponentPropsOnly = (props: Props) => {
+    return (<div>hoge</div>)
   }
-}
 
-class Working extends Component<{}> {
-  render() {
-    return <ExampleCSSModules foo="bar" />;
-  }
-}
+  it('Stateless Functional Component can be declared', () => {
+    const StatelessCSSComponent = CSSModules(StatelessComponent, styles);
+    CSSModules(StatelessComponent, styles, { allowMultiple: true });
+    CSSModules(StatelessComponentPropsOnly, styles);
+    CSSModules(StatelessComponentPropsOnly, styles, { allowMultiple: true });
+
+    class Working extends Component<{}> {
+      render() {
+        return <StatelessCSSComponent foo="bar" />;
+      }
+    }
+  });
+
+  it('Stateless Functional Component can be declared', () => {
+    class Failure extends Component<{}> {
+      render() {
+        // $ExpectError Unwrapped component won't be passed `styles`.
+        return <StatelessComponent foo="bar" />;
+      }
+    }
+  });
+});
+

--- a/definitions/npm/react-css-modules_v3.x.x/flow_v0.53.x-/test_react-css-modules-v3.js
+++ b/definitions/npm/react-css-modules_v3.x.x/flow_v0.53.x-/test_react-css-modules-v3.js
@@ -14,12 +14,28 @@ class ExampleModule extends Component<{
   }
 }
 
+type Props = {};
+
+type State = {};
+
+const ExampleModule2 = (props: Props, state: State) => {
+  return (<div>hoge</div>)
+}
+
+const ExampleModule3 = (props: Props, state: State) => {
+  return (<div>hoge</div>)
+}
+
 const ExampleCSSModules = CSSModules(ExampleModule, styles);
 const ExampleCSSModules2 = CSSModules(ExampleModule, styles, { allowMultiple: true });
+const ExampleCSSModules3 = CSSModules(ExampleModule2, styles);
+const ExampleCSSModules4 = CSSModules(ExampleModule2, styles, { allowMultiple: true });
+const ExampleCSSModules5 = CSSModules(ExampleModule3, styles);
+const ExampleCSSModules6 = CSSModules(ExampleModule3, styles, { allowMultiple: true });
 
 // $ExpectError invalid module option.
 const BustedCSSModule = CSSModules(ExampleModule, styles, { wubbaLubba: 'dub-dub' });
-1
+
 class Failure1 extends Component<{}> {
   render() {
 

--- a/definitions/npm/react-css-modules_v3.x.x/flow_v0.53.x-/test_react-css-modules-v3.js
+++ b/definitions/npm/react-css-modules_v3.x.x/flow_v0.53.x-/test_react-css-modules-v3.js
@@ -79,7 +79,7 @@ describe('Stateless Functional Component', () => {
     }
   });
 
-  it('Stateless Functional Component can be declared', () => {
+  it('Stateless Functional Component can be undeclared', () => {
     class Failure extends Component<{}> {
       render() {
         // $ExpectError Unwrapped component won't be passed `styles`.


### PR DESCRIPTION
Support stateless functional component style in `react-css-modules` and format code.