### PR TITLE
update promise-retry

### DIFF
--- a/definitions/npm/promise-retry_v1.1.x/flow_v0.45.x-/promise-retry_v1.1.x.js
+++ b/definitions/npm/promise-retry_v1.1.x/flow_v0.45.x-/promise-retry_v1.1.x.js
@@ -1,4 +1,4 @@
-type RetryFn = (err: Error) => void;
+type RetryFn = (err?: Error) => void;
 type Options = {|
   retries?: number,
   factor?: number,
@@ -8,6 +8,8 @@ type Options = {|
 |};
 
 declare module 'promise-retry' {
+  declare export type RetryOptions = Options;
+
   declare module.exports: <T>(
     handler: (retry: RetryFn, retryNumber: Number) => Promise<T>,
     options?: Options


### PR DESCRIPTION
`err` for `RetryFn` is optional https://github.com/IndigoUnited/node-promise-retry/blob/master/index.js#L9 and export `RetryOptions` for usage in code.