### PR TITLE
Add correct typings for CustomPicker HoC

### DIFF
--- a/definitions/npm/react-color_v2.x.x/flow_v0.56.x-/react-color_v2.x.x.js
+++ b/definitions/npm/react-color_v2.x.x/flow_v0.56.x-/react-color_v2.x.x.js
@@ -172,12 +172,14 @@ declare module "react-color/lib/components/common" {
     HexColor,
     RGBColor,
     HSLColor,
+    HSVColor,
     ColorChangeHandler
   } from "react-color";
 
   declare type PartialColorResult = {|
     hex?: HexColor,
     hsl?: HSLColor,
+    hsv?: HSVColor,
     rgb?: RGBColor
   |};
 

--- a/definitions/npm/react-color_v2.x.x/flow_v0.56.x-/react-color_v2.x.x.js
+++ b/definitions/npm/react-color_v2.x.x/flow_v0.56.x-/react-color_v2.x.x.js
@@ -8,6 +8,13 @@ declare module "react-color" {
     a?: number
   |};
 
+  declare export type HSVColor = {|
+    h: number,
+    s: number,
+    v: number,
+    a?: number
+  |};
+
   declare export type RGBColor = {|
     r: number,
     g: number,
@@ -15,11 +22,12 @@ declare module "react-color" {
     a?: number
   |};
 
-  declare export type Color = HexColor | HSLColor | RGBColor;
+  declare export type Color = HexColor | HSLColor | HSVColor | RGBColor;
 
   declare export type ColorResult = {|
     hex: HexColor,
     hsl: HSLColor,
+    hsv: HSVColor,
     rgb: RGBColor
   |};
 
@@ -131,16 +139,13 @@ declare module "react-color" {
   ) => void;
 
   declare export type InjectedColorProps = {
-    hex?: string,
-    hsl?: HSLColor,
-    rgb?: RGBColor,
-    onChange?: ColorWrapChangeHandler
-  };
-
-  declare export type ExportedColorProps = {
-    color?: Color,
-    onChange?: ColorChangeHandler,
-    onChangeComplete?: ColorChangeHandler
+    hex: string,
+    hsl: HSLColor,
+    hsv: HSVColor,
+    rgb: RGBColor,
+    oldHue: number,
+    onChange?: ColorWrapChangeHandler,
+    source: string
   };
 
   declare export class AlphaPicker extends React$Component<AlphaPickerProps> {}
@@ -157,9 +162,9 @@ declare module "react-color" {
   declare export class SwatchesPicker extends React$Component<SwatchesPickerProps> {}
   declare export class TwitterPicker extends React$Component<TwitterPickerProps> {}
 
-  declare export function CustomPicker<A>(
-    component: React$ComponentType<A & InjectedColorProps>
-  ): Class<A & ExportedColorProps>;
+  declare export function CustomPicker<Props: {}>(
+    Component: React$ComponentType<InjectedColorProps & $Supertype<Props>>
+  ): React$ComponentType<Props>;
 }
 
 declare module "react-color/lib/components/common" {

--- a/definitions/npm/react-color_v2.x.x/flow_v0.56.x-/test_react-color_v2.x.x.js
+++ b/definitions/npm/react-color_v2.x.x/flow_v0.56.x-/test_react-color_v2.x.x.js
@@ -1,4 +1,5 @@
-import React from "react";
+// @flow
+import * as React from "react";
 import { render } from "react-dom";
 import {
   AlphaPicker,
@@ -15,6 +16,7 @@ import {
   TwitterPicker,
   CustomPicker
 } from "react-color";
+import type { InjectedColorProps } from "react-color"
 import { EditableInput, Hue } from "react-color/lib/components/common";
 
 /**
@@ -125,40 +127,53 @@ render(<TwitterPicker colors={["#111", "#222"]} />, root);
  * Test custom picker
  */
 
-const MyPicker = CustomPicker(({ hex, hsl, onChange }) => {
-  const styles = {
-    hue: {
-      height: 10,
-      position: "relative",
-      marginBottom: 10
-    },
-    input: {
-      height: 34,
-      border: `1px solid ${hex}`,
-      paddingLeft: 10
-    },
-    swatch: {
-      width: 54,
-      height: 38,
-      background: hex
-    }
-  };
-  return (
-    <div>
-      <div style={styles.hue}>
-        {/* $ExpectError (hsl should be a valid HSL Object) */}
-        <Hue hsl="#ffffff" onChange={onChange} />
-        <Hue hsl={hsl} onChange={onChange} />
-      </div>
+type MyPickerProps = InjectedColorProps & { ownProp: boolean };
+const MyPicker = ({ hex, hsl, hsv, onChange }: MyPickerProps) => {
+ const styles = {
+   hue: {
+     height: 10,
+     position: "relative",
+     marginBottom: 10
+   },
+   input: {
+     height: 34,
+     border: `1px solid ${hex}`,
+     paddingLeft: 10
+   },
+   swatch: {
+     width: 54,
+     height: 38,
+     background: hex
+   }
+ };
+ // $ExpectError hsv is not string
+ const a = hsv.toUpperCase();
+ // $ExpectError hsl is not string
+ const b = hsl.toUpperCase();
+ const c = hex.toUpperCase();
+ return (
+   <div>
+     <div style={styles.hue}>
+       {/* $ExpectError (hsl should be a valid HSL Object) */}
+       <Hue hsl="#ffffff" onChange={onChange} />
+       {/* $ExpectError wrong type of onChange callback */}
+       <Hue hsl={hsl} onChange={(str: string) => {}} />
+       <Hue hsl={hsl} onChange={onChange} />
+     </div>
 
-      <div style={{ display: "flex" }}>
-        <EditableInput
-          style={{ input: styles.input }}
-          value={hex}
-          onChange={onChange}
-        />
-        <div style={styles.swatch} />
-      </div>
-    </div>
-  );
-});
+     <div style={{ display: "flex" }}>
+       <EditableInput
+         style={{ input: styles.input }}
+         value={hex}
+         onChange={onChange}
+       />
+       <div style={styles.swatch} />
+     </div>
+   </div>
+ );
+};
+
+const MyEnhancedPicker = CustomPicker(MyPicker);
+render(<MyEnhancedPicker ownProp={true} />, root);
+// $ExpectError ownProp is required
+render(<MyEnhancedPicker />, root);


### PR DESCRIPTION
I used [this](https://github.com/facebook/flow/issues/4759#issuecomment-327713650) as a guidance in writing the Hoc type annotations.

[This](https://github.com/casesandberg/react-color/blob/befb042d425e89d79c24c6611aa5bff9f2ab06a9/src/helpers/color.js#L30-L37) is what is injected by `CustomPicker`