### PR TITLE
Add missing libdefs `client.connected` to redis_v2.x.x

### DIFF
--- a/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
+++ b/definitions/npm/redis_v2.x.x/flow_v0.34.x-/redis_v2.x.x.js
@@ -105,6 +105,7 @@ declare type $npm$redis$DelF = $npm$redis$DelWithArrayKeys
 
 declare module "redis" {
   declare class RedisClient extends events$EventEmitter mixins RedisClientPromisified {
+    connected: boolean,
     hmset: (
       key: string,
       map: {[key: string]: string},


### PR DESCRIPTION
http://redis.js.org/#extras-clientconnected

RedisClient has property `connected` tracking the state of the connection.