### PR TITLE
[react-apollo] Move default type variable

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -261,13 +261,13 @@ declare module 'react-apollo' {
     context?: {[string]: any}
   }> {}
 
-  declare type SubscriptionResult<TData, TVariables> = {
+  declare type SubscriptionResult<TData, TVariables=void> = {
     loading: boolean,
     data?: TData,
     error?: ApolloError,
   }
 
-  declare type SubscriptionProps<TData, TVariables=void> = {
+  declare type SubscriptionProps<TData, TVariables> = {
     subscription: DocumentNode,
     variables?: TVariables,
     shouldResubscribe?: boolean | (SubscriptionProps<TData, TVariables>, SubscriptionProps<TData, TVariables>) => boolean,


### PR DESCRIPTION
By moving the type variable default definition the component becomes more usable.

Now we do not have to annotate the type of the variables, explicitly, in the child function, if they are not required.