### PR TITLE
fix react-dnd connector type to mesh well with recompose

### DIFF
--- a/definitions/npm/react-dnd_v2.x.x/flow_v0.53.x-/react-dnd_v2.x.x.js
+++ b/definitions/npm/react-dnd_v2.x.x/flow_v0.53.x-/react-dnd_v2.x.x.js
@@ -42,7 +42,7 @@ declare module "react-dnd" {
     ) => Class<
       ConnectedComponent<C, InstanceOf<C>, { ...CP } & $Diff<P, CP>>
     >) &
-    (<P: SP, C: React$StatelessFunctionalComponent<P>>(
+    (<P: SP, C: React$ComponentType<P>>(
       component: C
     ) => Class<ConnectedComponent<C, void, { ...CP } & $Diff<P, CP>>>);
 


### PR DESCRIPTION
We needed this change in our own codebase, we have a stateless function component that is wrapped with recompose `withHandlers` the following flow error would occur:

```
Cannot call DragSource(...) because:
 - Either React.StatelessFunctionalComponent [1] is incompatible with statics of React.Component [2] in type argument C.
 - Or React.StatelessFunctionalComponent [1] is incompatible with statics of React.Component [3] in type argument C.
 - Or a callable signature is missing in statics of React.Component [4] but exists in
   React.StatelessFunctionalComponent [5] in type argument C.
```

potentially addresses #1564 ?