### PR TITLE
Export more types in @sendgrid/mail

### DIFF
--- a/definitions/npm/@sendgrid/mail_v6.x.x/flow_v0.30.x-/mail_v6.x.x.js
+++ b/definitions/npm/@sendgrid/mail_v6.x.x/flow_v0.30.x-/mail_v6.x.x.js
@@ -1,6 +1,6 @@
 declare module '@sendgrid/mail' {
 
-  declare class ResponseError extends Error {
+  declare export class ResponseError extends Error {
     code: number;
     message: string;
     response: {
@@ -81,7 +81,7 @@ declare module '@sendgrid/mail' {
     };
   }
 
-  declare type EmailData = string | { name?: string; email: string; };
+  declare export type EmailData = string | { name?: string; email: string; };
 
   declare interface MailContent {
     type: string;


### PR DESCRIPTION
I needed to use these types inside of my app, so I figured that it would be a good idea to directly update the type definitions in Flow instead only in my own app.

Hope this helps.