### PR TITLE
socket.io-client: Add missing id definition

### DIFF
--- a/definitions/npm/socket.io-client_v2.x.x/flow_v0.34.x-/socket.io-client_v2.x.x.js
+++ b/definitions/npm/socket.io-client_v2.x.x/flow_v0.34.x-/socket.io-client_v2.x.x.js
@@ -48,6 +48,7 @@ declare module "socket.io-client" {
 
   declare export class Socket extends Emitter<Socket> {
     constructor(io: Manager, nsp: string, opts?: SocketOptions): Socket;
+    id: string;
     open(): Socket;
     connect(): Socket;
     send(...args: any[]): Socket;


### PR DESCRIPTION
For socket.io-client_v2.x.x