### PR TITLE
Jasmine: Add `.and` for spies, `pending`, `DEFAULT_TIMEOUT_INTERVAL`

### DIFF
--- a/definitions/npm/jasmine_v2.4.x/flow_v0.25.x-/jasmine_v2.4.x.js
+++ b/definitions/npm/jasmine_v2.4.x/flow_v0.25.x-/jasmine_v2.4.x.js
@@ -35,6 +35,7 @@ declare function fit(name: string, fn: Function, timeout?: number): void;
 declare function xit(name: string, fn: Function): void;
 
 declare function expect(value: mixed): JasmineExpectType;
+declare function pending(message?: string): void;
 declare function fail(err?: Error | string): void;
 
 // TODO handle return type
@@ -51,7 +52,18 @@ type JasmineCallsType = {
   reset(): void
 };
 
+type JasmineSpyStrategyType = {
+  callFake((...args: Array<any>) => any): JasmineSpyType,
+  callThrough(): JasmineSpyType,
+  identity: string,
+  returnValue(value: any): JasmineSpyType,
+  returnValues(...values: any): JasmineSpyType,
+  stub(): JasmineSpyType,
+  throwError(errorMessage?: string): JasmineSpyType
+};
+
 type JasmineSpyType = {
+  and: JasmineSpyStrategyType,
   calls: JasmineCallsType
 };
 
@@ -81,6 +93,7 @@ declare type JasmineMatchers = {
 };
 
 declare var jasmine: {
+  DEFAULT_TIMEOUT_INTERVAL: number,
   createSpy(name?: string): JasmineSpyType,
   any(val: mixed): void,
   anything(): void,

--- a/definitions/npm/jasmine_v2.4.x/test_jasmine_v2.4.x.js
+++ b/definitions/npm/jasmine_v2.4.x/test_jasmine_v2.4.x.js
@@ -1,0 +1,6 @@
+/* @flow */
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+
+// $ExpectError
+jasmine.DEFAULT_TIMEOUT_INTERVAL = null;

--- a/definitions/npm/jasmine_v2.4.x/test_jasmine_v2.4.x_pending.js
+++ b/definitions/npm/jasmine_v2.4.x/test_jasmine_v2.4.x_pending.js
@@ -1,0 +1,7 @@
+/* @flow */
+
+pending('this is not written yet');
+pending();
+
+// $ExpectError
+pending(true);

--- a/definitions/npm/jasmine_v2.4.x/test_jasmine_v2.4.x_spies.js
+++ b/definitions/npm/jasmine_v2.4.x/test_jasmine_v2.4.x_spies.js
@@ -1,0 +1,30 @@
+/* @flow */
+
+const namelessSpy = jasmine.createSpy();
+const spy = jasmine.createSpy('mySpy');
+
+// $ExpectError
+const badName = jasmine.createSpy(12);
+
+spy.calls.allArgs();
+spy.calls.all();
+spy.calls.mostRecent();
+spy.calls.first();
+spy.calls.any();
+spy.calls.count();
+spy.calls.reset();
+
+spy.and.callFake(() => {});
+
+// $ExpectError
+spy.and.callFake();
+
+spy.and.callThrough();
+spy.and.identity;
+spy.and.returnValue(undefined);
+spy.and.returnValue(null);
+spy.and.returnValue({});
+spy.and.returnValues({}, null, 12);
+spy.and.stub();
+spy.and.throwError('a bad thing happened');
+spy.and.throwError();


### PR DESCRIPTION
This exposes a bit more of Jasmine.

Unfortunately I haven't been able to run tests locally (Windows). Following the instructions in the README is kind of a non-starter because it immediately complains about an `ENOENT` related to the first definition. There's also a `CONTRIBUTING.md` in the definitions that throws a wrench in the works, which I had to locally delete to confirm structure.

I got a lot farther running `run_def_tests.cmd` but I hit a lot of errors, especially `ENOENT: no such file or directory, scandir 'C:\gitrepos\flow-typed\cli\.flow-bins-cache'`.

If anyone can lend advice, I'd much appreciate it, since I'd also like to submit some fixups for `lodash/fp` at some point.