### PR TITLE
Reselect: Remove duplicated file metadata

### DIFF
--- a/definitions/npm/reselect_v3.x.x/flow_v0.47.x-/reselect_v3.x.x.js
+++ b/definitions/npm/reselect_v3.x.x/flow_v0.47.x-/reselect_v3.x.x.js
@@ -1,6 +1,3 @@
-// flow-typed signature: 0199525b667f385f2e61dbeae3215f21
-// flow-typed version: b43dff3e0e/reselect_v3.x.x/flow_>=v0.28.x
-
 declare module "reselect" {
   declare type Selector<-TState, TProps, TResult> =
     (state: TState, props: TProps, ...rest: any[]) => TResult


### PR DESCRIPTION
Looks like the file metadata got committed, so this is just cleaning that up