### PR TITLE
update to latest from react-navigation/1.x

### DIFF
--- a/definitions/npm/react-navigation_v1.x.x/flow_v0.60.x-/react-navigation_v1.x.x.js
+++ b/definitions/npm/react-navigation_v1.x.x/flow_v0.60.x-/react-navigation_v1.x.x.js
@@ -113,27 +113,27 @@ declare module 'react-navigation' {
   |};
 
   declare export type NavigationReplaceAction = {|
-    type: 'Navigation/REPLACE',
-    key: string,
-    routeName: string,
-    params?: NavigationParams,
-    action?: NavigationNavigateAction,
+    +type: 'Navigation/REPLACE',
+    +key: string,
+    +routeName: string,
+    +params?: NavigationParams,
+    +action?: NavigationNavigateAction,
   |};
   declare export type NavigationPopAction = {|
-    type: 'Navigation/POP',
-    n?: number,
-    immediate?: boolean,
+    +type: 'Navigation/POP',
+    +n?: number,
+    +immediate?: boolean,
   |};
   declare export type NavigationPopToTopAction = {|
-    type: 'Navigation/POP_TO_TOP',
-    immediate?: boolean,
+    +type: 'Navigation/POP_TO_TOP',
+    +immediate?: boolean,
   |};
   declare export type NavigationPushAction = {|
-    type: 'Navigation/PUSH',
-    routeName: string,
-    params?: NavigationParams,
-    action?: NavigationNavigateAction,
-    key?: string,
+    +type: 'Navigation/PUSH',
+    +routeName: string,
+    +params?: NavigationParams,
+    +action?: NavigationNavigateAction,
+    +key?: string,
   |};
 
   declare export type NavigationAction =
@@ -360,6 +360,7 @@ declare module 'react-navigation' {
     initialRouteParams?: NavigationParams,
     paths?: NavigationPathsConfig,
     navigationOptions?: NavigationScreenConfig<*>,
+    initialRouteKey?: string,
   |};
 
   declare export type NavigationStackViewConfig = {|
@@ -490,6 +491,7 @@ declare module 'react-navigation' {
       action?: NavigationNavigateAction
     ) => boolean,
     setParams: (newParams: NavigationParams) => boolean,
+    getParam: (paramName: string, fallback?: any) => any,
     addListener: (
       eventName: string,
       callback: NavigationEventCallback
@@ -513,6 +515,29 @@ declare module 'react-navigation' {
     screenProps?: {},
     navigationOptions?: O,
   }>;
+
+  //declare export type NavigationNavigatorProps<O: {}, S: {}> =
+  //  | {}
+  //  | { navigation: NavigationScreenProp<S> }
+  //  | { screenProps: {} }
+  //  | { navigationOptions: O }
+  //  | {
+  //      navigation: NavigationScreenProp<S>,
+  //      screenProps: {},
+  //    }
+  //  | {
+  //      navigation: NavigationScreenProp<S>,
+  //      navigationOptions: O,
+  //    }
+  //  | {
+  //      screenProps: {},
+  //      navigationOptions: O,
+  //    }
+  //  | {
+  //      navigation: NavigationScreenProp<S>,
+  //      screenProps: {},
+  //      navigationOptions: O,
+  //    };
 
   /**
    * Navigation container
@@ -973,6 +998,8 @@ declare module 'react-navigation' {
     itemsContainerStyle?: ViewStyleProp,
     itemStyle?: ViewStyleProp,
     labelStyle?: TextStyleProp,
+    activeLabelStyle?: TextStyleProp,
+    inactiveLabelStyle?: TextStyleProp,
     iconContainerStyle?: ViewStyleProp,
     drawerPosition: 'left' | 'right',
   };
@@ -1052,13 +1079,17 @@ declare module 'react-navigation' {
   };
   declare export var TabBarBottom: React$ComponentType<_TabBarBottomProps>;
 
-  declare type _NavigationInjectedProps = {
-    navigation: NavigationScreenProp<NavigationStateRoute>,
-  };
-  declare export function withNavigation<T: {}>(
-    Component: React$ComponentType<T & _NavigationInjectedProps>
-  ): React$ComponentType<T>;
-  declare export function withNavigationFocus<T: {}>(
-    Component: React$ComponentType<T & _NavigationInjectedProps>
-  ): React$ComponentType<T>;
+  declare export function withNavigation<Props: {}>(
+    Component: React$ComponentType<Props>
+  ): React$ComponentType<
+    $Diff<
+      Props,
+      {
+        navigation: NavigationScreenProp<NavigationStateRoute> | void,
+      }
+      >
+    >;
+  declare export function withNavigationFocus<Props: {}>(
+    Component: React$ComponentType<Props>
+  ): React$ComponentType<$Diff<Props, { isFocused: boolean | void }>>;
 }


### PR DESCRIPTION
This update should simply get this repo synchronized with the flow types defined in [`react-navigation`](https://github.com/react-navigation/react-navigation/blob/master/flow/react-navigation.js). Most of the changes are from this recently approved pr: https://github.com/react-navigation/react-navigation/pull/4085. This fixes the following:

- The typedef for [`getParam`](https://reactnavigation.org/docs/navigation-prop.html#getparam-get-a-specific-param-value-with-a-fallback) is missing.

- The return type for `withNavigation` is incorrect per the [flow documentation](https://flow.org/en/docs/react/hoc/#toc-injecting-props-with-a-higher-order-component) for injecting props with an HOC. The injected prop should be removed from the returned component's prop types. I'm not sure why this doesn't seem to cause an issue in the example app, but flow insisted I need a `navigation` prop in my own app until I fixed this.