### PR TITLE
[algoliasearch] Fix async import() case

### DIFF
--- a/definitions/__util__/tdd_framework.js
+++ b/definitions/__util__/tdd_framework.js
@@ -22,5 +22,5 @@
 
 declare module 'flow-typed-test' {
   declare export function describe(label: string, fn: (...any) => void): void;
-  declare export function it(label: string, fn: (...any) => void): void;
+  declare export function it(label: string, fn: (...any) => void | Promise<void>): void;
 }

--- a/definitions/npm/algoliasearch_v3.x.x/flow_v0.56.x-/algoliasearch_v3.x.x.js
+++ b/definitions/npm/algoliasearch_v3.x.x/flow_v0.56.x-/algoliasearch_v3.x.x.js
@@ -169,11 +169,13 @@ declare module 'algoliasearch' {
   declare type ClientOptions = $algoliasearch$ClientOptions;
   declare type Index = $algoliasearch$Index;
   declare type Settings = $algoliasearch$Settings;
-  declare module.exports: (
-    applicationID: string,
-    apiKey: string,
-    options?: ClientOptions
-  ) => Client;
+  declare module.exports: {
+    (
+      applicationID: string,
+      apiKey: string,
+      options?: ClientOptions
+    ): Client;
+  }
 }
 
 declare module 'algoliasearch/reactnative' {
@@ -181,11 +183,13 @@ declare module 'algoliasearch/reactnative' {
   declare type ClientOptions = $algoliasearch$ClientOptions;
   declare type Index = $algoliasearch$Index;
   declare type Settings = $algoliasearch$Settings;
-  declare module.exports: (
-    applicationID: string,
-    apiKey: string,
-    options?: ClientOptions
-  ) => Client;
+  declare module.exports: {
+    (
+      applicationID: string,
+      apiKey: string,
+      options?: ClientOptions
+    ): Client;
+  }
 }
 
 declare module 'algoliasearch/lite' {
@@ -193,9 +197,11 @@ declare module 'algoliasearch/lite' {
   declare type ClientOptions = $algoliasearch$ClientOptions;
   declare type Index = $algoliasearch$IndexLite;
   declare type Settings = $algoliasearch$Settings;
-  declare module.exports: (
-    applicationID: string,
-    apiKey: string,
-    options?: ClientOptions
-  ) => Client;
+  declare module.exports: {
+    (
+      applicationID: string,
+      apiKey: string,
+      options?: ClientOptions
+    ): Client;
+  }
 }

--- a/definitions/npm/algoliasearch_v3.x.x/test_algoliasearch-v3.x.x.js
+++ b/definitions/npm/algoliasearch_v3.x.x/test_algoliasearch-v3.x.x.js
@@ -1,8 +1,25 @@
 // @flow
-import algoliasearch from 'algoliasearch';
+import algoliasearchImport from 'algoliasearch';
 
-const searchIndex = algoliasearch('', '').initIndex('');
-searchIndex.search('test').then((result) => console.warn(result.hits));
+function syncImportTests() {
+  const searchIndex = algoliasearchImport('', '').initIndex('');
+  searchIndex.search('test').then(result => console.warn(result.hits));
+  // $ExpectError
+  searchIndex.search('test').nonPromiseProperty;
+}
 
-// $ExpectError
-searchIndex.search('test').nonPromiseProperty;
+function requireTests() {
+  const algoliasearch = require('algoliasearch');
+  const searchIndex = algoliasearch('', '').initIndex('');
+  searchIndex.search('test').then(result => console.warn(result.hits));
+  // $ExpectError
+  searchIndex.search('test').nonPromiseProperty;
+}
+
+async function asyncImportTests() {
+  const algoliasearch = await import('algoliasearch');
+  const searchIndex = algoliasearch('', '').initIndex('');
+  searchIndex.search('test').then(result => console.warn(result.hits));
+  // $ExpectError
+  searchIndex.search('test').nonPromiseProperty;
+}

--- a/definitions/npm/algoliasearch_v3.x.x/test_algoliasearch-v3.x.x.js
+++ b/definitions/npm/algoliasearch_v3.x.x/test_algoliasearch-v3.x.x.js
@@ -1,25 +1,22 @@
 // @flow
+import { describe, it } from 'flow-typed-test';
 import algoliasearchImport from 'algoliasearch';
 
-function syncImportTests() {
-  const searchIndex = algoliasearchImport('', '').initIndex('');
-  searchIndex.search('test').then(result => console.warn(result.hits));
-  // $ExpectError
-  searchIndex.search('test').nonPromiseProperty;
-}
+describe('algoliasearch', () => {
+  it('works with `require`', () => {
+    const algoliasearch = require('algoliasearch');
+    const searchIndex = algoliasearch('', '').initIndex('');
+    searchIndex.search('test').then(result => result.hits);
+  });
 
-function requireTests() {
-  const algoliasearch = require('algoliasearch');
-  const searchIndex = algoliasearch('', '').initIndex('');
-  searchIndex.search('test').then(result => console.warn(result.hits));
-  // $ExpectError
-  searchIndex.search('test').nonPromiseProperty;
-}
+  it('works with `import` syntax', () => {
+    const searchIndex = algoliasearchImport('', '').initIndex('');
+    searchIndex.search('test').then(result => result.hits);
+  });
 
-async function asyncImportTests() {
-  const algoliasearch = await import('algoliasearch');
-  const searchIndex = algoliasearch('', '').initIndex('');
-  searchIndex.search('test').then(result => console.warn(result.hits));
-  // $ExpectError
-  searchIndex.search('test').nonPromiseProperty;
-}
+  it('works with `await import` syntax', async () => {
+    const algoliasearch = await import('algoliasearch');
+    const searchIndex = algoliasearch('', '').initIndex('');
+    searchIndex.search('test').then(result => result.hits);
+  });
+});


### PR DESCRIPTION
`algoliasearch` definition doesn't work when it's imported with an `await import()`. This fixes it.