### PR TITLE
Add missing `isValid` prop to `formik` libdef

### DIFF
--- a/definitions/npm/formik_v0.11.x/flow_v0.53.x-/formik_v0.11.x.js
+++ b/definitions/npm/formik_v0.11.x/flow_v0.53.x-/formik_v0.11.x.js
@@ -103,6 +103,8 @@ declare module "formik" {
     touched: FormikTouched<Values>,
     /** whether the form is currently submitting */
     isSubmitting: boolean,
+    /** whether the form is valid */
+    isValid: boolean,
     /** Top level status state, in case you need it */
     status?: any,
     /** Number of times user tried to submit the form */


### PR DESCRIPTION
This is a missing key that should added to Formik's state type. It's documented here: https://github.com/jaredpalmer/formik#isvalid-boolean