### PR TITLE
[reselect_v3.x.x] add other fields (recomputations, resultFunc, etc.) to selector types

### DIFF
--- a/definitions/npm/reselect_v3.x.x/flow_v0.47.x-/reselect_v3.x.x.js
+++ b/definitions/npm/reselect_v3.x.x/flow_v0.47.x-/reselect_v3.x.x.js
@@ -1,85 +1,93 @@
 declare module "reselect" {
-  declare type Selector<-TState, TProps, TResult> =
+  declare type InputSelector<-TState, TProps, TResult> =
     (state: TState, props: TProps, ...rest: any[]) => TResult
+
+  declare type OutputSelector<-TState, TProps, TResult> =
+    & InputSelector<TState, TProps, TResult>
+    & {
+      recomputations(): number,
+      resetRecomputations(): void,
+      resultFunc(state: TState, props: TProps, ...rest: Array<any>): TResult,
+    };
 
   declare type SelectorCreator = {
     <TState, TProps, TResult, T1>(
-      selector1: Selector<TState, TProps, T1>,
+      selector1: InputSelector<TState, TProps, T1>,
       resultFunc: (arg1: T1) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <TState, TProps, TResult, T1>(
-      selectors: [Selector<TState, TProps, T1>],
+      selectors: [InputSelector<TState, TProps, T1>],
       resultFunc: (arg1: T1) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
 
     <TState, TProps, TResult, T1, T2>(
-      selector1: Selector<TState, TProps, T1>,
-      selector2: Selector<TState, TProps, T2>,
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
       resultFunc: (arg1: T1, arg2: T2) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <TState, TProps, TResult, T1, T2>(
-      selectors: [Selector<TState, TProps, T1>, Selector<TState, TProps, T2>],
+      selectors: [InputSelector<TState, TProps, T1>, InputSelector<TState, TProps, T2>],
       resultFunc: (arg1: T1, arg2: T2) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
 
     <TState, TProps, TResult, T1, T2, T3>(
-      selector1: Selector<TState, TProps, T1>,
-      selector2: Selector<TState, TProps, T2>,
-      selector3: Selector<TState, TProps, T3>,
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
       resultFunc: (arg1: T1, arg2: T2, arg3: T3) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <TState, TProps, TResult, T1, T2, T3>(
       selectors: [
-        Selector<TState, TProps, T1>,
-        Selector<TState, TProps, T2>,
-        Selector<TState, TProps, T3>
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>
       ],
       resultFunc: (arg1: T1, arg2: T2, arg3: T3) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
 
     <TState, TProps, TResult, T1, T2, T3, T4>(
-      selector1: Selector<TState, TProps, T1>,
-      selector2: Selector<TState, TProps, T2>,
-      selector3: Selector<TState, TProps, T3>,
-      selector4: Selector<TState, TProps, T4>,
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
       resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <TState, TProps, TResult, T1, T2, T3, T4>(
       selectors: [
-        Selector<TState, TProps, T1>,
-        Selector<TState, TProps, T2>,
-        Selector<TState, TProps, T3>,
-        Selector<TState, TProps, T4>
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>
       ],
       resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
 
     <TState, TProps, TResult, T1, T2, T3, T4, T5>(
-      selector1: Selector<TState, TProps, T1>,
-      selector2: Selector<TState, TProps, T2>,
-      selector3: Selector<TState, TProps, T3>,
-      selector4: Selector<TState, TProps, T4>,
-      selector5: Selector<TState, TProps, T5>,
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
       resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <TState, TProps, TResult, T1, T2, T3, T4, T5>(
       selectors: [
-        Selector<TState, TProps, T1>,
-        Selector<TState, TProps, T2>,
-        Selector<TState, TProps, T3>,
-        Selector<TState, TProps, T4>,
-        Selector<TState, TProps, T5>
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>
       ],
       resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
 
     <TState, TProps, TResult, T1, T2, T3, T4, T5, T6>(
-      selector1: Selector<TState, TProps, T1>,
-      selector2: Selector<TState, TProps, T2>,
-      selector3: Selector<TState, TProps, T3>,
-      selector4: Selector<TState, TProps, T4>,
-      selector5: Selector<TState, TProps, T5>,
-      selector6: Selector<TState, TProps, T6>,
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
       resultFunc: (
         arg1: T1,
         arg2: T2,
@@ -88,15 +96,15 @@ declare module "reselect" {
         arg5: T5,
         arg6: T6
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <TState, TProps, TResult, T1, T2, T3, T4, T5, T6>(
       selectors: [
-        Selector<TState, TProps, T1>,
-        Selector<TState, TProps, T2>,
-        Selector<TState, TProps, T3>,
-        Selector<TState, TProps, T4>,
-        Selector<TState, TProps, T5>,
-        Selector<TState, TProps, T6>
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>
       ],
       resultFunc: (
         arg1: T1,
@@ -106,16 +114,16 @@ declare module "reselect" {
         arg5: T5,
         arg6: T6
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
 
     <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7>(
-      selector1: Selector<TState, TProps, T1>,
-      selector2: Selector<TState, TProps, T2>,
-      selector3: Selector<TState, TProps, T3>,
-      selector4: Selector<TState, TProps, T4>,
-      selector5: Selector<TState, TProps, T5>,
-      selector6: Selector<TState, TProps, T6>,
-      selector7: Selector<TState, TProps, T7>,
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
       resultFunc: (
         arg1: T1,
         arg2: T2,
@@ -125,16 +133,16 @@ declare module "reselect" {
         arg6: T6,
         arg7: T7
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7>(
       selectors: [
-        Selector<TState, TProps, T1>,
-        Selector<TState, TProps, T2>,
-        Selector<TState, TProps, T3>,
-        Selector<TState, TProps, T4>,
-        Selector<TState, TProps, T5>,
-        Selector<TState, TProps, T6>,
-        Selector<TState, TProps, T7>
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>
       ],
       resultFunc: (
         arg1: T1,
@@ -145,17 +153,17 @@ declare module "reselect" {
         arg6: T6,
         arg7: T7
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
 
     <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8>(
-      selector1: Selector<TState, TProps, T1>,
-      selector2: Selector<TState, TProps, T2>,
-      selector3: Selector<TState, TProps, T3>,
-      selector4: Selector<TState, TProps, T4>,
-      selector5: Selector<TState, TProps, T5>,
-      selector6: Selector<TState, TProps, T6>,
-      selector7: Selector<TState, TProps, T7>,
-      selector8: Selector<TState, TProps, T8>,
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
       resultFunc: (
         arg1: T1,
         arg2: T2,
@@ -166,17 +174,17 @@ declare module "reselect" {
         arg7: T7,
         arg8: T8
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8>(
       selectors: [
-        Selector<TState, TProps, T1>,
-        Selector<TState, TProps, T2>,
-        Selector<TState, TProps, T3>,
-        Selector<TState, TProps, T4>,
-        Selector<TState, TProps, T5>,
-        Selector<TState, TProps, T6>,
-        Selector<TState, TProps, T7>,
-        Selector<TState, TProps, T8>
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>
       ],
       resultFunc: (
         arg1: T1,
@@ -188,18 +196,18 @@ declare module "reselect" {
         arg7: T7,
         arg8: T8
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
 
     <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
-      selector1: Selector<TState, TProps, T1>,
-      selector2: Selector<TState, TProps, T2>,
-      selector3: Selector<TState, TProps, T3>,
-      selector4: Selector<TState, TProps, T4>,
-      selector5: Selector<TState, TProps, T5>,
-      selector6: Selector<TState, TProps, T6>,
-      selector7: Selector<TState, TProps, T7>,
-      selector8: Selector<TState, TProps, T8>,
-      selector9: Selector<TState, TProps, T9>,
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
       resultFunc: (
         arg1: T1,
         arg2: T2,
@@ -211,18 +219,18 @@ declare module "reselect" {
         arg8: T8,
         arg9: T9
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
       selectors: [
-        Selector<TState, TProps, T1>,
-        Selector<TState, TProps, T2>,
-        Selector<TState, TProps, T3>,
-        Selector<TState, TProps, T4>,
-        Selector<TState, TProps, T5>,
-        Selector<TState, TProps, T6>,
-        Selector<TState, TProps, T7>,
-        Selector<TState, TProps, T8>,
-        Selector<TState, TProps, T9>
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>
       ],
       resultFunc: (
         arg1: T1,
@@ -235,19 +243,19 @@ declare module "reselect" {
         arg8: T8,
         arg9: T9
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
 
     <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
-      selector1: Selector<TState, TProps, T1>,
-      selector2: Selector<TState, TProps, T2>,
-      selector3: Selector<TState, TProps, T3>,
-      selector4: Selector<TState, TProps, T4>,
-      selector5: Selector<TState, TProps, T5>,
-      selector6: Selector<TState, TProps, T6>,
-      selector7: Selector<TState, TProps, T7>,
-      selector8: Selector<TState, TProps, T8>,
-      selector9: Selector<TState, TProps, T9>,
-      selector10: Selector<TState, TProps, T10>,
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
+      selector10: InputSelector<TState, TProps, T10>,
       resultFunc: (
         arg1: T1,
         arg2: T2,
@@ -260,19 +268,19 @@ declare module "reselect" {
         arg9: T9,
         arg10: T10
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
       selectors: [
-        Selector<TState, TProps, T1>,
-        Selector<TState, TProps, T2>,
-        Selector<TState, TProps, T3>,
-        Selector<TState, TProps, T4>,
-        Selector<TState, TProps, T5>,
-        Selector<TState, TProps, T6>,
-        Selector<TState, TProps, T7>,
-        Selector<TState, TProps, T8>,
-        Selector<TState, TProps, T9>,
-        Selector<TState, TProps, T10>
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>,
+        InputSelector<TState, TProps, T10>
       ],
       resultFunc: (
         arg1: T1,
@@ -286,20 +294,20 @@ declare module "reselect" {
         arg9: T9,
         arg10: T10
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
 
     <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
-      selector1: Selector<TState, TProps, T1>,
-      selector2: Selector<TState, TProps, T2>,
-      selector3: Selector<TState, TProps, T3>,
-      selector4: Selector<TState, TProps, T4>,
-      selector5: Selector<TState, TProps, T5>,
-      selector6: Selector<TState, TProps, T6>,
-      selector7: Selector<TState, TProps, T7>,
-      selector8: Selector<TState, TProps, T8>,
-      selector9: Selector<TState, TProps, T9>,
-      selector10: Selector<TState, TProps, T10>,
-      selector11: Selector<TState, TProps, T11>,
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
+      selector10: InputSelector<TState, TProps, T10>,
+      selector11: InputSelector<TState, TProps, T11>,
       resultFunc: (
         arg1: T1,
         arg2: T2,
@@ -313,20 +321,20 @@ declare module "reselect" {
         arg10: T10,
         arg11: T11
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
       selectors: [
-        Selector<TState, TProps, T1>,
-        Selector<TState, TProps, T2>,
-        Selector<TState, TProps, T3>,
-        Selector<TState, TProps, T4>,
-        Selector<TState, TProps, T5>,
-        Selector<TState, TProps, T6>,
-        Selector<TState, TProps, T7>,
-        Selector<TState, TProps, T8>,
-        Selector<TState, TProps, T9>,
-        Selector<TState, TProps, T10>,
-        Selector<TState, TProps, T11>
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>,
+        InputSelector<TState, TProps, T10>,
+        InputSelector<TState, TProps, T11>
       ],
       resultFunc: (
         arg1: T1,
@@ -341,7 +349,7 @@ declare module "reselect" {
         arg10: T10,
         arg11: T11
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
 
     <
       TState,
@@ -360,18 +368,18 @@ declare module "reselect" {
       T11,
       T12
     >(
-      selector1: Selector<TState, TProps, T1>,
-      selector2: Selector<TState, TProps, T2>,
-      selector3: Selector<TState, TProps, T3>,
-      selector4: Selector<TState, TProps, T4>,
-      selector5: Selector<TState, TProps, T5>,
-      selector6: Selector<TState, TProps, T6>,
-      selector7: Selector<TState, TProps, T7>,
-      selector8: Selector<TState, TProps, T8>,
-      selector9: Selector<TState, TProps, T9>,
-      selector10: Selector<TState, TProps, T10>,
-      selector11: Selector<TState, TProps, T11>,
-      selector12: Selector<TState, TProps, T12>,
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
+      selector10: InputSelector<TState, TProps, T10>,
+      selector11: InputSelector<TState, TProps, T11>,
+      selector12: InputSelector<TState, TProps, T12>,
       resultFunc: (
         arg1: T1,
         arg2: T2,
@@ -386,7 +394,7 @@ declare module "reselect" {
         arg11: T11,
         arg12: T12
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <
       TState,
       TProps,
@@ -405,18 +413,18 @@ declare module "reselect" {
       T12
     >(
       selectors: [
-        Selector<TState, TProps, T1>,
-        Selector<TState, TProps, T2>,
-        Selector<TState, TProps, T3>,
-        Selector<TState, TProps, T4>,
-        Selector<TState, TProps, T5>,
-        Selector<TState, TProps, T6>,
-        Selector<TState, TProps, T7>,
-        Selector<TState, TProps, T8>,
-        Selector<TState, TProps, T9>,
-        Selector<TState, TProps, T10>,
-        Selector<TState, TProps, T11>,
-        Selector<TState, TProps, T12>
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>,
+        InputSelector<TState, TProps, T10>,
+        InputSelector<TState, TProps, T11>,
+        InputSelector<TState, TProps, T12>
       ],
       resultFunc: (
         arg1: T1,
@@ -432,7 +440,7 @@ declare module "reselect" {
         arg11: T11,
         arg12: T12
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
 
     <
       TState,
@@ -452,19 +460,19 @@ declare module "reselect" {
       T12,
       T13
     >(
-      selector1: Selector<TState, TProps, T1>,
-      selector2: Selector<TState, TProps, T2>,
-      selector3: Selector<TState, TProps, T3>,
-      selector4: Selector<TState, TProps, T4>,
-      selector5: Selector<TState, TProps, T5>,
-      selector6: Selector<TState, TProps, T6>,
-      selector7: Selector<TState, TProps, T7>,
-      selector8: Selector<TState, TProps, T8>,
-      selector9: Selector<TState, TProps, T9>,
-      selector10: Selector<TState, TProps, T10>,
-      selector11: Selector<TState, TProps, T11>,
-      selector12: Selector<TState, TProps, T12>,
-      selector13: Selector<TState, TProps, T13>,
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
+      selector10: InputSelector<TState, TProps, T10>,
+      selector11: InputSelector<TState, TProps, T11>,
+      selector12: InputSelector<TState, TProps, T12>,
+      selector13: InputSelector<TState, TProps, T13>,
       resultFunc: (
         arg1: T1,
         arg2: T2,
@@ -480,7 +488,7 @@ declare module "reselect" {
         arg12: T12,
         arg13: T13
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <
       TState,
       TProps,
@@ -500,19 +508,19 @@ declare module "reselect" {
       T13
     >(
       selectors: [
-        Selector<TState, TProps, T1>,
-        Selector<TState, TProps, T2>,
-        Selector<TState, TProps, T3>,
-        Selector<TState, TProps, T4>,
-        Selector<TState, TProps, T5>,
-        Selector<TState, TProps, T6>,
-        Selector<TState, TProps, T7>,
-        Selector<TState, TProps, T8>,
-        Selector<TState, TProps, T9>,
-        Selector<TState, TProps, T10>,
-        Selector<TState, TProps, T11>,
-        Selector<TState, TProps, T12>,
-        Selector<TState, TProps, T13>
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>,
+        InputSelector<TState, TProps, T10>,
+        InputSelector<TState, TProps, T11>,
+        InputSelector<TState, TProps, T12>,
+        InputSelector<TState, TProps, T13>
       ],
       resultFunc: (
         arg1: T1,
@@ -529,7 +537,7 @@ declare module "reselect" {
         arg12: T12,
         arg13: T13
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
 
     <
       TState,
@@ -550,20 +558,20 @@ declare module "reselect" {
       T13,
       T14
     >(
-      selector1: Selector<TState, TProps, T1>,
-      selector2: Selector<TState, TProps, T2>,
-      selector3: Selector<TState, TProps, T3>,
-      selector4: Selector<TState, TProps, T4>,
-      selector5: Selector<TState, TProps, T5>,
-      selector6: Selector<TState, TProps, T6>,
-      selector7: Selector<TState, TProps, T7>,
-      selector8: Selector<TState, TProps, T8>,
-      selector9: Selector<TState, TProps, T9>,
-      selector10: Selector<TState, TProps, T10>,
-      selector11: Selector<TState, TProps, T11>,
-      selector12: Selector<TState, TProps, T12>,
-      selector13: Selector<TState, TProps, T13>,
-      selector14: Selector<TState, TProps, T14>,
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
+      selector10: InputSelector<TState, TProps, T10>,
+      selector11: InputSelector<TState, TProps, T11>,
+      selector12: InputSelector<TState, TProps, T12>,
+      selector13: InputSelector<TState, TProps, T13>,
+      selector14: InputSelector<TState, TProps, T14>,
       resultFunc: (
         arg1: T1,
         arg2: T2,
@@ -580,7 +588,7 @@ declare module "reselect" {
         arg13: T13,
         arg14: T14
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <
       TState,
       TProps,
@@ -601,20 +609,20 @@ declare module "reselect" {
       T14
     >(
       selectors: [
-        Selector<TState, TProps, T1>,
-        Selector<TState, TProps, T2>,
-        Selector<TState, TProps, T3>,
-        Selector<TState, TProps, T4>,
-        Selector<TState, TProps, T5>,
-        Selector<TState, TProps, T6>,
-        Selector<TState, TProps, T7>,
-        Selector<TState, TProps, T8>,
-        Selector<TState, TProps, T9>,
-        Selector<TState, TProps, T10>,
-        Selector<TState, TProps, T11>,
-        Selector<TState, TProps, T12>,
-        Selector<TState, TProps, T13>,
-        Selector<TState, TProps, T14>
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>,
+        InputSelector<TState, TProps, T10>,
+        InputSelector<TState, TProps, T11>,
+        InputSelector<TState, TProps, T12>,
+        InputSelector<TState, TProps, T13>,
+        InputSelector<TState, TProps, T14>
       ],
       resultFunc: (
         arg1: T1,
@@ -632,7 +640,7 @@ declare module "reselect" {
         arg13: T13,
         arg14: T14
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
 
     <
       TState,
@@ -654,21 +662,21 @@ declare module "reselect" {
       T14,
       T15
     >(
-      selector1: Selector<TState, TProps, T1>,
-      selector2: Selector<TState, TProps, T2>,
-      selector3: Selector<TState, TProps, T3>,
-      selector4: Selector<TState, TProps, T4>,
-      selector5: Selector<TState, TProps, T5>,
-      selector6: Selector<TState, TProps, T6>,
-      selector7: Selector<TState, TProps, T7>,
-      selector8: Selector<TState, TProps, T8>,
-      selector9: Selector<TState, TProps, T9>,
-      selector10: Selector<TState, TProps, T10>,
-      selector11: Selector<TState, TProps, T11>,
-      selector12: Selector<TState, TProps, T12>,
-      selector13: Selector<TState, TProps, T13>,
-      selector14: Selector<TState, TProps, T14>,
-      selector15: Selector<TState, TProps, T15>,
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
+      selector10: InputSelector<TState, TProps, T10>,
+      selector11: InputSelector<TState, TProps, T11>,
+      selector12: InputSelector<TState, TProps, T12>,
+      selector13: InputSelector<TState, TProps, T13>,
+      selector14: InputSelector<TState, TProps, T14>,
+      selector15: InputSelector<TState, TProps, T15>,
       resultFunc: (
         arg1: T1,
         arg2: T2,
@@ -686,7 +694,7 @@ declare module "reselect" {
         arg14: T14,
         arg15: T15
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <
       TState,
       TProps,
@@ -708,21 +716,21 @@ declare module "reselect" {
       T15
     >(
       selectors: [
-        Selector<TState, TProps, T1>,
-        Selector<TState, TProps, T2>,
-        Selector<TState, TProps, T3>,
-        Selector<TState, TProps, T4>,
-        Selector<TState, TProps, T5>,
-        Selector<TState, TProps, T6>,
-        Selector<TState, TProps, T7>,
-        Selector<TState, TProps, T8>,
-        Selector<TState, TProps, T9>,
-        Selector<TState, TProps, T10>,
-        Selector<TState, TProps, T11>,
-        Selector<TState, TProps, T12>,
-        Selector<TState, TProps, T13>,
-        Selector<TState, TProps, T14>,
-        Selector<TState, TProps, T15>
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>,
+        InputSelector<TState, TProps, T10>,
+        InputSelector<TState, TProps, T11>,
+        InputSelector<TState, TProps, T12>,
+        InputSelector<TState, TProps, T13>,
+        InputSelector<TState, TProps, T14>,
+        InputSelector<TState, TProps, T15>
       ],
       resultFunc: (
         arg1: T1,
@@ -741,7 +749,7 @@ declare module "reselect" {
         arg14: T14,
         arg15: T15
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
 
     <
       TState,
@@ -764,22 +772,22 @@ declare module "reselect" {
       T15,
       T16
     >(
-      selector1: Selector<TState, TProps, T1>,
-      selector2: Selector<TState, TProps, T2>,
-      selector3: Selector<TState, TProps, T3>,
-      selector4: Selector<TState, TProps, T4>,
-      selector5: Selector<TState, TProps, T5>,
-      selector6: Selector<TState, TProps, T6>,
-      selector7: Selector<TState, TProps, T7>,
-      selector8: Selector<TState, TProps, T8>,
-      selector9: Selector<TState, TProps, T9>,
-      selector10: Selector<TState, TProps, T10>,
-      selector11: Selector<TState, TProps, T11>,
-      selector12: Selector<TState, TProps, T12>,
-      selector13: Selector<TState, TProps, T13>,
-      selector14: Selector<TState, TProps, T14>,
-      selector15: Selector<TState, TProps, T15>,
-      selector16: Selector<TState, TProps, T16>,
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
+      selector10: InputSelector<TState, TProps, T10>,
+      selector11: InputSelector<TState, TProps, T11>,
+      selector12: InputSelector<TState, TProps, T12>,
+      selector13: InputSelector<TState, TProps, T13>,
+      selector14: InputSelector<TState, TProps, T14>,
+      selector15: InputSelector<TState, TProps, T15>,
+      selector16: InputSelector<TState, TProps, T16>,
       resultFunc: (
         arg1: T1,
         arg2: T2,
@@ -798,7 +806,7 @@ declare module "reselect" {
         arg15: T15,
         arg16: T16
       ) => TResult
-    ): Selector<TState, TProps, TResult>,
+    ): OutputSelector<TState, TProps, TResult>,
     <
       TState,
       TProps,
@@ -821,22 +829,22 @@ declare module "reselect" {
       T16
     >(
       selectors: [
-        Selector<TState, TProps, T1>,
-        Selector<TState, TProps, T2>,
-        Selector<TState, TProps, T3>,
-        Selector<TState, TProps, T4>,
-        Selector<TState, TProps, T5>,
-        Selector<TState, TProps, T6>,
-        Selector<TState, TProps, T7>,
-        Selector<TState, TProps, T8>,
-        Selector<TState, TProps, T9>,
-        Selector<TState, TProps, T10>,
-        Selector<TState, TProps, T11>,
-        Selector<TState, TProps, T12>,
-        Selector<TState, TProps, T13>,
-        Selector<TState, TProps, T14>,
-        Selector<TState, TProps, T15>,
-        Selector<TState, TProps, T16>
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>,
+        InputSelector<TState, TProps, T10>,
+        InputSelector<TState, TProps, T11>,
+        InputSelector<TState, TProps, T12>,
+        InputSelector<TState, TProps, T13>,
+        InputSelector<TState, TProps, T14>,
+        InputSelector<TState, TProps, T15>,
+        InputSelector<TState, TProps, T16>
       ],
       resultFunc: (
         arg1: T1,
@@ -856,7 +864,7 @@ declare module "reselect" {
         arg15: T15,
         arg16: T16
       ) => TResult
-    ): Selector<TState, TProps, TResult>
+    ): OutputSelector<TState, TProps, TResult>
   };
 
   declare type Reselect = {
@@ -874,10 +882,10 @@ declare module "reselect" {
 
     createStructuredSelector: <TState, TProps>(
       inputSelectors: {
-        [k: string | number]: Selector<TState, TProps, any>
+        [k: string | number]: InputSelector<TState, TProps, any>
       },
       selectorCreator?: SelectorCreator
-    ) => Selector<TState, TProps, any>
+    ) => OutputSelector<TState, TProps, any>
   };
 
   declare module.exports: Reselect;

--- a/definitions/npm/reselect_v3.x.x/test_reselect_3.x.x.js
+++ b/definitions/npm/reselect_v3.x.x/test_reselect_3.x.x.js
@@ -184,3 +184,37 @@ createStructuredSelector({
   x: 10,
   y: 20
 });
+
+// TEST: Should pass for accessing selector recomputations
+createSelector(
+  (state: State, props: TestProps, test) => state.x + props.x + test,
+  (state: State, props: TestProps, test) => state.y + props.x + test,
+  (x, y) => {
+    return x + y;
+  }
+).recomputations() + 5;
+// END TEST
+
+// TEST: Should pass for reseting selector recomputations
+createSelector(
+  (state: State, props: TestProps, test) => state.x + props.x + test,
+  (state: State, props: TestProps, test) => state.y + props.x + test,
+  (x, y) => {
+    return x + y;
+  }
+).resetRecomputations();
+// END TEST
+
+// TEST: Should pass for accessing selector resultFunc
+createSelector(
+  (state: State, props: TestProps, test) => state.x + props.x + test,
+  (state: State, props: TestProps, test) => state.y + props.x + test,
+  (x, y) => {
+    return x + y;
+  }
+).resultFunc(
+  { x: 100, y: 200 },
+  {x: 10},
+  10,
+) + 15;
+// END TEST


### PR DESCRIPTION
This PR adds flow typing for the extra fields placed on selectors.

You can find these extra fields here: https://github.com/reduxjs/reselect/blob/master/src/index.js#L81-L83

They are also mentioned in the documentation.  For example: https://github.com/reduxjs/reselect#q-how-do-i-test-a-selector