### PR TITLE
fix(sequelize): fix invalid errors from BelongsToMany association definitions

### DIFF
--- a/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/sequelize_v4.x.x.js
+++ b/definitions/npm/sequelize_v4.x.x/flow_v0.42.x-/sequelize_v4.x.x.js
@@ -1465,7 +1465,7 @@ declare module "sequelize" {
     TargetInitAttributes: Object,
     Target: Model<TargetAttributes, TargetInitAttributes>,
     ThroughAttributes: Object,
-    Through: Model<ThroughAttributes>
+    Through: Model<ThroughAttributes, any>
   > extends Association<Source, Target> {
     associationType: 'BelongsToMany';
     foreignKey: string;
@@ -3889,7 +3889,7 @@ declare module "sequelize" {
       TargetInitAttributes: Object,
       Target: Model<TargetAttributes, TargetInitAttributes>,
       ThroughAttributes: Object,
-      Through: Model<ThroughAttributes>
+      Through: Model<ThroughAttributes, any>
     >(
       target: Class<Target>,
       options: AssociationOptionsBelongsToMany<Through>


### PR DESCRIPTION
This fixes invalid flow errors like the following:

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/server/collections/Organization.js:68:5

Cannot instantiate BelongsToMany because:
 • property createdAt is missing in UsersOrganizationsJoinInitAttributes [1] but exists in object
   type [2] in type argument TInitAttributes [3] of type argument Through.
 • property updatedAt is missing in UsersOrganizationsJoinInitAttributes [1] but exists in object
   type [2] in type argument TInitAttributes [3] of type argument Through.

     src/server/collections/Organization.js
       58│   createdAt: Date;
       59│   updatedAt: Date;
       60│
       61│   static Users: Association.BelongsToMany<OrganizationAttributes,
       62│     OrganizationInitAttributes,
       63│     Organization,
       64│     UserAttributes,
       65│     UserInitAttributes,
       66│     User,
       67│     UsersOrganizationsJoinAttributes,
       68│     UsersOrganizationsJoin> = (null: any)
       69│
       70│   getUsers: BelongsToManyGetMany<User>
       71│   setUsers: BelongsToManySetMany<User, number, UsersOrganizationsJoinInitAttributes>

     flow-typed/npm/sequelize_v4.x.x.js
 [3] 3081│   declare export class Model<TAttributes, TInitAttributes = TAttributes, TPlainAttributes = TAttributes> {

     src/server/collections/UsersOrganizationsJoin.js
 [2]   12│ export type UsersOrganizationsJoinAttributes = UsersOrganizationsJoinInitAttributes & {
       13│   createdAt: Date;
       14│   updatedAt: Date;
       15│ }
       16│
 [1]   17│ export default class UsersOrganizationsJoin extends Model<UsersOrganizationsJoinAttributes, UsersOrganizationsJoinInitAttributes> {


Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/server/collections/Organization.js:166:18

Cannot assign this.belongsToMany(...) to this.Users because:
 • property createdAt is missing in UsersOrganizationsJoinInitAttributes [1] but exists in object
   type [2] in type argument TInitAttributes [3] of type argument Through [4].
 • property updatedAt is missing in UsersOrganizationsJoinInitAttributes [1] but exists in object
   type [2] in type argument TInitAttributes [3] of type argument Through [4].

     src/server/collections/Organization.js
      163│   }
      164│
      165│   static initAssociations() {
      166│     this.Users = this.belongsToMany(User, {through: UsersOrganizationsJoin})
      167│     this.Sites = this.hasMany(Site)
      168│     this.UserGroups = this.hasMany(UserGroup)
      169│     this.Gateways = this.hasMany(Gateway)

     flow-typed/npm/sequelize_v4.x.x.js
 [4] 1469│     Through: Model<ThroughAttributes>
         :
 [3] 3081│   declare export class Model<TAttributes, TInitAttributes = TAttributes, TPlainAttributes = TAttributes> {

     src/server/collections/UsersOrganizationsJoin.js
 [2]   12│ export type UsersOrganizationsJoinAttributes = UsersOrganizationsJoinInitAttributes & {
       13│   createdAt: Date;
       14│   updatedAt: Date;
       15│ }
       16│
 [1]   17│ export default class UsersOrganizationsJoin extends Model<UsersOrganizationsJoinAttributes, UsersOrganizationsJoinInitAttributes> {
```