### PR TITLE
[react-helmet] Fix wrong typing of toComponent on attributes

### DIFF
--- a/definitions/npm/react-helmet_v5.x.x/flow_v0.53.x-/react-helmet_v5.x.x.js
+++ b/definitions/npm/react-helmet_v5.x.x/flow_v0.53.x-/react-helmet_v5.x.x.js
@@ -27,10 +27,15 @@ declare module 'react-helmet' {
     toComponent(): [React$Element<*>] | React$Element<*> | Array<Object>;
   }
 
+  declare interface AttributeTagMethods {
+    toString(): string;
+    toComponent(): {[string]: *};
+  }
+
   declare interface StateOnServer {
     base: TagMethods;
-    bodyAttributes: TagMethods,
-    htmlAttributes: TagMethods;
+    bodyAttributes: AttributeTagMethods,
+    htmlAttributes: AttributeTagMethods;
     link: TagMethods;
     meta: TagMethods;
     noscript: TagMethods;

--- a/definitions/npm/react-helmet_v5.x.x/test_react-helmet.js
+++ b/definitions/npm/react-helmet_v5.x.x/test_react-helmet.js
@@ -57,4 +57,19 @@ heads.forEach((head) => {
   (head.script.toString(): boolean);
   // $ExpectError
   (head.style.toString(): boolean);
+
+  const Component = (
+    <html {...head.htmlAttributes.toComponent()}>
+      <head>
+        {head.title.toComponent()}
+        {head.meta.toComponent()}
+        {head.link.toComponent()}
+        {head.script.toComponent()}
+        {head.style.toComponent()}
+        {head.base.toComponent()}
+      </head>
+      <body {...head.bodyAttributes.toComponent()}>
+      </body>
+    </html>
+  )
 });


### PR DESCRIPTION
This PR fixes a bug in the annotations to React Helmet, where the `body` and `html` attributes have the same types as e.g. `title` and `meta` components.