### PR TITLE
Fix FetchOptions in apollo-link-http

### DIFF
--- a/definitions/npm/apollo-link-http_v1.2.x/flow_v0.56.x-/apollo-link-http_v1.2.x.js
+++ b/definitions/npm/apollo-link-http_v1.2.x/flow_v0.56.x-/apollo-link-http_v1.2.x.js
@@ -56,7 +56,7 @@ declare module "apollo-link-http" {
     (operation: Operation): string;
   }
 
-  declare export interface FetchOptions {
+  declare export type FetchOptions = {
     uri?: string | UriFunction;
     fetch?: any;
     includeExtensions?: boolean;


### PR DESCRIPTION
Using type instead of interface removes string | UriFunction errors

Fixes #2026