### PR TITLE
Observable.catch() returns union type

### DIFF
--- a/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.25.0-v0.33.x/rxjs_v5.0.x.js
@@ -330,7 +330,7 @@ declare class rxjs$Observable<+T> {
 
   catch<U>(
     selector: (err: any, caught: rxjs$Observable<T>) => rxjs$Observable<U>
-  ): rxjs$Observable<U>;
+  ): rxjs$Observable<T | U>;
 
   concat<U>(...sources: rxjs$Observable<U>[]): rxjs$Observable<T | U>;
 

--- a/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
+++ b/definitions/npm/rxjs_v5.0.x/flow_v0.34.x-/rxjs_v5.0.x.js
@@ -370,7 +370,7 @@ declare class rxjs$Observable<+T> {
 
   catch<U>(
     selector: (err: any, caught: rxjs$Observable<T>) => rxjs$Observable<U>
-  ): rxjs$Observable<U>;
+  ): rxjs$Observable<T | U>;
 
   concat<U>(...sources: rxjs$Observable<U>[]): rxjs$Observable<T | U>;
 

--- a/definitions/npm/rxjs_v5.0.x/test_rxjs.js
+++ b/definitions/npm/rxjs_v5.0.x/test_rxjs.js
@@ -346,3 +346,6 @@ Observable.of(1)
 (numbers.last(): Observable<number>);
 // $ExpectError
 (numbers.last(): Observable<string>);
+
+// $ExpectError
+(Observable.of(0).catch(() => Observable.of('foo')): Observable<string>);


### PR DESCRIPTION
Before this change, adding `.catch()` to an observable would obscure any
type errors in the return type of the source observable.

FYI @matthewwithanm 