### PR TITLE
Add libdef for react-splitter-layout

### DIFF
--- a/definitions/npm/react-splitter-layout_v3.x.x/flow_v0.53.x-/react-splitter-layout_v3.x.x.js
+++ b/definitions/npm/react-splitter-layout_v3.x.x/flow_v0.53.x-/react-splitter-layout_v3.x.x.js
@@ -1,0 +1,17 @@
+declare type $$reactsplitterlayout$$Props = {|
+  +customClassName?: string,
+  +vertical?: boolean,
+  +percentage?: boolean,
+  +primaryIndex?: 0 | 1,
+  +primaryMinSize?: number,
+  +secondaryMinSize?: number,
+  +secondaryInitialSize?: number,
+  +onDragStart?: () => mixed,
+  +onDragEnd?: () => mixed,
+  +onSecondaryPaneSizeChange?: number => mixed,
+  +children: React$Node,
+|};
+
+declare module 'react-splitter-layout' {
+  declare export default React$ComponentType<$$reactsplitterlayout$$Props>
+}

--- a/definitions/npm/react-splitter-layout_v3.x.x/flow_v0.53.x-/test_splitter-layout.js
+++ b/definitions/npm/react-splitter-layout_v3.x.x/flow_v0.53.x-/test_splitter-layout.js
@@ -3,6 +3,16 @@ import React from 'react';
 import SplitterLayout from 'react-splitter-layout';
 
 it('checks it takes at least 1 pane', () => {
+  /* react-splitter-layout accepts several children but will render only the
+   * first 2. When there's only one child it will render this child without the
+   * splitter element. It also accepts `undefined` or `null` as child, and in
+   * this case it will render only the other child. Because this is a licit
+   * usage we test it here to prevent future regressions, even if the libdef as
+   * it's currently defined doesn't special-case these values.
+   *
+   * In the future we might want to stricten the libdef to accept only 2
+   * children as it's likely a mistake to accept more than 2.
+   */
   let element = (
     <SplitterLayout>
       <div>pane 1</div>
@@ -30,7 +40,6 @@ it('checks it takes at least 1 pane', () => {
     </SplitterLayout>
   )
 
-  // Note: react-splitter-layout will render only the first 2
   element = (
     <SplitterLayout>
       <div>pane 1</div>

--- a/definitions/npm/react-splitter-layout_v3.x.x/test_splitter-layout.js
+++ b/definitions/npm/react-splitter-layout_v3.x.x/test_splitter-layout.js
@@ -1,0 +1,93 @@
+import { describe, it } from 'flow-typed-test';
+import React from 'react';
+import SplitterLayout from 'react-splitter-layout';
+
+it('checks it takes at least 1 pane', () => {
+  let element = (
+    <SplitterLayout>
+      <div>pane 1</div>
+      <div>pane 2</div>
+    </SplitterLayout>
+  );
+
+  element = (
+    <SplitterLayout>
+      <div>pane 1</div>
+    </SplitterLayout>
+  );
+
+  element = (
+    <SplitterLayout>
+      <div>pane 1</div>
+      {undefined}
+    </SplitterLayout>
+  )
+
+  element = (
+    <SplitterLayout>
+      {null}
+      <div>pane 1</div>
+    </SplitterLayout>
+  )
+
+  // Note: react-splitter-layout will render only the first 2
+  element = (
+    <SplitterLayout>
+      <div>pane 1</div>
+      <div>pane 2</div>
+      <div>pane 3</div>
+    </SplitterLayout>
+  );
+
+  // $ExpectError
+  element = <SplitterLayout/>;
+});
+
+it('checks various props', () => {
+  let element = (
+    <SplitterLayout
+      customClassName="classname"
+      vertical={true}
+      percentage
+      primaryIndex={1}
+      primaryMinSize={50}
+      secondaryMinSize={25}
+      secondaryInitialSize={25}
+      onDragStart={() => {}}
+      onDragEnd={() => {}}
+      onSecondaryPaneSizeChange={(size: number) => {}}
+    >
+      <div>pane 1</div>
+      <div>pane 2</div>
+    </SplitterLayout>
+  );
+
+  element = (
+    <SplitterLayout
+      onSecondaryPaneSizeChange={() => {}}
+    >
+      <div>pane 1</div>
+      <div>pane 2</div>
+    </SplitterLayout>
+  );
+
+  element = (
+    // $ExpectError
+    <SplitterLayout
+      onSecondaryPaneSizeChange={(size: string) => {}}
+    >
+      <div>pane 1</div>
+      <div>pane 2</div>
+    </SplitterLayout>
+  );
+
+  element = (
+    // $ExpectError
+    <SplitterLayout
+      primaryIndex={2}
+    >
+      <div>pane 1</div>
+      <div>pane 2</div>
+    </SplitterLayout>
+  );
+});


### PR DESCRIPTION
This is a new libdef to support [react-splitter-layout](https://github.com/zesik/react-splitter-layout).