### PR TITLE
Fix problems with Formik types

### DIFF
--- a/definitions/npm/formik_v0.11.x/flow_v0.53.x-/formik_v0.11.x.js
+++ b/definitions/npm/formik_v0.11.x/flow_v0.53.x-/formik_v0.11.x.js
@@ -9,33 +9,58 @@ declare module "formik" {
     [field: $Keys<Values>]: boolean
   };
 
-  declare export type FormikActions<Values> = {
+  declare export interface FormikActions<Values> {
     /** Manually set top level status. */
-    setStatus: (status?: any) => void,
+    setStatus(status?: any): void;
     /**
      * Manually set top level error
      * @deprecated since 0.8.0
      */
-    setError: (e: any) => void,
+    setError(e: any): void;
     /** Manually set errors object */
-    setErrors: (errors: FormikErrors<Values>) => void,
+    setErrors(errors: FormikErrors<Values>): void;
     /** Manually set isSubmitting */
-    setSubmitting: (isSubmitting: boolean) => void,
+    setSubmitting(isSubmitting: boolean): void;
     /** Manually set touched object */
-    setTouched: (touched: FormikTouched<Values>) => void,
+    setTouched(touched: FormikTouched<Values>): void;
     /** Manually set values object  */
-    setValues: (values: Values) => void,
+    setValues(values: Values): void;
     /** Set value of form field directly */
-    setFieldValue: (field: $Keys<Values>, value: any, shouldValidate?: boolean) => void,
+    setFieldValue(
+      field: $Keys<Values>,
+      value: any,
+      shouldValidate?: boolean
+    ): void;
+    setFieldValue(field: string, value: any, shouldValidate?: boolean): void;
     /** Set error message of a form field directly */
-    setFieldError: (field: $Keys<Values>, message: string) => void,
+    setFieldError(field: $Keys<Values>, message: string): void;
+    setFieldError(field: string, message: string): void;
     /** Set whether field has been touched directly */
-    setFieldTouched: (field: $Keys<Values>, isTouched?: boolean, shouldValidate?: boolean) => void,
+    setFieldTouched(
+      field: $Keys<Values>,
+      isTouched?: boolean,
+      shouldValidate?: boolean
+    ): void;
+    setFieldTouched(
+      field: string,
+      isTouched?: boolean,
+      shouldValidate?: boolean
+    ): void;
+    /** Validate form values */
+    validateForm(values?: any): void;
     /** Reset form */
-    resetForm: (nextValues?: any) => void,
+    resetForm(nextValues?: any): void;
     /** Submit the form imperatively */
-    submitForm: () => void
-  };
+    submitForm(): void;
+    /** Set Formik state, careful! */
+    setFormikState(
+      f: (
+        prevState: $ReadOnly<FormikState<Values>>,
+        props: any
+      ) => $Shape<FormikState<Values>>,
+      callback?: () => any
+    ): void;
+  }
 
   declare export type FormikSharedConfig = {
     /** Tells Formik to validate the form on each input's onChange event */
@@ -106,7 +131,7 @@ declare module "formik" {
     /** Top level status state, in case you need it */
     status?: any,
     /** Number of times user tried to submit the form */
-    submitCount: number,
+    submitCount: number
   };
 
   /**
@@ -126,23 +151,13 @@ declare module "formik" {
    */
   declare export type FormikHandlers = {
     /** Form submit handler */
-    // TODO: React.FormEvent<HTMLFormElement>
-    handleSubmit: (e: Function) => any,
-    /** Reset form event handler  */
-    handleReset: () => void;
+    handleSubmit: (e: SyntheticEvent<HTMLFormElement>) => any,
     /** Classic React change handler, keyed by input name */
-    // TODO: React.ChangeEvent<any>
-    handleChange: (e: Function) => any,
-    /** Mark input as touched */
-    handleBlur: (e: any) => any,
-    /** Classic React change handler, keyed by input name */
-    handleChange(e: Function): void;
-    /** Preact-like linkState. Will return a handleChange function.  */
-    handleChange(field: string): ((e: Function) => void);
-    /** Change value of form field directly */
-    handleChangeValue: (name: string, value: any) => any,
+    handleChange: (e: SyntheticEvent<any>) => any,
+    /** Classic React blur handler */
+    handleBlur: (e: any) => void,
     /** Reset form event handler  */
-    handleReset: () => any
+    handleReset: () => void
   };
 
   declare export type FormikProps<Values> = FormikState<Values> &
@@ -184,7 +199,7 @@ declare module "formik" {
       /** Value of the input */
       value: any,
       /* name of the input */
-      name?: string,
+      name: string
     },
     form: FormikProps<any>
   };
