### PR TITLE
Export koa-bodyparser as a CommonJS module

### DIFF
--- a/definitions/npm/koa-bodyparser_v4.x.x/flow_v0.56.x-/koa-bodyparser_v4.x.x.js
+++ b/definitions/npm/koa-bodyparser_v4.x.x/flow_v0.56.x-/koa-bodyparser_v4.x.x.js
@@ -21,5 +21,5 @@ declare module "koa-bodyparser" {
     onerror?: (err: Error, ctx: Context) => void
   |};
 
-  declare export default function bodyParser(opts?: Options): Middleware;
+  declare module.exports: (opts?: Options) => Middleware;
 }

--- a/definitions/npm/koa-bodyparser_v4.x.x/flow_v0.56.x-/test_koa-bodyparser_v4.x.x.js
+++ b/definitions/npm/koa-bodyparser_v4.x.x/flow_v0.56.x-/test_koa-bodyparser_v4.x.x.js
@@ -14,3 +14,7 @@ bodyParser({ strict: true });
 // $ExpectError (Must use valid types for options)
 bodyParser({ formLimit: 56 });
 bodyParser({ formLimit: "56kb" });
+
+// Should work when requiring koa-bodyparser
+var requiredBodyParser = require('koa-bodyparser');
+requiredBodyParser();


### PR DESCRIPTION
This matches the codebase here better: https://github.com/koajs/bodyparser/blob/master/index.js#L28