### PR TITLE
Jest 22.X.X - Chore: Update spyOn type to reflect third optional accessType argument

### DIFF
--- a/definitions/npm/jest_v22.x.x/flow_v0.39.x-/jest_v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.39.x-/jest_v22.x.x.js
@@ -448,7 +448,7 @@ type JestObjectType = {
    * Creates a mock function similar to jest.fn but also tracks calls to
    * object[methodName].
    */
-  spyOn(object: Object, methodName: string): JestMockFn<any, any>,
+  spyOn(object: Object, methodName: string, accessType?: "get" | "set"): JestMockFn<any, any>,
   /**
    * Set the default timeout interval for tests and before/after hooks in milliseconds.
    * Note: The default timeout interval is 5 seconds if this method is not called.

--- a/definitions/npm/jest_v22.x.x/flow_v0.39.x-/test_jest-v22.x.x.js
+++ b/definitions/npm/jest_v22.x.x/flow_v0.39.x-/test_jest-v22.x.x.js
@@ -185,7 +185,7 @@ jest.dontMock("testModule1").dontMock("testModule2");
 
 jest.resetModules().resetModules();
 
-jest.spyOn({}, "foo");
+jest.spyOn({}, "foo", "get");
 
 jest.setTimeout(1000);
 


### PR DESCRIPTION
From Jest Docs - 
Since Jest 22.1.0+, the jest.spyOn method takes an optional third argument of accessType that can be either 'get' or 'set', which proves to be useful when you want to spy on a getter or a setter, respectively.

This PR adds accessType as optional with values of either "get" or "set"