### PR TITLE
Delete CONTRIBUTING.md

### DIFF
--- a/definitions/npm/react-navigation_v1.x.x/CONTRIBUTING.md
+++ b/definitions/npm/react-navigation_v1.x.x/CONTRIBUTING.md
@@ -1,5 +1,0 @@
-# Contributing to the React Navigation Flow libdef
-
-Please do not make changes directly to the libdef file in `flow-typed` without first submitting a PR to the [libdef within the `react-navigation` repo](https://github.com/react-navigation/react-navigation/blob/master/flow/react-navigation.js). After your PR has been accepted in `react-navigation`, you can go ahead and submit a PR on `flow-typed`.
-
-We admittedly have a slightly unusual system for maintaing our Flow types. We used to host Flow types directly in-package, but that prevented us from simultaneously supporting multiple React Native versions. To enable that support, we've moved our libdef to `flow-typed`, but we still want to (1) have our CI typecheck the libdef against our example projects, and (2) review any changes to the libdef.


### PR DESCRIPTION
UNCAUGHT ERROR: Error: react-navigation_v1.x.x/CONTRIBUTING.md: Unexpected file name. This directory can only contain test files or a libdef file named `react-navigation_v1.x.x.js`.
    at validationError (/Users/skilurus/.nvm/versions/node/v8.9.4/lib/node_modules/flow-typed/dist/lib/validationErrors.js:14:11)
    at /Users/skilurus/.nvm/versions/node/v8.9.4/lib/node_modules/flow-typed/dist/lib/npm/npmLibDefs.js:113:53
    at Array.forEach (<anonymous>)
    at extractLibDefsFromNpmPkgDir$ (/Users/skilurus/.nvm/versions/node/v8.9.4/lib/node_modules/flow-typed/dist/lib/npm/npmLibDefs.js:95:23)
    at tryCatch (/Users/skilurus/.nvm/versions/node/v8.9.4/lib/node_modules/flow-typed/node_modules/regenerator-runtime/runtime.js:65:40)
    at Generator.invoke [as _invoke] (/Users/skilurus/.nvm/versions/node/v8.9.4/lib/node_modules/flow-typed/node_modules/regenerator-runtime/runtime.js:303:22)
    at Generator.prototype.(anonymous function) [as next] (/Users/skilurus/.nvm/versions/node/v8.9.4/lib/node_modules/flow-typed/node_modules/regenerator-runtime/runtime.js:117:21)
    at tryCatch (/Users/skilurus/.nvm/versions/node/v8.9.4/lib/node_modules/flow-typed/node_modules/regenerator-runtime/runtime.js:65:40)
    at invoke (/Users/skilurus/.nvm/versions/node/v8.9.4/lib/node_modules/flow-typed/node_modules/regenerator-runtime/runtime.js:155:20)
    at /Users/skilurus/.nvm/versions/node/v8.9.4/lib/node_modules/flow-typed/node_modules/regenerator-runtime/runtime.js:165:13