### PR TITLE
[react-apollo] Improve usability of Query and Mutation components

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -50,15 +50,15 @@ declare module 'react-apollo' {
 
   declare export type GraphqlData<TResult, TVariables> = GraphqlQueryControls &
     TResult & {
-      variables: TVariables,
-      refetch: (variables?: TVariables) => Promise<ApolloQueryResult<any>>,
-    };
+    variables: TVariables,
+    refetch: (variables?: TVariables) => Promise<ApolloQueryResult<any>>,
+  };
 
   declare export type ChildProps<
     TOwnProps,
     TResult,
     TVariables: Object = {}
-  > = {
+    > = {
     data: GraphqlData<TResult, TVariables>,
     mutate: MutationFunc<TResult, TVariables>,
   } & TOwnProps;
@@ -128,7 +128,7 @@ declare module 'react-apollo' {
     TProps: {},
     TChildProps: {},
     TVariables: {}
-  > {
+    > {
     +options?: OptionDescription<TProps, TVariables>;
     props?: (
       props: OptionProps<TProps, TResult, TVariables>
@@ -145,7 +145,7 @@ declare module 'react-apollo' {
     TOwnProps: Object = {},
     TVariables: Object = {},
     TMergedProps: Object = ChildProps<TOwnProps, TResult, TVariables>
-  > {
+    > {
     (
       component: React$ComponentType<TMergedProps>
     ): React$ComponentType<TOwnProps>;
@@ -211,10 +211,10 @@ declare module 'react-apollo' {
 
   declare export function cleanupApolloState(apolloState: any): void;
 
-  declare type QueryRenderPropFunction<TData, TVariables> = ({
-    data?: TData,
+  declare export type QueryRenderProps<TData, TVariables> = {
+    data?: TData | {||},
     loading: boolean,
-    error: ?ApolloError,
+    error?: ApolloError,
     variables: TVariables,
     networkStatus: NetworkStatus,
     refetch: (variables?: TVariables) => Promise<mixed>,
@@ -225,12 +225,14 @@ declare module 'react-apollo' {
     subscribeToMore: (options: {document?: DocumentNode, variables?: TVariables, updateQuery?: Function, onError?: Function}) => () => void,
     updateQuery: (previousResult: TData, options?: {variables: TVariables}) => TData,
     client: ApolloClient
-  }) => React$Node
+  }
 
-  declare export class Query<TData> extends React$Component<{
+  declare export type QueryRenderPropFunction<TData, TVariables> = (QueryRenderProps<TData, TVariables>) => React$Node
+
+  declare export class Query<TData, TVariables> extends React$Component<{
     query: DocumentNode,
-    children: QueryRenderPropFunction<TData, {[string]: any}>,
-    variables?: {[string]: any},
+    children: QueryRenderPropFunction<TData, TVariables>,
+    variables?: TVariables,
     pollInterval?: number,
     notifyOnNetworkStatusChange?: boolean,
     fetchPolicy?: FetchPolicy,
@@ -241,26 +243,28 @@ declare module 'react-apollo' {
     context?: {[string]: any}
   }> {}
 
-  declare type MutateFunction = (options: {
-    variables?: {[string]: any},
+  declare export type MutationFunction<TVariables> = (options: {
+    variables?: TVariables,
     optimisticResponse?: Object,
     refetchQueries?: (mutationResult: FetchResult) => Array<{query: DocumentNode, variables: {[string]: any}}>,
     update?: (cache: DataProxy, mutationResult: FetchResult) => any
   }) => Promise<*>
 
-  declare type MutationRenderPropFunction<TData> = (mutate: MutateFunction, result: {loading: boolean, error: ?ApolloError, data: TData}) => React$Node
-    declare export class Mutation<TData> extends React$Component<{
+  declare export type MutationResult<TData> = {loading: boolean, error?: ApolloError, data?: TData}
+
+  declare export type MutationRenderPropFunction<TData, TVariables> = (mutate: MutationFunction<TVariables>, result: MutationResult<TData>) => React$Node
+
+  declare export class Mutation<TData, TVariables> extends React$Component<{
     mutation: DocumentNode,
-    children: MutationRenderPropFunction<TData>,
-    variables?: {[string]: any},
+    children: MutationRenderPropFunction<TData, TVariables>,
+    variables?: TVariables,
     update?: (cache: DataProxy, mutationResult: FetchResult) => any,
     ignoreResults?: boolean,
     optimisticResponse?: Object,
-    refetchQueries?: (mutationResult: FetchResult) => Array<{query: DocumentNode, variables: {[string]: any}}>,
+    refetchQueries?: (mutationResult: FetchResult) => Array<{query: DocumentNode, variables: TVariables}>,
     onCompleted?: (data: TData) => void,
     onError?: (error: ApolloError) => void,
     context?: {[string]: any}
   }> {}
-
 
 }

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
@@ -1,9 +1,14 @@
 // @flow
 import * as React from 'react';
-import { it } from 'flow-typed-test';
+import { it, describe } from 'flow-typed-test';
 import {
+  Query,
+  Mutation,
   graphql,
   withApollo,
+  type MutationFunction,
+  type MutationResult,
+  type QueryRenderProps,
   type OperationComponent,
   type GraphqlQueryControls,
   type ChildProps,
@@ -195,7 +200,6 @@ it('works with Variables specified', () => {
       return null; // actual component with data;
     }
   }
-
   const CharacterWithData = withCharacter(Character);
 });
 
@@ -210,3 +214,49 @@ it('works with withApollo HOC', () => {
   (Manual: React.ComponentType<{}>);
 })
 
+describe('Query', () => {
+  it('works', () => {
+    type Vars = {|foo: string|}
+    type Res = {|res: string|}
+    const vars: Vars = {foo: 'bar'}
+    const q = (
+      <Query variables={vars} query={HERO_QUERY}>
+        {({data}: QueryRenderProps<Res, Vars>) => {
+          // $ExpectError Cannot get `data.res`
+          data.res
+          if (!data) {
+            return
+          }
+          const d1: Res | {||} = data
+          // $ExpectError Cannot get `data.res` because property `res` is missing in object type
+          const s: string = data.res
+          if (d1.res) {
+            const d2: Res = d1
+            const s: string = d1.res
+          }
+        }}
+      </Query>
+    )
+  })
+})
+
+describe('Mutation', () => {
+  it('works', () => {
+    type Vars = {|foo: string|}
+    type Res = {|res: string|}
+    const vars: Vars = {foo: 'bar'}
+    const q = (
+      <Mutation variables={vars} mutation={HERO_QUERY}>
+        {(update: MutationFunction<Vars>, {data}: MutationResult<Res>) => {
+          // $ExpectError Cannot get `data.res`
+          data.res
+          if (!data) {
+            return
+          }
+          const d1: Res = data
+          const s: string = data.res
+        }}
+      </Mutation>
+    )
+  })
+})


### PR DESCRIPTION
By exporting and using type arguments it becomes
very easy to use these components with e.g. apollo-codegen

So given a mutation with vars of type `MVars` and result of type `MData` or a query with data `QData` or vars `QVars`, we can annotate like this:

```jsx
<Mutation>
  {(update: MutationFunction<MVars>, result: MutationResult<MData>) => { ... }}
</Mutation>
<Query>
  {(props: QueryRenderProps <QData, QVars>) => { ... }}
</Query>

```

Needs tests!