### PR TITLE
Add generic Function type to Jasmine Spy

### DIFF
--- a/definitions/npm/jasmine_v2.4.x/flow_v0.25.x-/jasmine_v2.4.x.js
+++ b/definitions/npm/jasmine_v2.4.x/flow_v0.25.x-/jasmine_v2.4.x.js
@@ -62,10 +62,12 @@ type JasmineSpyStrategyType = {
   throwError(errorMessage?: string): JasmineSpyType
 };
 
-type JasmineSpyType = {
+type JasmineSpyTypeProto = {
   and: JasmineSpyStrategyType,
   calls: JasmineCallsType
 };
+
+type JasmineSpyType = JasmineSpyTypeProto & Function;
 
 type JasmineClockType = {
   install(): void,


### PR DESCRIPTION
Currently, a JasmineSpyType cannot be passed in as a parameter where a function is expected.