### PR TITLE
raven-js: Fix showReportDialog method to have optional options arg

### DIFF
--- a/definitions/npm/raven-js_v3.17.x/flow_v0.38.x-/raven-js_v3.17.x.js
+++ b/definitions/npm/raven-js_v3.17.x/flow_v0.38.x-/raven-js_v3.17.x.js
@@ -215,7 +215,14 @@ declare module "raven-js" {
     setShouldSendCallback(data: any, orig?: any): this,
 
     /** Show Sentry user feedback dialog */
-    showReportDialog(options: Object): void,
+    showReportDialog(options?: { 
+      eventId?: string, 
+      dsn?: string, 
+      user?: { 
+        name?: string, 
+        email?: string 
+      } 
+    }): void,
 
     /** Configure Raven DSN */
     setDSN(dsn: string): void

--- a/definitions/npm/raven-js_v3.17.x/test_raven-js.js
+++ b/definitions/npm/raven-js_v3.17.x/test_raven-js.js
@@ -1,22 +1,67 @@
-import raven from "raven-js";
+import Raven from "raven-js";
+import { it, describe } from "flow-typed-test";
 
-// $ExpectError
-raven.config();
+describe("raven-js", () => {
+  describe("Raven.config", () => {
+    it("works", () => {
+      Raven.config("dsn");
+      Raven.config("dsn", {});
+      Raven.config("dsn", {
+        level: "critical"
+      });
+      Raven.config("dsn").install();
 
-// $ExpectError
-raven.config(0, 0);
+      // $ExpectError - dsn argument is required
+      Raven.config();
 
-raven.config("dsn");
-raven.config("dsn", {});
-raven.config("dsn", {
-  level: "critical"
+      // $ExpectError - dsn argument must be a string
+      Raven.config(0);
+
+      // $ExpectError - high is not a valid level option
+      Raven.config("dsn", {
+        level: "high"
+      });
+
+      // $ExpectError - unknown is not a method on Raven
+      Raven.config("dsn").unknown();
+    });
+  });
+
+  describe("Raven.isSetup", () => {
+    it("works", () => {
+      const isSetup: boolean = Raven.isSetup();
+
+      // $ExpectError - Raven.isSetup returns a boolean
+      const isSetupString: string = Raven.isSetup();
+    });
+  });
+
+  describe("Raven.showReportDialog", () => {
+    it("works", () => {
+      Raven.showReportDialog();
+      Raven.showReportDialog({});
+      Raven.showReportDialog({
+        dsn: "dsn"
+      });
+      Raven.showReportDialog({
+        eventId: "eventId",
+        ddsn: "dsn",
+        user: {
+          name: "name",
+          email: "email"
+        }
+      });
+
+      // $ExpectError - eventId must be a string
+      Raven.showReportDialog({ eventId: 1 });
+
+      // $ExpectError - dsn must be a string
+      Raven.showReportDialog({ dsn: 1 });
+
+      // $ExpectError - user name must be a string
+      Raven.showReportDialog({
+        user: { name: { first: "first", last: "last" } }
+      });
+    });
+  });
 });
-
-// $ExpectError
-raven.config("dsn", {
-  level: "abc123"
-});
-
-raven.config("dsn").install();
-
-(raven.isSetup(): boolean);


### PR DESCRIPTION
The options argument to showReportDialog should be optional. As can be seen [here](https://github.com/getsentry/raven-js/blob/master/src/raven.js#L881), raven-js supplies a default if one is not provided. Can also see in the [docs](https://docs.sentry.io/clients/javascript/usage/#user-feedback) that the method is called without supplying an options argument. Typed out the object shape while I was there.