### PR TITLE
Update redux-actions to match updated redux definitions

### DIFF
--- a/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
+++ b/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
@@ -58,6 +58,7 @@ declare module "redux-actions" {
   declare function createActions(...identityActions: string[]): Object;
 
   declare type Reducer<S, A> = (state: S, action: A) => S;
+  declare type ReduxReducer<S, A> = (state: S | void, action: A) => S;
 
   declare type ReducerMap<S, A> =
     | { next: Reducer<S, A> }
@@ -70,7 +71,7 @@ declare module "redux-actions" {
    * `handleActions`. For example:
    *
    *     import { type Reducer } from 'redux'
-   *     import { createAction, handleAction, type Action } from 'redux-actions'
+   *     import { createAction, handleAction, type ActionType } from 'redux-actions'
    *
    *     const increment = createAction(INCREMENT, (count: number) => count)
    *
@@ -89,14 +90,14 @@ declare module "redux-actions" {
     type: Type,
     reducer: ReducerDefinition<State, Action>,
     defaultState: State
-  ): Reducer<State, Action>;
+  ): ReduxReducer<State, Action>;
 
   declare function handleActions<State, Action>(
     reducers: {
       [key: string]: Reducer<State, Action> | ReducerMap<State, Action>
     },
     defaultState?: State
-  ): Reducer<State, Action>;
+  ): ReduxReducer<State, Action>;
 
   declare function combineActions(
     ...types: (string | Symbol | Function)[]

--- a/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
+++ b/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/redux-actions_v2.x.x.js
@@ -57,6 +57,20 @@ declare module "redux-actions" {
   ): Object;
   declare function createActions(...identityActions: string[]): Object;
 
+  /*
+   * The semantics of the reducer (i.e. ReduxReducer<S, A>) returned by either
+   * `handleAction` or `handleActions` are actually different from the semantics
+   * of the reducer (i.e. Reducer<S, A>) that are consumed by either `handleAction`
+   * or `handleActions`.
+   *
+   * Reducers (i.e. Reducer<S, A>) consumed by either `handleAction` or `handleActions`
+   * are assumed to be given the actual `State` type, since internally,
+   * `redux-actions` will perform the action type matching for us, and will always
+   * provide the expected state type.
+   *
+   * The reducers returned by either `handleAction` or `handleActions` will be
+   * compatible with the `redux` library.
+  */
   declare type Reducer<S, A> = (state: S, action: A) => S;
   declare type ReduxReducer<S, A> = (state: S | void, action: A) => S;
 

--- a/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/test_handleActions.js
+++ b/definitions/npm/redux-actions_v2.x.x/flow_v0.39.x-/test_handleActions.js
@@ -5,24 +5,32 @@ import type { ActionType, Reducer } from "redux-actions";
 
 const INCREMENT = "INCREMENT";
 const INCREMENT2 = "INCREMENT2";
-const NOT_INCREMENT = "NOT_INCREMENT";
 
 const increment = createAction(INCREMENT, (x: number) => x);
 const increment2 = createAction(INCREMENT2, (x: number, y: string) => x);
+const decrement = createAction("DECREMENT", (x: number) => x);
 
-const initState: { count: number } = { count: 0 };
+type StateType = { count: number };
+const initState: StateType = { count: 0 };
 
 function test_handleActions() {
   handleActions(
     {
-      [INCREMENT]: (state, action: ActionType<typeof increment>) => {
+      [INCREMENT]: (state: StateType, action: ActionType<typeof increment>): StateType => {
         return { count: state.count + 1 };
       },
-      [String(increment2)]: (state, action: ActionType<typeof increment2>) => {
+
+      [String(increment2)]: (state: StateType, action: ActionType<typeof increment2>): StateType => {
         assert(action.payload, (x: number) => {});
         return {
           count: state.count + action.payload
         };
+      },
+
+      [decrement.toString()]: (state: StateType, action: ActionType<typeof decrement>): StateType => {
+        assert(action.payload, (x: number) => {});
+        const decrementCount: number = action.payload;
+        return { count: state.count - decrementCount };
       },
 
       INFERS_STATE_TYPE: (state, action) => {


### PR DESCRIPTION
Closes https://github.com/flowtype/flow-typed/issues/1963

Referred updated redux definitions are at: https://github.com/flowtype/flow-typed/pull/1958

-----



The semantics of the reducer returned by either `handleAction` or `handleActions` are actually different from the semantics of the reducer that are consumed by either `handleAction` or `handleActions`.

Reducers consumed by either `handleAction` or `handleActions` are assumed to be given the actual `State` type, since internally, `redux-actions` will perform the action type matching for us, and will always provide the expected state.

See the following tests:

- https://github.com/redux-utilities/redux-actions/blob/de4e8f13192d306fff9bb3929a140356d557def0/src/__tests__/handleAction-test.js#L45-L51

- https://github.com/redux-utilities/redux-actions/blob/de4e8f13192d306fff9bb3929a140356d557def0/src/__tests__/handleActions-test.js#L303-L308

This is why I've kept the `Reducer<S, A>` type as declared originally; and instead, define a new reducer type that is assumed by the `redux` library:

```
declare type ReduxReducer<S, A> = (state: S | void, action: A) => S;
```
