### PR TITLE
added optional keepOffset parameter to Moment.toISOString()

### DIFF
--- a/definitions/npm/moment_v2.3.x/flow_v0.34.x-/moment_v2.3.x.js
+++ b/definitions/npm/moment_v2.3.x/flow_v0.34.x-/moment_v2.3.x.js
@@ -260,7 +260,9 @@ declare class moment$Moment {
   toDate(): Date,
   toArray(): Array<number>,
   toJSON(): string,
-  toISOString(): string,
+  toISOString(
+    keepOffset?: boolean
+  ): string,
   toObject(): moment$MomentObject,
   isBefore(
     date?: moment$Moment | string | number | Date | Array<number>,

--- a/definitions/npm/moment_v2.3.x/test_moment-v2.js
+++ b/definitions/npm/moment_v2.3.x/test_moment-v2.js
@@ -10,6 +10,7 @@ moment.unix("1234");
 // Display
 const A: Date = moment().toDate();
 const x: string = moment().toISOString();
+const y: string = moment().toISOString(true);
 
 // Get + Set
 // $ExpectError
@@ -53,6 +54,8 @@ moment().calendar(null, {
   // $ExpectError (>=0.56.0)
   sameElse: () => {}
 });
+// $ExpectError
+const y: string = moment().toISOString('foo');
 
 // UTC offsets
 let n: number;


### PR DESCRIPTION
The keepOffset optional parameter was added to version 2.20 of moment.  Since it is a minor change and backwards compatible, I added it to the 2.3 type definition.  If it's better to create a new version, I can.