### PR TITLE
Apollo Client Libdef (also add to react-apollo)

### DIFF
--- a/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
+++ b/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
@@ -9,406 +9,39 @@ declare module "apollo-client" {
     ValueNode,
     SelectionNode,
     NameNode
+    // $FlowFixMe - Can't import types from node_modules at the moment
   } from "graphql";
 
-  import type { Middleware } from "redux";
-
-  declare export interface Request {
-    // causes flow errors
-    // property `$key` of Request. Indexable signature not found in
-    // property `$value` of Request. Indexable signature not found in
-    // [additionalKey: string]: any,
-    debugName?: string;
-    query?: DocumentNode;
-    variables?: Object;
-    operationName?: string | null;
-  }
-
-  declare export interface NetworkInterface {
-    query(request: Request): Promise<ExecutionResult>;
-  }
-
-  declare export interface BatchedNetworkInterface {
-    batchQuery(requests: Request[]): Promise<ExecutionResult[]>;
-  }
-
-  declare export interface MiddlewareRequest {
-    request: Request;
-    options: RequestOptions;
-  }
-
-  declare export interface MiddlewareInterface {
-    applyMiddleware(request: MiddlewareRequest, next: Function): void;
-  }
-
-  declare export interface BatchMiddlewareRequest {
-    requests: Request[];
-    options: RequestOptions;
-  }
-
-  declare export interface BatchMiddlewareInterface {
-    applyBatchMiddleware(request: BatchMiddlewareRequest, next: Function): void;
-  }
-  declare export interface AfterwareResponse {
-    response: Response;
-    options: RequestOptions;
-  }
-
-  declare export interface AfterwareInterface {
-    applyAfterware(response: AfterwareResponse, next: Function): any;
-  }
-
-  declare export interface BatchAfterwareResponse {
-    responses: Response[];
-    options: RequestOptions;
-  }
-
-  declare export interface BatchAfterwareInterface {
-    applyBatchAfterware(response: BatchAfterwareResponse, next: Function): any;
-  }
-
-  declare export interface PrintedRequest {
-    debugName?: string;
-    query?: string;
-    variables?: Object;
-    operationName?: string | null;
-  }
-
-  declare export interface SubscriptionNetworkInterface {
-    subscribe(
-      request: Request,
-      handler: (error: any, result: any) => void
-    ): number;
-    unsubscribe(id: Number): void;
-  }
-
-  declare export type NetworkMiddleware =
-    | Array<MiddlewareInterface>
-    | Array<BatchMiddlewareInterface>;
-  declare export type NetworkAfterware =
-    | Array<AfterwareInterface>
-    | Array<BatchAfterwareInterface>;
-
-  declare export class HTTPNetworkInterface {
-    _uri: string;
-    _opts: RequestOptions;
-    _middlewares: NetworkMiddleware;
-    _afterwares: NetworkAfterware;
-    use(middlewares: NetworkMiddleware): HTTPNetworkInterface;
-    useAfter(afterwares: NetworkAfterware): HTTPNetworkInterface;
-    query(request: Request): Promise<ExecutionResult>;
-  }
-
-  declare export interface BatchRequestAndOptions {
-    requests: Request[];
-    options: RequestOptions;
-  }
-
-  declare export interface BatchResponseAndOptions {
-    responses: Response[];
-    options: RequestOptions;
-  }
-
-  declare export type BatchingNetworkInterfaceOptions = {
-    uri: string,
-    batchInterval: number,
-    // compatibility with NetworkInterfaceOptions
-    opts?: ?RequestOptions
-  };
-
-  declare export function createBatchingNetworkInterface(
-    options: BatchingNetworkInterfaceOptions
-  ): HTTPNetworkInterface;
-
-  declare export class HTTPBatchedNetworkInterface extends BaseNetworkInterface {
-    _middlewares: NetworkMiddleware;
-    _afterwares: NetworkAfterware;
-    constructor(
-      uri: string,
-      batchInterval: number,
-      fetchOpts: RequestOptions
-    ): this;
-    query(request: Request): Promise<ExecutionResult>;
-    batchQuery(requests: Request[]): Promise<ExecutionResult[]>;
-    applyBatchMiddlewares(
-      opts: BatchRequestAndOptions
-    ): Promise<BatchRequestAndOptions>;
-    applyBatchAfterwares(
-      opts: BatchResponseAndOptions
-    ): Promise<BatchResponseAndOptions>;
-    use(middlewares: BatchMiddlewareInterface[]): HTTPNetworkInterface;
-    useAfter(afterwares: BatchAfterwareInterface[]): HTTPNetworkInterface;
-  }
-
-  declare export interface RequestAndOptions {
-    request: Request;
-    options: RequestOptions;
-  }
-
-  declare export interface ResponseAndOptions {
-    response: Response;
-    options: RequestOptions;
-  }
-
-  declare export type NetworkInterfaceOptions = {
-    // compatibility with BatchNetworkInrfaceOptions
-    // also network interfaces throws an error in case you haven't provide an uri
-    // in this case is right to fail typecheck too
-    uri: string,
-    opts?: ?RequestOptions
-  };
-
-  declare export function printRequest(request: Request): PrintedRequest;
-
-  declare export function createNetworkInterface(
-    uriOrInterfaceOpts: string | NetworkInterfaceOptions,
-    secondArgOpts?: NetworkInterfaceOptions
-  ): HTTPNetworkInterface;
-
-  declare export class BaseNetworkInterface {
-    _middlewares: NetworkMiddleware;
-    _afterwares: NetworkAfterware;
-    _uri: string;
-    _opts: RequestOptions;
-    constructor(uri: string | void, opts?: RequestOptions): this;
-    query(request: Request): Promise<ExecutionResult>;
-  }
-
-  declare export class HTTPFetchNetworkInterface extends BaseNetworkInterface {
-    _middlewares: NetworkMiddleware;
-    _afterwares: NetworkAfterware;
-    applyMiddlewares(
-      requestAndOptions: RequestAndOptions
-    ): Promise<RequestAndOptions>;
-    applyAfterwares(opts: ResponseAndOptions): Promise<ResponseAndOptions>;
-    fetchFromRemoteEndpoint(opts: RequestAndOptions): Promise<Response>;
-    query(request: Request): Promise<ExecutionResult>;
-    use(middlewares: MiddlewareInterface[]): HTTPNetworkInterface;
-    useAfter(afterwares: AfterwareInterface[]): HTTPNetworkInterface;
-  }
-
-  declare export type FetchPolicy =
-    | "cache-first"
-    | "cache-and-network"
-    | "network-only"
-    | "cache-only"
-    | "standby";
-
-  declare export type SubscribeToMoreOptions = {
-    document: DocumentNode,
-    variables?: {
-      [key: string]: any
-    },
-    updateQuery?: (
-      previousQueryResult: Object,
-      options: {
-        subscriptionData: {
-          data: any
-        },
-        variables: {
-          [key: string]: any
-        }
-      }
-    ) => Object,
-    onError?: (error: Error) => void
-  };
-
-  declare export type MutationUpdaterFn<T = { [key: string]: any }> = (
-    proxy: DataProxy,
-    mutationResult: ApolloExecutionResult<T>
-  ) => void;
-
-  declare export interface ModifiableWatchQueryOptions {
-    variables?: {
-      [key: string]: any
-    };
-    pollInterval?: number;
-    fetchPolicy?: FetchPolicy;
-    fetchResults?: boolean;
-    notifyOnNetworkStatusChange?: boolean;
-    reducer?: OperationResultReducer;
-  }
-
-  declare export interface WatchQueryOptions {
-    query: DocumentNode;
-    metadata?: any;
-  }
-
-  declare export interface FetchMoreQueryOptions {
-    query?: DocumentNode;
-    +variables?: {
-      [key: string]: any
-    };
-  }
-
-  declare export interface SubscriptionOptions {
-    query: DocumentNode;
-    variables?: {
-      [key: string]: any
-    };
-  }
-
-  declare export type MutationOptions<T = { [key: string]: any }> = {
-    mutation: DocumentNode,
-    variables?: Object,
-    optimisticResponse?: Object,
-    updateQueries?: MutationQueryReducersMap<T>,
-    refetchQueries?: string[] | PureQueryOptions[],
-    update?: MutationUpdaterFn<T>
-  };
-
-  declare export type QueryListener = (
-    queryStoreValue: QueryStoreValue
-  ) => void;
-  declare export type FetchType = number;
-  declare export type PureQueryOptions = {
-    query: DocumentNode,
-    variables?: {
-      [key: string]: any
-    }
-  };
-
-  declare export type ApolloQueryResult<T> = {
-    data: T,
-    loading: boolean,
-    networkStatus: NetworkStatus,
-    stale: boolean
-  };
-
-  declare export type ApolloExecutionResult<T = { [key: string]: any }> = {
-    data: T
-  };
-
-  declare export type IdGetter = (value: Object) => string | null | void;
-
-  declare export type ListValue = Array<null | IdValue>;
-
-  declare export type StoreValue =
-    | number
-    | string
-    | string[]
-    | IdValue
-    | ListValue
-    | JsonValue
-    | null
-    | void;
-
-  declare export interface NormalizedCache {
-    [dataId: string]: StoreObject;
-  }
-
-  declare export interface StoreObject {
-    [storeFieldKey: string]: StoreValue;
-    __typename?: string;
-  }
-
-  declare export interface IdValue {
-    type: "id";
-    id: string;
-    generated: boolean;
-  }
-
-  declare export interface JsonValue {
-    type: "json";
-    json: any;
-  }
-
-  declare export function valueToObjectRepresentation(
-    argObj: any,
-    name: NameNode,
-    value: ValueNode,
-    variables?: Object
-  ): void;
-
-  declare export function storeKeyNameFromField(
-    field: FieldNode,
-    variables?: Object
-  ): string;
-
-  declare export function storeKeyNameFromFieldNameAndArgs(
-    fieldName: string,
-    args?: Object
-  ): string;
-
-  declare export function resultKeyNameFromField(field: FieldNode): string;
-
-  declare export function isField(selection: SelectionNode): FieldNode;
-
-  declare export function isInlineFragment(
-    selection: SelectionNode
-  ): InlineFragmentNode;
-
-  declare export function graphQLResultHasError(
-    result: ExecutionResult
-  ): number | void;
-
-  declare export function isIdValue(idObject: StoreValue): IdValue;
-
-  declare export function toIdValue(id: string, generated?: boolean): IdValue;
-
-  declare export function isJsonValue(jsonObject: StoreValue): JsonValue;
-
-  declare export type MutationQueryReducer<T> = (
-    previousResult: Object,
-    options: {
-      mutationResult: ApolloExecutionResult<T>,
-      queryName: string | null,
-      queryVariables: Object
-    }
-  ) => Object;
-
-  declare export type MutationQueryReducersMap<T = { [key: string]: any }> = {
-    [queryName: string]: MutationQueryReducer<T>
-  };
-
-  declare export type OperationResultReducer = (
-    previousResult: Object,
-    action: ApolloAction,
-    variables: Object
-  ) => Object;
-
-  declare export type OperationResultReducerMap = {
-    [queryId: string]: OperationResultReducer
-  };
-
-  declare export type ApolloCurrentResult<T> = {
-    data: T | {},
-    loading: boolean,
-    networkStatus: NetworkStatus,
-    error?: ApolloError,
-    partial?: boolean
-  };
-
-  declare export interface FetchMoreOptions {
-    updateQuery: (
-      previousQueryResult: Object,
-      options: {
-        fetchMoreResult: Object,
-        queryVariables: Object
-      }
-    ) => Object;
-  }
-
-  declare export interface UpdateQueryOptions {
-    variables?: Object;
-  }
+  declare export function print(ast: any): string;
 
   declare export class ObservableQuery<T> extends Observable<
     ApolloQueryResult<T>
   > {
     options: WatchQueryOptions;
     queryId: string;
-    variables: {
-      [key: string]: any
-    };
+    variables: { [key: string]: any };
+    isCurrentlyPolling: boolean;
+    shouldSubscribe: boolean;
+    isTornDown: boolean;
+    scheduler: QueryScheduler<any>;
+    queryManager: QueryManager<any>;
+    observers: Observer<ApolloQueryResult<T>>[];
+    subscriptionHandles: Subscription[];
+    lastResult: ApolloQueryResult<T>;
+    lastError: ApolloError;
+    lastVariables: { [key: string]: any };
+
     constructor(data: {
-      scheduler: QueryScheduler,
+      scheduler: QueryScheduler<any>,
       options: WatchQueryOptions,
       shouldSubscribe?: boolean
     }): this;
+
     result(): Promise<ApolloQueryResult<T>>;
     currentResult(): ApolloCurrentResult<T>;
     getLastResult(): ApolloQueryResult<T>;
+    getLastError(): ApolloError;
+    resetLastResults(): void;
     refetch(variables?: any): Promise<ApolloQueryResult<T>>;
     fetchMore(
       fetchMoreOptions: FetchMoreQueryOptions & FetchMoreOptions
@@ -419,7 +52,8 @@ declare module "apollo-client" {
     ): Promise<ApolloQueryResult<T>>;
     setVariables(
       variables: any,
-      tryFetch?: boolean
+      tryFetch?: boolean,
+      fetchResults?: boolean
     ): Promise<ApolloQueryResult<T>>;
     updateQuery(
       mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any
@@ -428,503 +62,105 @@ declare module "apollo-client" {
     startPolling(pollInterval: number): void;
   }
 
-  declare export type CleanupFunction = () => void;
+  declare class QueryManager<TStore> {
+    scheduler: QueryScheduler<TStore>;
+    link: ApolloLink;
+    mutationStore: MutationStore;
+    queryStore: QueryStore;
+    dataStore: DataStore<TStore>;
 
-  declare export type SubscriberFunction<T> = (
-    observer: Observer<T>
-  ) => Subscription | CleanupFunction;
-
-  declare export interface Observer<T> {
-    next?: (value: T) => void;
-    error?: (error: Error) => void;
-    complete?: () => void;
-  }
-
-  declare export interface Subscription {
-    unsubscribe: CleanupFunction;
-  }
-
-  declare export class Observable<T> {
-    constructor(subscriberFunction: SubscriberFunction<T>): this;
-    subscribe(observer: Observer<T>): Subscription;
-  }
-
-  declare export type NetworkStatus = number;
-  declare export function isNetworkRequestInFlight(
-    networkStatus: NetworkStatus
-  ): boolean;
-
-  declare export interface MutationStore {
-    [mutationId: string]: MutationStoreValue;
-  }
-
-  declare export interface MutationStoreValue {
-    mutationString: string;
-    variables: Object;
-    loading: boolean;
-    error: Error | null;
-  }
-
-  declare export type IntrospectionResultData = {
-    __schema: {
-      types: Array<{
-        kind: string,
-        name: string,
-        possibleTypes: Array<{
-          name: string
-        }>
-      }>
-    }
-  };
-
-  declare export class FragmentMatcherInterface {
-    match(
-      idValue: IdValue,
-      typeCondition: string,
-      context: ReadStoreContext
-    ): boolean;
-  }
-
-  declare export class IntrospectionFragmentMatcher extends FragmentMatcherInterface {
-    constructor(options?: {
-      introspectionQueryResultData?: IntrospectionResultData
+    constructor({
+      link: ApolloLink,
+      queryDeduplication?: boolean,
+      store: DataStore<TStore>,
+      onBroadcast?: () => void,
+      ssrMode?: boolean
     }): this;
-    match(
-      idValue: IdValue,
-      typeCondition: string,
-      context: ReadStoreContext
-    ): boolean;
+
+    mutate<T>(options: MutationOptions<>): Promise<FetchResult<T>>;
+    fetchQuery<T>(
+      queryId: string,
+      options: WatchQueryOptions,
+      fetchType?: FetchType,
+      fetchMoreForQueryId?: string
+    ): Promise<FetchResult<T>>;
+    queryListenerForObserver<T>(
+      queryId: string,
+      options: WatchQueryOptions,
+      observer: Observer<ApolloQueryResult<T>>
+    ): QueryListener;
+    watchQuery<T>(
+      options: WatchQueryOptions,
+      shouldSubscribe?: boolean
+    ): ObservableQuery<T>;
+    query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
+    generateQueryId(): string;
+    stopQueryInStore(queryId: string): void;
+    addQueryListener(queryId: string, listener: QueryListener): void;
+    updateQueryWatch(
+      queryId: string,
+      document: DocumentNode,
+      options: WatchQueryOptions
+    ): void;
+    addFetchQueryPromise<T>(
+      requestId: number,
+      promise: Promise<ApolloQueryResult<T>>,
+      resolve: (result: ApolloQueryResult<T>) => void,
+      reject: (error: Error) => void
+    ): void;
+    removeFetchQueryPromise(requestId: number): void;
+    addObservableQuery<T>(
+      queryId: string,
+      observableQuery: ObservableQuery<T>
+    ): void;
+    removeObservableQuery(queryId: string): void;
+    clearStore(): Promise<void>;
+    resetStore(): Promise<ApolloQueryResult<any>[]>;
   }
 
-  declare export class HeuristicFragmentMatcher extends FragmentMatcherInterface {
-    constructor(): this;
-    ensureReady(): Promise<void>;
-    canBypassInit(): boolean;
-    match(
-      idValue: IdValue,
-      typeCondition: string,
-      context: ReadStoreContext
-    ): boolean;
+  declare class QueryStore {
+    getStore(): { [queryId: string]: QueryStoreValue };
+    get(queryId: string): QueryStoreValue;
+    initQuery(query: {
+      queryId: string,
+      document: DocumentNode,
+      storePreviousVariables: boolean,
+      variables: Object,
+      isPoll: boolean,
+      isRefetch: boolean,
+      metadata: any,
+      fetchMoreForQueryId: string | void
+    }): void;
+    markQueryResult(
+      queryId: string,
+      result: ExecutionResult,
+      fetchMoreForQueryId: string | void
+    ): void;
+    markQueryError(
+      queryId: string,
+      error: Error,
+      fetchMoreForQueryId: string | void
+    ): void;
+    markQueryResultClient(queryId: string, complete: boolean): void;
+    stopQuery(queryId: string): void;
+    reset(observableQueryIds: string[]): void;
   }
 
-  declare export interface DataProxyReadQueryOptions {
-    query: DocumentNode;
-    variables?: Object;
-  }
-
-  declare export interface DataProxyReadFragmentOptions {
-    id: string;
-    fragment: DocumentNode;
-    fragmentName?: string;
-    variables?: Object;
-  }
-
-  declare export interface DataProxyWriteQueryOptions {
-    data: any;
-    query: DocumentNode;
-    variables?: Object;
-  }
-
-  declare export interface DataProxyWriteFragmentOptions {
-    data: any;
-    id: string;
-    fragment: DocumentNode;
-    fragmentName?: string;
-    variables?: Object;
-  }
-
-  declare export class DataProxy {
-    readQuery<QueryType>(options: DataProxyReadQueryOptions): QueryType;
-    readFragment<FragmentType>(
-      options: DataProxyReadFragmentOptions
-    ): FragmentType | null;
-    writeQuery(options: DataProxyWriteQueryOptions): void;
-    writeFragment(options: DataProxyWriteFragmentOptions): void;
-  }
-
-  declare export class ReduxDataProxy extends DataProxy {
-    constructor(
-      store: ApolloStore,
-      reduxRootSelector: (state: any) => Store,
-      fragmentMatcher: FragmentMatcherInterface,
-      reducerConfig: ApolloReducerConfig
-    ): this;
-    readQuery<QueryType>(options: DataProxyReadQueryOptions): QueryType;
-    readFragment<FragmentType>(
-      options: DataProxyReadFragmentOptions
-    ): FragmentType | null;
-    writeQuery(options: DataProxyWriteQueryOptions): void;
-    writeFragment(options: DataProxyWriteFragmentOptions): void;
-  }
-
-  declare export class TransactionDataProxy extends DataProxy {
-    constructor(
-      data: NormalizedCache,
-      reducerConfig: ApolloReducerConfig
-    ): this;
-    finish(): Array<DataWrite>;
-    readQuery<QueryType>(options: DataProxyReadQueryOptions): QueryType;
-    readFragment<FragmentType>(
-      options: DataProxyReadFragmentOptions
-    ): FragmentType | null;
-    writeQuery(options: DataProxyWriteQueryOptions): void;
-    writeFragment(options: DataProxyWriteFragmentOptions): void;
-  }
-
-  declare export type QueryResultAction = {
-    type: "APOLLO_QUERY_RESULT",
-    result: ExecutionResult,
-    queryId: string,
-    document: DocumentNode,
-    operationName: string | null,
-    requestId: number,
-    fetchMoreForQueryId?: string,
-    extraReducers?: ApolloReducer[]
-  };
-
-  declare export type ApolloAction =
-    | QueryResultAction
-    | QueryErrorAction
-    | QueryInitAction
-    | QueryResultClientAction
-    | QueryStopAction
-    | MutationInitAction
-    | MutationResultAction
-    | MutationErrorAction
-    | UpdateQueryResultAction
-    | StoreResetAction
-    | SubscriptionResultAction
-    | WriteAction;
-
-  declare export function mutations(
-    previousState: MutationStore | void,
-    action: ApolloAction
-  ): MutationStore;
-
-  declare export interface QueryErrorAction {
-    type: "APOLLO_QUERY_ERROR";
-    error: Error;
-    queryId: string;
-    requestId: number;
-    fetchMoreForQueryId?: string;
-  }
-
-  declare export interface QueryInitAction {
-    type: "APOLLO_QUERY_INIT";
-    queryString: string;
-    document: DocumentNode;
-    variables: Object;
-    fetchPolicy: FetchPolicy;
-    queryId: string;
-    requestId: number;
-    storePreviousVariables: boolean;
-    isRefetch: boolean;
-    isPoll: boolean;
-    fetchMoreForQueryId?: string;
-    metadata: any;
-  }
-
-  declare export interface QueryResultClientAction {
-    type: "APOLLO_QUERY_RESULT_CLIENT";
-    result: ExecutionResult;
-    complete: boolean;
-    queryId: string;
-    requestId: number;
-  }
-
-  declare export interface QueryStopAction {
-    type: "APOLLO_QUERY_STOP";
-    queryId: string;
-  }
-
-  declare export type QueryWithUpdater = {
-    reducer: MutationQueryReducer<Object>,
-    query: QueryStoreValue
-  };
-
-  declare export interface MutationInitAction {
-    type: "APOLLO_MUTATION_INIT";
-    mutationString: string;
-    mutation: DocumentNode;
-    variables: Object;
-    operationName: string | null;
-    mutationId: string;
-    optimisticResponse: Object | void;
-    extraReducers?: ApolloReducer[];
-    updateQueries?: {
-      [queryId: string]: QueryWithUpdater
-    };
-    update?: (proxy: DataProxy, mutationResult: Object) => void;
-  }
-
-  declare export interface MutationResultAction {
-    type: "APOLLO_MUTATION_RESULT";
-    result: ExecutionResult;
-    document: DocumentNode;
-    operationName: string | null;
-    variables: Object;
-    mutationId: string;
-    extraReducers?: ApolloReducer[];
-    updateQueries?: {
-      [queryId: string]: QueryWithUpdater
-    };
-    update?: (proxy: DataProxy, mutationResult: Object) => void;
-  }
-
-  declare export interface MutationErrorAction {
-    type: "APOLLO_MUTATION_ERROR";
-    error: Error;
-    mutationId: string;
-  }
-
-  declare export interface UpdateQueryResultAction {
-    type: "APOLLO_UPDATE_QUERY_RESULT";
-    variables: any;
-    document: DocumentNode;
-    newResult: Object;
-  }
-
-  declare export interface StoreResetAction {
-    type: "APOLLO_STORE_RESET";
-    observableQueryIds: string[];
-  }
-
-  declare export interface SubscriptionResultAction {
-    type: "APOLLO_SUBSCRIPTION_RESULT";
-    result: ExecutionResult;
-    subscriptionId: number;
-    variables: Object;
-    document: DocumentNode;
-    operationName: string | null;
-    extraReducers?: ApolloReducer[];
-  }
-
-  declare export interface DataWrite {
-    rootId: string;
-    result: any;
-    document: DocumentNode;
-    variables: Object;
-  }
-
-  declare export interface WriteAction {
-    type: "APOLLO_WRITE";
-    writes: Array<DataWrite>;
-  }
-
-  declare export function isQueryResultAction(
-    action: ApolloAction
-  ): QueryResultAction;
-
-  declare export function isQueryErrorAction(
-    action: ApolloAction
-  ): QueryErrorAction;
-
-  declare export function isQueryInitAction(
-    action: ApolloAction
-  ): QueryInitAction;
-
-  declare export function isQueryResultClientAction(
-    action: ApolloAction
-  ): QueryResultClientAction;
-
-  declare export function isQueryStopAction(
-    action: ApolloAction
-  ): QueryStopAction;
-
-  declare export function isMutationInitAction(
-    action: ApolloAction
-  ): MutationInitAction;
-
-  declare export function isMutationResultAction(
-    action: ApolloAction
-  ): MutationResultAction;
-
-  declare export function isMutationErrorAction(
-    action: ApolloAction
-  ): MutationErrorAction;
-
-  declare export function isUpdateQueryResultAction(
-    action: ApolloAction
-  ): UpdateQueryResultAction;
-
-  declare export function isStoreResetAction(
-    action: ApolloAction
-  ): StoreResetAction;
-
-  declare export function isSubscriptionResultAction(
-    action: ApolloAction
-  ): SubscriptionResultAction;
-
-  declare export function isWriteAction(action: ApolloAction): WriteAction;
-
-  declare export type ApolloStateSelector = (state: any) => Store;
-  declare export class ApolloError extends Error {
-    message: string;
-    graphQLErrors: GraphQLError[];
-    networkError: Error | null;
-    extraInfo: any;
-    constructor(info: ErrorConstructor): this;
-  }
-  declare export function isApolloError(err: Error): ApolloError;
-
-  declare interface ErrorConstructor {
-    graphQLErrors?: GraphQLError[];
-    networkError?: Error | null;
-    errorMessage?: string;
-    extraInfo?: any;
-  }
-
-  declare export type OptimisticStoreItem = {
-    mutationId: string,
-    data: NormalizedCache
-  };
-
-  declare export type OptimisticStore = OptimisticStoreItem[];
-
-  declare export interface Store {
-    data: NormalizedCache;
-    queries: QueryStore;
-    mutations: MutationStore;
-    optimistic: OptimisticStore;
-    reducerError: ReducerError | null;
-  }
-
-  declare export interface ApolloStore {
-    dispatch: (action: ApolloAction) => void;
-    getState: () => any;
-  }
-  declare export type ApolloReducer = (
-    store: NormalizedCache,
-    action: ApolloAction
-  ) => NormalizedCache;
-
-  declare export type ApolloReducerConfig = {
-    dataIdFromObject?: IdGetter,
-    customResolvers?: CustomResolverMap,
-    fragmentMatcher?: FragmentMatcher,
-    addTypename?: boolean
-  };
-
-  declare export interface ReducerError {
-    error: Error;
-    queryId?: string;
-    mutationId?: string;
-    subscriptionId?: number;
-  }
-
-  declare export function getDataWithOptimisticResults(
-    store: Store
-  ): NormalizedCache;
-
-  declare export function optimistic(
-    previousState: any[] | void,
-    action: any,
-    store: any,
-    config: any
-  ): OptimisticStore;
-
-  declare export type QueryStoreValue = {
-    queryString: string,
-    document: DocumentNode,
-    variables: Object,
-    previousVariables: Object | null,
-    networkStatus: NetworkStatus,
-    networkError: Error | null,
-    graphQLErrors: GraphQLError[],
-    lastRequestId: number,
-    metadata: any
-  };
-
-  declare export interface QueryStore {
-    [queryId: string]: QueryStoreValue;
-  }
-
-  declare export interface SelectionSetWithRoot {
-    id: string;
-    typeName: string;
-    selectionSet: SelectionSetNode;
-  }
-
-  declare export function queries(
-    previousState: QueryStore | void,
-    action: ApolloAction
-  ): QueryStore;
-
-  declare type FragmentMatcher = (
-    rootValue: any,
-    typeCondition: string,
-    context: any
-  ) => boolean;
-
-  declare export type DiffResult = {
-    result?: any,
-    isMissing?: boolean
-  };
-
-  declare export type ReadQueryOptions = {
-    store: NormalizedCache,
-    query: DocumentNode,
-    fragmentMatcherFunction?: FragmentMatcher,
-    variables?: Object,
-    previousResult?: any,
-    rootId?: string,
-    config?: ApolloReducerConfig
-  };
-
-  declare export type DiffQueryAgainstStoreOptions = ReadQueryOptions & {
-    returnPartialData?: boolean
-  };
-
-  declare export type CustomResolver = (
-    rootValue: any,
-    args: {
-      [argName: string]: any
-    }
-  ) => any;
-
-  declare export type CustomResolverMap = {
-    [typeName: string]: {
-      [fieldName: string]: CustomResolver
-    }
-  };
-
-  declare export type ReadStoreContext = {
-    store: NormalizedCache,
-    returnPartialData: boolean,
-    hasMissingField: boolean,
-    customResolvers: CustomResolverMap
-  };
-
-  declare export function readQueryFromStore<QueryType>(
-    options: ReadQueryOptions
-  ): QueryType;
-
-  declare export function diffQueryAgainstStore(
-    result: DiffQueryAgainstStoreOptions
-  ): DiffResult;
-
-  declare export function assertIdValue(idValue: IdValue): void;
-
-  declare export class QueryScheduler {
-    inFlightQueries: {
-      [queryId: string]: WatchQueryOptions
-    };
-    registeredQueries: {
-      [queryId: string]: WatchQueryOptions
-    };
-    intervalQueries: {
-      [interval: number]: string[]
-    };
-    queryManager: QueryManager;
-    constructor(queryManager: {
-      queryManager: QueryManager
+  declare class QueryScheduler<TCacheShape> {
+    inFlightQueries: { [queryId: string]: WatchQueryOptions };
+    registeredQueries: { [queryId: string]: WatchQueryOptions };
+    intervalQueries: { [interval: number]: string[] };
+    queryManager: QueryManager<TCacheShape>;
+    constructor({
+      queryManager: QueryManager<TCacheShape>,
+      ssrMode?: boolean
     }): this;
-    checkInFlight(queryId: string): boolean;
+    checkInFlight(queryId: string): ?boolean;
     fetchQuery<T>(
       queryId: string,
       options: WatchQueryOptions,
       fetchType: FetchType
-    ): Promise<{}>;
+    ): Promise<FetchResult<T>>;
     startPollingQuery<T>(
       options: WatchQueryOptions,
       queryId: string,
@@ -939,164 +175,533 @@ declare module "apollo-client" {
     registerPollingQuery<T>(
       queryOptions: WatchQueryOptions
     ): ObservableQuery<T>;
+    markMutationError(mutationId: string, error: Error): void;
+    reset(): void;
   }
 
-  declare export function createApolloReducer(
-    config: ApolloReducerConfig
-  ): (state: Store, action: ApolloAction) => Store;
-
-  declare export function createApolloStore(init?: {
-    reduxRootKey?: string,
-    initialState?: any,
-    config?: ApolloReducerConfig,
-    reportCrashes?: boolean,
-    logger?: Middleware<*, *>
-  }): ApolloStore;
-
-  declare export function createApolloReducer(
-    config: ApolloReducerConfig
-  ): (state: Store, action: ApolloAction) => Store;
-
-  declare export function createApolloStore(store?: {
-    reduxRootKey?: string,
-    initialState?: any,
-    config?: ApolloReducerConfig,
-    reportCrashes?: boolean,
-    logger?: Middleware<*, *>
-  }): ApolloStore;
-
-  declare export class QueryManager {
-    pollingTimers: {
-      [queryId: string]: any
-    };
-    scheduler: QueryScheduler;
-    store: ApolloStore;
-    networkInterface: NetworkInterface;
-    ssrMode: boolean;
-    constructor(setup: {
-      networkInterface: NetworkInterface,
-      store: ApolloStore,
-      reduxRootSelector: ApolloStateSelector,
-      fragmentMatcher?: FragmentMatcherInterface,
-      reducerConfig?: ApolloReducerConfig,
-      addTypename?: boolean,
-      queryDeduplication?: boolean,
-      ssrMode?: boolean
-    }): this;
-    broadcastNewStore(store: any): void;
-    mutate<T>(mutationOpts: {
-      mutation: DocumentNode,
-      variables?: Object,
-      optimisticResponse?: Object,
-      updateQueries?: MutationQueryReducersMap<T>,
-      refetchQueries?: string[] | PureQueryOptions[],
-      update?: (proxy: DataProxy, mutationResult: Object) => void
-    }): Promise<ApolloExecutionResult<T>>;
-    fetchQuery<T>(
-      queryId: string,
-      options: WatchQueryOptions,
-      fetchType?: FetchType,
-      fetchMoreForQueryId?: string
-    ): Promise<ApolloQueryResult<T>>;
-    queryListenerForObserver<T>(
-      queryId: string,
-      options: WatchQueryOptions,
-      observer: Observer<ApolloQueryResult<T>>
-    ): QueryListener;
-    watchQuery<T>(
-      options: WatchQueryOptions,
-      shouldSubscribe?: boolean
-    ): ObservableQuery<T>;
-    query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
-    generateQueryId(): string;
-    stopQueryInStore(queryId: string): void;
-    getApolloState(): Store;
-    selectApolloState(store: any): Store;
-    getInitialState(): {
-      data: Object
-    };
-    getDataWithOptimisticResults(): NormalizedCache;
-    addQueryListener(queryId: string, listener: QueryListener): void;
-    addFetchQueryPromise<T>(
-      requestId: number,
-      promise: Promise<ApolloQueryResult<T>>,
-      resolve: (result: ApolloQueryResult<T>) => void,
-      reject: (error: Error) => void
+  declare class DataStore<TSerialized> {
+    constructor(initialCache: ApolloCache<TSerialized>): this;
+    getCache(): ApolloCache<TSerialized>;
+    markQueryResult(
+      result: ExecutionResult,
+      document: DocumentNode,
+      variables: any,
+      fetchMoreForQueryId: string | void,
+      ignoreErrors?: boolean
     ): void;
-    removeFetchQueryPromise(requestId: number): void;
-    addObservableQuery<T>(
-      queryId: string,
-      observableQuery: ObservableQuery<T>
+    markSubscriptionResult(
+      result: ExecutionResult,
+      document: DocumentNode,
+      variables: any
     ): void;
-    removeObservableQuery(queryId: string): void;
-    resetStore(): void;
-    startQuery<T>(
-      queryId: string,
-      options: WatchQueryOptions,
-      listener: QueryListener
-    ): string;
-    startGraphQLSubscription(options: SubscriptionOptions): Observable<any>;
-    removeQuery(queryId: string): void;
-    stopQuery(queryId: string): void;
-    getCurrentQueryResult<T>(
-      observableQuery: ObservableQuery<T>,
-      isOptimistic?: boolean
-    ): any;
-    getQueryWithPreviousResult<T>(
-      queryIdOrObservable: string | ObservableQuery<T>,
-      isOptimistic?: boolean
-    ): {
-      previousResult: any,
-      variables: {
-        [key: string]: any
-      } | void,
-      document: DocumentNode
-    };
+    markMutationInit(mutation: {
+      mutationId: string,
+      document: DocumentNode,
+      variables: any,
+      updateQueries: { [queryId: string]: QueryWithUpdater },
+      update: ((proxy: DataProxy, mutationResult: Object) => void) | void,
+      optimisticResponse: Object | Function | void
+    }): void;
+    markMutationResult(mutation: {
+      mutationId: string,
+      result: ExecutionResult,
+      document: DocumentNode,
+      variables: any,
+      updateQueries: { [queryId: string]: QueryWithUpdater },
+      update: ((proxy: DataProxy, mutationResult: Object) => void) | void
+    }): void;
+    markMutationComplete({
+      mutationId: string,
+      optimisticResponse?: any
+    }): void;
+    markUpdateQueryResult(
+      document: DocumentNode,
+      variables: any,
+      newResult: any
+    ): void;
+    reset(): Promise<void>;
   }
 
-  declare export class ApolloClient extends DataProxy {
-    networkInterface: NetworkInterface;
-    store: ApolloStore;
-    reduxRootSelector: ApolloStateSelector | null;
-    initialState: any;
-    queryManager: QueryManager;
-    reducerConfig: ApolloReducerConfig;
-    addTypename: boolean;
+  declare type QueryWithUpdater = {
+    updater: MutationQueryReducer<Object>,
+    query: QueryStoreValue
+  };
+
+  declare interface MutationStoreValue {
+    mutationString: string;
+    variables: Object;
+    loading: boolean;
+    error: Error | null;
+  }
+
+  declare class MutationStore {
+    getStore(): { [mutationId: string]: MutationStoreValue };
+    get(mutationId: string): MutationStoreValue;
+    initMutation(
+      mutationId: string,
+      mutationString: string,
+      variables: Object | void
+    ): void;
+  }
+
+  declare export interface FetchMoreOptions {
+    updateQuery: (
+      previousQueryResult: { [key: string]: any },
+      options: {
+        fetchMoreResult?: { [key: string]: any },
+        queryVariables: { [key: string]: any }
+      }
+    ) => Object;
+  }
+
+  declare export interface UpdateQueryOptions {
+    variables?: Object;
+  }
+
+  declare export type ApolloCurrentResult<T> = {
+    data: T | {},
+    errors?: Array<GraphQLError>,
+    loading: boolean,
+    networkStatus: NetworkStatus,
+    error?: ApolloError,
+    partial?: boolean
+  };
+
+  declare interface ModifiableWatchQueryOptions {
+    variables?: { [key: string]: any };
+    pollInterval?: number;
+    fetchPolicy?: FetchPolicy;
+    errorPolicy?: ErrorPolicy;
+    fetchResults?: boolean;
+    notifyOnNetworkStatusChange?: boolean;
+  }
+
+  declare export interface WatchQueryOptions
+    extends ModifiableWatchQueryOptions {
+    query: DocumentNode;
+    metadata?: any;
+    context?: any;
+  }
+
+  declare type RefetchQueryDescription = Array<string | PureQueryOptions>;
+
+  declare interface MutationBaseOptions<T = { [key: string]: any }> {
+    optimisticResponse?: Object | Function;
+    updateQueries?: MutationQueryReducersMap<T>;
+    optimisticResponse?: Object;
+    refetchQueries?:
+      | ((result: ExecutionResult) => RefetchQueryDescription)
+      | RefetchQueryDescription;
+    update?: MutationUpdaterFn<T>;
+    errorPolicy?: ErrorPolicy;
+    variables?: any;
+  }
+
+  declare export interface MutationOptions<T = { [key: string]: any }>
+    extends MutationBaseOptions<T> {
+    mutation: DocumentNode;
+    context?: any;
+    fetchPolicy?: FetchPolicy;
+  }
+
+  declare export interface SubscriptionOptions {
+    query: DocumentNode;
+    variables?: { [key: string]: any };
+  }
+
+  declare export type FetchPolicy =
+    | "cache-first"
+    | "cache-and-network"
+    | "network-only"
+    | "cache-only"
+    | "no-cache"
+    | "standby";
+
+  declare export type ErrorPolicy = "none" | "ignore" | "all";
+
+  declare export interface FetchMoreQueryOptions {
+    query?: DocumentNode;
+    variables?: { [key: string]: any };
+  }
+
+  declare export type SubscribeToMoreOptions = {
+    document: DocumentNode,
+    variables?: { [key: string]: any },
+    updateQuery?: (
+      previousQueryResult: Object,
+      options: {
+        subscriptionData: { data: any },
+        variables?: { [key: string]: any }
+      }
+    ) => Object,
+    onError?: (error: Error) => void
+  };
+
+  declare export type MutationUpdaterFn<T = { [key: string]: any }> = (
+    proxy: DataProxy,
+    mutationResult: FetchResult<T>
+  ) => void;
+
+  declare export type NetworkStatus = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+  declare export type QueryListener = (
+    queryStoreValue: QueryStoreValue,
+    newData?: any
+  ) => void;
+
+  declare export type QueryStoreValue = {
+    document: DocumentNode,
+    variables: Object,
+    previousVariables: Object | null,
+    networkStatus: NetworkStatus,
+    networkError: Error | null,
+    graphQLErrors: GraphQLError[],
+    metadata: any
+  };
+
+  declare export type PureQueryOptions = {
+    query: DocumentNode,
+    variables?: { [key: string]: any }
+  };
+
+  declare export type ApolloQueryResult<T> = {
+    data: T,
+    errors?: Array<GraphQLError>,
+    loading: boolean,
+    networkStatus: NetworkStatus,
+    stale: boolean
+  };
+
+  declare export type FetchType = 1 | 2 | 3;
+
+  declare export type MutationQueryReducer<T> = (
+    previousResult: { [key: string]: any },
+    options: {
+      mutationResult: FetchResult<T>,
+      queryName: string | void,
+      queryVariables: { [key: string]: any }
+    }
+  ) => { [key: string]: any };
+
+  declare export type MutationQueryReducersMap<T = { [key: string]: any }> = {
+    [queryName: string]: MutationQueryReducer<T>
+  };
+
+  declare export class ApolloError extends Error {
+    message: string;
+    graphQLErrors: Array<GraphQLError>;
+    networkError: Error | null;
+    extraInfo: any;
+    constructor(info: ErrorConstructor): this;
+  }
+
+  declare interface ErrorConstructor {
+    graphQLErrors?: Array<GraphQLError>;
+    networkError?: Error | null;
+    errorMessage?: string;
+    extraInfo?: any;
+  }
+
+  declare interface DefaultOptions {
+    watchQuery?: ModifiableWatchQueryOptions;
+    query?: ModifiableWatchQueryOptions;
+    mutate?: MutationBaseOptions<>;
+  }
+
+  declare export type ApolloClientOptions<TCacheShape> = {
+    link: ApolloLink,
+    cache: ApolloCache<TCacheShape>,
+    ssrMode?: boolean,
+    ssrForceFetchDelay?: number,
+    connectToDevTools?: boolean,
+    queryDeduplication?: boolean,
+    defaultOptions?: DefaultOptions
+  };
+
+  declare export class ApolloClient<TCacheShape> {
+    link: ApolloLink;
+    store: DataStore<TCacheShape>;
+    cache: ApolloCache<TCacheShape>;
+    queryManager: QueryManager<TCacheShape>;
     disableNetworkFetches: boolean;
-    dataId: IdGetter | void;
-    dataIdFromObject: IdGetter | void;
-    fieldWithArgs: (fieldName: string, args?: Object) => string;
     version: string;
     queryDeduplication: boolean;
-    constructor(options?: {
-      networkInterface?: NetworkInterface,
-      reduxRootSelector?: string | ApolloStateSelector,
-      initialState?: any,
-      dataIdFromObject?: IdGetter,
-      ssrMode?: boolean,
-      ssrForceFetchDelay?: number,
-      addTypename?: boolean,
-      customResolvers?: CustomResolverMap,
-      connectToDevTools?: boolean,
-      queryDeduplication?: boolean,
-      fragmentMatcher?: FragmentMatcherInterface
-    }): this;
+    defaultOptions: DefaultOptions;
+    devToolsHookCb: Function;
+    proxy: ApolloCache<TCacheShape> | void;
+    ssrMode: boolean;
+    resetStoreCallbacks: Array<() => Promise<any>>;
+
+    constructor(options: ApolloClientOptions<TCacheShape>): this;
     watchQuery<T>(options: WatchQueryOptions): ObservableQuery<T>;
     query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
-    mutate<T>(options: MutationOptions<T>): Promise<ApolloExecutionResult<T>>;
+    mutate<T>(options: MutationOptions<T>): Promise<FetchResult<T>>;
     subscribe(options: SubscriptionOptions): Observable<any>;
-    readQuery<T>(options: DataProxyReadQueryOptions): T;
+    readQuery<T>(options: DataProxyReadQueryOptions): T | null;
     readFragment<T>(options: DataProxyReadFragmentOptions): T | null;
     writeQuery(options: DataProxyWriteQueryOptions): void;
     writeFragment(options: DataProxyWriteFragmentOptions): void;
-    reducer(): (state: Store, action: ApolloAction) => Store;
-    __actionHookForDevTools(cb: Function): void;
-    middleware: <S, A>() => Middleware<S, A>;
-    initStore(): void;
-    resetStore(): void;
-    getInitialState(): {
-      data: Object
-    };
+    writeData(options: DataProxyWriteDataOptions): void;
+    __actionHookForDevTools(cb: () => any): void;
+    __requestRaw(payload: GraphQLRequest): Observable<ExecutionResult>;
+    initQueryManager(): void;
+    resetStore(): Promise<Array<ApolloQueryResult<any>> | null>;
+    onResetStore(cb: () => Promise<any>): () => void;
+    reFetchObservableQueries(
+      includeStandby?: boolean
+    ): Promise<ApolloQueryResult<any>[]> | Promise<null>;
   }
+
   declare export default typeof ApolloClient;
+
+  /* TODO: Move to apollo-link libdef */
+  declare export class ApolloLink {
+    constructor(request?: RequestHandler): this;
+
+    static empty(): ApolloLink;
+    static from(links: Array<ApolloLink>): ApolloLink;
+    static split(
+      test: (op: Operation) => boolean,
+      left: ApolloLink | RequestHandler,
+      right: ApolloLink | RequestHandler
+    ): ApolloLink;
+    static execute(
+      link: ApolloLink,
+      operation: GraphQLRequest
+    ): Observable<FetchResult<>>;
+
+    split(
+      test: (op: Operation) => boolean,
+      left: ApolloLink | RequestHandler,
+      right: ApolloLink | RequestHandler
+    ): ApolloLink;
+
+    concat(next: ApolloLink | RequestHandler): ApolloLink;
+
+    request(
+      operation: Operation,
+      forward?: NextLink
+    ): Observable<FetchResult<>> | null;
+  }
+
+  declare interface GraphQLRequest {
+    query: DocumentNode;
+    variables?: { [key: string]: any };
+    operationName?: string;
+    context?: { [key: string]: any };
+    extensions?: { [key: string]: any };
+  }
+
+  declare interface Operation {
+    query: DocumentNode;
+    variables: { [key: string]: any };
+    operationName: string;
+    extensions: { [key: string]: any };
+    setContext: (context: { [key: string]: any }) => { [key: string]: any };
+    getContext: () => { [key: string]: any };
+    toKey: () => string;
+  }
+
+  declare type FetchResult<
+    C = { [key: string]: any },
+    E = { [key: string]: any }
+  > = ExecutionResult & { extension?: E, context?: C };
+
+  declare type NextLink = (operation: Operation) => Observable<FetchResult<>>;
+
+  declare type RequestHandler = (
+    operation: Operation,
+    forward?: NextLink
+  ) => Observable<FetchResult<>> | null;
+
+  declare class Observable<T> {
+    subscribe(
+      observerOrNext: ((value: T) => void) | ZenObservableObserver<T>,
+      error?: (error: any) => void,
+      complete?: () => void
+    ): ZenObservableSubscription;
+
+    forEach(fn: (value: T) => void): Promise<void>;
+
+    map<R>(fn: (value: T) => R): Observable<R>;
+
+    filter(fn: (value: T) => boolean): Observable<T>;
+
+    reduce<R>(
+      fn: (previousValue: R | T, currentValue: T) => R | T,
+      initialValue?: R | T
+    ): Observable<R | T>;
+
+    flatMap<R>(fn: (value: T) => ZenObservableObservableLike<R>): Observable<R>;
+
+    from<R>(
+      observable: Observable<R> | ZenObservableObservableLike<R> | Array<R>
+    ): Observable<R>;
+
+    of<R>(...args: Array<R>): Observable<R>;
+  }
+
+  declare interface Observer<T> {
+    start?: (subscription: Subscription) => any;
+    next?: (value: T) => void;
+    error?: (errorValue: any) => void;
+    complete?: () => void;
+  }
+
+  declare interface Subscription {
+    closed: boolean;
+    unsubscribe(): void;
+  }
+
+  declare interface ZenObservableSubscriptionObserver<T> {
+    closed: boolean;
+    next(value: T): void;
+    error(errorValue: any): void;
+    complete(): void;
+  }
+
+  declare interface ZenObservableSubscription {
+    closed: boolean;
+    unsubscribe(): void;
+  }
+
+  declare interface ZenObservableObserver<T> {
+    start?: (subscription: ZenObservableSubscription) => any;
+    next?: (value: T) => void;
+    error?: (errorValue: any) => void;
+    complete?: () => void;
+  }
+
+  declare type ZenObservableSubscriber<T> = (
+    observer: ZenObservableSubscriptionObserver<T>
+  ) => void | (() => void) | Subscription;
+
+  declare interface ZenObservableObservableLike<T> {
+    subscribe?: ZenObservableSubscriber<T>;
+  }
+  /* End TODO: Move to apollo-link libdef */
+
+  /* TODO: Move these types to apollo-cache libdef */
+  declare class ApolloCache<TSerialized> {
+    read<T>(query: CacheReadOptions): T | null;
+    write(write: CacheWriteOptions): void;
+    diff<T>(query: CacheDiffOptions): CacheDiffResult<T>;
+    watch(watch: CacheWatchOptions): () => void;
+    evict(query: CacheEvictOptions): CacheEvictionResult;
+    reset(): Promise<void>;
+
+    restore(serializedState: TSerialized): ApolloCache<TSerialized>;
+    extract(optimistic?: boolean): TSerialized;
+
+    removeOptimistic(id: string): void;
+
+    performTransaction(transaction: Transaction<TSerialized>): void;
+    recordOptimisticTransaction(
+      transaction: Transaction<TSerialized>,
+      id: string
+    ): void;
+
+    transformDocument(document: DocumentNode): DocumentNode;
+    transformForLink(document: DocumentNode): DocumentNode;
+
+    readQuery<QueryType>(
+      options: DataProxyReadQueryOptions,
+      optimistic?: boolean
+    ): QueryType | null;
+    readFragment<FragmentType>(
+      options: DataProxyReadFragmentOptions,
+      optimistic?: boolean
+    ): FragmentType | null;
+    writeQuery(options: CacheWriteQueryOptions): void;
+    writeFragment(options: CacheWriteFragmentOptions): void;
+    writeData(options: CacheWriteDataOptions): void;
+  }
+
+  declare type Transaction<T> = (c: ApolloCache<T>) => void;
+
+  declare type CacheWatchCallback = (newData: any) => void;
+
+  declare interface CacheEvictionResult {
+    success: boolean;
+  }
+
+  declare interface CacheReadOptions extends DataProxyReadQueryOptions {
+    rootId?: string;
+    previousResult?: any;
+    optimistic: boolean;
+  }
+
+  declare interface CacheWriteOptions extends DataProxyReadQueryOptions {
+    dataId: string;
+    result: any;
+  }
+
+  declare interface CacheDiffOptions extends CacheReadOptions {
+    returnPartialData?: boolean;
+  }
+
+  declare interface CacheWatchOptions extends CacheReadOptions {
+    callback: CacheWatchCallback;
+  }
+
+  declare interface CacheEvictOptions extends DataProxyReadQueryOptions {
+    rootId?: string;
+  }
+
+  declare type CacheDiffResult<T> = DataProxyDiffResult<T>;
+  declare type CacheWriteQueryOptions = DataProxyWriteQueryOptions;
+  declare type CacheWriteFragmentOptions = DataProxyWriteFragmentOptions;
+  declare type CacheWriteDataOptions = DataProxyWriteDataOptions;
+  declare type CacheReadFragmentOptions = DataProxyReadFragmentOptions;
+
+  declare interface DataProxyReadQueryOptions {
+    query: DocumentNode;
+    variables?: any;
+  }
+
+  declare interface DataProxyReadFragmentOptions {
+    id: string;
+    fragment: DocumentNode;
+    fragmentName?: string;
+    variables?: any;
+  }
+
+  declare interface DataProxyWriteQueryOptions {
+    data: any;
+    query: DocumentNode;
+    variables?: any;
+  }
+
+  declare interface DataProxyWriteFragmentOptions {
+    data: any;
+    id: string;
+    fragment: DocumentNode;
+    fragmentName?: string;
+    variables?: any;
+  }
+
+  declare interface DataProxyWriteDataOptions {
+    data: any;
+    id?: string;
+  }
+
+  declare type DataProxyDiffResult<T> = {
+    result?: T,
+    complete?: boolean
+  };
+
+  declare interface DataProxy {
+    readQuery<QueryType>(
+      options: DataProxyReadQueryOptions,
+      optimistic?: boolean
+    ): QueryType | null;
+    readFragment<FragmentType>(
+      options: DataProxyReadFragmentOptions,
+      optimistic?: boolean
+    ): FragmentType | null;
+    writeQuery(options: DataProxyWriteQueryOptions): void;
+    writeFragment(options: DataProxyWriteFragmentOptions): void;
+    writeData(options: DataProxyWriteDataOptions): void;
+  }
+  /* End TODO: Move these types to apollo-cache libdef */
 }

--- a/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
+++ b/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
@@ -1,1089 +1,1102 @@
-// @flow
-import type {
-  DocumentNode,
-  ExecutionResult,
-  GraphQLError,
-  SelectionSetNode,
-  FieldNode,
-  InlineFragmentNode,
-  ValueNode,
-  SelectionNode,
-  NameNode
-} from "graphql";
+declare module "apollo-client" {
+  import type {
+    DocumentNode,
+    ExecutionResult,
+    GraphQLError,
+    SelectionSetNode,
+    FieldNode,
+    InlineFragmentNode,
+    ValueNode,
+    SelectionNode,
+    NameNode
+  } from "graphql";
 
-import type { Middleware } from "redux";
+  import type { Middleware } from "redux";
 
-export interface Request {
-  // causes flow errors
-  // property `$key` of Request. Indexable signature not found in
-  // property `$value` of Request. Indexable signature not found in
-  // [additionalKey: string]: any,
-  debugName?: string;
-  query?: DocumentNode;
-  variables?: Object;
-  operationName?: string | null;
-}
+  declare export interface Request {
+    // causes flow errors
+    // property `$key` of Request. Indexable signature not found in
+    // property `$value` of Request. Indexable signature not found in
+    // [additionalKey: string]: any,
+    debugName?: string;
+    query?: DocumentNode;
+    variables?: Object;
+    operationName?: string | null;
+  }
 
-export interface NetworkInterface {
-  query(request: Request): Promise<ExecutionResult>;
-}
+  declare export interface NetworkInterface {
+    query(request: Request): Promise<ExecutionResult>;
+  }
 
-export interface BatchedNetworkInterface {
-  batchQuery(requests: Request[]): Promise<ExecutionResult[]>;
-}
+  declare export interface BatchedNetworkInterface {
+    batchQuery(requests: Request[]): Promise<ExecutionResult[]>;
+  }
 
-export interface MiddlewareRequest {
-  request: Request;
-  options: RequestOptions;
-}
+  declare export interface MiddlewareRequest {
+    request: Request;
+    options: RequestOptions;
+  }
 
-export interface MiddlewareInterface {
-  applyMiddleware(request: MiddlewareRequest, next: Function): void;
-}
+  declare export interface MiddlewareInterface {
+    applyMiddleware(request: MiddlewareRequest, next: Function): void;
+  }
 
-export interface BatchMiddlewareRequest {
-  requests: Request[];
-  options: RequestOptions;
-}
+  declare export interface BatchMiddlewareRequest {
+    requests: Request[];
+    options: RequestOptions;
+  }
 
-export interface BatchMiddlewareInterface {
-  applyBatchMiddleware(request: BatchMiddlewareRequest, next: Function): void;
-}
-export interface AfterwareResponse {
-  response: Response;
-  options: RequestOptions;
-}
+  declare export interface BatchMiddlewareInterface {
+    applyBatchMiddleware(request: BatchMiddlewareRequest, next: Function): void;
+  }
+  declare export interface AfterwareResponse {
+    response: Response;
+    options: RequestOptions;
+  }
 
-export interface AfterwareInterface {
-  applyAfterware(response: AfterwareResponse, next: Function): any;
-}
+  declare export interface AfterwareInterface {
+    applyAfterware(response: AfterwareResponse, next: Function): any;
+  }
 
-export interface BatchAfterwareResponse {
-  responses: Response[];
-  options: RequestOptions;
-}
+  declare export interface BatchAfterwareResponse {
+    responses: Response[];
+    options: RequestOptions;
+  }
 
-export interface BatchAfterwareInterface {
-  applyBatchAfterware(response: BatchAfterwareResponse, next: Function): any;
-}
+  declare export interface BatchAfterwareInterface {
+    applyBatchAfterware(response: BatchAfterwareResponse, next: Function): any;
+  }
 
-export interface PrintedRequest {
-  debugName?: string;
-  query?: string;
-  variables?: Object;
-  operationName?: string | null;
-}
+  declare export interface PrintedRequest {
+    debugName?: string;
+    query?: string;
+    variables?: Object;
+    operationName?: string | null;
+  }
 
-export interface SubscriptionNetworkInterface {
-  subscribe(
-    request: Request,
-    handler: (error: any, result: any) => void
-  ): number;
-  unsubscribe(id: Number): void;
-}
+  declare export interface SubscriptionNetworkInterface {
+    subscribe(
+      request: Request,
+      handler: (error: any, result: any) => void
+    ): number;
+    unsubscribe(id: Number): void;
+  }
 
-export type NetworkMiddleware =
-  | Array<MiddlewareInterface>
-  | Array<BatchMiddlewareInterface>;
-export type NetworkAfterware =
-  | Array<AfterwareInterface>
-  | Array<BatchAfterwareInterface>;
+  declare export type NetworkMiddleware =
+    | Array<MiddlewareInterface>
+    | Array<BatchMiddlewareInterface>;
+  declare export type NetworkAfterware =
+    | Array<AfterwareInterface>
+    | Array<BatchAfterwareInterface>;
 
-declare export class HTTPNetworkInterface {
-  _uri: string;
-  _opts: RequestOptions;
-  _middlewares: NetworkMiddleware;
-  _afterwares: NetworkAfterware;
-  use(middlewares: NetworkMiddleware): HTTPNetworkInterface;
-  useAfter(afterwares: NetworkAfterware): HTTPNetworkInterface;
-  query(request: Request): Promise<ExecutionResult>;
-}
+  declare export class HTTPNetworkInterface {
+    _uri: string;
+    _opts: RequestOptions;
+    _middlewares: NetworkMiddleware;
+    _afterwares: NetworkAfterware;
+    use(middlewares: NetworkMiddleware): HTTPNetworkInterface;
+    useAfter(afterwares: NetworkAfterware): HTTPNetworkInterface;
+    query(request: Request): Promise<ExecutionResult>;
+  }
 
-export interface BatchRequestAndOptions {
-  requests: Request[];
-  options: RequestOptions;
-}
+  declare export interface BatchRequestAndOptions {
+    requests: Request[];
+    options: RequestOptions;
+  }
 
-export interface BatchResponseAndOptions {
-  responses: Response[];
-  options: RequestOptions;
-}
+  declare export interface BatchResponseAndOptions {
+    responses: Response[];
+    options: RequestOptions;
+  }
 
-export type BatchingNetworkInterfaceOptions = {
-  uri: string,
-  batchInterval: number,
-  // compatibility with NetworkInterfaceOptions
-  opts?: ?RequestOptions
-};
-
-declare export function createBatchingNetworkInterface(
-  options: BatchingNetworkInterfaceOptions
-): HTTPNetworkInterface;
-
-declare export class HTTPBatchedNetworkInterface extends BaseNetworkInterface {
-  _middlewares: NetworkMiddleware;
-  _afterwares: NetworkAfterware;
-  constructor(
+  declare export type BatchingNetworkInterfaceOptions = {
     uri: string,
     batchInterval: number,
-    fetchOpts: RequestOptions
-  ): this;
-  query(request: Request): Promise<ExecutionResult>;
-  batchQuery(requests: Request[]): Promise<ExecutionResult[]>;
-  applyBatchMiddlewares(
-    opts: BatchRequestAndOptions
-  ): Promise<BatchRequestAndOptions>;
-  applyBatchAfterwares(
-    opts: BatchResponseAndOptions
-  ): Promise<BatchResponseAndOptions>;
-  use(middlewares: BatchMiddlewareInterface[]): HTTPNetworkInterface;
-  useAfter(afterwares: BatchAfterwareInterface[]): HTTPNetworkInterface;
-}
+    // compatibility with NetworkInterfaceOptions
+    opts?: ?RequestOptions
+  };
 
-export interface RequestAndOptions {
-  request: Request;
-  options: RequestOptions;
-}
+  declare export function createBatchingNetworkInterface(
+    options: BatchingNetworkInterfaceOptions
+  ): HTTPNetworkInterface;
 
-export interface ResponseAndOptions {
-  response: Response;
-  options: RequestOptions;
-}
+  declare export class HTTPBatchedNetworkInterface extends BaseNetworkInterface {
+    _middlewares: NetworkMiddleware;
+    _afterwares: NetworkAfterware;
+    constructor(
+      uri: string,
+      batchInterval: number,
+      fetchOpts: RequestOptions
+    ): this;
+    query(request: Request): Promise<ExecutionResult>;
+    batchQuery(requests: Request[]): Promise<ExecutionResult[]>;
+    applyBatchMiddlewares(
+      opts: BatchRequestAndOptions
+    ): Promise<BatchRequestAndOptions>;
+    applyBatchAfterwares(
+      opts: BatchResponseAndOptions
+    ): Promise<BatchResponseAndOptions>;
+    use(middlewares: BatchMiddlewareInterface[]): HTTPNetworkInterface;
+    useAfter(afterwares: BatchAfterwareInterface[]): HTTPNetworkInterface;
+  }
 
-export type NetworkInterfaceOptions = {
-  // compatibility with BatchNetworkInrfaceOptions
-  // also network interfaces throws an error in case you haven't provide an uri
-  // in this case is right to fail typecheck too
-  uri: string,
-  opts?: ?RequestOptions
-};
+  declare export interface RequestAndOptions {
+    request: Request;
+    options: RequestOptions;
+  }
 
-declare export function printRequest(request: Request): PrintedRequest;
+  declare export interface ResponseAndOptions {
+    response: Response;
+    options: RequestOptions;
+  }
 
-declare export function createNetworkInterface(
-  uriOrInterfaceOpts: string | NetworkInterfaceOptions,
-  secondArgOpts?: NetworkInterfaceOptions
-): HTTPNetworkInterface;
+  declare export type NetworkInterfaceOptions = {
+    // compatibility with BatchNetworkInrfaceOptions
+    // also network interfaces throws an error in case you haven't provide an uri
+    // in this case is right to fail typecheck too
+    uri: string,
+    opts?: ?RequestOptions
+  };
 
-declare export class BaseNetworkInterface {
-  _middlewares: NetworkMiddleware;
-  _afterwares: NetworkAfterware;
-  _uri: string;
-  _opts: RequestOptions;
-  constructor(uri: string | void, opts?: RequestOptions): this;
-  query(request: Request): Promise<ExecutionResult>;
-}
+  declare export function printRequest(request: Request): PrintedRequest;
 
-declare export class HTTPFetchNetworkInterface extends BaseNetworkInterface {
-  _middlewares: NetworkMiddleware;
-  _afterwares: NetworkAfterware;
-  applyMiddlewares(
-    requestAndOptions: RequestAndOptions
-  ): Promise<RequestAndOptions>;
-  applyAfterwares(opts: ResponseAndOptions): Promise<ResponseAndOptions>;
-  fetchFromRemoteEndpoint(opts: RequestAndOptions): Promise<Response>;
-  query(request: Request): Promise<ExecutionResult>;
-  use(middlewares: MiddlewareInterface[]): HTTPNetworkInterface;
-  useAfter(afterwares: AfterwareInterface[]): HTTPNetworkInterface;
-}
+  declare export function createNetworkInterface(
+    uriOrInterfaceOpts: string | NetworkInterfaceOptions,
+    secondArgOpts?: NetworkInterfaceOptions
+  ): HTTPNetworkInterface;
 
-export type FetchPolicy =
-  | "cache-first"
-  | "cache-and-network"
-  | "network-only"
-  | "cache-only"
-  | "standby";
+  declare export class BaseNetworkInterface {
+    _middlewares: NetworkMiddleware;
+    _afterwares: NetworkAfterware;
+    _uri: string;
+    _opts: RequestOptions;
+    constructor(uri: string | void, opts?: RequestOptions): this;
+    query(request: Request): Promise<ExecutionResult>;
+  }
 
-export type SubscribeToMoreOptions = {
-  document: DocumentNode,
-  variables?: {
-    [key: string]: any
-  },
-  updateQuery?: (
-    previousQueryResult: Object,
-    options: {
-      subscriptionData: {
-        data: any
-      },
-      variables: {
-        [key: string]: any
+  declare export class HTTPFetchNetworkInterface extends BaseNetworkInterface {
+    _middlewares: NetworkMiddleware;
+    _afterwares: NetworkAfterware;
+    applyMiddlewares(
+      requestAndOptions: RequestAndOptions
+    ): Promise<RequestAndOptions>;
+    applyAfterwares(opts: ResponseAndOptions): Promise<ResponseAndOptions>;
+    fetchFromRemoteEndpoint(opts: RequestAndOptions): Promise<Response>;
+    query(request: Request): Promise<ExecutionResult>;
+    use(middlewares: MiddlewareInterface[]): HTTPNetworkInterface;
+    useAfter(afterwares: AfterwareInterface[]): HTTPNetworkInterface;
+  }
+
+  declare export type FetchPolicy =
+    | "cache-first"
+    | "cache-and-network"
+    | "network-only"
+    | "cache-only"
+    | "standby";
+
+  declare export type SubscribeToMoreOptions = {
+    document: DocumentNode,
+    variables?: {
+      [key: string]: any
+    },
+    updateQuery?: (
+      previousQueryResult: Object,
+      options: {
+        subscriptionData: {
+          data: any
+        },
+        variables: {
+          [key: string]: any
+        }
       }
-    }
-  ) => Object,
-  onError?: (error: Error) => void
-};
-
-export type MutationUpdaterFn<T = { [key: string]: any }> = (
-  proxy: DataProxy,
-  mutationResult: ApolloExecutionResult<T>
-) => void;
-
-export interface ModifiableWatchQueryOptions {
-  variables?: {
-    [key: string]: any
+    ) => Object,
+    onError?: (error: Error) => void
   };
-  pollInterval?: number;
-  fetchPolicy?: FetchPolicy;
-  fetchResults?: boolean;
-  notifyOnNetworkStatusChange?: boolean;
-  reducer?: OperationResultReducer;
-}
 
-export interface WatchQueryOptions {
-  query: DocumentNode;
-  metadata?: any;
-}
+  declare export type MutationUpdaterFn<T = { [key: string]: any }> = (
+    proxy: DataProxy,
+    mutationResult: ApolloExecutionResult<T>
+  ) => void;
 
-export interface FetchMoreQueryOptions {
-  query?: DocumentNode;
-  +variables?: {
-    [key: string]: any
-  };
-}
-
-export interface SubscriptionOptions {
-  query: DocumentNode;
-  variables?: {
-    [key: string]: any
-  };
-}
-
-export type MutationOptions<T = { [key: string]: any }> = {
-  mutation: DocumentNode,
-  variables?: Object,
-  optimisticResponse?: Object,
-  updateQueries?: MutationQueryReducersMap<T>,
-  refetchQueries?: string[] | PureQueryOptions[],
-  update?: MutationUpdaterFn<T>
-};
-
-export type QueryListener = (queryStoreValue: QueryStoreValue) => void;
-export type FetchType = number;
-export type PureQueryOptions = {
-  query: DocumentNode,
-  variables?: {
-    [key: string]: any
+  declare export interface ModifiableWatchQueryOptions {
+    variables?: {
+      [key: string]: any
+    };
+    pollInterval?: number;
+    fetchPolicy?: FetchPolicy;
+    fetchResults?: boolean;
+    notifyOnNetworkStatusChange?: boolean;
+    reducer?: OperationResultReducer;
   }
-};
 
-export type ApolloQueryResult<T> = {
-  data: T,
-  loading: boolean,
-  networkStatus: NetworkStatus,
-  stale: boolean
-};
-
-export type ApolloExecutionResult<T = { [key: string]: any }> = {
-  data: T
-};
-
-export type IdGetter = (value: Object) => string | null | void;
-
-export type ListValue = Array<null | IdValue>;
-
-export type StoreValue =
-  | number
-  | string
-  | string[]
-  | IdValue
-  | ListValue
-  | JsonValue
-  | null
-  | void;
-
-export interface NormalizedCache {
-  [dataId: string]: StoreObject;
-}
-
-export interface StoreObject {
-  [storeFieldKey: string]: StoreValue;
-  __typename?: string;
-}
-
-export interface IdValue {
-  type: "id";
-  id: string;
-  generated: boolean;
-}
-
-export interface JsonValue {
-  type: "json";
-  json: any;
-}
-
-declare export function valueToObjectRepresentation(
-  argObj: any,
-  name: NameNode,
-  value: ValueNode,
-  variables?: Object
-): void;
-
-declare export function storeKeyNameFromField(
-  field: FieldNode,
-  variables?: Object
-): string;
-
-declare export function storeKeyNameFromFieldNameAndArgs(
-  fieldName: string,
-  args?: Object
-): string;
-
-declare export function resultKeyNameFromField(field: FieldNode): string;
-
-declare export function isField(selection: SelectionNode): FieldNode;
-
-declare export function isInlineFragment(
-  selection: SelectionNode
-): InlineFragmentNode;
-
-declare export function graphQLResultHasError(
-  result: ExecutionResult
-): number | void;
-
-declare export function isIdValue(idObject: StoreValue): IdValue;
-
-declare export function toIdValue(id: string, generated?: boolean): IdValue;
-
-declare export function isJsonValue(jsonObject: StoreValue): JsonValue;
-
-export type MutationQueryReducer<T> = (
-  previousResult: Object,
-  options: {
-    mutationResult: ApolloExecutionResult<T>,
-    queryName: string | null,
-    queryVariables: Object
+  declare export interface WatchQueryOptions {
+    query: DocumentNode;
+    metadata?: any;
   }
-) => Object;
 
-export type MutationQueryReducersMap<T = { [key: string]: any }> = {
-  [queryName: string]: MutationQueryReducer<T>
-};
-
-export type OperationResultReducer = (
-  previousResult: Object,
-  action: ApolloAction,
-  variables: Object
-) => Object;
-
-export type OperationResultReducerMap = {
-  [queryId: string]: OperationResultReducer
-};
-
-export type ApolloCurrentResult<T> = {
-  data: T | {},
-  loading: boolean,
-  networkStatus: NetworkStatus,
-  error?: ApolloError,
-  partial?: boolean
-};
-
-export interface FetchMoreOptions {
-  updateQuery: (
-    previousQueryResult: Object,
-    options: {
-      fetchMoreResult: Object,
-      queryVariables: Object
-    }
-  ) => Object;
-}
-
-export interface UpdateQueryOptions {
-  variables?: Object;
-}
-
-declare export class ObservableQuery<T> extends Observable<
-  ApolloQueryResult<T>
-> {
-  options: WatchQueryOptions;
-  queryId: string;
-  variables: {
-    [key: string]: any
-  };
-  constructor(data: {
-    scheduler: QueryScheduler,
-    options: WatchQueryOptions,
-    shouldSubscribe?: boolean
-  }): this;
-  result(): Promise<ApolloQueryResult<T>>;
-  currentResult(): ApolloCurrentResult<T>;
-  getLastResult(): ApolloQueryResult<T>;
-  refetch(variables?: any): Promise<ApolloQueryResult<T>>;
-  fetchMore(
-    fetchMoreOptions: FetchMoreQueryOptions & FetchMoreOptions
-  ): Promise<ApolloQueryResult<T>>;
-  subscribeToMore(options: SubscribeToMoreOptions): () => void;
-  setOptions(opts: ModifiableWatchQueryOptions): Promise<ApolloQueryResult<T>>;
-  setVariables(
-    variables: any,
-    tryFetch?: boolean
-  ): Promise<ApolloQueryResult<T>>;
-  updateQuery(
-    mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any
-  ): void;
-  stopPolling(): void;
-  startPolling(pollInterval: number): void;
-}
-
-export type CleanupFunction = () => void;
-
-export type SubscriberFunction<T> = (
-  observer: Observer<T>
-) => Subscription | CleanupFunction;
-
-export interface Observer<T> {
-  next?: (value: T) => void;
-  error?: (error: Error) => void;
-  complete?: () => void;
-}
-
-export interface Subscription {
-  unsubscribe: CleanupFunction;
-}
-
-declare export class Observable<T> {
-  constructor(subscriberFunction: SubscriberFunction<T>): this;
-  subscribe(observer: Observer<T>): Subscription;
-}
-
-export type NetworkStatus = number;
-declare export function isNetworkRequestInFlight(
-  networkStatus: NetworkStatus
-): boolean;
-
-export interface MutationStore {
-  [mutationId: string]: MutationStoreValue;
-}
-
-export interface MutationStoreValue {
-  mutationString: string;
-  variables: Object;
-  loading: boolean;
-  error: Error | null;
-}
-
-export type IntrospectionResultData = {
-  __schema: {
-    types: Array<{
-      kind: string,
-      name: string,
-      possibleTypes: Array<{
-        name: string
-      }>
-    }>
+  declare export interface FetchMoreQueryOptions {
+    query?: DocumentNode;
+    +variables?: {
+      [key: string]: any
+    };
   }
-};
 
-declare export class FragmentMatcherInterface {
-  match(
-    idValue: IdValue,
-    typeCondition: string,
-    context: ReadStoreContext
-  ): boolean;
-}
-
-declare export class IntrospectionFragmentMatcher extends FragmentMatcherInterface {
-  constructor(options?: {
-    introspectionQueryResultData?: IntrospectionResultData
-  }): this;
-  match(
-    idValue: IdValue,
-    typeCondition: string,
-    context: ReadStoreContext
-  ): boolean;
-}
-
-declare export class HeuristicFragmentMatcher extends FragmentMatcherInterface {
-  constructor(): this;
-  ensureReady(): Promise<void>;
-  canBypassInit(): boolean;
-  match(
-    idValue: IdValue,
-    typeCondition: string,
-    context: ReadStoreContext
-  ): boolean;
-}
-
-export interface DataProxyReadQueryOptions {
-  query: DocumentNode;
-  variables?: Object;
-}
-
-export interface DataProxyReadFragmentOptions {
-  id: string;
-  fragment: DocumentNode;
-  fragmentName?: string;
-  variables?: Object;
-}
-
-export interface DataProxyWriteQueryOptions {
-  data: any;
-  query: DocumentNode;
-  variables?: Object;
-}
-
-export interface DataProxyWriteFragmentOptions {
-  data: any;
-  id: string;
-  fragment: DocumentNode;
-  fragmentName?: string;
-  variables?: Object;
-}
-
-declare export class DataProxy {
-  readQuery<QueryType>(options: DataProxyReadQueryOptions): QueryType;
-  readFragment<FragmentType>(
-    options: DataProxyReadFragmentOptions
-  ): FragmentType | null;
-  writeQuery(options: DataProxyWriteQueryOptions): void;
-  writeFragment(options: DataProxyWriteFragmentOptions): void;
-}
-
-declare export class ReduxDataProxy extends DataProxy {
-  constructor(
-    store: ApolloStore,
-    reduxRootSelector: (state: any) => Store,
-    fragmentMatcher: FragmentMatcherInterface,
-    reducerConfig: ApolloReducerConfig
-  ): this;
-  readQuery<QueryType>(options: DataProxyReadQueryOptions): QueryType;
-  readFragment<FragmentType>(
-    options: DataProxyReadFragmentOptions
-  ): FragmentType | null;
-  writeQuery(options: DataProxyWriteQueryOptions): void;
-  writeFragment(options: DataProxyWriteFragmentOptions): void;
-}
-
-declare export class TransactionDataProxy extends DataProxy {
-  constructor(data: NormalizedCache, reducerConfig: ApolloReducerConfig): this;
-  finish(): Array<DataWrite>;
-  readQuery<QueryType>(options: DataProxyReadQueryOptions): QueryType;
-  readFragment<FragmentType>(
-    options: DataProxyReadFragmentOptions
-  ): FragmentType | null;
-  writeQuery(options: DataProxyWriteQueryOptions): void;
-  writeFragment(options: DataProxyWriteFragmentOptions): void;
-}
-
-export type QueryResultAction = {
-  type: "APOLLO_QUERY_RESULT",
-  result: ExecutionResult,
-  queryId: string,
-  document: DocumentNode,
-  operationName: string | null,
-  requestId: number,
-  fetchMoreForQueryId?: string,
-  extraReducers?: ApolloReducer[]
-};
-
-export type ApolloAction =
-  | QueryResultAction
-  | QueryErrorAction
-  | QueryInitAction
-  | QueryResultClientAction
-  | QueryStopAction
-  | MutationInitAction
-  | MutationResultAction
-  | MutationErrorAction
-  | UpdateQueryResultAction
-  | StoreResetAction
-  | SubscriptionResultAction
-  | WriteAction;
-
-declare export function mutations(
-  previousState: MutationStore | void,
-  action: ApolloAction
-): MutationStore;
-
-export interface QueryErrorAction {
-  type: "APOLLO_QUERY_ERROR";
-  error: Error;
-  queryId: string;
-  requestId: number;
-  fetchMoreForQueryId?: string;
-}
-
-export interface QueryInitAction {
-  type: "APOLLO_QUERY_INIT";
-  queryString: string;
-  document: DocumentNode;
-  variables: Object;
-  fetchPolicy: FetchPolicy;
-  queryId: string;
-  requestId: number;
-  storePreviousVariables: boolean;
-  isRefetch: boolean;
-  isPoll: boolean;
-  fetchMoreForQueryId?: string;
-  metadata: any;
-}
-
-export interface QueryResultClientAction {
-  type: "APOLLO_QUERY_RESULT_CLIENT";
-  result: ExecutionResult;
-  complete: boolean;
-  queryId: string;
-  requestId: number;
-}
-
-export interface QueryStopAction {
-  type: "APOLLO_QUERY_STOP";
-  queryId: string;
-}
-
-export type QueryWithUpdater = {
-  reducer: MutationQueryReducer<Object>,
-  query: QueryStoreValue
-};
-
-export interface MutationInitAction {
-  type: "APOLLO_MUTATION_INIT";
-  mutationString: string;
-  mutation: DocumentNode;
-  variables: Object;
-  operationName: string | null;
-  mutationId: string;
-  optimisticResponse: Object | void;
-  extraReducers?: ApolloReducer[];
-  updateQueries?: {
-    [queryId: string]: QueryWithUpdater
-  };
-  update?: (proxy: DataProxy, mutationResult: Object) => void;
-}
-
-export interface MutationResultAction {
-  type: "APOLLO_MUTATION_RESULT";
-  result: ExecutionResult;
-  document: DocumentNode;
-  operationName: string | null;
-  variables: Object;
-  mutationId: string;
-  extraReducers?: ApolloReducer[];
-  updateQueries?: {
-    [queryId: string]: QueryWithUpdater
-  };
-  update?: (proxy: DataProxy, mutationResult: Object) => void;
-}
-
-export interface MutationErrorAction {
-  type: "APOLLO_MUTATION_ERROR";
-  error: Error;
-  mutationId: string;
-}
-
-export interface UpdateQueryResultAction {
-  type: "APOLLO_UPDATE_QUERY_RESULT";
-  variables: any;
-  document: DocumentNode;
-  newResult: Object;
-}
-
-export interface StoreResetAction {
-  type: "APOLLO_STORE_RESET";
-  observableQueryIds: string[];
-}
-
-export interface SubscriptionResultAction {
-  type: "APOLLO_SUBSCRIPTION_RESULT";
-  result: ExecutionResult;
-  subscriptionId: number;
-  variables: Object;
-  document: DocumentNode;
-  operationName: string | null;
-  extraReducers?: ApolloReducer[];
-}
-
-export interface DataWrite {
-  rootId: string;
-  result: any;
-  document: DocumentNode;
-  variables: Object;
-}
-
-export interface WriteAction {
-  type: "APOLLO_WRITE";
-  writes: Array<DataWrite>;
-}
-
-declare export function isQueryResultAction(
-  action: ApolloAction
-): QueryResultAction;
-
-declare export function isQueryErrorAction(
-  action: ApolloAction
-): QueryErrorAction;
-
-declare export function isQueryInitAction(
-  action: ApolloAction
-): QueryInitAction;
-
-declare export function isQueryResultClientAction(
-  action: ApolloAction
-): QueryResultClientAction;
-
-declare export function isQueryStopAction(
-  action: ApolloAction
-): QueryStopAction;
-
-declare export function isMutationInitAction(
-  action: ApolloAction
-): MutationInitAction;
-
-declare export function isMutationResultAction(
-  action: ApolloAction
-): MutationResultAction;
-
-declare export function isMutationErrorAction(
-  action: ApolloAction
-): MutationErrorAction;
-
-declare export function isUpdateQueryResultAction(
-  action: ApolloAction
-): UpdateQueryResultAction;
-
-declare export function isStoreResetAction(
-  action: ApolloAction
-): StoreResetAction;
-
-declare export function isSubscriptionResultAction(
-  action: ApolloAction
-): SubscriptionResultAction;
-
-declare export function isWriteAction(action: ApolloAction): WriteAction;
-
-export type ApolloStateSelector = (state: any) => Store;
-declare export class ApolloError extends Error {
-  message: string;
-  graphQLErrors: GraphQLError[];
-  networkError: Error | null;
-  extraInfo: any;
-  constructor(info: ErrorConstructor): this;
-}
-declare export function isApolloError(err: Error): ApolloError;
-
-interface ErrorConstructor {
-  graphQLErrors?: GraphQLError[];
-  networkError?: Error | null;
-  errorMessage?: string;
-  extraInfo?: any;
-}
-
-export type OptimisticStoreItem = {
-  mutationId: string,
-  data: NormalizedCache
-};
-
-export type OptimisticStore = OptimisticStoreItem[];
-
-export interface Store {
-  data: NormalizedCache;
-  queries: QueryStore;
-  mutations: MutationStore;
-  optimistic: OptimisticStore;
-  reducerError: ReducerError | null;
-}
-
-export interface ApolloStore {
-  dispatch: (action: ApolloAction) => void;
-  getState: () => any;
-}
-export type ApolloReducer = (
-  store: NormalizedCache,
-  action: ApolloAction
-) => NormalizedCache;
-
-export type ApolloReducerConfig = {
-  dataIdFromObject?: IdGetter,
-  customResolvers?: CustomResolverMap,
-  fragmentMatcher?: FragmentMatcher,
-  addTypename?: boolean
-};
-
-export interface ReducerError {
-  error: Error;
-  queryId?: string;
-  mutationId?: string;
-  subscriptionId?: number;
-}
-
-declare export function getDataWithOptimisticResults(
-  store: Store
-): NormalizedCache;
-
-declare export function optimistic(
-  previousState: any[] | void,
-  action: any,
-  store: any,
-  config: any
-): OptimisticStore;
-
-export type QueryStoreValue = {
-  queryString: string,
-  document: DocumentNode,
-  variables: Object,
-  previousVariables: Object | null,
-  networkStatus: NetworkStatus,
-  networkError: Error | null,
-  graphQLErrors: GraphQLError[],
-  lastRequestId: number,
-  metadata: any
-};
-
-export interface QueryStore {
-  [queryId: string]: QueryStoreValue;
-}
-
-export interface SelectionSetWithRoot {
-  id: string;
-  typeName: string;
-  selectionSet: SelectionSetNode;
-}
-
-declare export function queries(
-  previousState: QueryStore | void,
-  action: ApolloAction
-): QueryStore;
-
-type FragmentMatcher = (
-  rootValue: any,
-  typeCondition: string,
-  context: any
-) => boolean;
-
-export type DiffResult = {
-  result?: any,
-  isMissing?: boolean
-};
-
-export type ReadQueryOptions = {
-  store: NormalizedCache,
-  query: DocumentNode,
-  fragmentMatcherFunction?: FragmentMatcher,
-  variables?: Object,
-  previousResult?: any,
-  rootId?: string,
-  config?: ApolloReducerConfig
-};
-
-export type DiffQueryAgainstStoreOptions = ReadQueryOptions & {
-  returnPartialData?: boolean
-};
-
-export type CustomResolver = (
-  rootValue: any,
-  args: {
-    [argName: string]: any
+  declare export interface SubscriptionOptions {
+    query: DocumentNode;
+    variables?: {
+      [key: string]: any
+    };
   }
-) => any;
 
-export type CustomResolverMap = {
-  [typeName: string]: {
-    [fieldName: string]: CustomResolver
-  }
-};
-
-export type ReadStoreContext = {
-  store: NormalizedCache,
-  returnPartialData: boolean,
-  hasMissingField: boolean,
-  customResolvers: CustomResolverMap
-};
-
-declare export function readQueryFromStore<QueryType>(
-  options: ReadQueryOptions
-): QueryType;
-
-declare export function diffQueryAgainstStore(
-  result: DiffQueryAgainstStoreOptions
-): DiffResult;
-
-declare export function assertIdValue(idValue: IdValue): void;
-
-declare export class QueryScheduler {
-  inFlightQueries: {
-    [queryId: string]: WatchQueryOptions
-  };
-  registeredQueries: {
-    [queryId: string]: WatchQueryOptions
-  };
-  intervalQueries: {
-    [interval: number]: string[]
-  };
-  queryManager: QueryManager;
-  constructor(queryManager: {
-    queryManager: QueryManager
-  }): this;
-  checkInFlight(queryId: string): boolean;
-  fetchQuery<T>(
-    queryId: string,
-    options: WatchQueryOptions,
-    fetchType: FetchType
-  ): Promise<{}>;
-  startPollingQuery<T>(
-    options: WatchQueryOptions,
-    queryId: string,
-    listener?: QueryListener
-  ): string;
-  stopPollingQuery(queryId: string): void;
-  fetchQueriesOnInterval<T>(interval: number): void;
-  addQueryOnInterval<T>(queryId: string, queryOptions: WatchQueryOptions): void;
-  registerPollingQuery<T>(queryOptions: WatchQueryOptions): ObservableQuery<T>;
-}
-
-declare export function createApolloReducer(
-  config: ApolloReducerConfig
-): (state: Store, action: ApolloAction) => Store;
-
-declare export function createApolloStore(init?: {
-  reduxRootKey?: string,
-  initialState?: any,
-  config?: ApolloReducerConfig,
-  reportCrashes?: boolean,
-  logger?: Middleware<*, *>
-}): ApolloStore;
-
-declare export function createApolloReducer(
-  config: ApolloReducerConfig
-): (state: Store, action: ApolloAction) => Store;
-
-declare export function createApolloStore(store?: {
-  reduxRootKey?: string,
-  initialState?: any,
-  config?: ApolloReducerConfig,
-  reportCrashes?: boolean,
-  logger?: Middleware<*, *>
-}): ApolloStore;
-
-declare export class QueryManager {
-  pollingTimers: {
-    [queryId: string]: any
-  };
-  scheduler: QueryScheduler;
-  store: ApolloStore;
-  networkInterface: NetworkInterface;
-  ssrMode: boolean;
-  constructor(setup: {
-    networkInterface: NetworkInterface,
-    store: ApolloStore,
-    reduxRootSelector: ApolloStateSelector,
-    fragmentMatcher?: FragmentMatcherInterface,
-    reducerConfig?: ApolloReducerConfig,
-    addTypename?: boolean,
-    queryDeduplication?: boolean,
-    ssrMode?: boolean
-  }): this;
-  broadcastNewStore(store: any): void;
-  mutate<T>(mutationOpts: {
+  declare export type MutationOptions<T = { [key: string]: any }> = {
     mutation: DocumentNode,
     variables?: Object,
     optimisticResponse?: Object,
     updateQueries?: MutationQueryReducersMap<T>,
     refetchQueries?: string[] | PureQueryOptions[],
-    update?: (proxy: DataProxy, mutationResult: Object) => void
-  }): Promise<ApolloExecutionResult<T>>;
-  fetchQuery<T>(
-    queryId: string,
-    options: WatchQueryOptions,
-    fetchType?: FetchType,
-    fetchMoreForQueryId?: string
-  ): Promise<ApolloQueryResult<T>>;
-  queryListenerForObserver<T>(
-    queryId: string,
-    options: WatchQueryOptions,
-    observer: Observer<ApolloQueryResult<T>>
-  ): QueryListener;
-  watchQuery<T>(
-    options: WatchQueryOptions,
-    shouldSubscribe?: boolean
-  ): ObservableQuery<T>;
-  query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
-  generateQueryId(): string;
-  stopQueryInStore(queryId: string): void;
-  getApolloState(): Store;
-  selectApolloState(store: any): Store;
-  getInitialState(): {
-    data: Object
+    update?: MutationUpdaterFn<T>
   };
-  getDataWithOptimisticResults(): NormalizedCache;
-  addQueryListener(queryId: string, listener: QueryListener): void;
-  addFetchQueryPromise<T>(
-    requestId: number,
-    promise: Promise<ApolloQueryResult<T>>,
-    resolve: (result: ApolloQueryResult<T>) => void,
-    reject: (error: Error) => void
+
+  declare export type QueryListener = (
+    queryStoreValue: QueryStoreValue
+  ) => void;
+  declare export type FetchType = number;
+  declare export type PureQueryOptions = {
+    query: DocumentNode,
+    variables?: {
+      [key: string]: any
+    }
+  };
+
+  declare export type ApolloQueryResult<T> = {
+    data: T,
+    loading: boolean,
+    networkStatus: NetworkStatus,
+    stale: boolean
+  };
+
+  declare export type ApolloExecutionResult<T = { [key: string]: any }> = {
+    data: T
+  };
+
+  declare export type IdGetter = (value: Object) => string | null | void;
+
+  declare export type ListValue = Array<null | IdValue>;
+
+  declare export type StoreValue =
+    | number
+    | string
+    | string[]
+    | IdValue
+    | ListValue
+    | JsonValue
+    | null
+    | void;
+
+  declare export interface NormalizedCache {
+    [dataId: string]: StoreObject;
+  }
+
+  declare export interface StoreObject {
+    [storeFieldKey: string]: StoreValue;
+    __typename?: string;
+  }
+
+  declare export interface IdValue {
+    type: "id";
+    id: string;
+    generated: boolean;
+  }
+
+  declare export interface JsonValue {
+    type: "json";
+    json: any;
+  }
+
+  declare export function valueToObjectRepresentation(
+    argObj: any,
+    name: NameNode,
+    value: ValueNode,
+    variables?: Object
   ): void;
-  removeFetchQueryPromise(requestId: number): void;
-  addObservableQuery<T>(
-    queryId: string,
-    observableQuery: ObservableQuery<T>
-  ): void;
-  removeObservableQuery(queryId: string): void;
-  resetStore(): void;
-  startQuery<T>(
-    queryId: string,
-    options: WatchQueryOptions,
-    listener: QueryListener
+
+  declare export function storeKeyNameFromField(
+    field: FieldNode,
+    variables?: Object
   ): string;
-  startGraphQLSubscription(options: SubscriptionOptions): Observable<any>;
-  removeQuery(queryId: string): void;
-  stopQuery(queryId: string): void;
-  getCurrentQueryResult<T>(
-    observableQuery: ObservableQuery<T>,
-    isOptimistic?: boolean
-  ): any;
-  getQueryWithPreviousResult<T>(
-    queryIdOrObservable: string | ObservableQuery<T>,
-    isOptimistic?: boolean
-  ): {
-    previousResult: any,
+
+  declare export function storeKeyNameFromFieldNameAndArgs(
+    fieldName: string,
+    args?: Object
+  ): string;
+
+  declare export function resultKeyNameFromField(field: FieldNode): string;
+
+  declare export function isField(selection: SelectionNode): FieldNode;
+
+  declare export function isInlineFragment(
+    selection: SelectionNode
+  ): InlineFragmentNode;
+
+  declare export function graphQLResultHasError(
+    result: ExecutionResult
+  ): number | void;
+
+  declare export function isIdValue(idObject: StoreValue): IdValue;
+
+  declare export function toIdValue(id: string, generated?: boolean): IdValue;
+
+  declare export function isJsonValue(jsonObject: StoreValue): JsonValue;
+
+  declare export type MutationQueryReducer<T> = (
+    previousResult: Object,
+    options: {
+      mutationResult: ApolloExecutionResult<T>,
+      queryName: string | null,
+      queryVariables: Object
+    }
+  ) => Object;
+
+  declare export type MutationQueryReducersMap<T = { [key: string]: any }> = {
+    [queryName: string]: MutationQueryReducer<T>
+  };
+
+  declare export type OperationResultReducer = (
+    previousResult: Object,
+    action: ApolloAction,
+    variables: Object
+  ) => Object;
+
+  declare export type OperationResultReducerMap = {
+    [queryId: string]: OperationResultReducer
+  };
+
+  declare export type ApolloCurrentResult<T> = {
+    data: T | {},
+    loading: boolean,
+    networkStatus: NetworkStatus,
+    error?: ApolloError,
+    partial?: boolean
+  };
+
+  declare export interface FetchMoreOptions {
+    updateQuery: (
+      previousQueryResult: Object,
+      options: {
+        fetchMoreResult: Object,
+        queryVariables: Object
+      }
+    ) => Object;
+  }
+
+  declare export interface UpdateQueryOptions {
+    variables?: Object;
+  }
+
+  declare export class ObservableQuery<T> extends Observable<
+    ApolloQueryResult<T>
+  > {
+    options: WatchQueryOptions;
+    queryId: string;
     variables: {
       [key: string]: any
-    } | void,
-    document: DocumentNode
-  };
-}
+    };
+    constructor(data: {
+      scheduler: QueryScheduler,
+      options: WatchQueryOptions,
+      shouldSubscribe?: boolean
+    }): this;
+    result(): Promise<ApolloQueryResult<T>>;
+    currentResult(): ApolloCurrentResult<T>;
+    getLastResult(): ApolloQueryResult<T>;
+    refetch(variables?: any): Promise<ApolloQueryResult<T>>;
+    fetchMore(
+      fetchMoreOptions: FetchMoreQueryOptions & FetchMoreOptions
+    ): Promise<ApolloQueryResult<T>>;
+    subscribeToMore(options: SubscribeToMoreOptions): () => void;
+    setOptions(
+      opts: ModifiableWatchQueryOptions
+    ): Promise<ApolloQueryResult<T>>;
+    setVariables(
+      variables: any,
+      tryFetch?: boolean
+    ): Promise<ApolloQueryResult<T>>;
+    updateQuery(
+      mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any
+    ): void;
+    stopPolling(): void;
+    startPolling(pollInterval: number): void;
+  }
 
-declare export class ApolloClient extends DataProxy {
-  networkInterface: NetworkInterface;
-  store: ApolloStore;
-  reduxRootSelector: ApolloStateSelector | null;
-  initialState: any;
-  queryManager: QueryManager;
-  reducerConfig: ApolloReducerConfig;
-  addTypename: boolean;
-  disableNetworkFetches: boolean;
-  dataId: IdGetter | void;
-  dataIdFromObject: IdGetter | void;
-  fieldWithArgs: (fieldName: string, args?: Object) => string;
-  version: string;
-  queryDeduplication: boolean;
-  constructor(options?: {
-    networkInterface?: NetworkInterface,
-    reduxRootSelector?: string | ApolloStateSelector,
-    initialState?: any,
-    dataIdFromObject?: IdGetter,
-    ssrMode?: boolean,
-    ssrForceFetchDelay?: number,
-    addTypename?: boolean,
-    customResolvers?: CustomResolverMap,
-    connectToDevTools?: boolean,
-    queryDeduplication?: boolean,
-    fragmentMatcher?: FragmentMatcherInterface
-  }): this;
-  watchQuery<T>(options: WatchQueryOptions): ObservableQuery<T>;
-  query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
-  mutate<T>(options: MutationOptions<T>): Promise<ApolloExecutionResult<T>>;
-  subscribe(options: SubscriptionOptions): Observable<any>;
-  readQuery<T>(options: DataProxyReadQueryOptions): T;
-  readFragment<T>(options: DataProxyReadFragmentOptions): T | null;
-  writeQuery(options: DataProxyWriteQueryOptions): void;
-  writeFragment(options: DataProxyWriteFragmentOptions): void;
-  reducer(): (state: Store, action: ApolloAction) => Store;
-  __actionHookForDevTools(cb: Function): void;
-  middleware: <S, A>() => Middleware<S, A>;
-  initStore(): void;
-  resetStore(): void;
-  getInitialState(): {
-    data: Object
+  declare export type CleanupFunction = () => void;
+
+  declare export type SubscriberFunction<T> = (
+    observer: Observer<T>
+  ) => Subscription | CleanupFunction;
+
+  declare export interface Observer<T> {
+    next?: (value: T) => void;
+    error?: (error: Error) => void;
+    complete?: () => void;
+  }
+
+  declare export interface Subscription {
+    unsubscribe: CleanupFunction;
+  }
+
+  declare export class Observable<T> {
+    constructor(subscriberFunction: SubscriberFunction<T>): this;
+    subscribe(observer: Observer<T>): Subscription;
+  }
+
+  declare export type NetworkStatus = number;
+  declare export function isNetworkRequestInFlight(
+    networkStatus: NetworkStatus
+  ): boolean;
+
+  declare export interface MutationStore {
+    [mutationId: string]: MutationStoreValue;
+  }
+
+  declare export interface MutationStoreValue {
+    mutationString: string;
+    variables: Object;
+    loading: boolean;
+    error: Error | null;
+  }
+
+  declare export type IntrospectionResultData = {
+    __schema: {
+      types: Array<{
+        kind: string,
+        name: string,
+        possibleTypes: Array<{
+          name: string
+        }>
+      }>
+    }
   };
+
+  declare export class FragmentMatcherInterface {
+    match(
+      idValue: IdValue,
+      typeCondition: string,
+      context: ReadStoreContext
+    ): boolean;
+  }
+
+  declare export class IntrospectionFragmentMatcher extends FragmentMatcherInterface {
+    constructor(options?: {
+      introspectionQueryResultData?: IntrospectionResultData
+    }): this;
+    match(
+      idValue: IdValue,
+      typeCondition: string,
+      context: ReadStoreContext
+    ): boolean;
+  }
+
+  declare export class HeuristicFragmentMatcher extends FragmentMatcherInterface {
+    constructor(): this;
+    ensureReady(): Promise<void>;
+    canBypassInit(): boolean;
+    match(
+      idValue: IdValue,
+      typeCondition: string,
+      context: ReadStoreContext
+    ): boolean;
+  }
+
+  declare export interface DataProxyReadQueryOptions {
+    query: DocumentNode;
+    variables?: Object;
+  }
+
+  declare export interface DataProxyReadFragmentOptions {
+    id: string;
+    fragment: DocumentNode;
+    fragmentName?: string;
+    variables?: Object;
+  }
+
+  declare export interface DataProxyWriteQueryOptions {
+    data: any;
+    query: DocumentNode;
+    variables?: Object;
+  }
+
+  declare export interface DataProxyWriteFragmentOptions {
+    data: any;
+    id: string;
+    fragment: DocumentNode;
+    fragmentName?: string;
+    variables?: Object;
+  }
+
+  declare export class DataProxy {
+    readQuery<QueryType>(options: DataProxyReadQueryOptions): QueryType;
+    readFragment<FragmentType>(
+      options: DataProxyReadFragmentOptions
+    ): FragmentType | null;
+    writeQuery(options: DataProxyWriteQueryOptions): void;
+    writeFragment(options: DataProxyWriteFragmentOptions): void;
+  }
+
+  declare export class ReduxDataProxy extends DataProxy {
+    constructor(
+      store: ApolloStore,
+      reduxRootSelector: (state: any) => Store,
+      fragmentMatcher: FragmentMatcherInterface,
+      reducerConfig: ApolloReducerConfig
+    ): this;
+    readQuery<QueryType>(options: DataProxyReadQueryOptions): QueryType;
+    readFragment<FragmentType>(
+      options: DataProxyReadFragmentOptions
+    ): FragmentType | null;
+    writeQuery(options: DataProxyWriteQueryOptions): void;
+    writeFragment(options: DataProxyWriteFragmentOptions): void;
+  }
+
+  declare export class TransactionDataProxy extends DataProxy {
+    constructor(
+      data: NormalizedCache,
+      reducerConfig: ApolloReducerConfig
+    ): this;
+    finish(): Array<DataWrite>;
+    readQuery<QueryType>(options: DataProxyReadQueryOptions): QueryType;
+    readFragment<FragmentType>(
+      options: DataProxyReadFragmentOptions
+    ): FragmentType | null;
+    writeQuery(options: DataProxyWriteQueryOptions): void;
+    writeFragment(options: DataProxyWriteFragmentOptions): void;
+  }
+
+  declare export type QueryResultAction = {
+    type: "APOLLO_QUERY_RESULT",
+    result: ExecutionResult,
+    queryId: string,
+    document: DocumentNode,
+    operationName: string | null,
+    requestId: number,
+    fetchMoreForQueryId?: string,
+    extraReducers?: ApolloReducer[]
+  };
+
+  declare export type ApolloAction =
+    | QueryResultAction
+    | QueryErrorAction
+    | QueryInitAction
+    | QueryResultClientAction
+    | QueryStopAction
+    | MutationInitAction
+    | MutationResultAction
+    | MutationErrorAction
+    | UpdateQueryResultAction
+    | StoreResetAction
+    | SubscriptionResultAction
+    | WriteAction;
+
+  declare export function mutations(
+    previousState: MutationStore | void,
+    action: ApolloAction
+  ): MutationStore;
+
+  declare export interface QueryErrorAction {
+    type: "APOLLO_QUERY_ERROR";
+    error: Error;
+    queryId: string;
+    requestId: number;
+    fetchMoreForQueryId?: string;
+  }
+
+  declare export interface QueryInitAction {
+    type: "APOLLO_QUERY_INIT";
+    queryString: string;
+    document: DocumentNode;
+    variables: Object;
+    fetchPolicy: FetchPolicy;
+    queryId: string;
+    requestId: number;
+    storePreviousVariables: boolean;
+    isRefetch: boolean;
+    isPoll: boolean;
+    fetchMoreForQueryId?: string;
+    metadata: any;
+  }
+
+  declare export interface QueryResultClientAction {
+    type: "APOLLO_QUERY_RESULT_CLIENT";
+    result: ExecutionResult;
+    complete: boolean;
+    queryId: string;
+    requestId: number;
+  }
+
+  declare export interface QueryStopAction {
+    type: "APOLLO_QUERY_STOP";
+    queryId: string;
+  }
+
+  declare export type QueryWithUpdater = {
+    reducer: MutationQueryReducer<Object>,
+    query: QueryStoreValue
+  };
+
+  declare export interface MutationInitAction {
+    type: "APOLLO_MUTATION_INIT";
+    mutationString: string;
+    mutation: DocumentNode;
+    variables: Object;
+    operationName: string | null;
+    mutationId: string;
+    optimisticResponse: Object | void;
+    extraReducers?: ApolloReducer[];
+    updateQueries?: {
+      [queryId: string]: QueryWithUpdater
+    };
+    update?: (proxy: DataProxy, mutationResult: Object) => void;
+  }
+
+  declare export interface MutationResultAction {
+    type: "APOLLO_MUTATION_RESULT";
+    result: ExecutionResult;
+    document: DocumentNode;
+    operationName: string | null;
+    variables: Object;
+    mutationId: string;
+    extraReducers?: ApolloReducer[];
+    updateQueries?: {
+      [queryId: string]: QueryWithUpdater
+    };
+    update?: (proxy: DataProxy, mutationResult: Object) => void;
+  }
+
+  declare export interface MutationErrorAction {
+    type: "APOLLO_MUTATION_ERROR";
+    error: Error;
+    mutationId: string;
+  }
+
+  declare export interface UpdateQueryResultAction {
+    type: "APOLLO_UPDATE_QUERY_RESULT";
+    variables: any;
+    document: DocumentNode;
+    newResult: Object;
+  }
+
+  declare export interface StoreResetAction {
+    type: "APOLLO_STORE_RESET";
+    observableQueryIds: string[];
+  }
+
+  declare export interface SubscriptionResultAction {
+    type: "APOLLO_SUBSCRIPTION_RESULT";
+    result: ExecutionResult;
+    subscriptionId: number;
+    variables: Object;
+    document: DocumentNode;
+    operationName: string | null;
+    extraReducers?: ApolloReducer[];
+  }
+
+  declare export interface DataWrite {
+    rootId: string;
+    result: any;
+    document: DocumentNode;
+    variables: Object;
+  }
+
+  declare export interface WriteAction {
+    type: "APOLLO_WRITE";
+    writes: Array<DataWrite>;
+  }
+
+  declare export function isQueryResultAction(
+    action: ApolloAction
+  ): QueryResultAction;
+
+  declare export function isQueryErrorAction(
+    action: ApolloAction
+  ): QueryErrorAction;
+
+  declare export function isQueryInitAction(
+    action: ApolloAction
+  ): QueryInitAction;
+
+  declare export function isQueryResultClientAction(
+    action: ApolloAction
+  ): QueryResultClientAction;
+
+  declare export function isQueryStopAction(
+    action: ApolloAction
+  ): QueryStopAction;
+
+  declare export function isMutationInitAction(
+    action: ApolloAction
+  ): MutationInitAction;
+
+  declare export function isMutationResultAction(
+    action: ApolloAction
+  ): MutationResultAction;
+
+  declare export function isMutationErrorAction(
+    action: ApolloAction
+  ): MutationErrorAction;
+
+  declare export function isUpdateQueryResultAction(
+    action: ApolloAction
+  ): UpdateQueryResultAction;
+
+  declare export function isStoreResetAction(
+    action: ApolloAction
+  ): StoreResetAction;
+
+  declare export function isSubscriptionResultAction(
+    action: ApolloAction
+  ): SubscriptionResultAction;
+
+  declare export function isWriteAction(action: ApolloAction): WriteAction;
+
+  declare export type ApolloStateSelector = (state: any) => Store;
+  declare export class ApolloError extends Error {
+    message: string;
+    graphQLErrors: GraphQLError[];
+    networkError: Error | null;
+    extraInfo: any;
+    constructor(info: ErrorConstructor): this;
+  }
+  declare export function isApolloError(err: Error): ApolloError;
+
+  declare interface ErrorConstructor {
+    graphQLErrors?: GraphQLError[];
+    networkError?: Error | null;
+    errorMessage?: string;
+    extraInfo?: any;
+  }
+
+  declare export type OptimisticStoreItem = {
+    mutationId: string,
+    data: NormalizedCache
+  };
+
+  declare export type OptimisticStore = OptimisticStoreItem[];
+
+  declare export interface Store {
+    data: NormalizedCache;
+    queries: QueryStore;
+    mutations: MutationStore;
+    optimistic: OptimisticStore;
+    reducerError: ReducerError | null;
+  }
+
+  declare export interface ApolloStore {
+    dispatch: (action: ApolloAction) => void;
+    getState: () => any;
+  }
+  declare export type ApolloReducer = (
+    store: NormalizedCache,
+    action: ApolloAction
+  ) => NormalizedCache;
+
+  declare export type ApolloReducerConfig = {
+    dataIdFromObject?: IdGetter,
+    customResolvers?: CustomResolverMap,
+    fragmentMatcher?: FragmentMatcher,
+    addTypename?: boolean
+  };
+
+  declare export interface ReducerError {
+    error: Error;
+    queryId?: string;
+    mutationId?: string;
+    subscriptionId?: number;
+  }
+
+  declare export function getDataWithOptimisticResults(
+    store: Store
+  ): NormalizedCache;
+
+  declare export function optimistic(
+    previousState: any[] | void,
+    action: any,
+    store: any,
+    config: any
+  ): OptimisticStore;
+
+  declare export type QueryStoreValue = {
+    queryString: string,
+    document: DocumentNode,
+    variables: Object,
+    previousVariables: Object | null,
+    networkStatus: NetworkStatus,
+    networkError: Error | null,
+    graphQLErrors: GraphQLError[],
+    lastRequestId: number,
+    metadata: any
+  };
+
+  declare export interface QueryStore {
+    [queryId: string]: QueryStoreValue;
+  }
+
+  declare export interface SelectionSetWithRoot {
+    id: string;
+    typeName: string;
+    selectionSet: SelectionSetNode;
+  }
+
+  declare export function queries(
+    previousState: QueryStore | void,
+    action: ApolloAction
+  ): QueryStore;
+
+  declare type FragmentMatcher = (
+    rootValue: any,
+    typeCondition: string,
+    context: any
+  ) => boolean;
+
+  declare export type DiffResult = {
+    result?: any,
+    isMissing?: boolean
+  };
+
+  declare export type ReadQueryOptions = {
+    store: NormalizedCache,
+    query: DocumentNode,
+    fragmentMatcherFunction?: FragmentMatcher,
+    variables?: Object,
+    previousResult?: any,
+    rootId?: string,
+    config?: ApolloReducerConfig
+  };
+
+  declare export type DiffQueryAgainstStoreOptions = ReadQueryOptions & {
+    returnPartialData?: boolean
+  };
+
+  declare export type CustomResolver = (
+    rootValue: any,
+    args: {
+      [argName: string]: any
+    }
+  ) => any;
+
+  declare export type CustomResolverMap = {
+    [typeName: string]: {
+      [fieldName: string]: CustomResolver
+    }
+  };
+
+  declare export type ReadStoreContext = {
+    store: NormalizedCache,
+    returnPartialData: boolean,
+    hasMissingField: boolean,
+    customResolvers: CustomResolverMap
+  };
+
+  declare export function readQueryFromStore<QueryType>(
+    options: ReadQueryOptions
+  ): QueryType;
+
+  declare export function diffQueryAgainstStore(
+    result: DiffQueryAgainstStoreOptions
+  ): DiffResult;
+
+  declare export function assertIdValue(idValue: IdValue): void;
+
+  declare export class QueryScheduler {
+    inFlightQueries: {
+      [queryId: string]: WatchQueryOptions
+    };
+    registeredQueries: {
+      [queryId: string]: WatchQueryOptions
+    };
+    intervalQueries: {
+      [interval: number]: string[]
+    };
+    queryManager: QueryManager;
+    constructor(queryManager: {
+      queryManager: QueryManager
+    }): this;
+    checkInFlight(queryId: string): boolean;
+    fetchQuery<T>(
+      queryId: string,
+      options: WatchQueryOptions,
+      fetchType: FetchType
+    ): Promise<{}>;
+    startPollingQuery<T>(
+      options: WatchQueryOptions,
+      queryId: string,
+      listener?: QueryListener
+    ): string;
+    stopPollingQuery(queryId: string): void;
+    fetchQueriesOnInterval<T>(interval: number): void;
+    addQueryOnInterval<T>(
+      queryId: string,
+      queryOptions: WatchQueryOptions
+    ): void;
+    registerPollingQuery<T>(
+      queryOptions: WatchQueryOptions
+    ): ObservableQuery<T>;
+  }
+
+  declare export function createApolloReducer(
+    config: ApolloReducerConfig
+  ): (state: Store, action: ApolloAction) => Store;
+
+  declare export function createApolloStore(init?: {
+    reduxRootKey?: string,
+    initialState?: any,
+    config?: ApolloReducerConfig,
+    reportCrashes?: boolean,
+    logger?: Middleware<*, *>
+  }): ApolloStore;
+
+  declare export function createApolloReducer(
+    config: ApolloReducerConfig
+  ): (state: Store, action: ApolloAction) => Store;
+
+  declare export function createApolloStore(store?: {
+    reduxRootKey?: string,
+    initialState?: any,
+    config?: ApolloReducerConfig,
+    reportCrashes?: boolean,
+    logger?: Middleware<*, *>
+  }): ApolloStore;
+
+  declare export class QueryManager {
+    pollingTimers: {
+      [queryId: string]: any
+    };
+    scheduler: QueryScheduler;
+    store: ApolloStore;
+    networkInterface: NetworkInterface;
+    ssrMode: boolean;
+    constructor(setup: {
+      networkInterface: NetworkInterface,
+      store: ApolloStore,
+      reduxRootSelector: ApolloStateSelector,
+      fragmentMatcher?: FragmentMatcherInterface,
+      reducerConfig?: ApolloReducerConfig,
+      addTypename?: boolean,
+      queryDeduplication?: boolean,
+      ssrMode?: boolean
+    }): this;
+    broadcastNewStore(store: any): void;
+    mutate<T>(mutationOpts: {
+      mutation: DocumentNode,
+      variables?: Object,
+      optimisticResponse?: Object,
+      updateQueries?: MutationQueryReducersMap<T>,
+      refetchQueries?: string[] | PureQueryOptions[],
+      update?: (proxy: DataProxy, mutationResult: Object) => void
+    }): Promise<ApolloExecutionResult<T>>;
+    fetchQuery<T>(
+      queryId: string,
+      options: WatchQueryOptions,
+      fetchType?: FetchType,
+      fetchMoreForQueryId?: string
+    ): Promise<ApolloQueryResult<T>>;
+    queryListenerForObserver<T>(
+      queryId: string,
+      options: WatchQueryOptions,
+      observer: Observer<ApolloQueryResult<T>>
+    ): QueryListener;
+    watchQuery<T>(
+      options: WatchQueryOptions,
+      shouldSubscribe?: boolean
+    ): ObservableQuery<T>;
+    query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
+    generateQueryId(): string;
+    stopQueryInStore(queryId: string): void;
+    getApolloState(): Store;
+    selectApolloState(store: any): Store;
+    getInitialState(): {
+      data: Object
+    };
+    getDataWithOptimisticResults(): NormalizedCache;
+    addQueryListener(queryId: string, listener: QueryListener): void;
+    addFetchQueryPromise<T>(
+      requestId: number,
+      promise: Promise<ApolloQueryResult<T>>,
+      resolve: (result: ApolloQueryResult<T>) => void,
+      reject: (error: Error) => void
+    ): void;
+    removeFetchQueryPromise(requestId: number): void;
+    addObservableQuery<T>(
+      queryId: string,
+      observableQuery: ObservableQuery<T>
+    ): void;
+    removeObservableQuery(queryId: string): void;
+    resetStore(): void;
+    startQuery<T>(
+      queryId: string,
+      options: WatchQueryOptions,
+      listener: QueryListener
+    ): string;
+    startGraphQLSubscription(options: SubscriptionOptions): Observable<any>;
+    removeQuery(queryId: string): void;
+    stopQuery(queryId: string): void;
+    getCurrentQueryResult<T>(
+      observableQuery: ObservableQuery<T>,
+      isOptimistic?: boolean
+    ): any;
+    getQueryWithPreviousResult<T>(
+      queryIdOrObservable: string | ObservableQuery<T>,
+      isOptimistic?: boolean
+    ): {
+      previousResult: any,
+      variables: {
+        [key: string]: any
+      } | void,
+      document: DocumentNode
+    };
+  }
+
+  declare export class ApolloClient extends DataProxy {
+    networkInterface: NetworkInterface;
+    store: ApolloStore;
+    reduxRootSelector: ApolloStateSelector | null;
+    initialState: any;
+    queryManager: QueryManager;
+    reducerConfig: ApolloReducerConfig;
+    addTypename: boolean;
+    disableNetworkFetches: boolean;
+    dataId: IdGetter | void;
+    dataIdFromObject: IdGetter | void;
+    fieldWithArgs: (fieldName: string, args?: Object) => string;
+    version: string;
+    queryDeduplication: boolean;
+    constructor(options?: {
+      networkInterface?: NetworkInterface,
+      reduxRootSelector?: string | ApolloStateSelector,
+      initialState?: any,
+      dataIdFromObject?: IdGetter,
+      ssrMode?: boolean,
+      ssrForceFetchDelay?: number,
+      addTypename?: boolean,
+      customResolvers?: CustomResolverMap,
+      connectToDevTools?: boolean,
+      queryDeduplication?: boolean,
+      fragmentMatcher?: FragmentMatcherInterface
+    }): this;
+    watchQuery<T>(options: WatchQueryOptions): ObservableQuery<T>;
+    query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
+    mutate<T>(options: MutationOptions<T>): Promise<ApolloExecutionResult<T>>;
+    subscribe(options: SubscriptionOptions): Observable<any>;
+    readQuery<T>(options: DataProxyReadQueryOptions): T;
+    readFragment<T>(options: DataProxyReadFragmentOptions): T | null;
+    writeQuery(options: DataProxyWriteQueryOptions): void;
+    writeFragment(options: DataProxyWriteFragmentOptions): void;
+    reducer(): (state: Store, action: ApolloAction) => Store;
+    __actionHookForDevTools(cb: Function): void;
+    middleware: <S, A>() => Middleware<S, A>;
+    initStore(): void;
+    resetStore(): void;
+    getInitialState(): {
+      data: Object
+    };
+  }
+  declare export default typeof ApolloClient;
 }
-declare export default typeof ApolloClient;

--- a/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
+++ b/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
@@ -1,16 +1,8 @@
 declare module "apollo-client" {
-  import type {
-    DocumentNode,
-    ExecutionResult,
-    GraphQLError,
-    SelectionSetNode,
-    FieldNode,
-    InlineFragmentNode,
-    ValueNode,
-    SelectionNode,
-    NameNode
-    // $FlowFixMe - Can't import types from node_modules at the moment
-  } from "graphql";
+  // These types are from the graphql module. No way to import them at the moment
+  declare type DocumentNode = any;
+  declare type ExecutionResult = any;
+  declare type GraphQLError = any;
 
   declare export function print(ast: any): string;
 
@@ -403,9 +395,9 @@ declare module "apollo-client" {
   }
 
   declare interface DefaultOptions {
-    watchQuery?: ModifiableWatchQueryOptions;
-    query?: ModifiableWatchQueryOptions;
-    mutate?: MutationBaseOptions<>;
+    +watchQuery?: ModifiableWatchQueryOptions;
+    +query?: ModifiableWatchQueryOptions;
+    +mutate?: MutationBaseOptions<>;
   }
 
   declare export type ApolloClientOptions<TCacheShape> = {
@@ -582,7 +574,7 @@ declare module "apollo-client" {
   /* End TODO: Move to apollo-link libdef */
 
   /* TODO: Move these types to apollo-cache libdef */
-  declare class ApolloCache<TSerialized> {
+  declare export class ApolloCache<TSerialized> {
     read<T>(query: CacheReadOptions): T | null;
     write(write: CacheWriteOptions): void;
     diff<T>(query: CacheDiffOptions): CacheDiffResult<T>;

--- a/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
+++ b/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
@@ -1,0 +1,1089 @@
+// @flow
+import type {
+  DocumentNode,
+  ExecutionResult,
+  GraphQLError,
+  SelectionSetNode,
+  FieldNode,
+  InlineFragmentNode,
+  ValueNode,
+  SelectionNode,
+  NameNode
+} from "graphql";
+
+import type { Middleware } from "redux";
+
+export interface Request {
+  // causes flow errors
+  // property `$key` of Request. Indexable signature not found in
+  // property `$value` of Request. Indexable signature not found in
+  // [additionalKey: string]: any,
+  debugName?: string;
+  query?: DocumentNode;
+  variables?: Object;
+  operationName?: string | null;
+}
+
+export interface NetworkInterface {
+  query(request: Request): Promise<ExecutionResult>;
+}
+
+export interface BatchedNetworkInterface {
+  batchQuery(requests: Request[]): Promise<ExecutionResult[]>;
+}
+
+export interface MiddlewareRequest {
+  request: Request;
+  options: RequestOptions;
+}
+
+export interface MiddlewareInterface {
+  applyMiddleware(request: MiddlewareRequest, next: Function): void;
+}
+
+export interface BatchMiddlewareRequest {
+  requests: Request[];
+  options: RequestOptions;
+}
+
+export interface BatchMiddlewareInterface {
+  applyBatchMiddleware(request: BatchMiddlewareRequest, next: Function): void;
+}
+export interface AfterwareResponse {
+  response: Response;
+  options: RequestOptions;
+}
+
+export interface AfterwareInterface {
+  applyAfterware(response: AfterwareResponse, next: Function): any;
+}
+
+export interface BatchAfterwareResponse {
+  responses: Response[];
+  options: RequestOptions;
+}
+
+export interface BatchAfterwareInterface {
+  applyBatchAfterware(response: BatchAfterwareResponse, next: Function): any;
+}
+
+export interface PrintedRequest {
+  debugName?: string;
+  query?: string;
+  variables?: Object;
+  operationName?: string | null;
+}
+
+export interface SubscriptionNetworkInterface {
+  subscribe(
+    request: Request,
+    handler: (error: any, result: any) => void
+  ): number;
+  unsubscribe(id: Number): void;
+}
+
+export type NetworkMiddleware =
+  | Array<MiddlewareInterface>
+  | Array<BatchMiddlewareInterface>;
+export type NetworkAfterware =
+  | Array<AfterwareInterface>
+  | Array<BatchAfterwareInterface>;
+
+declare export class HTTPNetworkInterface {
+  _uri: string;
+  _opts: RequestOptions;
+  _middlewares: NetworkMiddleware;
+  _afterwares: NetworkAfterware;
+  use(middlewares: NetworkMiddleware): HTTPNetworkInterface;
+  useAfter(afterwares: NetworkAfterware): HTTPNetworkInterface;
+  query(request: Request): Promise<ExecutionResult>;
+}
+
+export interface BatchRequestAndOptions {
+  requests: Request[];
+  options: RequestOptions;
+}
+
+export interface BatchResponseAndOptions {
+  responses: Response[];
+  options: RequestOptions;
+}
+
+export type BatchingNetworkInterfaceOptions = {
+  uri: string,
+  batchInterval: number,
+  // compatibility with NetworkInterfaceOptions
+  opts?: ?RequestOptions
+};
+
+declare export function createBatchingNetworkInterface(
+  options: BatchingNetworkInterfaceOptions
+): HTTPNetworkInterface;
+
+declare export class HTTPBatchedNetworkInterface extends BaseNetworkInterface {
+  _middlewares: NetworkMiddleware;
+  _afterwares: NetworkAfterware;
+  constructor(
+    uri: string,
+    batchInterval: number,
+    fetchOpts: RequestOptions
+  ): this;
+  query(request: Request): Promise<ExecutionResult>;
+  batchQuery(requests: Request[]): Promise<ExecutionResult[]>;
+  applyBatchMiddlewares(
+    opts: BatchRequestAndOptions
+  ): Promise<BatchRequestAndOptions>;
+  applyBatchAfterwares(
+    opts: BatchResponseAndOptions
+  ): Promise<BatchResponseAndOptions>;
+  use(middlewares: BatchMiddlewareInterface[]): HTTPNetworkInterface;
+  useAfter(afterwares: BatchAfterwareInterface[]): HTTPNetworkInterface;
+}
+
+export interface RequestAndOptions {
+  request: Request;
+  options: RequestOptions;
+}
+
+export interface ResponseAndOptions {
+  response: Response;
+  options: RequestOptions;
+}
+
+export type NetworkInterfaceOptions = {
+  // compatibility with BatchNetworkInrfaceOptions
+  // also network interfaces throws an error in case you haven't provide an uri
+  // in this case is right to fail typecheck too
+  uri: string,
+  opts?: ?RequestOptions
+};
+
+declare export function printRequest(request: Request): PrintedRequest;
+
+declare export function createNetworkInterface(
+  uriOrInterfaceOpts: string | NetworkInterfaceOptions,
+  secondArgOpts?: NetworkInterfaceOptions
+): HTTPNetworkInterface;
+
+declare export class BaseNetworkInterface {
+  _middlewares: NetworkMiddleware;
+  _afterwares: NetworkAfterware;
+  _uri: string;
+  _opts: RequestOptions;
+  constructor(uri: string | void, opts?: RequestOptions): this;
+  query(request: Request): Promise<ExecutionResult>;
+}
+
+declare export class HTTPFetchNetworkInterface extends BaseNetworkInterface {
+  _middlewares: NetworkMiddleware;
+  _afterwares: NetworkAfterware;
+  applyMiddlewares(
+    requestAndOptions: RequestAndOptions
+  ): Promise<RequestAndOptions>;
+  applyAfterwares(opts: ResponseAndOptions): Promise<ResponseAndOptions>;
+  fetchFromRemoteEndpoint(opts: RequestAndOptions): Promise<Response>;
+  query(request: Request): Promise<ExecutionResult>;
+  use(middlewares: MiddlewareInterface[]): HTTPNetworkInterface;
+  useAfter(afterwares: AfterwareInterface[]): HTTPNetworkInterface;
+}
+
+export type FetchPolicy =
+  | "cache-first"
+  | "cache-and-network"
+  | "network-only"
+  | "cache-only"
+  | "standby";
+
+export type SubscribeToMoreOptions = {
+  document: DocumentNode,
+  variables?: {
+    [key: string]: any
+  },
+  updateQuery?: (
+    previousQueryResult: Object,
+    options: {
+      subscriptionData: {
+        data: any
+      },
+      variables: {
+        [key: string]: any
+      }
+    }
+  ) => Object,
+  onError?: (error: Error) => void
+};
+
+export type MutationUpdaterFn<T = { [key: string]: any }> = (
+  proxy: DataProxy,
+  mutationResult: ApolloExecutionResult<T>
+) => void;
+
+export interface ModifiableWatchQueryOptions {
+  variables?: {
+    [key: string]: any
+  };
+  pollInterval?: number;
+  fetchPolicy?: FetchPolicy;
+  fetchResults?: boolean;
+  notifyOnNetworkStatusChange?: boolean;
+  reducer?: OperationResultReducer;
+}
+
+export interface WatchQueryOptions {
+  query: DocumentNode;
+  metadata?: any;
+}
+
+export interface FetchMoreQueryOptions {
+  query?: DocumentNode;
+  +variables?: {
+    [key: string]: any
+  };
+}
+
+export interface SubscriptionOptions {
+  query: DocumentNode;
+  variables?: {
+    [key: string]: any
+  };
+}
+
+export type MutationOptions<T = { [key: string]: any }> = {
+  mutation: DocumentNode,
+  variables?: Object,
+  optimisticResponse?: Object,
+  updateQueries?: MutationQueryReducersMap<T>,
+  refetchQueries?: string[] | PureQueryOptions[],
+  update?: MutationUpdaterFn<T>
+};
+
+export type QueryListener = (queryStoreValue: QueryStoreValue) => void;
+export type FetchType = number;
+export type PureQueryOptions = {
+  query: DocumentNode,
+  variables?: {
+    [key: string]: any
+  }
+};
+
+export type ApolloQueryResult<T> = {
+  data: T,
+  loading: boolean,
+  networkStatus: NetworkStatus,
+  stale: boolean
+};
+
+export type ApolloExecutionResult<T = { [key: string]: any }> = {
+  data: T
+};
+
+export type IdGetter = (value: Object) => string | null | void;
+
+export type ListValue = Array<null | IdValue>;
+
+export type StoreValue =
+  | number
+  | string
+  | string[]
+  | IdValue
+  | ListValue
+  | JsonValue
+  | null
+  | void;
+
+export interface NormalizedCache {
+  [dataId: string]: StoreObject;
+}
+
+export interface StoreObject {
+  [storeFieldKey: string]: StoreValue;
+  __typename?: string;
+}
+
+export interface IdValue {
+  type: "id";
+  id: string;
+  generated: boolean;
+}
+
+export interface JsonValue {
+  type: "json";
+  json: any;
+}
+
+declare export function valueToObjectRepresentation(
+  argObj: any,
+  name: NameNode,
+  value: ValueNode,
+  variables?: Object
+): void;
+
+declare export function storeKeyNameFromField(
+  field: FieldNode,
+  variables?: Object
+): string;
+
+declare export function storeKeyNameFromFieldNameAndArgs(
+  fieldName: string,
+  args?: Object
+): string;
+
+declare export function resultKeyNameFromField(field: FieldNode): string;
+
+declare export function isField(selection: SelectionNode): FieldNode;
+
+declare export function isInlineFragment(
+  selection: SelectionNode
+): InlineFragmentNode;
+
+declare export function graphQLResultHasError(
+  result: ExecutionResult
+): number | void;
+
+declare export function isIdValue(idObject: StoreValue): IdValue;
+
+declare export function toIdValue(id: string, generated?: boolean): IdValue;
+
+declare export function isJsonValue(jsonObject: StoreValue): JsonValue;
+
+export type MutationQueryReducer<T> = (
+  previousResult: Object,
+  options: {
+    mutationResult: ApolloExecutionResult<T>,
+    queryName: string | null,
+    queryVariables: Object
+  }
+) => Object;
+
+export type MutationQueryReducersMap<T = { [key: string]: any }> = {
+  [queryName: string]: MutationQueryReducer<T>
+};
+
+export type OperationResultReducer = (
+  previousResult: Object,
+  action: ApolloAction,
+  variables: Object
+) => Object;
+
+export type OperationResultReducerMap = {
+  [queryId: string]: OperationResultReducer
+};
+
+export type ApolloCurrentResult<T> = {
+  data: T | {},
+  loading: boolean,
+  networkStatus: NetworkStatus,
+  error?: ApolloError,
+  partial?: boolean
+};
+
+export interface FetchMoreOptions {
+  updateQuery: (
+    previousQueryResult: Object,
+    options: {
+      fetchMoreResult: Object,
+      queryVariables: Object
+    }
+  ) => Object;
+}
+
+export interface UpdateQueryOptions {
+  variables?: Object;
+}
+
+declare export class ObservableQuery<T> extends Observable<
+  ApolloQueryResult<T>
+> {
+  options: WatchQueryOptions;
+  queryId: string;
+  variables: {
+    [key: string]: any
+  };
+  constructor(data: {
+    scheduler: QueryScheduler,
+    options: WatchQueryOptions,
+    shouldSubscribe?: boolean
+  }): this;
+  result(): Promise<ApolloQueryResult<T>>;
+  currentResult(): ApolloCurrentResult<T>;
+  getLastResult(): ApolloQueryResult<T>;
+  refetch(variables?: any): Promise<ApolloQueryResult<T>>;
+  fetchMore(
+    fetchMoreOptions: FetchMoreQueryOptions & FetchMoreOptions
+  ): Promise<ApolloQueryResult<T>>;
+  subscribeToMore(options: SubscribeToMoreOptions): () => void;
+  setOptions(opts: ModifiableWatchQueryOptions): Promise<ApolloQueryResult<T>>;
+  setVariables(
+    variables: any,
+    tryFetch?: boolean
+  ): Promise<ApolloQueryResult<T>>;
+  updateQuery(
+    mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any
+  ): void;
+  stopPolling(): void;
+  startPolling(pollInterval: number): void;
+}
+
+export type CleanupFunction = () => void;
+
+export type SubscriberFunction<T> = (
+  observer: Observer<T>
+) => Subscription | CleanupFunction;
+
+export interface Observer<T> {
+  next?: (value: T) => void;
+  error?: (error: Error) => void;
+  complete?: () => void;
+}
+
+export interface Subscription {
+  unsubscribe: CleanupFunction;
+}
+
+declare export class Observable<T> {
+  constructor(subscriberFunction: SubscriberFunction<T>): this;
+  subscribe(observer: Observer<T>): Subscription;
+}
+
+export type NetworkStatus = number;
+declare export function isNetworkRequestInFlight(
+  networkStatus: NetworkStatus
+): boolean;
+
+export interface MutationStore {
+  [mutationId: string]: MutationStoreValue;
+}
+
+export interface MutationStoreValue {
+  mutationString: string;
+  variables: Object;
+  loading: boolean;
+  error: Error | null;
+}
+
+export type IntrospectionResultData = {
+  __schema: {
+    types: Array<{
+      kind: string,
+      name: string,
+      possibleTypes: Array<{
+        name: string
+      }>
+    }>
+  }
+};
+
+declare export class FragmentMatcherInterface {
+  match(
+    idValue: IdValue,
+    typeCondition: string,
+    context: ReadStoreContext
+  ): boolean;
+}
+
+declare export class IntrospectionFragmentMatcher extends FragmentMatcherInterface {
+  constructor(options?: {
+    introspectionQueryResultData?: IntrospectionResultData
+  }): this;
+  match(
+    idValue: IdValue,
+    typeCondition: string,
+    context: ReadStoreContext
+  ): boolean;
+}
+
+declare export class HeuristicFragmentMatcher extends FragmentMatcherInterface {
+  constructor(): this;
+  ensureReady(): Promise<void>;
+  canBypassInit(): boolean;
+  match(
+    idValue: IdValue,
+    typeCondition: string,
+    context: ReadStoreContext
+  ): boolean;
+}
+
+export interface DataProxyReadQueryOptions {
+  query: DocumentNode;
+  variables?: Object;
+}
+
+export interface DataProxyReadFragmentOptions {
+  id: string;
+  fragment: DocumentNode;
+  fragmentName?: string;
+  variables?: Object;
+}
+
+export interface DataProxyWriteQueryOptions {
+  data: any;
+  query: DocumentNode;
+  variables?: Object;
+}
+
+export interface DataProxyWriteFragmentOptions {
+  data: any;
+  id: string;
+  fragment: DocumentNode;
+  fragmentName?: string;
+  variables?: Object;
+}
+
+declare export class DataProxy {
+  readQuery<QueryType>(options: DataProxyReadQueryOptions): QueryType;
+  readFragment<FragmentType>(
+    options: DataProxyReadFragmentOptions
+  ): FragmentType | null;
+  writeQuery(options: DataProxyWriteQueryOptions): void;
+  writeFragment(options: DataProxyWriteFragmentOptions): void;
+}
+
+declare export class ReduxDataProxy extends DataProxy {
+  constructor(
+    store: ApolloStore,
+    reduxRootSelector: (state: any) => Store,
+    fragmentMatcher: FragmentMatcherInterface,
+    reducerConfig: ApolloReducerConfig
+  ): this;
+  readQuery<QueryType>(options: DataProxyReadQueryOptions): QueryType;
+  readFragment<FragmentType>(
+    options: DataProxyReadFragmentOptions
+  ): FragmentType | null;
+  writeQuery(options: DataProxyWriteQueryOptions): void;
+  writeFragment(options: DataProxyWriteFragmentOptions): void;
+}
+
+declare export class TransactionDataProxy extends DataProxy {
+  constructor(data: NormalizedCache, reducerConfig: ApolloReducerConfig): this;
+  finish(): Array<DataWrite>;
+  readQuery<QueryType>(options: DataProxyReadQueryOptions): QueryType;
+  readFragment<FragmentType>(
+    options: DataProxyReadFragmentOptions
+  ): FragmentType | null;
+  writeQuery(options: DataProxyWriteQueryOptions): void;
+  writeFragment(options: DataProxyWriteFragmentOptions): void;
+}
+
+export type QueryResultAction = {
+  type: "APOLLO_QUERY_RESULT",
+  result: ExecutionResult,
+  queryId: string,
+  document: DocumentNode,
+  operationName: string | null,
+  requestId: number,
+  fetchMoreForQueryId?: string,
+  extraReducers?: ApolloReducer[]
+};
+
+export type ApolloAction =
+  | QueryResultAction
+  | QueryErrorAction
+  | QueryInitAction
+  | QueryResultClientAction
+  | QueryStopAction
+  | MutationInitAction
+  | MutationResultAction
+  | MutationErrorAction
+  | UpdateQueryResultAction
+  | StoreResetAction
+  | SubscriptionResultAction
+  | WriteAction;
+
+declare export function mutations(
+  previousState: MutationStore | void,
+  action: ApolloAction
+): MutationStore;
+
+export interface QueryErrorAction {
+  type: "APOLLO_QUERY_ERROR";
+  error: Error;
+  queryId: string;
+  requestId: number;
+  fetchMoreForQueryId?: string;
+}
+
+export interface QueryInitAction {
+  type: "APOLLO_QUERY_INIT";
+  queryString: string;
+  document: DocumentNode;
+  variables: Object;
+  fetchPolicy: FetchPolicy;
+  queryId: string;
+  requestId: number;
+  storePreviousVariables: boolean;
+  isRefetch: boolean;
+  isPoll: boolean;
+  fetchMoreForQueryId?: string;
+  metadata: any;
+}
+
+export interface QueryResultClientAction {
+  type: "APOLLO_QUERY_RESULT_CLIENT";
+  result: ExecutionResult;
+  complete: boolean;
+  queryId: string;
+  requestId: number;
+}
+
+export interface QueryStopAction {
+  type: "APOLLO_QUERY_STOP";
+  queryId: string;
+}
+
+export type QueryWithUpdater = {
+  reducer: MutationQueryReducer<Object>,
+  query: QueryStoreValue
+};
+
+export interface MutationInitAction {
+  type: "APOLLO_MUTATION_INIT";
+  mutationString: string;
+  mutation: DocumentNode;
+  variables: Object;
+  operationName: string | null;
+  mutationId: string;
+  optimisticResponse: Object | void;
+  extraReducers?: ApolloReducer[];
+  updateQueries?: {
+    [queryId: string]: QueryWithUpdater
+  };
+  update?: (proxy: DataProxy, mutationResult: Object) => void;
+}
+
+export interface MutationResultAction {
+  type: "APOLLO_MUTATION_RESULT";
+  result: ExecutionResult;
+  document: DocumentNode;
+  operationName: string | null;
+  variables: Object;
+  mutationId: string;
+  extraReducers?: ApolloReducer[];
+  updateQueries?: {
+    [queryId: string]: QueryWithUpdater
+  };
+  update?: (proxy: DataProxy, mutationResult: Object) => void;
+}
+
+export interface MutationErrorAction {
+  type: "APOLLO_MUTATION_ERROR";
+  error: Error;
+  mutationId: string;
+}
+
+export interface UpdateQueryResultAction {
+  type: "APOLLO_UPDATE_QUERY_RESULT";
+  variables: any;
+  document: DocumentNode;
+  newResult: Object;
+}
+
+export interface StoreResetAction {
+  type: "APOLLO_STORE_RESET";
+  observableQueryIds: string[];
+}
+
+export interface SubscriptionResultAction {
+  type: "APOLLO_SUBSCRIPTION_RESULT";
+  result: ExecutionResult;
+  subscriptionId: number;
+  variables: Object;
+  document: DocumentNode;
+  operationName: string | null;
+  extraReducers?: ApolloReducer[];
+}
+
+export interface DataWrite {
+  rootId: string;
+  result: any;
+  document: DocumentNode;
+  variables: Object;
+}
+
+export interface WriteAction {
+  type: "APOLLO_WRITE";
+  writes: Array<DataWrite>;
+}
+
+declare export function isQueryResultAction(
+  action: ApolloAction
+): QueryResultAction;
+
+declare export function isQueryErrorAction(
+  action: ApolloAction
+): QueryErrorAction;
+
+declare export function isQueryInitAction(
+  action: ApolloAction
+): QueryInitAction;
+
+declare export function isQueryResultClientAction(
+  action: ApolloAction
+): QueryResultClientAction;
+
+declare export function isQueryStopAction(
+  action: ApolloAction
+): QueryStopAction;
+
+declare export function isMutationInitAction(
+  action: ApolloAction
+): MutationInitAction;
+
+declare export function isMutationResultAction(
+  action: ApolloAction
+): MutationResultAction;
+
+declare export function isMutationErrorAction(
+  action: ApolloAction
+): MutationErrorAction;
+
+declare export function isUpdateQueryResultAction(
+  action: ApolloAction
+): UpdateQueryResultAction;
+
+declare export function isStoreResetAction(
+  action: ApolloAction
+): StoreResetAction;
+
+declare export function isSubscriptionResultAction(
+  action: ApolloAction
+): SubscriptionResultAction;
+
+declare export function isWriteAction(action: ApolloAction): WriteAction;
+
+export type ApolloStateSelector = (state: any) => Store;
+declare export class ApolloError extends Error {
+  message: string;
+  graphQLErrors: GraphQLError[];
+  networkError: Error | null;
+  extraInfo: any;
+  constructor(info: ErrorConstructor): this;
+}
+declare export function isApolloError(err: Error): ApolloError;
+
+interface ErrorConstructor {
+  graphQLErrors?: GraphQLError[];
+  networkError?: Error | null;
+  errorMessage?: string;
+  extraInfo?: any;
+}
+
+export type OptimisticStoreItem = {
+  mutationId: string,
+  data: NormalizedCache
+};
+
+export type OptimisticStore = OptimisticStoreItem[];
+
+export interface Store {
+  data: NormalizedCache;
+  queries: QueryStore;
+  mutations: MutationStore;
+  optimistic: OptimisticStore;
+  reducerError: ReducerError | null;
+}
+
+export interface ApolloStore {
+  dispatch: (action: ApolloAction) => void;
+  getState: () => any;
+}
+export type ApolloReducer = (
+  store: NormalizedCache,
+  action: ApolloAction
+) => NormalizedCache;
+
+export type ApolloReducerConfig = {
+  dataIdFromObject?: IdGetter,
+  customResolvers?: CustomResolverMap,
+  fragmentMatcher?: FragmentMatcher,
+  addTypename?: boolean
+};
+
+export interface ReducerError {
+  error: Error;
+  queryId?: string;
+  mutationId?: string;
+  subscriptionId?: number;
+}
+
+declare export function getDataWithOptimisticResults(
+  store: Store
+): NormalizedCache;
+
+declare export function optimistic(
+  previousState: any[] | void,
+  action: any,
+  store: any,
+  config: any
+): OptimisticStore;
+
+export type QueryStoreValue = {
+  queryString: string,
+  document: DocumentNode,
+  variables: Object,
+  previousVariables: Object | null,
+  networkStatus: NetworkStatus,
+  networkError: Error | null,
+  graphQLErrors: GraphQLError[],
+  lastRequestId: number,
+  metadata: any
+};
+
+export interface QueryStore {
+  [queryId: string]: QueryStoreValue;
+}
+
+export interface SelectionSetWithRoot {
+  id: string;
+  typeName: string;
+  selectionSet: SelectionSetNode;
+}
+
+declare export function queries(
+  previousState: QueryStore | void,
+  action: ApolloAction
+): QueryStore;
+
+type FragmentMatcher = (
+  rootValue: any,
+  typeCondition: string,
+  context: any
+) => boolean;
+
+export type DiffResult = {
+  result?: any,
+  isMissing?: boolean
+};
+
+export type ReadQueryOptions = {
+  store: NormalizedCache,
+  query: DocumentNode,
+  fragmentMatcherFunction?: FragmentMatcher,
+  variables?: Object,
+  previousResult?: any,
+  rootId?: string,
+  config?: ApolloReducerConfig
+};
+
+export type DiffQueryAgainstStoreOptions = ReadQueryOptions & {
+  returnPartialData?: boolean
+};
+
+export type CustomResolver = (
+  rootValue: any,
+  args: {
+    [argName: string]: any
+  }
+) => any;
+
+export type CustomResolverMap = {
+  [typeName: string]: {
+    [fieldName: string]: CustomResolver
+  }
+};
+
+export type ReadStoreContext = {
+  store: NormalizedCache,
+  returnPartialData: boolean,
+  hasMissingField: boolean,
+  customResolvers: CustomResolverMap
+};
+
+declare export function readQueryFromStore<QueryType>(
+  options: ReadQueryOptions
+): QueryType;
+
+declare export function diffQueryAgainstStore(
+  result: DiffQueryAgainstStoreOptions
+): DiffResult;
+
+declare export function assertIdValue(idValue: IdValue): void;
+
+declare export class QueryScheduler {
+  inFlightQueries: {
+    [queryId: string]: WatchQueryOptions
+  };
+  registeredQueries: {
+    [queryId: string]: WatchQueryOptions
+  };
+  intervalQueries: {
+    [interval: number]: string[]
+  };
+  queryManager: QueryManager;
+  constructor(queryManager: {
+    queryManager: QueryManager
+  }): this;
+  checkInFlight(queryId: string): boolean;
+  fetchQuery<T>(
+    queryId: string,
+    options: WatchQueryOptions,
+    fetchType: FetchType
+  ): Promise<{}>;
+  startPollingQuery<T>(
+    options: WatchQueryOptions,
+    queryId: string,
+    listener?: QueryListener
+  ): string;
+  stopPollingQuery(queryId: string): void;
+  fetchQueriesOnInterval<T>(interval: number): void;
+  addQueryOnInterval<T>(queryId: string, queryOptions: WatchQueryOptions): void;
+  registerPollingQuery<T>(queryOptions: WatchQueryOptions): ObservableQuery<T>;
+}
+
+declare export function createApolloReducer(
+  config: ApolloReducerConfig
+): (state: Store, action: ApolloAction) => Store;
+
+declare export function createApolloStore(init?: {
+  reduxRootKey?: string,
+  initialState?: any,
+  config?: ApolloReducerConfig,
+  reportCrashes?: boolean,
+  logger?: Middleware<*, *>
+}): ApolloStore;
+
+declare export function createApolloReducer(
+  config: ApolloReducerConfig
+): (state: Store, action: ApolloAction) => Store;
+
+declare export function createApolloStore(store?: {
+  reduxRootKey?: string,
+  initialState?: any,
+  config?: ApolloReducerConfig,
+  reportCrashes?: boolean,
+  logger?: Middleware<*, *>
+}): ApolloStore;
+
+declare export class QueryManager {
+  pollingTimers: {
+    [queryId: string]: any
+  };
+  scheduler: QueryScheduler;
+  store: ApolloStore;
+  networkInterface: NetworkInterface;
+  ssrMode: boolean;
+  constructor(setup: {
+    networkInterface: NetworkInterface,
+    store: ApolloStore,
+    reduxRootSelector: ApolloStateSelector,
+    fragmentMatcher?: FragmentMatcherInterface,
+    reducerConfig?: ApolloReducerConfig,
+    addTypename?: boolean,
+    queryDeduplication?: boolean,
+    ssrMode?: boolean
+  }): this;
+  broadcastNewStore(store: any): void;
+  mutate<T>(mutationOpts: {
+    mutation: DocumentNode,
+    variables?: Object,
+    optimisticResponse?: Object,
+    updateQueries?: MutationQueryReducersMap<T>,
+    refetchQueries?: string[] | PureQueryOptions[],
+    update?: (proxy: DataProxy, mutationResult: Object) => void
+  }): Promise<ApolloExecutionResult<T>>;
+  fetchQuery<T>(
+    queryId: string,
+    options: WatchQueryOptions,
+    fetchType?: FetchType,
+    fetchMoreForQueryId?: string
+  ): Promise<ApolloQueryResult<T>>;
+  queryListenerForObserver<T>(
+    queryId: string,
+    options: WatchQueryOptions,
+    observer: Observer<ApolloQueryResult<T>>
+  ): QueryListener;
+  watchQuery<T>(
+    options: WatchQueryOptions,
+    shouldSubscribe?: boolean
+  ): ObservableQuery<T>;
+  query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
+  generateQueryId(): string;
+  stopQueryInStore(queryId: string): void;
+  getApolloState(): Store;
+  selectApolloState(store: any): Store;
+  getInitialState(): {
+    data: Object
+  };
+  getDataWithOptimisticResults(): NormalizedCache;
+  addQueryListener(queryId: string, listener: QueryListener): void;
+  addFetchQueryPromise<T>(
+    requestId: number,
+    promise: Promise<ApolloQueryResult<T>>,
+    resolve: (result: ApolloQueryResult<T>) => void,
+    reject: (error: Error) => void
+  ): void;
+  removeFetchQueryPromise(requestId: number): void;
+  addObservableQuery<T>(
+    queryId: string,
+    observableQuery: ObservableQuery<T>
+  ): void;
+  removeObservableQuery(queryId: string): void;
+  resetStore(): void;
+  startQuery<T>(
+    queryId: string,
+    options: WatchQueryOptions,
+    listener: QueryListener
+  ): string;
+  startGraphQLSubscription(options: SubscriptionOptions): Observable<any>;
+  removeQuery(queryId: string): void;
+  stopQuery(queryId: string): void;
+  getCurrentQueryResult<T>(
+    observableQuery: ObservableQuery<T>,
+    isOptimistic?: boolean
+  ): any;
+  getQueryWithPreviousResult<T>(
+    queryIdOrObservable: string | ObservableQuery<T>,
+    isOptimistic?: boolean
+  ): {
+    previousResult: any,
+    variables: {
+      [key: string]: any
+    } | void,
+    document: DocumentNode
+  };
+}
+
+declare export class ApolloClient extends DataProxy {
+  networkInterface: NetworkInterface;
+  store: ApolloStore;
+  reduxRootSelector: ApolloStateSelector | null;
+  initialState: any;
+  queryManager: QueryManager;
+  reducerConfig: ApolloReducerConfig;
+  addTypename: boolean;
+  disableNetworkFetches: boolean;
+  dataId: IdGetter | void;
+  dataIdFromObject: IdGetter | void;
+  fieldWithArgs: (fieldName: string, args?: Object) => string;
+  version: string;
+  queryDeduplication: boolean;
+  constructor(options?: {
+    networkInterface?: NetworkInterface,
+    reduxRootSelector?: string | ApolloStateSelector,
+    initialState?: any,
+    dataIdFromObject?: IdGetter,
+    ssrMode?: boolean,
+    ssrForceFetchDelay?: number,
+    addTypename?: boolean,
+    customResolvers?: CustomResolverMap,
+    connectToDevTools?: boolean,
+    queryDeduplication?: boolean,
+    fragmentMatcher?: FragmentMatcherInterface
+  }): this;
+  watchQuery<T>(options: WatchQueryOptions): ObservableQuery<T>;
+  query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
+  mutate<T>(options: MutationOptions<T>): Promise<ApolloExecutionResult<T>>;
+  subscribe(options: SubscriptionOptions): Observable<any>;
+  readQuery<T>(options: DataProxyReadQueryOptions): T;
+  readFragment<T>(options: DataProxyReadFragmentOptions): T | null;
+  writeQuery(options: DataProxyWriteQueryOptions): void;
+  writeFragment(options: DataProxyWriteFragmentOptions): void;
+  reducer(): (state: Store, action: ApolloAction) => Store;
+  __actionHookForDevTools(cb: Function): void;
+  middleware: <S, A>() => Middleware<S, A>;
+  initStore(): void;
+  resetStore(): void;
+  getInitialState(): {
+    data: Object
+  };
+}
+declare export default typeof ApolloClient;

--- a/definitions/npm/apollo-client_v2.x.x/test_apollo-client_v2.x.x.js
+++ b/definitions/npm/apollo-client_v2.x.x/test_apollo-client_v2.x.x.js
@@ -1,0 +1,97 @@
+// @flow
+
+import { ApolloClient, ApolloLink, ApolloCache } from "apollo-client";
+import { describe, it } from "flow-typed-test";
+
+const link = new ApolloLink();
+const cache = new ApolloCache();
+
+describe("apollo-client", () => {
+  describe("ApolloClient initialization", () => {
+    it("passes when passed correct configuration", () => {
+      new ApolloClient({
+        link,
+        cache
+      });
+    });
+
+    it("passes when passed optional cnfig options", () => {
+      new ApolloClient({
+        link,
+        cache,
+        ssrMode: true,
+        ssrForceFetchDelay: 1000,
+        connectToDevTools: true,
+        queryDeduplication: true,
+        defaultOptions: {
+          query: {
+            fetchPolicy: "cache-and-network"
+          }
+        }
+      });
+    });
+
+    it("raises error when missing link", () => {
+      // $ExpectError - link required to initialize ApolloClient
+      new ApolloClient({
+        cache
+      });
+    });
+
+    it("raises error when missing cache", () => {
+      // $ExpectError - cache required to initialize ApolloClient
+      new ApolloClient({
+        link
+      });
+    });
+
+    it("raises error when passing invalid connectToDevTools", () => {
+      // $ExpectError - connectToDevTools must be boolean
+      new ApolloClient({
+        link,
+        cache,
+        connectToDevTools: "true"
+      });
+    });
+
+    it("raises error when passing invalid ssrMode", () => {
+      // $ExpectError - ssrMode must be boolean
+      new ApolloClient({
+        link,
+        cache,
+        ssrMode: "true"
+      });
+    });
+
+    it("raises error when passing invalid ssrForceFetchDelay", () => {
+      // $ExpectError - ssrForceFetchDelay must be number
+      new ApolloClient({
+        link,
+        cache,
+        ssrForceFetchDelay: "true"
+      });
+    });
+
+    it("raises error when passing invalid queryDeduplication", () => {
+      // $ExpectError - queryDeduplication must be boolean
+      new ApolloClient({
+        link,
+        cache,
+        queryDeduplication: "true"
+      });
+    });
+
+    it("raises error when passing invalid defaultOptions", () => {
+      // $ExpectError - defaultOptions fetchPolicy is invalid
+      new ApolloClient({
+        link,
+        cache,
+        defaultOptions: {
+          query: {
+            fetchPolicy: "invalidFetchPolicy"
+          }
+        }
+      });
+    });
+  });
+});

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -1,73 +1,762 @@
-// @flow
-import type {
-  ApolloClient,
-  DataProxy,
-  MutationQueryReducersMap,
-  ApolloQueryResult,
-  ApolloError,
-  FetchPolicy as FetchPolicyAC,
-  FetchMoreOptions as FetchMoreOptionsAC,
-  UpdateQueryOptions,
-  FetchMoreQueryOptions as FetchMoreQueryOptionsAC,
-  SubscribeToMoreOptions as SubscribeToMoreOptionsAC,
-  MutationUpdaterFn,
-} from 'apollo-client';
-import type { DocumentNode, VariableDefinitionNode } from 'graphql';
+declare module "react-apollo" {
+  /**
+   * Copied types from Apollo Client libdef
+   * Please update apollo-client libdef as well if updating these types
+   */
+  declare class ObservableQuery<T> extends Observable<ApolloQueryResult<T>> {
+    options: WatchQueryOptions;
+    queryId: string;
+    variables: { [key: string]: any };
+    isCurrentlyPolling: boolean;
+    shouldSubscribe: boolean;
+    isTornDown: boolean;
+    scheduler: QueryScheduler<any>;
+    queryManager: QueryManager<any>;
+    observers: Observer<ApolloQueryResult<T>>[];
+    subscriptionHandles: SubscriptionLINK[];
+    lastResult: ApolloQueryResult<T>;
+    lastError: ApolloError;
+    lastVariables: { [key: string]: any };
 
-declare module 'react-apollo' {
+    constructor(data: {
+      scheduler: QueryScheduler<any>,
+      options: WatchQueryOptions,
+      shouldSubscribe?: boolean
+    }): this;
 
-  declare export type NetworkStatus = 1 | 2 | 3 | 4 | 6 | 7 | 8;
+    result(): Promise<ApolloQueryResult<T>>;
+    currentResult(): ApolloCurrentResult<T>;
+    getLastResult(): ApolloQueryResult<T>;
+    getLastError(): ApolloError;
+    resetLastResults(): void;
+    refetch(variables?: any): Promise<ApolloQueryResult<T>>;
+    fetchMore(
+      fetchMoreOptions: FetchMoreQueryOptions<any> & FetchMoreOptions<any, any>
+    ): Promise<ApolloQueryResult<T>>;
+    subscribeToMore(options: SubscribeToMoreOptions<any, any>): () => void;
+    setOptions(
+      opts: ModifiableWatchQueryOptions
+    ): Promise<ApolloQueryResult<T>>;
+    setVariables(
+      variables: any,
+      tryFetch?: boolean,
+      fetchResults?: boolean
+    ): Promise<ApolloQueryResult<T>>;
+    updateQuery(
+      mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any
+    ): void;
+    stopPolling(): void;
+    startPolling(pollInterval: number): void;
+  }
 
-  declare export interface ProviderProps {
-    client: ApolloClient;
+  declare class QueryManager<TStore> {
+    scheduler: QueryScheduler<TStore>;
+    link: ApolloLink;
+    mutationStore: MutationStore;
+    queryStore: QueryStore;
+    dataStore: DataStore<TStore>;
+
+    constructor({
+      link: ApolloLink,
+      queryDeduplication?: boolean,
+      store: DataStore<TStore>,
+      onBroadcast?: () => void,
+      ssrMode?: boolean
+    }): this;
+
+    mutate<T>(options: MutationOptions<>): Promise<FetchResult<T>>;
+    fetchQuery<T>(
+      queryId: string,
+      options: WatchQueryOptions,
+      fetchType?: FetchType,
+      fetchMoreForQueryId?: string
+    ): Promise<FetchResult<T>>;
+    queryListenerForObserver<T>(
+      queryId: string,
+      options: WatchQueryOptions,
+      observer: Observer<ApolloQueryResult<T>>
+    ): QueryListener;
+    watchQuery<T>(
+      options: WatchQueryOptions,
+      shouldSubscribe?: boolean
+    ): ObservableQuery<T>;
+    query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
+    generateQueryId(): string;
+    stopQueryInStore(queryId: string): void;
+    addQueryListener(queryId: string, listener: QueryListener): void;
+    updateQueryWatch(
+      queryId: string,
+      document: DocumentNode,
+      options: WatchQueryOptions
+    ): void;
+    addFetchQueryPromise<T>(
+      requestId: number,
+      promise: Promise<ApolloQueryResult<T>>,
+      resolve: (result: ApolloQueryResult<T>) => void,
+      reject: (error: Error) => void
+    ): void;
+    removeFetchQueryPromise(requestId: number): void;
+    addObservableQuery<T>(
+      queryId: string,
+      observableQuery: ObservableQuery<T>
+    ): void;
+    removeObservableQuery(queryId: string): void;
+    clearStore(): Promise<void>;
+    resetStore(): Promise<ApolloQueryResult<any>[]>;
+  }
+
+  declare class QueryStore {
+    getStore(): { [queryId: string]: QueryStoreValue };
+    get(queryId: string): QueryStoreValue;
+    initQuery(query: {
+      queryId: string,
+      document: DocumentNode,
+      storePreviousVariables: boolean,
+      variables: Object,
+      isPoll: boolean,
+      isRefetch: boolean,
+      metadata: any,
+      fetchMoreForQueryId: string | void
+    }): void;
+    markQueryResult(
+      queryId: string,
+      result: ExecutionResult<>,
+      fetchMoreForQueryId: string | void
+    ): void;
+    markQueryError(
+      queryId: string,
+      error: Error,
+      fetchMoreForQueryId: string | void
+    ): void;
+    markQueryResultClient(queryId: string, complete: boolean): void;
+    stopQuery(queryId: string): void;
+    reset(observableQueryIds: string[]): void;
+  }
+
+  declare class QueryScheduler<TCacheShape> {
+    inFlightQueries: { [queryId: string]: WatchQueryOptions };
+    registeredQueries: { [queryId: string]: WatchQueryOptions };
+    intervalQueries: { [interval: number]: string[] };
+    queryManager: QueryManager<TCacheShape>;
+    constructor({
+      queryManager: QueryManager<TCacheShape>,
+      ssrMode?: boolean
+    }): this;
+    checkInFlight(queryId: string): ?boolean;
+    fetchQuery<T>(
+      queryId: string,
+      options: WatchQueryOptions,
+      fetchType: FetchType
+    ): Promise<FetchResult<T>>;
+    startPollingQuery<T>(
+      options: WatchQueryOptions,
+      queryId: string,
+      listener?: QueryListener
+    ): string;
+    stopPollingQuery(queryId: string): void;
+    fetchQueriesOnInterval<T>(interval: number): void;
+    addQueryOnInterval<T>(
+      queryId: string,
+      queryOptions: WatchQueryOptions
+    ): void;
+    registerPollingQuery<T>(
+      queryOptions: WatchQueryOptions
+    ): ObservableQuery<T>;
+    markMutationError(mutationId: string, error: Error): void;
+    reset(): void;
+  }
+
+  declare class DataStore<TSerialized> {
+    constructor(initialCache: ApolloCache<TSerialized>): this;
+    getCache(): ApolloCache<TSerialized>;
+    markQueryResult(
+      result: ExecutionResult<>,
+      document: DocumentNode,
+      variables: any,
+      fetchMoreForQueryId: string | void,
+      ignoreErrors?: boolean
+    ): void;
+    markSubscriptionResult(
+      result: ExecutionResult<>,
+      document: DocumentNode,
+      variables: any
+    ): void;
+    markMutationInit(mutation: {
+      mutationId: string,
+      document: DocumentNode,
+      variables: any,
+      updateQueries: { [queryId: string]: QueryWithUpdater },
+      update: ((proxy: DataProxy, mutationResult: Object) => void) | void,
+      optimisticResponse: Object | Function | void
+    }): void;
+    markMutationResult(mutation: {
+      mutationId: string,
+      result: ExecutionResult<>,
+      document: DocumentNode,
+      variables: any,
+      updateQueries: { [queryId: string]: QueryWithUpdater },
+      update: ((proxy: DataProxy, mutationResult: Object) => void) | void
+    }): void;
+    markMutationComplete({
+      mutationId: string,
+      optimisticResponse?: any
+    }): void;
+    markUpdateQueryResult(
+      document: DocumentNode,
+      variables: any,
+      newResult: any
+    ): void;
+    reset(): Promise<void>;
+  }
+
+  declare type QueryWithUpdater = {
+    updater: MutationQueryReducer<Object>,
+    query: QueryStoreValue
+  };
+
+  declare interface MutationStoreValue {
+    mutationString: string;
+    variables: Object;
+    loading: boolean;
+    error: Error | null;
+  }
+
+  declare class MutationStore {
+    getStore(): { [mutationId: string]: MutationStoreValue };
+    get(mutationId: string): MutationStoreValue;
+    initMutation(
+      mutationId: string,
+      mutationString: string,
+      variables: Object | void
+    ): void;
+  }
+
+  declare export interface FetchMoreOptions<TData, TVariables> {
+    updateQuery: (
+      previousQueryResult: TData,
+      options: {
+        fetchMoreResult?: TData,
+        variables: TVariables
+      }
+    ) => TData;
+  }
+
+  declare export interface UpdateQueryOptions {
+    variables?: Object;
+  }
+
+  declare export type ApolloCurrentResult<T> = {
+    data: T | {},
+    errors?: Array<GraphQLError>,
+    loading: boolean,
+    networkStatus: NetworkStatus,
+    error?: ApolloError,
+    partial?: boolean
+  };
+
+  declare interface ModifiableWatchQueryOptions {
+    variables?: { [key: string]: any };
+    pollInterval?: number;
+    fetchPolicy?: FetchPolicy;
+    errorPolicy?: ErrorPolicy;
+    fetchResults?: boolean;
+    notifyOnNetworkStatusChange?: boolean;
+  }
+
+  declare export interface WatchQueryOptions
+    extends ModifiableWatchQueryOptions {
+    query: DocumentNode;
+    metadata?: any;
+    context?: any;
+  }
+
+  declare type RefetchQueryDescription = Array<string | PureQueryOptions>;
+
+  declare interface MutationBaseOptions<T = { [key: string]: any }> {
+    optimisticResponse?: Object | Function;
+    updateQueries?: MutationQueryReducersMap<T>;
+    optimisticResponse?: Object;
+    refetchQueries?:
+      | ((result: ExecutionResult<>) => RefetchQueryDescription)
+      | RefetchQueryDescription;
+    update?: MutationUpdaterFn<T>;
+    errorPolicy?: ErrorPolicy;
+    variables?: any;
+  }
+
+  declare export interface MutationOptions<T = { [key: string]: any }>
+    extends MutationBaseOptions<T> {
+    mutation: DocumentNode;
+    context?: any;
+    fetchPolicy?: FetchPolicy;
+  }
+
+  declare export interface SubscriptionOptions {
+    query: DocumentNode;
+    variables?: { [key: string]: any };
+  }
+
+  declare export type FetchPolicy =
+    | "cache-first"
+    | "cache-and-network"
+    | "network-only"
+    | "cache-only"
+    | "no-cache"
+    | "standby";
+
+  declare export type ErrorPolicy = "none" | "ignore" | "all";
+
+  declare export interface FetchMoreQueryOptions<TVariables> {
+    variables: $Shape<TVariables>;
+  }
+
+  declare export type SubscribeToMoreOptions<
+    TData,
+    TSubscriptionData,
+    TSubscriptionVariables = void
+  > = {
+    document?: DocumentNode,
+    variables?: TSubscriptionVariables,
+    updateQuery?: (
+      previousResult: TData,
+      result: {
+        subscriptionData: { data?: TSubscriptionData },
+        variables: TSubscriptionVariables
+      }
+    ) => TData,
+    onError?: (error: Error) => void
+  };
+
+  declare export type MutationUpdaterFn<T = OperationVariables> = (
+    proxy: DataProxy,
+    mutationResult: FetchResult<T>
+  ) => void;
+
+  declare export type NetworkStatus = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+  declare export type QueryListener = (
+    queryStoreValue: QueryStoreValue,
+    newData?: any
+  ) => void;
+
+  declare export type QueryStoreValue = {
+    document: DocumentNode,
+    variables: Object,
+    previousVariables: Object | null,
+    networkStatus: NetworkStatus,
+    networkError: Error | null,
+    graphQLErrors: GraphQLError[],
+    metadata: any
+  };
+
+  declare export type PureQueryOptions = {
+    query: DocumentNode,
+    variables?: { [key: string]: any }
+  };
+
+  declare export type ApolloQueryResult<T> = {
+    data: T,
+    errors?: Array<GraphQLError>,
+    loading: boolean,
+    networkStatus: NetworkStatus,
+    stale: boolean
+  };
+
+  declare export type FetchType = 1 | 2 | 3;
+
+  declare export type MutationQueryReducer<T> = (
+    previousResult: { [key: string]: any },
+    options: {
+      mutationResult: FetchResult<T>,
+      queryName: string | void,
+      queryVariables: { [key: string]: any }
+    }
+  ) => { [key: string]: any };
+
+  declare export type MutationQueryReducersMap<T = { [key: string]: any }> = {
+    [queryName: string]: MutationQueryReducer<T>
+  };
+
+  declare class ApolloError extends Error {
+    message: string;
+    graphQLErrors: Array<GraphQLError>;
+    networkError: Error | null;
+    extraInfo: any;
+    constructor(info: ErrorConstructor): this;
+  }
+
+  declare interface ErrorConstructor {
+    graphQLErrors?: Array<GraphQLError>;
+    networkError?: Error | null;
+    errorMessage?: string;
+    extraInfo?: any;
+  }
+
+  declare interface DefaultOptions {
+    +watchQuery?: ModifiableWatchQueryOptions;
+    +query?: ModifiableWatchQueryOptions;
+    +mutate?: MutationBaseOptions<>;
+  }
+
+  declare type ApolloClientOptions<TCacheShape> = {
+    link: ApolloLink,
+    cache: ApolloCache<TCacheShape>,
+    ssrMode?: boolean,
+    ssrForceFetchDelay?: number,
+    connectToDevTools?: boolean,
+    queryDeduplication?: boolean,
+    defaultOptions?: DefaultOptions
+  };
+
+  declare class ApolloClient<TCacheShape> {
+    link: ApolloLink;
+    store: DataStore<TCacheShape>;
+    cache: ApolloCache<TCacheShape>;
+    queryManager: QueryManager<TCacheShape>;
+    disableNetworkFetches: boolean;
+    version: string;
+    queryDeduplication: boolean;
+    defaultOptions: DefaultOptions;
+    devToolsHookCb: Function;
+    proxy: ApolloCache<TCacheShape> | void;
+    ssrMode: boolean;
+    resetStoreCallbacks: Array<() => Promise<any>>;
+
+    constructor(options: ApolloClientOptions<TCacheShape>): this;
+    watchQuery<T>(options: WatchQueryOptions): ObservableQuery<T>;
+    query<T>(options: WatchQueryOptions): Promise<ApolloQueryResult<T>>;
+    mutate<T>(options: MutationOptions<T>): Promise<FetchResult<T>>;
+    subscribe(options: SubscriptionOptions): Observable<any>;
+    readQuery<T>(options: DataProxyReadQueryOptions): T | null;
+    readFragment<T>(options: DataProxyReadFragmentOptions): T | null;
+    writeQuery(options: DataProxyWriteQueryOptions): void;
+    writeFragment(options: DataProxyWriteFragmentOptions): void;
+    writeData(options: DataProxyWriteDataOptions): void;
+    __actionHookForDevTools(cb: () => any): void;
+    __requestRaw(payload: GraphQLRequest): Observable<ExecutionResult<>>;
+    initQueryManager(): void;
+    resetStore(): Promise<Array<ApolloQueryResult<any>> | null>;
+    onResetStore(cb: () => Promise<any>): () => void;
+    reFetchObservableQueries(
+      includeStandby?: boolean
+    ): Promise<ApolloQueryResult<any>[]> | Promise<null>;
+  }
+
+  /* apollo-link types */
+  declare class ApolloLink {
+    constructor(request?: RequestHandler): this;
+
+    static empty(): ApolloLink;
+    static from(links: Array<ApolloLink>): ApolloLink;
+    static split(
+      test: (op: Operation) => boolean,
+      left: ApolloLink | RequestHandler,
+      right: ApolloLink | RequestHandler
+    ): ApolloLink;
+    static execute(
+      link: ApolloLink,
+      operation: GraphQLRequest
+    ): Observable<FetchResult<>>;
+
+    split(
+      test: (op: Operation) => boolean,
+      left: ApolloLink | RequestHandler,
+      right: ApolloLink | RequestHandler
+    ): ApolloLink;
+
+    concat(next: ApolloLink | RequestHandler): ApolloLink;
+
+    request(
+      operation: Operation,
+      forward?: NextLink
+    ): Observable<FetchResult<>> | null;
+  }
+
+  declare interface GraphQLRequest {
+    query: DocumentNode;
+    variables?: { [key: string]: any };
+    operationName?: string;
+    context?: { [key: string]: any };
+    extensions?: { [key: string]: any };
+  }
+
+  declare interface Operation {
+    query: DocumentNode;
+    variables: { [key: string]: any };
+    operationName: string;
+    extensions: { [key: string]: any };
+    setContext: (context: { [key: string]: any }) => { [key: string]: any };
+    getContext: () => { [key: string]: any };
+    toKey: () => string;
+  }
+
+  declare type FetchResult<
+    C = { [key: string]: any },
+    E = { [key: string]: any }
+  > = ExecutionResult<C> & { extension?: E, context?: C };
+
+  declare type NextLink = (operation: Operation) => Observable<FetchResult<>>;
+
+  declare type RequestHandler = (
+    operation: Operation,
+    forward?: NextLink
+  ) => Observable<FetchResult<>> | null;
+
+  declare class Observable<T> {
+    subscribe(
+      observerOrNext: ((value: T) => void) | ZenObservableObserver<T>,
+      error?: (error: any) => void,
+      complete?: () => void
+    ): ZenObservableSubscription;
+
+    forEach(fn: (value: T) => void): Promise<void>;
+
+    map<R>(fn: (value: T) => R): Observable<R>;
+
+    filter(fn: (value: T) => boolean): Observable<T>;
+
+    reduce<R>(
+      fn: (previousValue: R | T, currentValue: T) => R | T,
+      initialValue?: R | T
+    ): Observable<R | T>;
+
+    flatMap<R>(fn: (value: T) => ZenObservableObservableLike<R>): Observable<R>;
+
+    from<R>(
+      observable: Observable<R> | ZenObservableObservableLike<R> | Array<R>
+    ): Observable<R>;
+
+    of<R>(...args: Array<R>): Observable<R>;
+  }
+
+  declare interface Observer<T> {
+    start?: (subscription: SubscriptionLINK) => any;
+    next?: (value: T) => void;
+    error?: (errorValue: any) => void;
+    complete?: () => void;
+  }
+
+  declare interface SubscriptionLINK {
+    closed: boolean;
+    unsubscribe(): void;
+  }
+
+  declare interface ZenObservableSubscriptionObserver<T> {
+    closed: boolean;
+    next(value: T): void;
+    error(errorValue: any): void;
+    complete(): void;
+  }
+
+  declare interface ZenObservableSubscription {
+    closed: boolean;
+    unsubscribe(): void;
+  }
+
+  declare interface ZenObservableObserver<T> {
+    start?: (subscription: ZenObservableSubscription) => any;
+    next?: (value: T) => void;
+    error?: (errorValue: any) => void;
+    complete?: () => void;
+  }
+
+  declare type ZenObservableSubscriber<T> = (
+    observer: ZenObservableSubscriptionObserver<T>
+  ) => void | (() => void) | SubscriptionLINK;
+
+  declare interface ZenObservableObservableLike<T> {
+    subscribe?: ZenObservableSubscriber<T>;
+  }
+  /* apollo-link types */
+
+  /* apollo-cache types */
+  declare class ApolloCache<TSerialized> {
+    read<T>(query: CacheReadOptions): T | null;
+    write(write: CacheWriteOptions): void;
+    diff<T>(query: CacheDiffOptions): CacheDiffResult<T>;
+    watch(watch: CacheWatchOptions): () => void;
+    evict(query: CacheEvictOptions): CacheEvictionResult;
+    reset(): Promise<void>;
+
+    restore(serializedState: TSerialized): ApolloCache<TSerialized>;
+    extract(optimistic?: boolean): TSerialized;
+
+    removeOptimistic(id: string): void;
+
+    performTransaction(transaction: Transaction<TSerialized>): void;
+    recordOptimisticTransaction(
+      transaction: Transaction<TSerialized>,
+      id: string
+    ): void;
+
+    transformDocument(document: DocumentNode): DocumentNode;
+    transformForLink(document: DocumentNode): DocumentNode;
+
+    readQuery<QueryType>(
+      options: DataProxyReadQueryOptions,
+      optimistic?: boolean
+    ): QueryType | null;
+    readFragment<FragmentType>(
+      options: DataProxyReadFragmentOptions,
+      optimistic?: boolean
+    ): FragmentType | null;
+    writeQuery(options: CacheWriteQueryOptions): void;
+    writeFragment(options: CacheWriteFragmentOptions): void;
+    writeData(options: CacheWriteDataOptions): void;
+  }
+
+  declare type Transaction<T> = (c: ApolloCache<T>) => void;
+
+  declare type CacheWatchCallback = (newData: any) => void;
+
+  declare interface CacheEvictionResult {
+    success: boolean;
+  }
+
+  declare interface CacheReadOptions extends DataProxyReadQueryOptions {
+    rootId?: string;
+    previousResult?: any;
+    optimistic: boolean;
+  }
+
+  declare interface CacheWriteOptions extends DataProxyReadQueryOptions {
+    dataId: string;
+    result: any;
+  }
+
+  declare interface CacheDiffOptions extends CacheReadOptions {
+    returnPartialData?: boolean;
+  }
+
+  declare interface CacheWatchOptions extends CacheReadOptions {
+    callback: CacheWatchCallback;
+  }
+
+  declare interface CacheEvictOptions extends DataProxyReadQueryOptions {
+    rootId?: string;
+  }
+
+  declare type CacheDiffResult<T> = DataProxyDiffResult<T>;
+  declare type CacheWriteQueryOptions = DataProxyWriteQueryOptions;
+  declare type CacheWriteFragmentOptions = DataProxyWriteFragmentOptions;
+  declare type CacheWriteDataOptions = DataProxyWriteDataOptions;
+  declare type CacheReadFragmentOptions = DataProxyReadFragmentOptions;
+
+  declare interface DataProxyReadQueryOptions {
+    query: DocumentNode;
+    variables?: any;
+  }
+
+  declare interface DataProxyReadFragmentOptions {
+    id: string;
+    fragment: DocumentNode;
+    fragmentName?: string;
+    variables?: any;
+  }
+
+  declare interface DataProxyWriteQueryOptions {
+    data: any;
+    query: DocumentNode;
+    variables?: any;
+  }
+
+  declare interface DataProxyWriteFragmentOptions {
+    data: any;
+    id: string;
+    fragment: DocumentNode;
+    fragmentName?: string;
+    variables?: any;
+  }
+
+  declare interface DataProxyWriteDataOptions {
+    data: any;
+    id?: string;
+  }
+
+  declare type DataProxyDiffResult<T> = {
+    result?: T,
+    complete?: boolean
+  };
+
+  declare interface DataProxy {
+    readQuery<QueryType>(
+      options: DataProxyReadQueryOptions,
+      optimistic?: boolean
+    ): QueryType | null;
+    readFragment<FragmentType>(
+      options: DataProxyReadFragmentOptions,
+      optimistic?: boolean
+    ): FragmentType | null;
+    writeQuery(options: DataProxyWriteQueryOptions): void;
+    writeFragment(options: DataProxyWriteFragmentOptions): void;
+    writeData(options: DataProxyWriteDataOptions): void;
+  }
+  /* End apollo-cache types */
+
+  /** End from Apollo Client */
+
+  /**
+   * Types From graphql
+   * graphql types are maintained in the graphql-js repo
+   */
+  declare type DocumentNode = any;
+  declare type ExecutionResult<T> = {
+    data?: T,
+    extensions?: { [string]: any },
+    errors?: any[]
+  };
+  declare type GraphQLError = any;
+  declare type VariableDefinitionNode = any;
+  /** End From graphql */
+
+  declare export interface ApolloProviderProps<TCache> {
+    client: any; // ApolloClient<TCache>;
+    children: React$Node;
   }
 
   declare export interface ApolloConsumerProps {
-    children: (client: ApolloClient) => React$Node;
+    children: (client: ApolloClient<any>) => React$Node;
   }
 
-  declare export class ApolloConsumer extends React$Component<ApolloConsumerProps> {
-    render(): React$Node;
-  }
+  declare export class ApolloConsumer extends React$Component<
+    ApolloConsumerProps
+  > {}
 
-  declare export class ApolloProvider extends React$Component<ProviderProps> {
+  declare export class ApolloProvider<TCache> extends React$Component<
+    ApolloProviderProps<TCache>
+  > {
     childContextTypes: {
-      client: ApolloClient,
+      client: ApolloClient<TCache>,
+      operations: Map<string, { query: DocumentNode, variables: any }>
     };
-    contextTypes: {
-      client: ApolloClient,
-    };
+
     getChildContext(): {
-      client: ApolloClient,
+      client: ApolloClient<TCache>,
+      operations: Map<string, { query: DocumentNode, variables: any }>
     };
-    render(): React$Element<*>;
   }
 
   declare export type MutationFunc<TResult, TVariables> = (
     opts: MutationOpts<TVariables>
   ) => Promise<ApolloQueryResult<TResult>>;
 
-  declare export type GraphqlData<TResult, TVariables> = GraphqlQueryControls &
-    TResult & {
-    variables: TVariables,
-    refetch: (variables?: TVariables) => Promise<ApolloQueryResult<any>>,
-  };
+  declare export type GraphqlData<TResult, TVariables> = TResult &
+    GraphqlQueryControls<TVariables> & {
+      variables: TVariables,
+      refetch: (variables?: TVariables) => Promise<ApolloQueryResult<any>>
+    };
 
   declare export type ChildProps<
     TOwnProps,
     TResult,
     TVariables: Object = {}
-    > = {
+  > = {
     data: GraphqlData<TResult, TVariables>,
-    mutate: MutationFunc<TResult, TVariables>,
+    mutate: MutationFunc<TResult, TVariables>
   } & TOwnProps;
 
   // back compat
   declare export type DefaultChildProps<P, R> = ChildProps<P, R, {}>;
-
-  declare export type ErrorPolicy = 'none' | 'ignore' | 'all';
-
-  declare type PureQueryOptions = {query: DocumentNode, variables?: {[string]: any}}
 
   declare export type RefetchQueriesProviderFn = (
     ...args: any[]
@@ -79,31 +768,34 @@ declare module 'react-apollo' {
     refetchQueries?: string[] | PureQueryOptions[] | RefetchQueriesProviderFn,
     update?: MutationUpdaterFn<*>,
     errorPolicy?: ErrorPolicy,
-    $call?: empty, // Not function
+    $call?: empty // Not function
   };
 
   declare export type QueryOpts<TVariables> = {
     ssr?: boolean,
     variables?: TVariables,
-    fetchPolicy?: FetchPolicyAC,
+    fetchPolicy?: FetchPolicy,
     pollInterval?: number,
     skip?: boolean,
     errorPolicy?: ErrorPolicy,
-    $call?: empty, // Not function
+    $call?: empty // Not function
   };
 
-  declare export interface GraphqlQueryControls {
+  declare export interface GraphqlQueryControls<
+    TGraphQLVariables = OperationVariables
+  > {
     error?: ApolloError | any; // Added optional `any` to satisfy Flow < 0.62
     networkStatus: NetworkStatus;
     loading: boolean;
-    variables: Object;
+    variables: TGraphQLVariables;
     fetchMore: (
-      fetchMoreOptions: FetchMoreQueryOptionsAC & FetchMoreOptionsAC
+      fetchMoreOptions: FetchMoreQueryOptions<TGraphQLVariables> &
+        FetchMoreOptions<any, TGraphQLVariables>
     ) => Promise<ApolloQueryResult<any>>;
-    refetch: (variables?: Object) => Promise<ApolloQueryResult<any>>;
+    refetch: (variables?: TGraphQLVariables) => Promise<ApolloQueryResult<any>>;
     startPolling: (pollInterval: number) => void;
     stopPolling: () => void;
-    subscribeToMore: (options: SubscribeToMoreOptionsAC) => () => void;
+    subscribeToMore: (options: SubscribeToMoreOptions<any, any>) => () => void;
     updateQuery: (
       mapFn: (previousQueryResult: any, options: UpdateQueryOptions) => any
     ) => void;
@@ -121,7 +813,7 @@ declare module 'react-apollo' {
     | ((props: TProps) => QueryOpts<TVariables> | MutationOpts<TVariables>);
 
   declare export type NamedProps<P, R> = P & {
-    ownProps: R,
+    ownProps: R
   };
 
   declare export interface OperationOption<
@@ -129,7 +821,7 @@ declare module 'react-apollo' {
     TProps: {},
     TChildProps: {},
     TVariables: {}
-    > {
+  > {
     +options?: OptionDescription<TProps, TVariables>;
     props?: (
       props: OptionProps<TProps, TResult, TVariables>
@@ -146,7 +838,7 @@ declare module 'react-apollo' {
     TOwnProps: Object = {},
     TVariables: Object = {},
     TMergedProps: Object = ChildProps<TOwnProps, TResult, TVariables>
-    > {
+  > {
     (
       component: React$ComponentType<TMergedProps>
     ): React$ComponentType<TOwnProps>;
@@ -158,11 +850,11 @@ declare module 'react-apollo' {
   ): OperationComponent<TResult, TProps, TVariables, TChildProps>;
 
   declare type WithApolloOptions = {
-    withRef?: boolean,
+    withRef?: boolean
   };
 
   declare export function withApollo<TProps>(
-    component: React$ComponentType<{ client: ApolloClient } & TProps>,
+    component: React$ComponentType<{ client: ApolloClient<any> } & TProps>,
     operationOptions?: WithApolloOptions
   ): React$ComponentType<TProps>;
 
@@ -175,13 +867,7 @@ declare module 'react-apollo' {
   declare export function parser(document: DocumentNode): IDocumentDefinition;
 
   declare export interface Context {
-    client?: ApolloClient;
     [key: string]: any;
-  }
-
-  declare export interface QueryTreeArgument {
-    rootElement: React$Element<*>;
-    rootContext?: Context;
   }
 
   declare export interface QueryResult {
@@ -191,10 +877,10 @@ declare module 'react-apollo' {
   }
 
   declare export function walkTree(
-    element: React$Element<*>,
+    element: React$Node,
     context: Context,
     visitor: (
-      element: React$Element<*>,
+      element: React$Node,
       instance: any,
       context: Context
     ) => boolean | void
@@ -212,42 +898,41 @@ declare module 'react-apollo' {
 
   declare export function cleanupApolloState(apolloState: any): void;
 
-  declare export type SubscribeToMoreOptions<TData, TSubscriptionData, TSubscriptionVariables=void> = {
-    document?: DocumentNode,
-    variables?: TSubscriptionVariables,
-    updateQuery?: (previousResult: TData, result: {subscriptionData: {data?: TSubscriptionData}, variables: TSubscriptionVariables}) => TData,
-    onError?: Function
-  }
-
-  declare type FetchMoreOptions<TData, TVariables> = {|
-    variables?: TVariables,
-    updateQuery: (previousResult: TData, {fetchMoreResult: TData, variables: TVariables}) => TData
-  |}
-
-  declare type FetchMoreQueryOptions<TData, TVariables, TFetchMoreData, TFetchMoreVariables=void> = {|
-    query: DocumentNode,
-    variables?: TFetchMoreVariables,
-    updateQuery: (previousResult: TData, {fetchMoreResult: TFetchMoreData, variables: TFetchMoreVariables}) => TData
-  |}
-
-  declare export type QueryRenderProps<TData=any, TVariables=OperationVariables> = {
-    data?: TData | {||},
+  declare export type QueryRenderProps<
+    TData = any,
+    TVariables = OperationVariables
+  > = {
+    data: TData | {||} | void,
     loading: boolean,
     error?: ApolloError,
     variables: TVariables,
     networkStatus: NetworkStatus,
     refetch: (variables?: TVariables) => Promise<mixed>,
-    fetchMore: (options: FetchMoreOptions<TData, TVariables> | FetchMoreQueryOptions<TData, TVariables, any, any>) => Promise<mixed>,
+    fetchMore: ((
+      options: FetchMoreOptions<TData, TVariables> &
+        FetchMoreQueryOptions<TVariables>
+    ) => Promise<ApolloQueryResult<TData>>) &
+      (<TData2, TVariables2>(
+        options: { query: DocumentNode } & FetchMoreQueryOptions<TVariables2> &
+          FetchMoreOptions<TData2, TVariables2>
+      ) => Promise<ApolloQueryResult<TData2>>),
     load: () => void,
     startPolling: (interval: number) => void,
     stopPolling: (interval: number) => void,
-    subscribeToMore: (options: SubscribeToMoreOptions<TData, any, any>) => () => void,
-    updateQuery: (previousResult: TData, options: {variables: TVariables}) => TData,
-    client: ApolloClient
-  }
+    subscribeToMore: (
+      options: SubscribeToMoreOptions<TData, any, any>
+    ) => () => void,
+    updateQuery: (
+      previousResult: TData,
+      options: { variables: TVariables }
+    ) => TData,
+    client: ApolloClient<any>
+  };
 
-  declare export type QueryRenderPropFunction<TData, TVariables> = (QueryRenderProps<TData, TVariables>) => React$Node
-  declare type FetchPolicy = 'cache-first' | 'cache-and-network' | 'network-only' | 'cache-only'
+  declare export type QueryRenderPropFunction<TData, TVariables> = (
+    QueryRenderProps<TData, TVariables>
+  ) => React$Node;
+
   declare export class Query<TData, TVariables> extends React$Component<{
     query: DocumentNode,
     children: QueryRenderPropFunction<TData, TVariables>,
@@ -259,59 +944,71 @@ declare module 'react-apollo' {
     ssr?: boolean,
     displayName?: string,
     delay?: boolean,
-    context?: {[string]: any}
+    context?: { [string]: any }
   }> {}
 
-  declare type SubscriptionResult<TData, TVariables=void> = {
+  declare type SubscriptionResult<TData, TVariables = void> = {
     loading: boolean,
     data?: TData,
-    error?: ApolloError,
-  }
+    error?: ApolloError
+  };
 
-  declare type SubscriptionProps<TData=any, TVariables=OperationVariables> = {
+  declare type SubscriptionProps<
+    TData = any,
+    TVariables = OperationVariables
+  > = {
     subscription: DocumentNode,
     variables?: TVariables,
-    shouldResubscribe?: boolean | (SubscriptionProps<TData, TVariables>, SubscriptionProps<TData, TVariables>) => boolean,
-    children: (result: SubscriptionResult<TData, TVariables>) => React$Node,
-  }
+    shouldResubscribe?:
+      | boolean
+      | ((
+          SubscriptionProps<TData, TVariables>,
+          SubscriptionProps<TData, TVariables>
+        ) => boolean),
+    children: (result: SubscriptionResult<TData, TVariables>) => React$Node
+  };
 
-  declare export class Subscription<TData> extends React$Component<SubscriptionProps<TData>> {}
+  declare export class Subscription<TData> extends React$Component<
+    SubscriptionProps<TData>
+  > {}
 
-  declare type ExecutionResult<T> = {
-    data?: T;
-    extensions?: {[string]: any};
-    errors?: any[];
-  }
+  declare type OperationVariables = { [key: string]: any };
 
-  declare type FetchResult<C={[string]: any}, E={[string]: any}> = ExecutionResult<C> & {
-    extensions?: E,
-    context?: C
-  }
-
-  declare type OperationVariables = {[string]: any}
-
-  declare export type MutationFunction<TData=any, TVariables=OperationVariables> = (options: {
+  declare export type MutationFunction<
+    TData = any,
+    TVariables = OperationVariables
+  > = (options: {
     variables?: TVariables,
     optimisticResponse?: Object,
-    refetchQueries?: (mutationResult: FetchResult<>) => string[] | PureQueryOptions[] | RefetchQueriesProviderFn,
-    update?: (cache: DataProxy, mutationResult: FetchResult<>) => any
-  }) => Promise<void | FetchResult<TData>>
+    refetchQueries?: string[] | PureQueryOptions[] | RefetchQueriesProviderFn,
+    update?: MutationUpdaterFn<TData>
+  }) => Promise<void | FetchResult<TData>>;
 
-  declare export type MutationResult<TData={[string]: any}> = {loading: boolean, error?: ApolloError, data?: TData, called: boolean}
+  declare export type MutationResult<TData = { [string]: any }> = {
+    loading: boolean,
+    error?: ApolloError,
+    data?: TData,
+    called: boolean
+  };
 
-  declare export type MutationRenderPropFunction<TData, TVariables> = (mutate: MutationFunction<TData, TVariables>, result: MutationResult<TData>) => React$Node
+  declare export type MutationRenderPropFunction<TData, TVariables> = (
+    mutate: MutationFunction<TData, TVariables>,
+    result: MutationResult<TData>
+  ) => React$Node;
 
-  declare export class Mutation<TData, TVariables=void> extends React$Component<{
+  declare export class Mutation<
+    TData,
+    TVariables = void
+  > extends React$Component<{
     mutation: DocumentNode,
     children: MutationRenderPropFunction<TData, TVariables>,
     variables?: TVariables,
-    update?: (cache: DataProxy, mutationResult: FetchResult<>) => any,
+    update?: MutationUpdaterFn<TData>,
     ignoreResults?: boolean,
     optimisticResponse?: Object,
     refetchQueries?: string[] | PureQueryOptions[] | RefetchQueriesProviderFn,
     onCompleted?: (data: TData) => void,
     onError?: (error: ApolloError) => void,
-    context?: {[string]: any}
+    context?: { [string]: any }
   }> {}
-
 }

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/test_react-apollo_v2.x.x.js
@@ -1,7 +1,9 @@
 // @flow
-import * as React from 'react';
-import { it, describe } from 'flow-typed-test';
+import * as React from "react";
+import { it, describe } from "flow-typed-test";
 import {
+  ApolloProvider,
+  ApolloConsumer,
   Query,
   Mutation,
   graphql,
@@ -13,7 +15,8 @@ import {
   type GraphqlQueryControls,
   type ChildProps,
   type GraphqlData,
-} from 'react-apollo';
+  type PureQueryOptions
+} from "react-apollo";
 
 const gql = (strings, ...args) => {}; // graphql-tag stub
 
@@ -28,29 +31,36 @@ const mutation = gql`
   }
 `;
 
+type Hero = {
+  name: string,
+  id: string,
+  appearsIn: string[],
+  friends: Hero[]
+};
+
 type IQuery = {
   foo: string,
-  bar: string,
+  bar: string
 };
 
 const withData: OperationComponent<IQuery> = graphql(query);
 
-it('works with functional component', () => {
+it("works with functional component", () => {
   const FunctionalWithData = withData(({ data }) => {
-    // $ExpectError string type beeing treated as numerical
+    // $ExpectError string type being treated as numerical
     if (data.foo > 1) return <span />;
 
     return null;
   });
 });
 
-it('works with class component, this requires a stricter definition', () => {
+it("works with class component, this requires a stricter definition", () => {
   type BasicComponentProps = ChildProps<{}, IQuery>;
   class BasicComponent extends React.Component<BasicComponentProps> {
     render() {
       const { foo, bar } = this.props.data;
 
-      // $ExpectError string type beeing treated as numerical
+      // $ExpectError string type being treated as numerical
       if (bar > 1) return null;
 
       // The below works as expected
@@ -63,8 +73,8 @@ it('works with class component, this requires a stricter definition', () => {
 it("works with class component with it's own variable", () => {
   type CmplxOwnProps = {| faz: string |};
   type CmplxComponentProps = {
-    data: GraphqlQueryControls & IQuery,
-    mutate: any, // The mutation is actually required or we get a error at the withData
+    data: GraphqlQueryControls<> & IQuery,
+    mutate: any // The mutation is actually required or we get a error at the withData
   } & CmplxOwnProps;
   class CmplxComponent extends React.Component<CmplxComponentProps> {
     render() {
@@ -72,7 +82,7 @@ it("works with class component with it's own variable", () => {
       if (loading) return <div>Loading</div>;
       if (error) return <h1>ERROR</h1>;
 
-      // $ExpectError string type beeing treated as numerical
+      // $ExpectError string type being treated as numerical
       if (bar > 1) return null;
 
       // The below works as expected
@@ -94,7 +104,7 @@ it("works with class component with it's own variable Props specified at the end
   // since we don't rely on the ChildProps<P, R> we don't need the mutate: any
   type Cmplx2OwnProps = { faz: string }; // We can have exact own props as we don't rely on the TMergedProps
   type Cmplx2ComponentProps = {
-    data: IQuery & GraphqlQueryControls,
+    data: IQuery & GraphqlQueryControls<>
   } & Cmplx2OwnProps;
   class Cmplx2Component extends React.Component<Cmplx2ComponentProps> {
     render() {
@@ -102,7 +112,7 @@ it("works with class component with it's own variable Props specified at the end
       if (loading) return <div>Loading</div>;
       if (error) return <h1>ERROR</h1>;
 
-      // $ExpectError string type beeing treated as numerical
+      // $ExpectError string type being treated as numerical
       if (bar > 1) return null;
 
       // The below works as expected
@@ -122,43 +132,54 @@ it("works with class component with it's own variable Props specified at the end
   const Cmplx2WithData = withFancyData2(Cmplx2Component);
 });
 
-  const HERO_QUERY = gql`
-    query GetCharacter($episode: String!) {
-      hero(episode: $episode) {
+const HERO_QUERY = gql`
+  query GetCharacter($episode: String!, offset: Int) {
+    hero(episode: $episode, offset: $offset) {
+      name
+      id
+      friends {
         name
         id
-        friends {
-          name
-          id
-          appearsIn
-        }
+        appearsIn
       }
     }
-  `;
+  }
+`;
 
-it('works with Variables specified', () => {
+const OTHER_QUERY = gql`
+  query GetOther($other: String!) {
+    other(other: $other) {
+      name
+    }
+  }
+`;
 
-  type Hero = {
-    name: string,
-    id: string,
-    appearsIn: string[],
-    friends: Hero[],
-  };
+const HERO_MUTATION = gql`
+  mutation UpdateHero($input: HeroInput!) {
+    updateHero(input: $input) {
+      hero {
+        name
+        id
+      }
+    }
+  }
+`;
 
+it("works with Variables specified", () => {
   type Response = {
-    hero: Hero,
+    hero: Hero
   };
 
   type InputProps = {
-    episode: string,
+    episode: string
   };
 
   type Variables = {
-    episode: string,
+    episode: string
   };
 
   type Props = GraphqlData<Response, Variables> & {
-    someProp: string,
+    someProp: string
   };
 
   const withCharacter: OperationComponent<
@@ -172,7 +193,7 @@ it('works with Variables specified', () => {
       episode * 10;
       return {
         // $ExpectError [number] This type is incompatible with string
-        variables: { episode: 10 },
+        variables: { episode: 10 }
       };
     },
     props: ({ data, ownProps }) => ({
@@ -182,8 +203,8 @@ it('works with Variables specified', () => {
       // $ExpectError property `isHero`. Property not found on object type
       isHero: data && data.hero && data.hero.isHero,
       // $ExpectError Property `someProp`. This type is incompatible with string
-      someProp: 1,
-    }),
+      someProp: 1
+    })
   });
 
   withCharacter(({ loading, hero, error }) => {
@@ -203,7 +224,7 @@ it('works with Variables specified', () => {
   const CharacterWithData = withCharacter(Character);
 });
 
-it('works with withApollo HOC', () => {
+it("works with withApollo HOC", () => {
   const Manual = withApollo(({ client }) => {
     // XXX please don't ever actually do this
     client.query({ query: HERO_QUERY });
@@ -212,51 +233,476 @@ it('works with withApollo HOC', () => {
 
   // withApollo passes `client` property so that it is no longer required
   (Manual: React.ComponentType<{}>);
-})
+});
 
-describe('Query', () => {
-  it('works', () => {
-    type Vars = {|foo: string|}
-    type Res = {|res: string|}
-    const vars: Vars = {foo: 'bar'}
+type HeroQueryVariables = {
+  episode: string,
+  offset?: ?number
+};
+class HeroQueryComp extends Query<
+  { hero: ?Hero },
+  { episode: string, offset?: ?number }
+> {}
+
+describe("<Query />", () => {
+  it("works", () => {
+    type Vars = {| foo: string |};
+    type Res = {| res: string |};
+    const vars: Vars = { foo: "bar" };
     const q = (
       <Query variables={vars} query={HERO_QUERY}>
-        {({data}: QueryRenderProps<Res, Vars>) => {
+        {({ data }: QueryRenderProps<Res, Vars>) => {
           // $ExpectError Cannot get `data.res`
-          data.res
+          data.res;
           if (!data) {
-            return
+            return;
           }
-          const d1: Res | {||} = data
+          const d1: Res | {||} = data;
           // $ExpectError Cannot get `data.res` because property `res` is missing in object type
-          const s: string = data.res
+          const s: string = data.res;
           if (d1.res) {
-            const d2: Res = d1
-            const s: string = d1.res
+            const d2: Res = d1;
+            const s: string = d1.res;
           }
         }}
       </Query>
-    )
-  })
-})
+    );
+  });
 
-describe('Mutation', () => {
-  it('works', () => {
-    type Vars = {|foo: string|}
-    type Res = {|res: string|}
-    const vars: Vars = {foo: 'bar'}
+  it("works when extending Query with types", () => {
+    <HeroQueryComp query={HERO_QUERY} variables={{ episode: "episode" }}>
+      {({ data, loading, error }) => {
+        if (loading) return "Loading....";
+        if (error) return "Error!";
+        // $ExpectError Cannot get `data.hero`. data may be undefined
+        data.hero;
+        if (!data || !data.hero) {
+          return;
+        }
+        const hero = data.hero;
+
+        const nameAgain: string = hero.name;
+        // $ExpectError unknown is not a property on Hero
+        const unknown = hero.unknown;
+
+        return <div>{nameAgain}</div>;
+      }}
+    </HeroQueryComp>;
+  });
+
+  it("raises an error if accessing a prop in children function that doesnt exist", () => {
+    <HeroQueryComp query={HERO_QUERY} variables={{ episode: "episode" }}>
+      {// $ExpectError cannot render HeroQueryComp becuase errors is missing in children function (should be error instead of errors)
+      ({ data, loading, errors }) => {
+        if (loading) return "Loading....";
+        if (errors) return "Error!";
+        return String(data);
+      }}
+    </HeroQueryComp>;
+  });
+
+  describe("refetch", () => {
+    it("works if passed variablees that match the query", () => {
+      <HeroQueryComp query={HERO_QUERY} variables={{ episode: "episode" }}>
+        {({ data, refetch }) => {
+          const onClick = () => {
+            refetch();
+            refetch({ episode: "otherEpisode" });
+            // $ExpectError refetch variables do not match variables for query
+            refetch({ notEpisode: "otherEpisode" });
+          };
+          return <button onClick={onClick}>Click!</button>;
+        }}
+      </HeroQueryComp>;
+    });
+  });
+
+  describe("fetchMore", () => {
+    it("works when passed valid options", () => {
+      <HeroQueryComp query={HERO_QUERY} variables={{ episode: "episode" }}>
+        {({ data, fetchMore }) => {
+          const onClick = () => {
+            fetchMore({
+              variables: { episode: "episode2" },
+              updateQuery: (prev, options) => {
+                if (!options.fetchMoreResult) return prev;
+                return {
+                  hero: options.fetchMoreResult.hero
+                };
+              }
+            });
+
+            const variables: $Shape<HeroQueryVariables> = { offset: 1 };
+            fetchMore({
+              variables: variables,
+              updateQuery: (prev, options) => {
+                if (!options.fetchMoreResult) return prev;
+                return {
+                  hero: options.fetchMoreResult.hero
+                };
+              }
+            });
+
+            const otherVariables = { other: "1234" };
+            fetchMore({
+              query: OTHER_QUERY,
+              variables: otherVariables,
+              updateQuery: (prev, options) => {
+                if (!options.fetchMoreResult) return prev;
+                return {
+                  other: options.fetchMoreResult.other
+                };
+              }
+            });
+          };
+          return <button onClick={onClick}>Click!</button>;
+        }}
+      </HeroQueryComp>;
+    });
+
+    it("raises an error when passed invalid options", () => {
+      <HeroQueryComp query={HERO_QUERY} variables={{ episode: "episode" }}>
+        {({ data, fetchMore }) => {
+          const onClick = () => {
+            // $ExpectError variables must match $Shape of query variables
+            fetchMore({
+              variables: { other: "hello" },
+              updateQuery: (prev, options) => {
+                if (!options.fetchMoreResult) return prev;
+                return {
+                  hero: options.fetchMoreResult.hero
+                };
+              }
+            });
+
+            // $ExpectError must pass query option if passing different variables than query
+            fetchMore({
+              variables: { other: "1234" },
+              updateQuery: (prev, options) => {
+                if (!options.fetchMoreResult) return prev;
+                return {
+                  other: options.fetchMoreResult.other
+                };
+              }
+            });
+
+            fetchMore({
+              variables: { episode: "episode2" },
+              updateQuery: (prev, options) => {
+                if (!options.fetchMoreResult) return prev;
+                // $ExpectError updateQuery return type must match query response type
+                return {
+                  other: options.fetchMoreResult.hero
+                };
+              }
+            });
+          };
+          return <button onClick={onClick}>Click!</button>;
+        }}
+      </HeroQueryComp>;
+    });
+  });
+});
+
+type UpdateHeroMutationVariables = {
+  input: { id: string, name: string }
+};
+class UpdateHeroMutationComp extends Mutation<
+  { updateHero?: ?{ hero: ?Hero } },
+  UpdateHeroMutationVariables
+> {}
+
+describe("<Mutation />", () => {
+  it("works", () => {
+    type Vars = {| foo: string |};
+    type Res = {| res: string |};
+    const vars: Vars = { foo: "bar" };
     const q = (
       <Mutation variables={vars} mutation={HERO_QUERY}>
-        {(update: MutationFunction<Res, Vars>, {data}: MutationResult<Res>) => {
+        {(
+          update: MutationFunction<Res, Vars>,
+          { data }: MutationResult<Res>
+        ) => {
           // $ExpectError Cannot get `data.res`
-          data.res
+          data.res;
           if (!data) {
-            return
+            return;
           }
-          const d1: Res = data
-          const s: string = data.res
+          const d1: Res = data;
+          const s: string = data.res;
         }}
       </Mutation>
-    )
-  })
-})
+    );
+  });
+
+  it("works when extending Mutation with types", () => {
+    <UpdateHeroMutationComp mutation={HERO_MUTATION}>
+      {(updateHero, { loading, error, data, called }) => {
+        const onClick = () => {
+          updateHero({
+            variables: { input: { id: "1", name: "hero1" } }
+          });
+          // $ExpectError variables must match Mutation variables
+          updateHero({
+            variables: { id: "1", name: "hero1" }
+          });
+        };
+        return (
+          <div>
+            <button disabled={loading} onClick={onClick}>
+              Click
+            </button>
+            {error && error.message}
+          </div>
+        );
+      }}
+    </UpdateHeroMutationComp>;
+  });
+
+  describe("optimisticResponse", () => {
+    it("works when passed an optimisticResponse object", () => {
+      <UpdateHeroMutationComp mutation={HERO_MUTATION}>
+        {updateHero => {
+          const optimisticResponse = {
+            updateHero: {
+              __typename: "UpdateHeroPayload",
+              hero: {
+                __typename: "Hero",
+                name: "Hero1",
+                id: "1"
+              }
+            }
+          };
+          const onClick = () => {
+            updateHero({
+              optimisticResponse,
+              variables: { input: { id: "1", name: "hero1" } }
+            });
+
+            // $ExpectError optimisticResponse must be an object
+            updateHero({
+              optimisticResponse: "optimisticResponse",
+              variables: { input: { id: "1", name: "hero1" } }
+            });
+          };
+          return <button onClick={onClick}>Click</button>;
+        }}
+      </UpdateHeroMutationComp>;
+    });
+  });
+
+  describe("refetchQueries", () => {
+    it("works when passed refetchQueries to Mutation component", () => {
+      const queryOption = {
+        query: HERO_QUERY,
+        variables: { episode: "episode" }
+      };
+      const refetchQueries: PureQueryOptions[] = [queryOption];
+
+      <UpdateHeroMutationComp
+        mutation={HERO_MUTATION}
+        refetchQueries={refetchQueries}
+      >
+        {updateHero => {
+          const onClick = () => {
+            updateHero({
+              variables: { input: { id: "1", name: "hero1" } }
+            });
+          };
+          return <button onClick={onClick}>Click</button>;
+        }}
+      </UpdateHeroMutationComp>;
+
+      // $ExpectError refetchQueries must be an array of queries or a function that returns an array of queries
+      <UpdateHeroMutationComp
+        mutation={HERO_MUTATION}
+        refetchQueries={queryOption}
+      >
+        {updateHero => {
+          const onClick = () => {
+            updateHero({
+              variables: { input: { id: "1", name: "hero1" } }
+            });
+          };
+          return <button onClick={onClick}>Click</button>;
+        }}
+      </UpdateHeroMutationComp>;
+    });
+
+    it("works when passed refetchQueries to mutation function", () => {
+      <UpdateHeroMutationComp mutation={HERO_MUTATION}>
+        {updateHero => {
+          const onClick = () => {
+            const queryOption = {
+              query: HERO_QUERY,
+              variables: { episode: "episode" }
+            };
+            const refetchQueries: PureQueryOptions[] = [queryOption];
+            updateHero({
+              variables: { input: { id: "1", name: "hero1" } },
+              refetchQueries
+            });
+            updateHero({
+              variables: { input: { id: "1", name: "hero1" } },
+              refetchQueries: () => refetchQueries
+            });
+
+            updateHero({
+              variables: { input: { id: "1", name: "hero1" } },
+              // $ExpectError refetchQueries must be an array of queries or a function that returns an array of queries
+              refetchQueries: () => queryOption
+            });
+            // $ExpectError refetchQueries must be an array of queries or a function that returns an array of queries
+            updateHero({
+              variables: { input: { id: "1", name: "hero1" } },
+              refetchQueries: queryOption
+            });
+          };
+          return <button onClick={onClick}>Click</button>;
+        }}
+      </UpdateHeroMutationComp>;
+    });
+  });
+
+  describe("update", () => {
+    it("can manually update the cache after a mutation by passing update prop to the Mutation component", () => {
+      <UpdateHeroMutationComp
+        mutation={HERO_MUTATION}
+        update={(cache, { data }) => {
+          // $ExpectError data may be undefined
+          data.updateHero;
+          if (data && data.updateHero) {
+            const hero = cache.readQuery({
+              query: HERO_QUERY,
+              variables: { episoe: "episode" }
+            });
+            cache.writeQuery({
+              query: HERO_QUERY,
+              variables: { episode: "episode" },
+              data: { hero: data.updateHero }
+            });
+          }
+        }}
+      >
+        {updateHero => {
+          const onClick = () => {
+            updateHero({
+              variables: { input: { id: "1", name: "hero1" } }
+            });
+          };
+          return <button onClick={onClick}>Click</button>;
+        }}
+      </UpdateHeroMutationComp>;
+    });
+
+    it("can manually update the cache after a mutation using update on the mutation function", () => {
+      <UpdateHeroMutationComp mutation={HERO_MUTATION}>
+        {updateHero => {
+          const onClick = () => {
+            updateHero({
+              variables: { input: { id: "1", name: "hero1" } },
+              update: (cache, { data }) => {
+                // $ExpectError data may be undefined
+                data.updateHero;
+
+                if (data && data.updateHero) {
+                  const hero = cache.readQuery({
+                    query: HERO_QUERY,
+                    variables: { episoe: "episode" }
+                  });
+                  cache.writeQuery({
+                    query: HERO_QUERY,
+                    variables: { episode: "episode" },
+                    data: { hero: data.updateHero }
+                  });
+                  if (data.updateHero && data.updateHero.hero) {
+                    cache.writeFragment({
+                      id: "1",
+                      fragment: gql`
+                        fragment myHero on Hero {
+                          name
+                        }
+                      `,
+                      data: {
+                        name: data.updateHero.hero.name
+                      }
+                    });
+                  }
+
+                  // $ExpectError readQuery requires query
+                  cache.readQuery({
+                    variables: { episode: "episode" }
+                  });
+                  // $ExpectError writeQuery requires data
+                  cache.writeQuery({
+                    query: HERO_QUERY,
+                    variables: { episode: "episode" }
+                  });
+                  // $ExpectError writeFragment requires id
+                  cache.writeFragment({
+                    fragment: gql`
+                      fragment myHero on Hero {
+                        name
+                      }
+                    `,
+                    data: {
+                      name: "name"
+                    }
+                  });
+                  // $ExpectError cannot call unknownFunction on cache
+                  cache.unknwonFunction();
+                }
+              }
+            });
+          };
+          return <button onClick={onClick}>Click</button>;
+        }}
+      </UpdateHeroMutationComp>;
+    });
+  });
+});
+
+describe("<ApolloProvider />", () => {
+  it("works when passed client", () => {
+    // Should be an instance of ApolloClient
+    const client = {};
+    <ApolloProvider client={client}>
+      <div />
+    </ApolloProvider>;
+  });
+
+  it("raises an error when not passed a client", () => {
+    // $ExpectError ApolloPrivder requires client prop
+    <ApolloProvider>
+      <div />
+    </ApolloProvider>;
+  });
+
+  it("raises an error when not passed children", () => {
+    // Should be an instance of ApolloClient
+    const client = {};
+
+    // $ExpectError ApolloPrivder requires client prop
+    <ApolloProvider client={client} />;
+  });
+});
+
+describe("<ApolloConsumer />", () => {
+  it("passes ApolloClient to the consumer children", () => {
+    <ApolloConsumer>
+      {client => {
+        const onClick = () => {
+          client.resetStore();
+          client.query({ query: HERO_QUERY });
+          client.readQuery({
+            query: HERO_QUERY,
+            variables: { episode: "episode" }
+          });
+          // $ExpectError doSomethingElse is not a method of ApolloClient
+          client.doSomethingElse();
+        };
+        return <button onClick={onClick}>Click</button>;
+      }}
+    </ApolloConsumer>;
+  });
+});


### PR DESCRIPTION
- [x] Add some more tests
- [x] Resolve interop with the current react-apollo libdef. 

It seems that since the react-apollo libdef is importing types from apollo-client (which doesn't have types), even if I include this apollo-client libdef in my project, types that react-apollo imports end up getting clobbered to any. Either need to 

1. stop importing those types in react-apollo libdef or 
2. actually use the types added here.

Actually using the types is definitely the endgame, but might be a large effort that could be split to another PR.

