### PR TITLE
fixed type defs for styled components v3

### DIFF
--- a/definitions/npm/styled-components_v3.x.x/flow_v0.57.x-/styled-components_v3.x.x.js
+++ b/definitions/npm/styled-components_v3.x.x/flow_v0.57.x-/styled-components_v3.x.x.js
@@ -326,26 +326,24 @@ type $npm$styledComponents$StyledComponentsNativeComponentList = {|
 |}
 
 declare module 'styled-components' {
-  declare type Interpolation                                              = $npm$styledComponents$Interpolation;
-  declare type NameGenerator                                              = $npm$styledComponents$NameGenerator;
-  declare type Theme                                                      = $npm$styledComponents$Theme;
-  declare type ThemeProviderProps                                         = $npm$styledComponents$ThemeProviderProps;
-  declare type TaggedTemplateLiteral<R>                                   = $npm$styledComponents$TaggedTemplateLiteral<R>;
-  declare type ComponentListKeys                                          = $npm$styledComponents$StyledComponentsComponentListKeys;
+  declare export type Interpolation                                              = $npm$styledComponents$Interpolation;
+  declare export type NameGenerator                                              = $npm$styledComponents$NameGenerator;
+  declare export type Theme                                                      = $npm$styledComponents$Theme;
+  declare export type ThemeProviderProps                                         = $npm$styledComponents$ThemeProviderProps;
+  declare export type TaggedTemplateLiteral<R>                                   = $npm$styledComponents$TaggedTemplateLiteral<R>;
+  declare export type ComponentListKeys                                          = $npm$styledComponents$StyledComponentsComponentListKeys;
 
-  declare type ReactComponentFunctional<Props: {}, DefaultProps: ?{} = *> = $npm$styledComponents$ReactComponentFunctional<Props, DefaultProps>;
-  declare type ReactComponentFunctionalUndefinedDefaultProps<Props: {}>   = $npm$styledComponents$ReactComponentFunctionalUndefinedDefaultProps<Props>;
-  declare type ReactComponentClass<Props: {}, DefaultProps: ?{} = *>      = $npm$styledComponents$ReactComponentClass<Props, DefaultProps>;
-  declare type ReactComponentClassUndefinedDefaultProps<Props: {}>        = $npm$styledComponents$ReactComponentClassUndefinedDefaultProps<Props>;
-  declare type ReactComponentUnion<Props>                                 = $npm$styledComponents$ReactComponentUnion<Props>;
-  declare type ReactComponentIntersection<Props>                          = $npm$styledComponents$ReactComponentIntersection<Props>;
-  declare type ReactComponentStyledStaticProps<Props>                     = $npm$styledComponents$ReactComponentStyledStaticPropsWithComponent<Props, ComponentListKeys>;
-  declare type ReactComponentStyled<Props>                                = $npm$styledComponents$ReactComponentStyled<Props, ComponentListKeys>;
-  declare type ReactComponentStyledTaggedTemplateLiteral<Props>           = $npm$styledComponents$ReactComponentStyledTaggedTemplateLiteralWithComponent<Props, ComponentListKeys>;
+  declare export type ReactComponentFunctional<Props: {}, DefaultProps: ?{} = *> = $npm$styledComponents$ReactComponentFunctional<Props, DefaultProps>;
+  declare export type ReactComponentFunctionalUndefinedDefaultProps<Props: {}>   = $npm$styledComponents$ReactComponentFunctionalUndefinedDefaultProps<Props>;
+  declare export type ReactComponentClass<Props: {}, DefaultProps: ?{} = *>      = $npm$styledComponents$ReactComponentClass<Props, DefaultProps>;
+  declare export type ReactComponentClassUndefinedDefaultProps<Props: {}>        = $npm$styledComponents$ReactComponentClassUndefinedDefaultProps<Props>;
+  declare export type ReactComponentUnion<Props>                                 = $npm$styledComponents$ReactComponentUnion<Props>;
+  declare export type ReactComponentIntersection<Props>                          = $npm$styledComponents$ReactComponentIntersection<Props>;
+  declare export type ReactComponentStyledStaticProps<Props>                     = $npm$styledComponents$ReactComponentStyledStaticPropsWithComponent<Props, ComponentListKeys>;
+  declare export type ReactComponentStyled<Props>                                = $npm$styledComponents$ReactComponentStyled<Props, ComponentListKeys>;
+  declare export type ReactComponentStyledTaggedTemplateLiteral<Props>           = $npm$styledComponents$ReactComponentStyledTaggedTemplateLiteralWithComponent<Props, ComponentListKeys>;
 
-  declare export var $call: $npm$styledComponents$Call<ComponentListKeys>;
   declare export var injectGlobal: TaggedTemplateLiteral<void>;
-  declare export var css: TaggedTemplateLiteral<Array<Interpolation>>;
   declare export var keyframes: TaggedTemplateLiteral<string>;
   declare export var withTheme: $npm$styledComponents$WithTheme;
   declare export var ServerStyleSheet: typeof Npm$StyledComponents$ServerStyleSheet;
@@ -353,6 +351,8 @@ declare module 'styled-components' {
   declare export var ThemeProvider: typeof Npm$StyledComponents$ThemeProvider;
 
   declare export default {
+    $call: $npm$styledComponents$Call<ComponentListKeys>,
+    css: TaggedTemplateLiteral<Array<Interpolation>>,
     ...$npm$styledComponents$StyledComponentsComponentList,
     ...$npm$styledComponents$StyledComponentsNativeComponentList,
   }
@@ -376,12 +376,12 @@ declare module 'styled-components/native' {
   declare type ReactComponentStyled<Props>                                = $npm$styledComponents$ReactComponentStyled<Props, NativeComponentListKeys>;
   declare type ReactComponentStyledTaggedTemplateLiteral<Props>           = $npm$styledComponents$ReactComponentStyledTaggedTemplateLiteralWithComponent<Props, NativeComponentListKeys>;
 
-  declare export var $call: $npm$styledComponents$Call<NativeComponentListKeys>;
-  declare export var css: TaggedTemplateLiteral<Array<Interpolation>>;
   declare export var keyframes: TaggedTemplateLiteral<string>;
   declare export var withTheme: $npm$styledComponents$WithTheme;
   declare export var ThemeProvider: typeof Npm$StyledComponents$ThemeProvider;
   declare export default {
+    $call: $npm$styledComponents$Call<NativeComponentListKeys>,
+    css: TaggedTemplateLiteral<Array<Interpolation>>,
     ...$npm$styledComponents$StyledComponentsNativeComponentList,
   }
 }

--- a/definitions/npm/styled-components_v3.x.x/flow_v0.57.x-/styled-components_v3.x.x.js
+++ b/definitions/npm/styled-components_v3.x.x/flow_v0.57.x-/styled-components_v3.x.x.js
@@ -343,20 +343,19 @@ declare module 'styled-components' {
   declare type ReactComponentStyled<Props>                                = $npm$styledComponents$ReactComponentStyled<Props, ComponentListKeys>;
   declare type ReactComponentStyledTaggedTemplateLiteral<Props>           = $npm$styledComponents$ReactComponentStyledTaggedTemplateLiteralWithComponent<Props, ComponentListKeys>;
 
-  declare module.exports: {
-    $call: $npm$styledComponents$Call<ComponentListKeys>,
+  declare export var $call: $npm$styledComponents$Call<ComponentListKeys>;
+  declare export var injectGlobal: TaggedTemplateLiteral<void>;
+  declare export var css: TaggedTemplateLiteral<Array<Interpolation>>;
+  declare export var keyframes: TaggedTemplateLiteral<string>;
+  declare export var withTheme: $npm$styledComponents$WithTheme;
+  declare export var ServerStyleSheet: typeof Npm$StyledComponents$ServerStyleSheet;
+  declare export var StyleSheetManager: typeof Npm$StyledComponents$StyleSheetManager;
+  declare export var ThemeProvider: typeof Npm$StyledComponents$ThemeProvider;
 
-    injectGlobal: TaggedTemplateLiteral<void>,
-    css: TaggedTemplateLiteral<Array<Interpolation>>,
-    keyframes: TaggedTemplateLiteral<string>,
-    withTheme: $npm$styledComponents$WithTheme,
-    ServerStyleSheet: typeof Npm$StyledComponents$ServerStyleSheet,
-    StyleSheetManager: typeof Npm$StyledComponents$StyleSheetManager,
-    ThemeProvider: typeof Npm$StyledComponents$ThemeProvider,
-
+  declare export default {
     ...$npm$styledComponents$StyledComponentsComponentList,
     ...$npm$styledComponents$StyledComponentsNativeComponentList,
-  };
+  }
 }
 
 declare module 'styled-components/native' {
@@ -377,14 +376,12 @@ declare module 'styled-components/native' {
   declare type ReactComponentStyled<Props>                                = $npm$styledComponents$ReactComponentStyled<Props, NativeComponentListKeys>;
   declare type ReactComponentStyledTaggedTemplateLiteral<Props>           = $npm$styledComponents$ReactComponentStyledTaggedTemplateLiteralWithComponent<Props, NativeComponentListKeys>;
 
-  declare module.exports: {
-    $call: $npm$styledComponents$Call<NativeComponentListKeys>,
-
-    css: TaggedTemplateLiteral<Array<Interpolation>>,
-    keyframes: TaggedTemplateLiteral<string>,
-    withTheme: $npm$styledComponents$WithTheme,
-    ThemeProvider: typeof Npm$StyledComponents$ThemeProvider,
-
+  declare export var $call: $npm$styledComponents$Call<NativeComponentListKeys>;
+  declare export var css: TaggedTemplateLiteral<Array<Interpolation>>;
+  declare export var keyframes: TaggedTemplateLiteral<string>;
+  declare export var withTheme: $npm$styledComponents$WithTheme;
+  declare export var ThemeProvider: typeof Npm$StyledComponents$ThemeProvider;
+  declare export default {
     ...$npm$styledComponents$StyledComponentsNativeComponentList,
-  };
+  }
 }


### PR DESCRIPTION
styled-components had issue with getting full flow coverage, specifically with default exported `style`.
https://github.com/styled-components/styled-components/issues/1321

This PR fixed default exported types for it, helping in achieving full coverage.
<img width="739" alt="screen shot 2018-05-09 at 12 18 45" src="https://user-images.githubusercontent.com/4706261/39794245-507cc51a-5384-11e8-8c10-e76aa566c965.png">
