### PR TITLE
[react-apollo] Fix Query component typing

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -206,7 +206,7 @@ declare module 'react-apollo' {
   declare export function cleanupApolloState(apolloState: any): void;
 
   declare type QueryRenderPropFunction<TData, TVariables> = ({
-    data: TData,
+    data?: TData,
     loading: boolean,
     error: ?ApolloError,
     variables: TVariables,


### PR DESCRIPTION
If case of error, result object doesn't contain `data` property, please see the original TypeScript typings: https://github.com/apollographql/react-apollo/blob/master/src/Query.tsx#L97