### PR TITLE
Upgrade download flow

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -38,7 +38,8 @@
     "through": "^2.3.8",
     "unzipper": "^0.8.11",
     "which": "^1.3.0",
-    "yargs": "^4.2.0"
+    "yargs": "^4.2.0",
+    "yauzl-promise": "^2.1.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -36,7 +36,6 @@
     "semver": "^5.5.0",
     "table": "^4.0.2",
     "through": "^2.3.8",
-    "unzipper": "^0.8.11",
     "which": "^1.3.0",
     "yargs": "^4.2.0",
     "yauzl-promise": "^2.1.2"

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -351,7 +351,7 @@ async function runTests(
     const results = new Map();
     while (testGroups.length > 0) {
       const testGroup = testGroups.shift();
-      
+
       const testGroupErrors = await runTestGroup(
         repoDirPath,
         testGroup,

--- a/cli/src/commands/runTests.js
+++ b/cli/src/commands/runTests.js
@@ -321,7 +321,7 @@ async function runTests(
   repoDirPath: string,
   testPatterns: Array<string>,
   onlyChanged?: boolean,
-  numberOfFlowVersions: number,
+  flowBins: Array<Flow>,
 ): Promise<Map<string, Array<string>>> {
   const testPatternRes = testPatterns.map(patt => new RegExp(patt, 'g'));
   const testGroups = (await getTestGroups(repoDirPath, onlyChanged)).filter(
@@ -351,8 +351,7 @@ async function runTests(
     const results = new Map();
     while (testGroups.length > 0) {
       const testGroup = testGroups.shift();
-      const flowBins = await getFlowBinaries(BIN_DIR, numberOfFlowVersions);
-
+      
       const testGroupErrors = await runTestGroup(
         repoDirPath,
         testGroup,
@@ -431,11 +430,12 @@ export async function run(argv: Args): Promise<number> {
     );
   }
 
+  const flowBins = await getFlowBinaries(BIN_DIR, numberOfFlowVersions);
   const results = await runTests(
     repoDirPath,
     testPatterns,
     onlyChanged,
-    numberOfFlowVersions,
+    flowBins,
   );
   console.log(' ');
   Array.from(results).forEach(([testGroupName, errors]) => {

--- a/cli/src/lib/binaries.js
+++ b/cli/src/lib/binaries.js
@@ -1,0 +1,204 @@
+// @flow
+import {getGitHubClient} from './github';
+import {child_process} from './node';
+import os from 'os';
+import got from 'got';
+import semver from 'semver';
+import fs from 'fs-extra';
+import yauzl from 'yauzl-promise';
+import path from 'path';
+
+const githubClient = getGitHubClient();
+
+function getOsType() {
+  switch (os.type()) {
+    case 'Linux':
+      return 'linux64';
+    case 'Darwin':
+      return 'osx';
+    case 'Windows_NT':
+      return 'win64';
+
+    default:
+      throw new Error('Unsupported os.type()! ' + os.type());
+  }
+}
+
+const isWindows = os.type() === 'Windows_NT';
+export class Flow {
+  binPath: string;
+  version: string;
+
+  constructor(binPath: string) {
+    this.binPath = binPath;
+    // linux/macos flow bins has no ext
+    this.version = isWindows
+      ? path.parse(binPath).name
+      : path.parse(binPath).base;
+  }
+
+  runTests(
+    testDirPath: string,
+  ): Promise<{
+    stdErrOut: string,
+    errCode: ?number,
+    execError: ?Error,
+  }> {
+    return new Promise(res => {
+      const child = child_process.exec(
+        `${this.binPath} check --strip-root --all ${testDirPath}`,
+      );
+
+      let stdErrOut = '';
+      child.stdout.on('data', data => (stdErrOut += data));
+      child.stderr.on('data', data => (stdErrOut += data));
+
+      child.on('error', execError => {
+        res({stdErrOut, errCode: null, execError});
+      });
+
+      child.on('close', errCode => {
+        res({stdErrOut, errCode, execError: null});
+      });
+    });
+  }
+}
+
+function createBinFilename(binRoot, filename) {
+  return isWindows
+    ? path.resolve(binRoot, `${filename}.exe`)
+    : path.resolve(binRoot, filename);
+}
+
+async function extractZip(buffer, filepath, flowname) {
+  console.log(`Start unzipping '${flowname}' file`);
+  const zipFile = await yauzl.fromBuffer(buffer);
+  let entry = null;
+  while ((entry = await zipFile.readEntry())) {
+    if (entry.fileName.startsWith('flow/flow')) {
+      break;
+    }
+  }
+  if (!entry) {
+    throw new Error('flow binary not found in zip file');
+  }
+  const readStream = await zipFile.openReadStream(entry);
+  readStream.pipe(fs.createWriteStream(filepath));
+  await zipFile.close();
+  console.log(`'${flowname}' unzipped to cache`);
+}
+
+async function downloadBin(url, filepath, flowname) {
+  console.log(`start '${flowname}' downloading`);
+  const response = await got(url, {encoding: null});
+  console.log(`'${flowname}' downloaded`);
+  await extractZip(response.body, filepath, flowname);
+  if (!isWindows) {
+    await child_process.execP(`chmod 755 ${filepath}`);
+  }
+  return new Flow(filepath);
+}
+
+const osType = getOsType();
+function createFileName(version) {
+  return `flow-${osType}-${version}.zip`;
+}
+
+function getBinUrl(assets, version) {
+  const filename = createFileName(version);
+  for (const asset of assets) {
+    if (asset.name === filename) {
+      return asset.browser_download_url;
+    }
+  }
+}
+
+function filterActualVersions(releases, count, binRoot) {
+  function getKey(version) {
+    const major = semver.major(version);
+    const minor = semver.minor(version);
+    return `${major}.${minor}`;
+  }
+
+  return releases.reduce((res, release) => {
+    if (res.length === count) {
+      return res;
+    }
+    const key = getKey(release.tag_name);
+    return res.length && res[res.length - 1].key === key
+      ? res
+      : res.concat({
+          key: key,
+          version: release.tag_name,
+          filename: createBinFilename(binRoot, release.tag_name),
+          binUrl: getBinUrl(release.assets, release.tag_name),
+        });
+  }, []);
+}
+
+async function getActualVersions(count, binRoot) {
+  console.log('fetch data from github');
+  const dataFromGithub = await githubClient.repos.getReleases({
+    owner: 'facebook',
+    repo: 'flow',
+    page: 0,
+    per_page: 100,
+  });
+  console.log('data fetched');
+  return filterActualVersions(dataFromGithub.data, count, binRoot);
+}
+
+async function getCached(cacheLocation) {
+  console.log(`get data from cache`);
+  const files: Array<string> = await fs.readdir(cacheLocation);
+  return files.map(file => new Flow(path.resolve(cacheLocation, file)));
+}
+
+async function removeFile(binPath, filename) {
+  try {
+    await fs.unlink(binPath);
+    console.log(`${filename} removed from cache`);
+  } catch (_) {
+    console.error(`remove '${filename}' failed`);
+  }
+}
+
+function removeOutdatedVersionsFromCache(flows) {
+  return Promise.all(flows.map(f => removeFile(f.binPath, f.version)));
+}
+
+function downloadActualVersionsToCache(versions) {
+  return Promise.all(
+    versions.map(v => downloadBin(v.binUrl, v.filename, v.version)),
+  );
+}
+
+let memoizedFlowBinaries = null;
+export async function getFlowBinaries(binRoot: string, count: number) {
+  if (memoizedFlowBinaries) {
+    return memoizedFlowBinaries;
+  }
+  await fs.mkdirp(binRoot);
+
+  const [cached, actualVersions] = await Promise.all([
+    getCached(binRoot),
+    getActualVersions(count, binRoot),
+  ]);
+
+  const nonCachedVersions = actualVersions.filter(v =>
+    cached.every(c => c.version !== v.version),
+  );
+  const outdatedVersions = cached.filter(c =>
+    actualVersions.every(v => v.version !== c.version),
+  );
+
+  await Promise.all([
+    removeOutdatedVersionsFromCache(outdatedVersions),
+    downloadActualVersionsToCache(nonCachedVersions),
+  ]);
+
+  memoizedFlowBinaries = nonCachedVersions.length
+    ? await getCached(binRoot)
+    : cached;
+  return memoizedFlowBinaries;
+}

--- a/cli/src/lib/binaries.js
+++ b/cli/src/lib/binaries.js
@@ -70,6 +70,16 @@ function createBinFilename(binRoot, filename) {
     : path.resolve(binRoot, filename);
 }
 
+function saveFileFromStream(stream, filepath) {
+  return new Promise(res => {
+    stream.pipe(
+      fs.createWriteStream(filepath).on('close', () => {
+        res();
+      }),
+    );
+  });
+}
+
 async function extractZip(buffer, filepath, flowname) {
   console.log(`Start unzipping '${flowname}' file`);
   const zipFile = await yauzl.fromBuffer(buffer);
@@ -83,7 +93,7 @@ async function extractZip(buffer, filepath, flowname) {
     throw new Error('flow binary not found in zip file');
   }
   const readStream = await zipFile.openReadStream(entry);
-  readStream.pipe(fs.createWriteStream(filepath));
+  await saveFileFromStream(readStream, filepath);
   await zipFile.close();
   console.log(`'${flowname}' unzipped to cache`);
 }

--- a/cli/src/lib/github.js
+++ b/cli/src/lib/github.js
@@ -2,12 +2,36 @@
 
 import Octokit from '@octokit/rest';
 
-const CLIENT = new Octokit();
+type GetReleasesArgs = {
+  owner: string,
+  repo: string,
+  page: number,
+  per_page: number,
+};
+
+type Releases = {
+  data: $ReadOnlyArray<{
+    tag_name: string,
+    assets: $ReadOnlyArray<{
+      name: string,
+      browser_download_url: string,
+    }>,
+  }>,
+};
+
+type GitHubClient = {
+  repos: {
+    getReleases(args: GetReleasesArgs): Promise<Releases>,
+  },
+  authenticate(args: Object): void,
+};
+
+const CLIENT: GitHubClient = new Octokit();
 
 if (process.env.GH_TOK) {
   CLIENT.authenticate({type: 'oauth', token: process.env.GH_TOK});
 }
 
-export function gitHubClient(): Object {
+export function getGitHubClient() {
   return CLIENT;
 }

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -1094,6 +1094,10 @@ btoa-lite@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
 
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+
 buffer-indexof-polyfill@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz#a9fb806ce8145d5428510ce72f278bb363a638bf"
@@ -1652,6 +1656,10 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+events-intercept@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/events-intercept/-/events-intercept-2.0.0.tgz#adbf38681c5a4b2011c41ee41f61a34cba448897"
+
 exec-sh@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.0.tgz#14f75de3f20d286ef933099b2ce50a90359cef10"
@@ -1744,6 +1752,12 @@ fb-watchman@^2.0.0:
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
   dependencies:
     bser "^2.0.0"
+
+fd-slicer@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
+  dependencies:
+    pend "~1.2.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -3406,6 +3420,10 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -4559,3 +4577,23 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yauzl-clone@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/yauzl-clone/-/yauzl-clone-1.0.3.tgz#155ff4a64a2f3b888c22346c1e54a05fb922d98a"
+  dependencies:
+    events-intercept "^2.0.0"
+
+yauzl-promise@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yauzl-promise/-/yauzl-promise-2.1.2.tgz#fb65e1e87720ebc04d4dddc83887c580bd2c2192"
+  dependencies:
+    yauzl "^2.9.1"
+    yauzl-clone "^1.0.2"
+
+yauzl@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.9.1.tgz#a81981ea70a57946133883f029c5821a89359a7f"
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.0.1"

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -1009,30 +1009,15 @@ before-after-hook@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.1.0.tgz#83165e15a59460d13702cb8febd6a1807896db5a"
 
-big-integer@^1.6.17:
-  version "1.6.26"
-  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.26.tgz#3af1672fa62daf2d5ecafacf6e5aa0d25e02c1c8"
-
 binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
-
-binary@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
-  dependencies:
-    buffers "~0.1.1"
-    chainsaw "~0.1.0"
 
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
   dependencies:
     inherits "~2.0.0"
-
-bluebird@~3.4.1:
-  version "3.4.7"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
 
 boom@2.x.x:
   version "2.10.1"
@@ -1098,17 +1083,9 @@ buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
 
-buffer-indexof-polyfill@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz#a9fb806ce8145d5428510ce72f278bb363a638bf"
-
 buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
-
-buffers@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -1154,12 +1131,6 @@ center-align@^0.1.1:
   dependencies:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
-
-chainsaw@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
-  dependencies:
-    traverse ">=0.3.0 <0.4"
 
 chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -1484,12 +1455,6 @@ domexception@^1.0.0:
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
   dependencies:
     webidl-conversions "^4.0.2"
-
-duplexer2@~0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
-  dependencies:
-    readable-stream "^2.0.2"
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -2951,10 +2916,6 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-listenercount@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/listenercount/-/listenercount-1.0.1.tgz#84c8a72ab59c4725321480c975e6508342e70937"
-
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -3587,7 +3548,7 @@ readable-stream@^2.0.1, readable-stream@^2.1.4, readable-stream@^2.2.2:
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
-readable-stream@~2.1.4, readable-stream@~2.1.5:
+readable-stream@~2.1.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
   dependencies:
@@ -3895,10 +3856,6 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
 set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
-
-setimmediate@~1.0.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -4251,10 +4208,6 @@ tr46@^1.0.0:
   dependencies:
     punycode "^2.1.0"
 
-"traverse@>=0.3.0 <0.4":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
-
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
@@ -4311,20 +4264,6 @@ ultron@~1.1.0:
 universalify@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.0.tgz#9eb1c4651debcc670cc94f1a75762332bb967778"
-
-unzipper@^0.8.11:
-  version "0.8.11"
-  resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.8.11.tgz#894383dc6b4bdab944e446f665a82d40d167fbd4"
-  dependencies:
-    big-integer "^1.6.17"
-    binary "~0.3.0"
-    bluebird "~3.4.1"
-    buffer-indexof-polyfill "~1.0.0"
-    duplexer2 "~0.1.4"
-    fstream "~1.0.10"
-    listenercount "~1.0.1"
-    readable-stream "~2.1.5"
-    setimmediate "~1.0.4"
 
 url-parse-lax@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Changes:
1) Zip archives download to memory instead of disk. Only binary file writes to disk.
2) Downloaded only versions with latest patch. For example, 0.53.0, 0.53.1, 0.53.2 will be not checked. Only 0.53.3.
3) Total refactoring of download process.
