### PR TITLE
[react-apollo] Add defaults to type-variables on Subscription and Query

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -230,7 +230,7 @@ declare module 'react-apollo' {
     updateQuery: (previousResult: TData, {fetchMoreResult: TFetchMoreData, variables: TFetchMoreVariables}) => TData
   |}
 
-  declare export type QueryRenderProps<TData, TVariables=void> = {
+  declare export type QueryRenderProps<TData=any, TVariables=OperationVariables> = {
     data?: TData | {||},
     loading: boolean,
     error?: ApolloError,

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -268,7 +268,7 @@ declare module 'react-apollo' {
     error?: ApolloError,
   }
 
-  declare type SubscriptionProps<TData, TVariables> = {
+  declare type SubscriptionProps<TData=any, TVariables=OperationVariables> = {
     subscription: DocumentNode,
     variables?: TVariables,
     shouldResubscribe?: boolean | (SubscriptionProps<TData, TVariables>, SubscriptionProps<TData, TVariables>) => boolean,


### PR DESCRIPTION
Add type variable defaults to the `Subscription` and `Query` component props.