### PR TITLE
Add staticContext to ContextRouter

### DIFF
--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-v0.52.x/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.38.x-v0.52.x/react-router-dom_v4.x.x.js
@@ -87,6 +87,7 @@ declare module 'react-router-dom' {
     history: RouterHistory,
     location: Location,
     match: Match,
+    staticContext?: StaticRouterContext,
   }
 
   declare export type GetUserConfirmation =

--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.53.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.53.x-/react-router-dom_v4.x.x.js
@@ -83,8 +83,9 @@ declare module "react-router-dom" {
   declare export type ContextRouter = {|
     history: RouterHistory,
     location: Location,
-    match: Match
-  |};
+    match: Match,
+    staticContext?: StaticRouterContext,
+|};
 
   declare export type GetUserConfirmation = (
     message: string,


### PR DESCRIPTION
When using the `StaticRouter` the `staticContext` is set on the `ContextRouter` (see: https://reacttraining.com/react-router/web/example/static-router). This change reflects that.