### PR TITLE
Modify the contributing guidelines testing steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,9 +81,9 @@ the test-runner for *all* versions of Flow the package version supports. If you
 ever need to write a test for a particular version of Flow, you can put the
 `test_` file in the appropriate flow version directory.
 
-#### 5) Run your tests with `./run_def_tests.sh left-pad`
+#### 5) Run your tests with `flow-typed validate-defs definitions && flow-typed run-tests left-pad`
 
-You may also leave off the argument to run *all* tests (this takes a while). Please note that this test (and the one on Travis-CI) only will be able to run if the name of the repo folder is still "flow-typed".
+You may also leave off the argument `left-pad` to run *all* tests (this takes a while). Please note that this test (and the one on Travis-CI) only will be able to run if the name of the repo folder is still "flow-typed".
 
 #### 6) Send a pull request
 


### PR DESCRIPTION
Since `./run_def_tests.sh` is not working very well to run tests and
validate libdefs locally, I change the documentation to instead run the
command `flow-typed validate-defs definitions && flow-typed run-tests`.
This works like a charm.