@@ -214,6 +229,8 @@ declare module "formik" {
 
   declare export function withFormik<Props, Values>({
     mapPropsToValues: (props: Props) => Values,
-    validationSchema: (props: Props) => any,
-  }): (ComponentType<Props>) => ComponentType<$Diff<Props, FormikProps<Values>>>;
+    validationSchema: (props: Props) => any
+  }): (
+    ComponentType<Props>
+  ) => ComponentType<$Diff<Props, FormikProps<Values>>>;
 }

--- a/definitions/npm/formik_v0.11.x/flow_v0.53.x-/formik_v0.11.x.js
+++ b/definitions/npm/formik_v0.11.x/flow_v0.53.x-/formik_v0.11.x.js
@@ -9,6 +9,10 @@ declare module "formik" {
     [field: $Keys<Values>]: boolean
   };
 
+  /**
+   * Using interface here because interfaces support overloaded method signatures
+   * https://github.com/facebook/flow/issues/1556#issuecomment-200051475
+   */
   declare export interface FormikActions<Values> {
     /** Manually set top level status. */
     setStatus(status?: any): void;

--- a/definitions/npm/formik_v0.11.x/test_formik.js
+++ b/definitions/npm/formik_v0.11.x/test_formik.js
@@ -1,38 +1,120 @@
 // @flow
+
 import * as React from "react";
-import {
-  Formik,
-  Form,
-  Field,
-  type FieldProps,
-  type FormikActions,
-  type FormikConfig
+import { Formik, Form, Field } from "formik";
+import type {
+  FieldProps,
+  FormikErrors,
+  FormikTouched,
+  FormikActions,
+  FormikProps
 } from "formik";
+import { describe, it } from "flow-typed-test";
 
-<Formik
-  initialValues={{ foo: "hi" }}
-  onSubmit={(values: *, formikActions: FormikActions<*>) => {
-    values.foo;
-    values.bar;
-  }}
-/>;
+const i18n = { loadNamespaces: () => {} };
 
-const config1: FormikConfig = {
-  onSubmit: (values: *, formikActions: FormikActions<*>) => {}
-};
-// $ExpectError
-const configRequiresOnSubmit: FormikConfig = {
-  onSubmit: null
+type Values = {
+  text: string
 };
 
-const CustomInputComponent = (props: FieldProps) => <input />;
+describe("formik", () => {
+  describe("<Formik />", () => {
+    it("passes when used properly", () => {
+      <Formik
+        initialValues={{ text: "text" }}
+        validate={(values: Values) => {
+          const errors = {};
+          if (!values.text) {
+            errors.text = "Text Required";
+          }
+          return errors;
+        }}
+        onSubmit={(values: Values) => {}}
+        render={({
+          values,
+          errors,
+          touched,
+          handleChange,
+          handleBlur,
+          handleSubmit,
+          isSubmitting
+        }: FormikProps<Values>) => {
+          return (
+            <form onSubmit={handleSubmit}>
+              <input
+                type="text"
+                name="text"
+                onChange={(e: SyntheticInputEvent<>) => {
+                  handleChange(e);
+                }}
+                onBlur={handleBlur}
+                value={values.text}
+              />
+              {touched.text && errors.text && <div>{errors.text}</div>}
+              <button type="submit" disabled={isSubmitting}>
+                Submit
+              </button>
+            </form>
+          );
+        }}
+      />;
+    });
 
-<Form>
-  <Field type="email" name="email" placeholder="Email" />
-  <Field component="select" name="color">
-    <option value="red">Red</option>
-    <option value="green">Green</option>
-    <option value="blue">Blue</option>
-  </Field>
-  <Field component={CustomInputComponent} name="firstName" />
-</Form>;
+    it("raises error when trying to access values not in Values", () => {
+      <Formik
+        initialValues={{ text: "text" }}
+        validate={(values: Values) => {
+          const errors = {};
+          if (!values.text) {
+            errors.text = "Text Required";
+          }
+          return errors;
+        }}
+        onSubmit={(values: Values) => {}}
+        render={({
+          values,
+          errors,
+          touched,
+          handleChange,
+          handleBlur,
+          handleSubmit,
+          isSubmitting
+        }: FormikProps<Values>) => {
+          return (
+            <form onSubmit={handleSubmit}>
+              <input
+                type="text"
+                name="text"
+                onChange={handleChange}
+                onBlur={handleBlur}
+                // $ExpectError - email missing in values
+                value={values.email}
+              />
+              {/* $ExpectError - touched missing in values */}
+              {touched.email && errors.email && <div>{errors.email}</div>}
+              <button type="submit" disabled={isSubmitting}>
+                Submit
+              </button>
+            </form>
+          );
+        }}
+      />;
+    });
+  });
+
+  describe("<Form /> and <Field />", () => {
+    it("passes when used properly", () => {
+      const CustomInputComponent = (props: FieldProps) => <input />;
+
+      <Form>
+        <Field type="email" name="email" placeholder="Email" />
+        <Field component="select" name="color">
+          <option value="red">Red</option>
+          <option value="green">Green</option>
+          <option value="blue">Blue</option>
+        </Field>
+        <Field component={CustomInputComponent} name="firstName" />
+      </Form>;
+    });
+  });
+});

--- a/definitions/npm/formik_v0.11.x/test_formik.js
+++ b/definitions/npm/formik_v0.11.x/test_formik.js
@@ -2,13 +2,7 @@
 
 import * as React from "react";
 import { Formik, Form, Field } from "formik";
-import type {
-  FieldProps,
-  FormikErrors,
-  FormikTouched,
-  FormikActions,
-  FormikProps
-} from "formik";
+import type { FieldProps, FormikActions, FormikProps } from "formik";
 import { describe, it } from "flow-typed-test";
 
 const i18n = { loadNamespaces: () => {} };
@@ -29,7 +23,13 @@ describe("formik", () => {
           }
           return errors;
         }}
-        onSubmit={(values: Values) => {}}
+        onSubmit={(
+          values: Values,
+          { setSubmitting, setFieldError }: FormikActions<Values>
+        ) => {
+          setFieldError("text", "Text is Required!");
+          setSubmitting(false);
+        }}
         render={({
           values,
           errors,
@@ -99,6 +99,203 @@ describe("formik", () => {
           );
         }}
       />;
+    });
+  });
+
+  describe("FormikActions", () => {
+    describe("setStatus", () => {
+      it("passes when using setStatus properly", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          actions.setStatus("done");
+        };
+      });
+
+      it("raises error when passed more than one argument", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          // $ExpectError setStatus action expects only one argument
+          actions.setStatus("text", "done");
+        };
+      });
+    });
+
+    describe("setErrors", () => {
+      it("passes when using setErrors properly", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          actions.setErrors({ text: "Text is required" });
+        };
+      });
+
+      it("raises error when passed an unrecognized value key", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          // $ExpectError setErrors keys must match value fields
+          actions.setErrors({ other: "Text is required" });
+        };
+      });
+    });
+
+    describe("setSubmitting", () => {
+      it("passes when using setSubmitting properly", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          actions.setSubmitting(false);
+        };
+      });
+
+      it("raises error when passed a non-boolean", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          // $ExpectError setSubmitting only takes a boolean
+          actions.setSubmitting("false");
+        };
+      });
+    });
+
+    describe("setTouched", () => {
+      it("passes when using setTouched properly", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          actions.setTouched({
+            text: true
+          });
+        };
+      });
+
+      it("raises error when passed an unrecognized field or a non-boolean", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          // $ExpectError setTouched keys must match value fields
+          actions.setTouched({ other: true });
+          // $ExpectError setTouched value must be a boolean
+          actions.setTouched({ text: "true" });
+        };
+      });
+    });
+
+    describe("setValues", () => {
+      it("passes when using setValues properly", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          actions.setValues({
+            text: "Text"
+          });
+        };
+      });
+
+      it("raises error when passed something other than Values", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          // $ExpectError setValues keys must match value fields
+          actions.setValues({ other: "Text" });
+        };
+      });
+    });
+
+    describe("setFieldValue", () => {
+      it("passes when used properly", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          actions.setFieldValue("text", "Value");
+          actions.setFieldValue("text", "Value", true);
+          actions.setFieldValue("other", "Value");
+        };
+      });
+
+      it("raises error when not passed a field", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          // $ExpectError Field and value arguments expected
+          actions.setFieldValue({ text: "Text" });
+        };
+      });
+    });
+
+    describe("setFieldError", () => {
+      it("passes when used properly", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          actions.setFieldError("text", "Error");
+          actions.setFieldError("other", "Error");
+        };
+      });
+
+      it("raises error when not passed a field", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          // $ExpectError Field and value arguments expected
+          actions.setFieldError("Error");
+        };
+      });
+    });
+
+    describe("setFieldTouched", () => {
+      it("passes when used properly", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          actions.setFieldTouched("text", true);
+          actions.setFieldTouched("other", true);
+        };
+      });
+
+      it("raises error when not passed a field", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          // $ExpectError Field and value arguments expected
+          actions.setFieldTouched(true);
+        };
+      });
+    });
+
+    describe("validateForm", () => {
+      it("passes when used properly", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          actions.validateForm();
+          actions.validateForm({ text: "Text" });
+        };
+      });
+    });
+
+    describe("resetForm", () => {
+      it("passes when used properly", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          actions.resetForm();
+          actions.resetForm({ text: "Text" });
+        };
+      });
+
+      it("raises error if pass multiple arguments", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          // $ExpectError resetForm expects 0 or 1 arguments
+          actions.resetForm("text", "Text");
+        };
+      });
+    });
+
+    describe("submitForm", () => {
+      it("passes when used properly", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          actions.submitForm();
+        };
+      });
+
+      it("raises error if passed an argument", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          // $ExpectError submitForm expects no arguments
+          actions.submitForm({ text: "Text" });
+        };
+      });
+    });
+
+    describe("setFormikState", () => {
+      it("passes when used properly", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          actions.setFormikState(({ values }) => ({
+            values: { text: `#${values.text}` }
+          }));
+          actions.setFormikState(
+            ({ errors }) => ({
+              errors: { ...errors, text: "Text is required" }
+            }),
+            () => {}
+          );
+        };
+      });
+
+      it("raises error if return state shape other than FormikState<Values>", () => {
+        const testFunc = (actions: FormikActions<Values>) => {
+          // $ExpectError - must return correct state shape
+          actions.setFormikState(({ values }) => ({
+            text: `#${values.text}`
+          }));
+        };
+      });
     });
   });
 


### PR DESCRIPTION
* Correct FormikHandlers to match v0.11.x, rather than the 1.0.0 alpha
* Add missing validateForm to FormikActions
* Add some tests and use describe/it

The types for FormikHandlers looks to be based of the master Typescript typings, which is v1 alpha. Even so, they will need some corrections when we add the v1 flow-typed types. Changed it to match what's actually in v0.11.x (https://github.com/jaredpalmer/formik/blob/v0.11.11/src/formik.tsx)