### PR TITLE
Fix function declaration used with `$el.data("key")`

### DIFF
--- a/definitions/npm/jquery_v3.x.x/flow_v0.28.x-/jquery_v3.x.x.js
+++ b/definitions/npm/jquery_v3.x.x/flow_v0.28.x-/jquery_v3.x.x.js
@@ -1779,6 +1779,12 @@ declare class JQuery {
   clearQueue(queueName?: string): JQuery;
 
   /**
+   * Return the value: any at the named data store for the first element in the jQuery collection, as set by data(name, value) or by an HTML5 data-* attribute.
+   *
+   * @param key Name of the data stored.
+   */
+  data(key: string, _: void): any;
+  /**
    * Store arbitrary data associated with the matched elements.
    *
    * @param key A string naming the piece of data to set.
@@ -1793,12 +1799,6 @@ declare class JQuery {
   data(obj: {
     [key: string]: any
   }): JQuery;
-  /**
-   * Return the value: any at the named data store for the first element in the jQuery collection, as set by data(name, value) or by an HTML5 data-* attribute.
-   *
-   * @param key Name of the data stored.
-   */
-  data(key: string, _: void): any;
   /**
    * Return the value: any at the named data store for the first element in the jQuery collection, as set by data(name, value) or by an HTML5 data-* attribute.
    */


### PR DESCRIPTION
According to https://github.com/flowtype/flow-typed/issues/2160#issuecomment-386303024
The `data(key: string, _: void): any;` is more specific than `data(key: string, value: any): JQuery`
But flow is using `data(key: string, value: any): JQuery` anyway since it's on top

This commit reverse their positions to allow `data(key: string, _: void): any;` being used for expression like `$el.data("key")`