### PR TITLE
Fixes for uuid: add v3, predefined namespaces

### DIFF
--- a/definitions/npm/uuid_v3.x.x/flow_v0.32.x-/uuid_v3.x.x.js
+++ b/definitions/npm/uuid_v3.x.x/flow_v0.32.x-/uuid_v3.x.x.js
@@ -49,6 +49,23 @@ declare module "uuid/v1" {
   declare module.exports: Class<v1>;
 }
 
+declare module "uuid/v3" {
+  declare class v3 {
+    static (
+      name?: string | number[],
+      namespace?: string | number[],
+      buffer?: number[] | Buffer,
+      offset?: number
+    ): string,
+
+     static name: string,
+     static DNS: string,
+     static URL: string
+  }
+
+  declare module.exports: Class<v3>;
+}
+
 declare module "uuid/v4" {
   declare class v4 {
     static (
@@ -71,7 +88,11 @@ declare module "uuid/v5" {
       namespace?: string | number[],
       buffer?: number[] | Buffer,
       offset?: number
-    ): string
+    ): string,
+
+     static name: string,
+     static DNS: string,
+     static URL: string
   }
 
   declare module.exports: Class<v5>;

--- a/definitions/npm/uuid_v3.x.x/test_uuid_v3.x.x.js
+++ b/definitions/npm/uuid_v3.x.x/test_uuid_v3.x.x.js
@@ -1,6 +1,7 @@
 // @flow
 import uuid from "uuid";
 import v1 from "uuid/v1";
+import v3 from "uuid/v3";
 import v4 from "uuid/v4";
 import v5 from "uuid/v5";
 
@@ -10,6 +11,7 @@ import v5 from "uuid/v5";
 
 (v1(): string);
 (v4(): string);
+(v3(): string);
 (v5(): string);
 
 uuid.v1({
@@ -34,6 +36,8 @@ v1({ yolo: true });
 uuid.v4({ yolo: true });
 // $ExpectError
 v4({ yolo: true });
+// $ExpectError
+v3({ yolo: true });
 // $ExpectError
 v5({ yolo: true });
 
@@ -145,8 +149,25 @@ v4({
   rng: () => "bla"
 });
 
+v3.name;
+v3("bla");
+v3("bla", "bla");
+v3("bla", v3.DNS);
+v3("bla", v3.URL);
+v3([0x10, 0x91, 0x56, 0xbe, 0xc4, 0xfb, 0xc1, 0xea]);
+v3(
+  [0x10, 0x91, 0x56, 0xbe, 0xc4, 0xfb, 0xc1, 0xea],
+  [0x71, 0xb4, 0xef, 0xe1, 0x67, 0x1c, 0x58, 0x36]
+);
+
+// $ExpectError
+v3("bla", { yolo: true });
+
+v5.name;
 v5("bla");
 v5("bla", "bla");
+v5("bla", v5.DNS);
+v5("bla", v5.URL);
 v5([0x10, 0x91, 0x56, 0xbe, 0xc4, 0xfb, 0xc1, 0xea]);
 v5(
   [0x10, 0x91, 0x56, 0xbe, 0xc4, 0xfb, 0xc1, 0xea],


### PR DESCRIPTION
First PR here, sorry if I do something wrong.

Flow is flagging valid uses like the following:
```
const uuidv5 = require('uuid/v5');

// ... using predefined DNS namespace (for domain names)
uuidv5('hello.example.com', uuidv5.DNS); // ⇨ 'fdda765f-fc57-5604-a269-52a7df8164ec'

// ... using predefined URL namespace (for, well, URLs)
uuidv5('http://example.com/hello', uuidv5.URL); // ⇨ '3bbcee75-cecc-5b56-8031-b6641c1ed1f1'
```

I added defs for DNS and URL as well as defs for v3.