### PR TITLE
[react-redux] fix import position

### DIFF
--- a/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
+++ b/definitions/npm/react-redux_v5.x.x/flow_v0.62.0-/react-redux_v5.x.x.js
@@ -1,7 +1,7 @@
 import type { Dispatch, Store } from "redux";
+import type { ComponentType, ElementConfig } from 'react';
 
 declare module "react-redux" {
-  import type { ComponentType, ElementConfig } from 'react';
 
   declare export class Provider<S, A> extends React$Component<{
     store: Store<S, A>,


### PR DESCRIPTION
An error occurred at the current position.

```
undefined property hasReviewed [1] is incompatible with boolean [2].

     flow-typed/npm/react-redux_v5.x.x.js
     78│     SP: Object,
     79│     RSP: Object,
     80│     RDP: Object,
 [1] 81│     CP: $Diff<$Diff<ElementConfig<Com>, RSP>, RDP>,
     82│   >(
     83│     mapStateToProps: MapStateToProps<S, SP, RSP>,
     84│     mapDispatchToProps: MapDispatchToProps<A, DP, RDP>,

     javascripts/app/components/Bbs/App.jsx
 [2]  8│   hasReviewed: boolean,
```