### PR TITLE
lodash and lodash/fp: get/getOr accept nil collections

### DIFF
--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/lodash_v4.x.x.js
@@ -1126,7 +1126,7 @@ declare module "lodash" {
     functions(object?: ?Object): Array<string>;
     functionsIn(object?: ?Object): Array<string>;
     get(
-      object?: ?Object | ?$ReadOnlyArray<any>,
+      object?: ?Object | ?$ReadOnlyArray<any> | void | null,
       path?: ?$ReadOnlyArray<string> | string,
       defaultValue?: any
     ): any;
@@ -2764,8 +2764,8 @@ declare module "lodash/fp" {
     forOwnRight(iteratee: OIteratee<*>, object: Object): Object;
     functions(object: Object): Array<string>;
     functionsIn(object: Object): Array<string>;
-    get(path: $ReadOnlyArray<string> | string): (object: Object | $ReadOnlyArray<any>) => any;
-    get(path: $ReadOnlyArray<string> | string, object: Object | $ReadOnlyArray<any>): any;
+    get(path: $ReadOnlyArray<string> | string): (object: Object | $ReadOnlyArray<any> | void | null) => any;
+    get(path: $ReadOnlyArray<string> | string, object: Object | $ReadOnlyArray<any> | void | null): any;
     prop(path: Array<string> | string): (object: Object | Array<any>) => any;
     prop(path: Array<string> | string, object: Object | Array<any>): any;
     path(path: Array<string> | string): (object: Object | Array<any>) => any;
@@ -2775,15 +2775,15 @@ declare module "lodash/fp" {
     ): ((
       path: Array<string> | string
     ) => (object: Object | Array<any>) => any) &
-      ((path: Array<string> | string, object: Object | Array<any>) => any);
+      ((path: Array<string> | string, object: Object | $ReadOnlyArray<any> | void | null) => any);
     getOr(
       defaultValue: any,
       path: Array<string> | string
-    ): (object: Object | Array<any>) => any;
+    ): (object: Object | $ReadOnlyArray<any> | void | null) => any;
     getOr(
       defaultValue: any,
       path: Array<string> | string,
-      object: Object | Array<any>
+      object: Object | $ReadOnlyArray<any> | void | null
     ): any;
     propOr(
       defaultValue: any

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-fp-v4.x.x.js
@@ -157,6 +157,12 @@ get('2', [{ a: 'foo' }, { b: 'bar' }, { c: 'baz' }]);
 get('3', [[1, 2], [3, 4], [5, 6], [7, 8]]);
 get('3')([[1, 2], [3, 4], [5, 6], [7, 8]]);
 
+// Nil - it is safe to perform on nil root values, just like nil values along the "get" path
+get('thing', null);
+get('data', undefined);
+getOr('default', 'stuff', null);
+getOr(12345, 'info', undefined);
+
 // First argument must be string when looking for array items by index
 // $ExpectError number This type is incompatible with union: ?array type | string
 get(0, [1, 2, 3]);

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -16,6 +16,7 @@ import first from "lodash/first";
 import flatMap from "lodash/flatMap";
 import forEach from "lodash/forEach";
 import get from "lodash/get";
+import getOr from 'lodash/fp/getOr';
 import groupBy from "lodash/groupBy";
 import intersectionBy from "lodash/intersectionBy";
 import isEqual from "lodash/isEqual";

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -16,7 +16,6 @@ import first from "lodash/first";
 import flatMap from "lodash/flatMap";
 import forEach from "lodash/forEach";
 import get from "lodash/get";
-import getOr from 'lodash/fp/getOr';
 import groupBy from "lodash/groupBy";
 import intersectionBy from "lodash/intersectionBy";
 import isEqual from "lodash/isEqual";
@@ -169,8 +168,6 @@ get([[1, 2], [3, 4], [5, 6], [7, 8]], "3");
 // Nil - it is safe to perform on nil root values, just like nil values along the "get" path
 get(null, 'thing');
 get(undefined, 'data');
-getOr(null, 'stuff', 'default');
-getOr(undefined, 'info', 12345);
 
 // Second argument must be string when looking for array items by index
 // $ExpectError number This type is incompatible with union: ?array type | string

--- a/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
+++ b/definitions/npm/lodash_v4.x.x/flow_v0.63.x-/test_lodash-v4.x.x.js
@@ -165,6 +165,12 @@ get(["foo", "bar", "baz"], "[1]");
 get([{ a: "foo" }, { b: "bar" }, { c: "baz" }], "2");
 get([[1, 2], [3, 4], [5, 6], [7, 8]], "3");
 
+// Nil - it is safe to perform on nil root values, just like nil values along the "get" path
+get(null, 'thing');
+get(undefined, 'data');
+getOr(null, 'stuff', 'default');
+getOr(undefined, 'info', 12345);
+
 // Second argument must be string when looking for array items by index
 // $ExpectError number This type is incompatible with union: ?array type | string
 get([1, 2, 3], 0);


### PR DESCRIPTION
Virtually all lodash functions can take `null`/`undefined` for their input collection; for example, `map` will never run its iterator function and simply return an empty array. However, it's not clear how much of this should be allowed by Flow. Allowing nil on absolutely everything may dramatically lower the overall usefulness of the type-checking because even though those _may_ work with nil inputs, it's very often the case that the programmer never _intended_ that as a possibility and would have preferred an error.

Despite that, there's one case which seems extremely useful to allow `null`/`undefined`, which is `get`/`getOr`. Perhaps the primary use of these functions over simply `accessing.things['directly']` is because it avoids `cannot read property "directly" of undefined` errors with lodash's built-in nil checks. If for whatever reason lodash cannot get the value desired, it will return `undefined`.

It would very convenient to be able to extend this safety up to the root level:
`fp.get(['optional', 'property'], root)`
Currently the above will pass Flow if `optional` is a primitive or not defined, but will fail Flow if `root` may be nil. This PR allows nil values for `root`. This avoids the extra verbosity of doing a separate nil check when `get` is already nil-checking from top to bottom.