### PR TITLE
[apollo-client] Add extract and restore methods on ApolloClient

### DIFF
--- a/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
+++ b/definitions/npm/apollo-client_v2.x.x/flow_v0.57.x-/apollo-client_v2.x.x.js
@@ -455,6 +455,8 @@ declare module "apollo-client" {
     reFetchObservableQueries(
       includeStandby?: boolean
     ): Promise<ApolloQueryResult<any>[]> | Promise<null>;
+    extract(optimistic?: boolean): TCacheShape;
+    restore(serializedState: TCacheShape): ApolloCache<TCacheShape>;
   }
 
   /* apollo-link types */

--- a/definitions/npm/apollo-client_v2.x.x/test_apollo-client_v2.x.x.js
+++ b/definitions/npm/apollo-client_v2.x.x/test_apollo-client_v2.x.x.js
@@ -93,5 +93,20 @@ describe("apollo-client", () => {
         }
       });
     });
+
+    it("exposes extract", () => {
+      const client = new ApolloClient({
+        link,
+        cache
+      });
+      client.extract()
+    });
+    it("exposes restore", () => {
+      const client = new ApolloClient({
+        link,
+        cache
+      });
+      client.restore({})
+    });
   });
 });

--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -440,6 +440,8 @@ declare module "react-apollo" {
     reFetchObservableQueries(
       includeStandby?: boolean
     ): Promise<ApolloQueryResult<any>[]> | Promise<null>;
+    extract(optimistic?: boolean): TCacheShape;
+    restore(serializedState: TCacheShape): ApolloCache<TCacheShape>;
   }
 
   /* apollo-link types */


### PR DESCRIPTION
Add `extract` and `restore` methods

See https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/ApolloClient.ts#L442

@TLadd 