### PR TITLE
Make throttle-debounce function accept arguments

### DIFF
--- a/definitions/npm/throttle-debounce_v1.x.x/flow_v0.25.x-/throttle-debounce_v1.x.x.js
+++ b/definitions/npm/throttle-debounce_v1.x.x/flow_v0.25.x-/throttle-debounce_v1.x.x.js
@@ -6,20 +6,20 @@ declare module "throttle-debounce" {
   declare function throttle<T>(
     delay: number,
     noTrailing: boolean,
-    callback: () => T,
+    callback: (...args: Array<any>) => T,
     debounceMode: boolean
-  ): () => T;
+  ): (...args: Array<any>) => T;
   declare function throttle<T>(
     delay: number,
     noTrailing: boolean,
-    callback: () => T
-  ): () => T;
+    callback: (...args: Array<any>) => T
+  ): (...args: Array<any>) => T;
   declare function throttle<T>(
     delay: number,
-    callback: () => T,
+    callback: (...args: Array<any>) => T,
     debounceMode: boolean
-  ): () => T;
-  declare function throttle<T>(delay: number, callback: () => T): () => T;
+  ): (...args: Array<any>) => T;
+  declare function throttle<T>(delay: number, callback: (...args: Array<any>) => T): (...args: Array<any>) => T;
 
   /**
    * Debounce execution of a function. Debouncing, unlike throttling, guarantees that a function is only executed a single time,
@@ -28,7 +28,8 @@ declare module "throttle-debounce" {
   declare function debounce<T>(
     delay: number,
     atBegin: boolean,
-    callback: () => T
-  ): () => T;
-  declare function debounce<T>(delay: number, callback: () => T): () => T;
+    callback: (...args: Array<any>) => T)
+  ): (...args: Array<any>) => T;
+
+  declare function debounce<T>(delay: number, callback: (...args: Array<any>) => T): (...args: Array<any>) => T;
 }

--- a/definitions/npm/throttle-debounce_v1.x.x/flow_v0.25.x-/throttle-debounce_v1.x.x.js
+++ b/definitions/npm/throttle-debounce_v1.x.x/flow_v0.25.x-/throttle-debounce_v1.x.x.js
@@ -1,3 +1,6 @@
+// flow-typed signature: 2fd21db3d7d3c371b608c10f78bdc0a3
+// flow-typed version: da30fe6876/throttle-debounce_v1.x.x/flow_>=v0.25.x
+
 declare module "throttle-debounce" {
   /**
    * Throttle execution of a function. Especially useful for rate limiting execution of handlers
@@ -28,7 +31,7 @@ declare module "throttle-debounce" {
   declare function debounce<T>(
     delay: number,
     atBegin: boolean,
-    callback: (...args: Array<any>) => T)
+    callback: (...args: Array<any>) => T
   ): (...args: Array<any>) => T;
 
   declare function debounce<T>(delay: number, callback: (...args: Array<any>) => T): (...args: Array<any>) => T;

--- a/definitions/npm/throttle-debounce_v1.x.x/flow_v0.25.x-/throttle-debounce_v1.x.x.js
+++ b/definitions/npm/throttle-debounce_v1.x.x/flow_v0.25.x-/throttle-debounce_v1.x.x.js
@@ -1,6 +1,3 @@
-// flow-typed signature: 2fd21db3d7d3c371b608c10f78bdc0a3
-// flow-typed version: da30fe6876/throttle-debounce_v1.x.x/flow_>=v0.25.x
-
 declare module "throttle-debounce" {
   /**
    * Throttle execution of a function. Especially useful for rate limiting execution of handlers


### PR DESCRIPTION
Add generic type definition for ...args, that can be passed to throttle or debounce function callback