### PR TITLE
exposed class ApolloError

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -377,7 +377,7 @@ declare module "react-apollo" {
     [queryName: string]: MutationQueryReducer<T>
   };
 
-  declare class ApolloError extends Error {
+  declare export class ApolloError extends Error {
     message: string;
     graphQLErrors: Array<GraphQLError>;
     networkError: Error | null;


### PR DESCRIPTION
I need access to the `ApolloError` class in order to properly type my code.

```javascript
// @flow
import React, { Component } from 'react';
import type { Node } from 'react';
import type { ApolloError } from 'react-apollo';

type Props = {
  children: Node,
  loading: boolean,
  error?: ApolloError,
};
```