### PR TITLE
Support for `BackButton` in react-router-native

### DIFF
--- a/definitions/npm/react-router-native_v4.x.x/flow_v0.53.x-/react-router-native_v4.x.x.js
+++ b/definitions/npm/react-router-native_v4.x.x/flow_v0.53.x-/react-router-native_v4.x.x.js
@@ -14,6 +14,10 @@ declare module "react-router-native" {
   declare export class DeepLinking extends React$Component<{
     children?: React$Node
   }> {}
+  
+  declare export class BackButton extends React$Component<{
+    children?: React$Node
+  }> {}
 
   declare export class AndroidBackButton extends React$Component<{
     children?: React$Node


### PR DESCRIPTION
This PR adds support for the `BackButton` export in `react-router-native`. The current code only supports `AndroidBackButton` which is the legacy export.

See https://github.com/ReactTraining/react-router/blob/master/packages/react-router-native/main.js#L9 for the source code reference