### PR TITLE
Update sequelize transaction auto callback method signature

### DIFF
--- a/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/sequelize_v4.x.x.js
+++ b/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/sequelize_v4.x.x.js
@@ -7117,11 +7117,11 @@ declare module "sequelize" {
      * @param options Transaction Options
      * @param autoCallback Callback for the transaction
     */
-    transaction(options?: TransactionOptions): Promise<Transaction>,
-    transaction(
+    transaction<T, Fn: TransactionAutoCallback<T>>(autoCallback: Fn): Promise<T>,
+    transaction<T, Fn: TransactionAutoCallback<T>>(
       options: TransactionOptions,
-      autoCallback: (t: Transaction) => Promise<any>): Promise<void>,
-    transaction(autoCallback: (t: Transaction) => Promise<any>): Promise<void>,
+      autoCallback: Fn): Promise<T>,
+    transaction(options?: TransactionOptions): Promise<Transaction>,
 
     /**
      * Close all connections used by this sequelize instance, and free all references so the instance can be
@@ -7380,6 +7380,8 @@ declare module "sequelize" {
      */
     logging?: Function
   }
+
+  declare type TransactionAutoCallback<T> = (t:Transaction) => Promise<T> | T
 
   declare export interface fn {
     fn: string,

--- a/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/test_sequelize.js
+++ b/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/test_sequelize.js
@@ -1890,12 +1890,12 @@ s.transaction({
   });
 });
 
-s.transaction( function() {
-  return Promise.resolve();
-} );
-s.transaction( { isolationLevel : 'SERIALIZABLE' }, function( t ) { return Promise.resolve(); } );
-s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.SERIALIZABLE }, (t) => Promise.resolve() );
-s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.READ_COMMITTED }, (t) => Promise.resolve() );
+let autoCallback = (t: Transaction):Promise<string> => { return Promise.resolve('a') }
+let callbackValidator = (r:string) => {}
+s.transaction( autoCallback ).then( callbackValidator );
+s.transaction( { isolationLevel : 'SERIALIZABLE' }, autoCallback ).then( callbackValidator );
+s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.SERIALIZABLE }, autoCallback ).then( callbackValidator );
+s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.READ_COMMITTED }, autoCallback ).then( callbackValidator );
 
 // transaction types
 new Sequelize( '', { transactionType: 'DEFERRED' } );
@@ -1908,8 +1908,8 @@ s.transaction( { type : s.Transaction.TYPES.IMMEDIATE }, (t) => Promise.resolve(
 s.transaction( { type : s.Transaction.TYPES.EXCLUSIVE }, (t) => Promise.resolve() );
 
 // promise transaction
-s.transaction(async () => {
-});
+let asyncAutoCallback = async (t: Transaction):Promise<string> => 'a'
+s.transaction( asyncAutoCallback ).then( callbackValidator );
 
 // sync options types
 s.sync({


### PR DESCRIPTION
Adding an auto callback to sequelize changes the return signature of `transaction` to be whatever the auto callback resolves with.

There may be a slight issue with this implement in that, if you don't explicitly type the return signature of the passed in auto callback, flow can't seem figure out which method signature to use.

i.e.:
```
s.transaction( () => 'a' ).then( (a:string) => {} )
// Flow can't decide whether () => 'a' is transactionOptions or a callback
```

I think this might be a deficiency in flow's union refinement for overloaded methods, although I could be wrong.

Thoughts?