### PR TITLE
[react-apollo] Fix TVariables in OperationComponent

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -132,23 +132,21 @@ declare module 'react-apollo' {
     alias?: string;
   }
 
-  // Third argument of TMergedProps should be TVariables, but generics order
-  // is preserved for backward compatibility.
   declare export interface OperationComponent<
     TResult: Object = {},
     TOwnProps: Object = {},
-    TMergedProps: Object = ChildProps<TOwnProps, TResult, {}>,
-    TVariables: Object = {}
+    TVariables: Object = {},
+    TMergedProps: Object = ChildProps<TOwnProps, TResult, TVariables>
   > {
     (
       component: React$ComponentType<TMergedProps>
     ): React$ComponentType<TOwnProps>;
   }
 
-  declare export function graphql<TResult, TProps, TChildProps, TVariables>(
+  declare export function graphql<TResult, TProps, TVariables, TChildProps>(
     document: DocumentNode,
     operationOptions?: OperationOption<TResult, TProps, TChildProps, TVariables>
-  ): OperationComponent<TResult, TProps, TChildProps, TVariables>;
+  ): OperationComponent<TResult, TProps, TVariables, TChildProps>;
 
   declare type WithApolloOptions = {
     withRef?: boolean,

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
@@ -111,6 +111,7 @@ it("works with class component with it's own variable Props specified at the end
   const withFancyData2: OperationComponent<
     IQuery,
     Cmplx2OwnProps,
+    *,
     Cmplx2ComponentProps
   > = graphql(query);
   const Cmplx2WithData = withFancyData2(Cmplx2Component);
@@ -158,8 +159,8 @@ it('works with Variables specified', () => {
   const withCharacter: OperationComponent<
     Response,
     InputProps,
-    Props,
-    Variables
+    Variables,
+    Props
   > = graphql(HERO_QUERY, {
     options: ({ episode }) => {
       // $ExpectError [string] The operand of an arithmetic operation must be a number


### PR DESCRIPTION
This allows `TVariables` to be used correctly and adds check on the arguments passed to `mutate`. 

This will break backwards compatibility, but I think the effort for proper typing is beyond backwards compatibility, especially in a static type system. Breaking compatibility will surely be annoying, but it won't cause runtime issues. Having insufficient typing might on the other hand cause issues. 
The current solution creates a situation where we have types but not really enforce them, which renderes them useless. 

