### PR TITLE
[react-transition-group] Replace an interface with an object type

### DIFF
--- a/definitions/npm/react-transition-group_v2.x.x/flow_v0.60.x-/react-transition-group_v2.x.x.js
+++ b/definitions/npm/react-transition-group_v2.x.x/flow_v0.60.x-/react-transition-group_v2.x.x.js
@@ -18,7 +18,7 @@ declare module 'react-transition-group' {
   declare export type EnterHandler = (node: HTMLElement, isAppearing: boolean) => void;
   declare export type ExitHandler = (node: HTMLElement) => void;
 
-  declare interface TransitionActions {
+  declare type TransitionActions = {
     appear?: boolean;
     enter?: boolean;
     exit?: boolean;

--- a/definitions/npm/react-transition-group_v2.x.x/flow_v0.60.x-/react-transition-group_v2.x.x.js
+++ b/definitions/npm/react-transition-group_v2.x.x/flow_v0.60.x-/react-transition-group_v2.x.x.js
@@ -46,11 +46,8 @@ declare module 'react-transition-group' {
     children: ((status: TransitionStatus) => React$Node) | React$Node,
   }> {}
 
-  declare export class TransitionGroup extends React$Component<{
+  declare export class TransitionGroup extends React$Component<TransitionActions & {
     component?: React$ElementType | null,
-    appear?: boolean,
-    enter?: boolean,
-    exit?: boolean,
     children?: React$Node,
     childFactory?: (child: React$Node) => React$Node,
   }> {}

--- a/definitions/npm/react-transition-group_v2.x.x/test_react-transition-group.js
+++ b/definitions/npm/react-transition-group_v2.x.x/test_react-transition-group.js
@@ -52,6 +52,80 @@ describe('CSS/Transition', () => {
       // $ExpectError
       <Transition timeout={ 1 } />
     })
+
+    it('props should be compatible with other types with same structure', () => {
+      type WithTransitionProps = {
+        // props copied from Transition element config
+        mountOnEnter?: boolean,
+        unmountOnExit?: boolean,
+        appear?: boolean,
+        enter?: boolean,
+        exit?: boolean,
+        timeout: number,
+        addListener?: (node: HTMLElement, done: () => void) => void,
+        onEnter?: (node: HTMLElement, isAppearing: boolean) => void,
+        onEntering?: (node: HTMLElement, isAppearing: boolean) => void,
+        onEntered?: (node: HTMLElement, isAppearing: boolean) => void,
+        onExit?: (node: HTMLElement) => void,
+        onExiting?: (node: HTMLElement) => void,
+        onExited?: (node: HTMLElement) => void,
+        in?: boolean,
+
+        // custom props
+        children: React$Node,
+        getClassName(state: string): string
+      };
+
+      class WrapperComponent extends React.PureComponent<WithTransitionProps> {
+        render() {
+          const {
+            children,
+            mountOnEnter,
+            unmountOnExit,
+            appear,
+            enter,
+            exit,
+            timeout,
+            addListener,
+            onEnter,
+            onEntering,
+            onEntered,
+            onExit,
+            onExiting,
+            onExited,
+            in: transitionIn,
+            ...restProps
+          } = this.props;
+
+          return (
+            <Transition
+              in={transitionIn}
+              mountOnEnter={mountOnEnter}
+              unmountOnExit={unmountOnExit}
+              appear={appear}
+              enter={enter}
+              exit={exit}
+              timeout={timeout}
+              addListener={addListener}
+              onEnter={onEnter}
+              onEntering={onEntering}
+              onEntered={onEntered}
+              onExit={onExit}
+              onExited={onExited}
+              onExiting={onExiting}
+            >
+              {state => (
+                <div className={restProps.getClassName(state)}>
+                  {children}
+                </div>
+              )}
+            </Transition>
+          )
+        }
+      }
+
+      <WrapperComponent timeout={100} getClassName={state => `transition-${state}`}>Foobar</WrapperComponent>;
+    });
   })
 
   describe('CSSTransition', () => {


### PR DESCRIPTION
Looks like flow doesn't work well with interface and types intersections