### PR TITLE
Minor fix for formik's `handleSubmit` function

### DIFF
--- a/definitions/npm/formik_v0.11.x/flow_v0.53.x-/formik_v0.11.x.js
+++ b/definitions/npm/formik_v0.11.x/flow_v0.53.x-/formik_v0.11.x.js
@@ -155,7 +155,7 @@ declare module "formik" {
    */
   declare export type FormikHandlers = {
     /** Form submit handler */
-    handleSubmit: (e: SyntheticEvent<HTMLFormElement>) => any,
+    handleSubmit: (e: SyntheticEvent<any>) => any,
     /** Classic React change handler, keyed by input name */
     handleChange: (e: SyntheticEvent<any>) => any,
     /** Classic React blur handler */


### PR DESCRIPTION
The `handleSubmit` function in formik isn't always going to be attached to `<form onSubmit/>` element. It might be attached to a button (ie. `<button onClick={handleSubmit} />` or some custom component or whatever else. So we can't assume it's always going to be an `HTMLFormElement` in the event object.

@TLadd Any objections to this change? I noticed you made some large changes to this libdef last.