### PR TITLE
Update fantasy-options_v0.0.1/flow_v0.37.x

### DIFF
--- a/definitions/npm/fantasy-options_v0.0.1/flow_v0.37.x-/fantasy-options_v0.0.1.js
+++ b/definitions/npm/fantasy-options_v0.0.1/flow_v0.37.x-/fantasy-options_v0.0.1.js
@@ -2,7 +2,7 @@ declare module 'fantasy-options' {
   declare class OptionType<A> {
     ap(a: this): this,
     map<B>(f: (a: A) => B): OptionType<B>,
-    fold(f: (a: A) => mixed, g: (...rest: Array<void>) => mixed): mixed,
+    fold<B>(f: (a: A) => B, g: (...rest: Array<void>) => B): B,
     chain<B>(f: (a: A) => OptionType<B>): OptionType<B>,
     concat(a: OptionType<A>): this,
     getOrElse(a: A): A,

--- a/definitions/npm/fantasy-options_v0.0.1/flow_v0.37.x-/fantasy-options_v0.0.1.js
+++ b/definitions/npm/fantasy-options_v0.0.1/flow_v0.37.x-/fantasy-options_v0.0.1.js
@@ -2,7 +2,7 @@ declare module 'fantasy-options' {
   declare class OptionType<A> {
     ap(a: this): this,
     map<B>(f: (a: A) => B): OptionType<B>,
-    fold(f: (a: A) => A, g: (...rest: Array<void>) => A): A,
+    fold(f: (a: A) => mixed, g: (...rest: Array<void>) => mixed): mixed,
     chain<B>(f: (a: A) => OptionType<B>): OptionType<B>,
     concat(a: OptionType<A>): this,
     getOrElse(a: A): A,

--- a/definitions/npm/fantasy-options_v0.0.1/flow_v0.37.x-/test_options.js
+++ b/definitions/npm/fantasy-options_v0.0.1/flow_v0.37.x-/test_options.js
@@ -33,10 +33,10 @@ Some('world').fold(x => `Hello, ${x}!`, () => 'I dunno');
 None.fold(x => 'a', () => 'b');
 
 // $ExpectError
-Some('world').fold(x => x * 100, () => 'foo');
+Some('Hello').fold(x => `${x}, world!`, 24)
 
 // $ExpectError
-None.fold(x => x * 3, () => 'foo');
+Some('Hello').fold(42, () => 43)
 
 Some('Hello').chain(x => Some('world!'));
 
@@ -47,7 +47,7 @@ Some([1, 2]).concat(Some[(3, 4)]);
 
 Some([]).concat(None).getOrElse([]);
 
-// This should be an error, unsure how to type cocnat
+// This should be an error, unsure how to type concat
 Some(3).concat(Some([3, 3]));
 
 Some(3).orElse('foo');


### PR DESCRIPTION
Changed the return types in `fold` to allow return types other than the value contained in the Option.

The fantasyland spec is unclear on `fold` and from practical use it seems more often than not we want some `f :: A -> B` as the parameter as opposed to the identity function.

The only restriction, to make fold safe to use, is that `f` and `g` have the _same_ return type.