### PR TITLE
add Subscription component to react-apollo defs

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -236,12 +236,27 @@ declare module 'react-apollo' {
     pollInterval?: number,
     notifyOnNetworkStatusChange?: boolean,
     fetchPolicy?: FetchPolicy,
-    errorPolicty?: ErrorPolicy,
+    errorPolicy?: ErrorPolicy,
     ssr?: boolean,
     displayName?: string,
     delay?: boolean,
     context?: {[string]: any}
   }> {}
+
+  declare type SubscriptionResult<TData> = {
+    loading: boolean,
+    data?: TData,
+    error?: ApolloError,
+  }
+
+  declare type SubscriptionProps<TData> = {
+    subscription: DocumentNode,
+    variables?: { [string]: any },
+    shouldResubscribe?: boolean | (SubscriptionProps<TData>, SubscriptionProps<TData>) => boolean,
+    children: (result: SubscriptionResult<TData>) => React$Node,
+  }
+
+  declare export class Subscription<TData> extends React$Component<SubscriptionProps<TData>> {}
 
   declare export type MutationFunction<TVariables> = (options: {
     variables?: TVariables,


### PR DESCRIPTION
PR #2086 added types for react-apollo's `<Query>` and `<Mutation>` components, but not `<Subscription>`. This PR adds the `<Subscription>` component, and fixes a small typo in the definition of `<Query>`