### PR TITLE
Improve react-toggled libdefs

### DIFF
--- a/definitions/npm/react-toggled_v1.x.x/flow_v0.54.1-/react-toggled_v1.x.x.js
+++ b/definitions/npm/react-toggled_v1.x.x/flow_v0.54.1-/react-toggled_v1.x.x.js
@@ -1,18 +1,21 @@
 declare module 'react-toggled' {
   declare export type ToggledProps = {
     on: boolean,
-    getTogglerProps(): {
+    getTogglerProps<P>(props?: P): {
+      ...P,
       'aria-expanded': boolean,
       tabIndex: 0,
       onClick(): void
     },
-    getInputTogglerProps(): {
+    getInputTogglerProps<P>(props?: P): {
+      ...P,
       'aria-expanded': boolean,
       tabIndex: 0,
       onKeyUp(): void,
       onClick(): void
     },
-    getElementTogglerProps(): {
+    getElementTogglerProps<P>(props?: P): {
+      ...P,
       'aria-expanded': boolean,
       tabIndex: 0,
       onKeyUp(): void,
@@ -27,7 +30,7 @@ declare module 'react-toggled' {
     defaultOn?: boolean,
     onToggle?: (on: boolean, p: ToggledProps) => void,
     on?: boolean,
-    children: (ToggledProps) => React$Node | React$Node
+    children: React$Node | ((ToggledProps) => React$Node)
   };
 
   declare module.exports: React$ComponentType<ReactToggledProps>;

--- a/definitions/npm/react-toggled_v1.x.x/flow_v0.54.1-/test_react-toggled_v1.x.x.js
+++ b/definitions/npm/react-toggled_v1.x.x/flow_v0.54.1-/test_react-toggled_v1.x.x.js
@@ -2,29 +2,33 @@
 
 import React from 'react';
 import Toggle from 'react-toggled';
+import { describe, it } from 'flow-typed-test';
 
-{
+it('defaultOn prop should be boolean', () => {
   // $ExpectError
-  <Toggle defaultOn={2}><div/></Toggle>;
-}
+  <Toggle defaultOn={2}><div /></Toggle>;
+  <Toggle defaultOn><div /></Toggle>;
+});
 
-{
+it('on prop should be boolean', () => {
   // $ExpectError
-  <Toggle on={2}><div/></Toggle>;
-}
+  <Toggle on={2}><div /></Toggle>;
+  <Toggle on><div /></Toggle>;
+});
 
-{
+it('onToggle prop should be a function', () => {
   // $ExpectError
-  <Toggle onToggle={2}><div/></Toggle>;
-}
+  <Toggle onToggle={2}><div /></Toggle>;
+  <Toggle onToggle={() => {}}><div /></Toggle>;
+});
 
-{
+it('require children prop', () => {
   // $ExpectError
   <Toggle />;
-}
 
-{
-  <Toggle defaultOn>
+  <Toggle><div /></Toggle>;
+
+  <Toggle>
     {({ on, setOn, setOff, getTogglerProps, getInputTogglerProps, getElementTogglerProps, toggle }) => (
       <div>
         <button {...getTogglerProps()} onClick={setOn}/>
@@ -32,5 +36,17 @@ import Toggle from 'react-toggled';
         <input type="checkbox" {...getInputTogglerProps()}/>
       </div>
     )}
+  </Toggle>;
+
+  const overrides = { onClick: () => {} };
+  // getTogglerProps, getInputTogglerProps and getElementTogglerProps can take an optional argument
+  <Toggle>
+    {({ on, setOn, setOff, getTogglerProps, getInputTogglerProps, getElementTogglerProps, toggle }) => (
+      <div>
+        <button {...getTogglerProps(overrides)} onClick={setOn}/>
+        <div {...getElementTogglerProps(overrides)}/>
+        <input type="checkbox" {...getInputTogglerProps(overrides)}/>
+      </div>
+    )}
   </Toggle>
-}
+});


### PR DESCRIPTION
Describe an optional argument for `getTogglerProps`, `getElementTogglerProps`, and `getInputTogglerProps`