### PR TITLE
decimal.js-light: add v2.4.x libdefs

### DIFF
--- a/definitions/npm/decimal.js-light_v2.4.x/flow_v0.61.0-/decimal.js-light_v2.4.x.js
+++ b/definitions/npm/decimal.js-light_v2.4.x/flow_v0.61.0-/decimal.js-light_v2.4.x.js
@@ -1,0 +1,572 @@
+declare module 'decimal.js-light' {
+  declare type Numeric = string | number | Decimal;
+
+  declare type DecimalConfig = $Shape<{
+    precision: number;
+    rounding: number;
+    toExpNeg: number;
+    toExpPos: number;
+    LN10: Numeric;
+  }>;
+
+  declare class Decimal {
+    /**
+     * The Decimal constructor and exported function.
+     * Return a new Decimal instance.
+     *
+     * @param value {number|string|Decimal} A numeric value.
+     *
+     */
+    constructor(value: Numeric): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the absolute value of this Decimal.
+     */
+    absoluteValue(): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the absolute value of this Decimal.
+     */
+    abs(): Decimal;
+
+    /**
+     * Return
+     *   1    if the value of this Decimal is greater than the value of `y`,
+     *  -1    if the value of this Decimal is less than the value of `y`,
+     *   0    if they have the same value
+     */
+    comparedTo(y: Numeric): 1 | 0 | -1;
+
+    /**
+     * Return
+     *   1    if the value of this Decimal is greater than the value of `y`,
+     *  -1    if the value of this Decimal is less than the value of `y`,
+     *   0    if they have the same value
+     */
+    cmp(y: Numeric): 1 | 0 | -1;
+
+    /**
+     * Return the number of decimal places of the value of this Decimal.
+     */
+    decimalPlaces(): number;
+
+    /**
+     * Return the number of decimal places of the value of this Decimal.
+     */
+    dp(): number;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal divided by `y`, truncated to
+     * `precision` significant digits.
+     *
+     */
+    dividedBy(y: Numeric): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal divided by `y`, truncated to
+     * `precision` significant digits.
+     *
+     */
+    div(y: Numeric): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the integer part of dividing the value of this Decimal
+     * by the value of `y`, truncated to `precision` significant digits.
+     *
+     */
+    dividedToIntegerBy(y: Numeric): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the integer part of dividing the value of this Decimal
+     * by the value of `y`, truncated to `precision` significant digits.
+     *
+     */
+    idiv(y: Numeric): Decimal;
+
+    /**
+     * Return true if the value of this Decimal is equal to the value of `y`, otherwise return false.
+     */
+    equals(y: Numeric): boolean;
+
+    /**
+     * Return true if the value of this Decimal is equal to the value of `y`, otherwise return false.
+     */
+    eq(y: Numeric): boolean;
+
+    /**
+     * Return the (base 10) exponent value of this Decimal (this.e is the base 10000000 exponent).
+     */
+    exponent(): number;
+
+    /**
+     * Return true if the value of this Decimal is greater than the value of `y`, otherwise return
+     * false.
+     */
+    greaterThan(y: Numeric): boolean;
+
+    /**
+     * Return true if the value of this Decimal is greater than the value of `y`, otherwise return
+     * false.
+     */
+    gt(y: Numeric): boolean;
+
+    /**
+     * Return true if the value of this Decimal is greater than or equal to the value of `y`,
+     * otherwise return false.
+     *
+     */
+    greaterThanOrEqualTo(y: Numeric): boolean;
+
+    /**
+     * Return true if the value of this Decimal is greater than or equal to the value of `y`,
+     * otherwise return false.
+     *
+     */
+    gte(y: Numeric): boolean;
+
+    /**
+     * Return true if the value of this Decimal is an integer, otherwise return false.
+     *
+     */
+    isInteger(): boolean;
+
+    /**
+     * Return true if the value of this Decimal is an integer, otherwise return false.
+     *
+     */
+    isint(): boolean;
+
+    /**
+     * Return true if the value of this Decimal is negative, otherwise return false.
+     *
+     */
+    isNegative(): boolean;
+
+    /**
+     * Return true if the value of this Decimal is negative, otherwise return false.
+     *
+     */
+    isneg(): boolean;
+
+    /**
+     * Return true if the value of this Decimal is positive, otherwise return false.
+     *
+     */
+    isPositive(): boolean;
+
+    /**
+     * Return true if the value of this Decimal is positive, otherwise return false.
+     *
+     */
+    ispos(): boolean;
+
+    /**
+     * Return true if the value of this Decimal is 0, otherwise return false.
+     *
+     */
+    isZero(): boolean;
+
+    /**
+     * Return true if the value of this Decimal is less than `y`, otherwise return false.
+     *
+     */
+    lessThan(y: Numeric): boolean;
+
+    /**
+     * Return true if the value of this Decimal is less than `y`, otherwise return false.
+     *
+     */
+    lt(y: Numeric): boolean;
+
+    /**
+     * Return true if the value of this Decimal is less than or equal to `y`, otherwise return false.
+     *
+     */
+    lessThanOrEqualTo(y: Numeric): boolean;
+
+    /**
+     * Return true if the value of this Decimal is less than or equal to `y`, otherwise return false.
+     *
+     */
+    lte(y: Numeric): boolean;
+
+    /**
+     * Return the logarithm of the value of this Decimal to the specified base, truncated to
+     * `precision` significant digits.
+     *
+     * If no base is specified, return log[10](x).
+     *
+     * log[base](x) = ln(x) / ln(base)
+     *
+     * The maximum error of the result is 1 ulp (unit in the last place).
+     *
+     */
+    logarithm(base?: Numeric): Decimal;
+
+    /**
+     * Return the logarithm of the value of this Decimal to the specified base, truncated to
+     * `precision` significant digits.
+     *
+     * If no base is specified, return log[10](x).
+     *
+     * log[base](x) = ln(x) / ln(base)
+     *
+     * The maximum error of the result is 1 ulp (unit in the last place).
+     *
+     */
+    log(base?: Numeric): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal minus `y`, truncated to
+     * `precision` significant digits.
+     *
+     */
+    minus(y: Numeric): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal minus `y`, truncated to
+     * `precision` significant digits.
+     *
+     */
+    sub(y: Numeric): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal modulo `y`, truncated to
+     * `precision` significant digits.
+     *
+     */
+    modulo(y: Numeric): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal modulo `y`, truncated to
+     * `precision` significant digits.
+     *
+     */
+    mod(y: Numeric): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the natural exponential of the value of this Decimal,
+     * i.e. the base e raised to the power the value of this Decimal, truncated to `precision`
+     * significant digits.
+     *
+     */
+    naturalExponetial(): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the natural exponential of the value of this Decimal,
+     * i.e. the base e raised to the power the value of this Decimal, truncated to `precision`
+     * significant digits.
+     *
+     */
+    exp(): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the natural logarithm of the value of this Decimal,
+     * truncated to `precision` significant digits.
+     *
+     */
+    naturalLogarithm(): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the natural logarithm of the value of this Decimal,
+     * truncated to `precision` significant digits.
+     *
+     */
+    ln(): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal negated, i.e. as if multiplied by
+     * -1.
+     *
+     */
+    negated(): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal negated, i.e. as if multiplied by
+     * -1.
+     *
+     */
+    neg(): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal plus `y`, truncated to
+     * `precision` significant digits.
+     *
+     */
+    plus(y: Numeric): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal plus `y`, truncated to
+     * `precision` significant digits.
+     *
+     */
+    add(y: Numeric): Decimal;
+
+    /**
+     * Return the number of significant digits of the value of this Decimal.
+     *
+     * @param zeros {boolean|number} Whether to count integer-part trailing zeros: true, false, 1 or 0.
+     */
+    precision(zeros: boolean | number): number;
+
+    /**
+     * Return the number of significant digits of the value of this Decimal.
+     *
+     * @param zeros {boolean|number} Whether to count integer-part trailing zeros: true, false, 1 or 0.
+     */
+    sd(zeros: boolean | number): number;
+
+    /**
+     * Return a new Decimal whose value is the square root of this Decimal, truncated to `precision`
+     * significant digits.
+     *
+     */
+    squareRoot(): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the square root of this Decimal, truncated to `precision`
+     * significant digits.
+     *
+     */
+    sqrt(): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal times `y`, truncated to
+     * `precision` significant digits.
+     *
+     */
+    times(y: Numeric): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal times `y`, truncated to
+     * `precision` significant digits.
+     *
+     */
+    mul(y: Numeric): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal rounded to a maximum of `dp`
+     * decimal places using rounding mode `rm` or `rounding` if `rm` is omitted.
+     *
+     * If `dp` is omitted, return a new Decimal whose value is the value of this Decimal.
+     *
+     * @param dp {number} Decimal places. Integer, 0 to MAX_DIGITS inclusive.
+     * @param rm {number} Rounding mode. Integer, 0 to 8 inclusive.
+     *
+     */
+    toDecimalPlaces(dp?: number, rm?: number): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal rounded to a maximum of `dp`
+     * decimal places using rounding mode `rm` or `rounding` if `rm` is omitted.
+     *
+     * If `dp` is omitted, return a new Decimal whose value is the value of this Decimal.
+     *
+     * @param dp {number} Decimal places. Integer, 0 to MAX_DIGITS inclusive.
+     * @param rm {number} Rounding mode. Integer, 0 to 8 inclusive.
+     *
+     */
+    todp(dp?: number, rm?: number): Decimal;
+
+    /**
+     * Return a string representing the value of this Decimal in exponential notation rounded to
+     * `dp` fixed decimal places using rounding mode `rounding`.
+     *
+     * @param dp {number} Decimal places. Integer, 0 to MAX_DIGITS inclusive.
+     * @param rm {number} Rounding mode. Integer, 0 to 8 inclusive.
+     *
+     */
+    toExponential(dp?: number, rm?: number): string;
+
+    /**
+     * Return a string representing the value of this Decimal in normal (fixed-point) notation to
+     * `dp` fixed decimal places and rounded using rounding mode `rm` or `rounding` if `rm` is
+     * omitted.
+     *
+     * As with JavaScript numbers, (-0).toFixed(0) is '0', but e.g. (-0.00001).toFixed(0) is '-0'.
+     *
+     * @param dp {number} Decimal places. Integer, 0 to MAX_DIGITS inclusive.
+     * @param rm {number} Rounding mode. Integer, 0 to 8 inclusive.
+     *
+     * (-0).toFixed(0) is '0', but (-0.1).toFixed(0) is '-0'.
+     * (-0).toFixed(1) is '0.0', but (-0.01).toFixed(1) is '-0.0'.
+     * (-0).toFixed(3) is '0.000'.
+     * (-0.5).toFixed(0) is '-0'.
+     *
+     */
+    toFixed(dp?: number, rm?: number): string;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal rounded to a whole number using
+     * rounding mode `rounding`.
+     *
+     */
+    toInteger(): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal rounded to a whole number using
+     * rounding mode `rounding`.
+     *
+     */
+    toint(): Decimal;
+
+    /**
+     * Return the value of this Decimal converted to a number primitive.
+     *
+     */
+    toNumber(): number;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal raised to the power `y`,
+     * truncated to `precision` significant digits.
+     *
+     * For non-integer or very large exponents pow(x, y) is calculated using
+     *
+     *   x^y = exp(y*ln(x))
+     *
+     * The maximum error is 1 ulp (unit in last place).
+     *
+     * @param y {number|string|Decimal} The power to which to raise this Decimal.
+     *
+     */
+    toPower(y: Numeric): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal raised to the power `y`,
+     * truncated to `precision` significant digits.
+     *
+     * For non-integer or very large exponents pow(x, y) is calculated using
+     *
+     *   x^y = exp(y*ln(x))
+     *
+     * The maximum error is 1 ulp (unit in last place).
+     *
+     * @param y {number|string|Decimal} The power to which to raise this Decimal.
+     *
+     */
+    pow(y: Numeric): Decimal;
+
+    /**
+     * Return a string representing the value of this Decimal rounded to `sd` significant digits
+     * using rounding mode `rounding`.
+     *
+     * Return exponential notation if `sd` is less than the number of digits necessary to represent
+     * the integer part of the value in normal notation.
+     *
+     * @param sd {number} Significant digits. Integer, 1 to MAX_DIGITS inclusive.
+     * @param rm {number} Rounding mode. Integer, 0 to 8 inclusive.
+     *
+     */
+    toPrecision(sd?: number, rm?: number): string;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal rounded to a maximum of `sd`
+     * significant digits using rounding mode `rm`, or to `precision` and `rounding` respectively if
+     * omitted.
+     *
+     * @param sd {number} Significant digits. Integer, 1 to MAX_DIGITS inclusive.
+     * @param rm {number} Rounding mode. Integer, 0 to 8 inclusive.
+     *
+     */
+    toSignificantDigits(sd?: number, rm?: number): Decimal;
+
+    /**
+     * Return a new Decimal whose value is the value of this Decimal rounded to a maximum of `sd`
+     * significant digits using rounding mode `rm`, or to `precision` and `rounding` respectively if
+     * omitted.
+     *
+     * @param sd {number} Significant digits. Integer, 1 to MAX_DIGITS inclusive.
+     * @param rm {number} Rounding mode. Integer, 0 to 8 inclusive.
+     *
+     */
+    tosd(sd?: number, rm?: number): Decimal;
+
+    /**
+     * Return a string representing the value of this Decimal.
+     *
+     * Return exponential notation if this Decimal has a positive exponent equal to or greater than
+     * `toExpPos`, or a negative exponent equal to or less than `toExpNeg`.
+     *
+     */
+    toString(): string;
+
+    /**
+     * Return a string representing the value of this Decimal.
+     *
+     * Return exponential notation if this Decimal has a positive exponent equal to or greater than
+     * `toExpPos`, or a negative exponent equal to or less than `toExpNeg`.
+     *
+     */
+    valueOf(): string;
+
+    /**
+     * Return a string representing the value of this Decimal.
+     *
+     * Return exponential notation if this Decimal has a positive exponent equal to or greater than
+     * `toExpPos`, or a negative exponent equal to or less than `toExpNeg`.
+     *
+     */
+    val(): string;
+
+    /**
+     * Return a string representing the value of this Decimal.
+     *
+     * Return exponential notation if this Decimal has a positive exponent equal to or greater than
+     * `toExpPos`, or a negative exponent equal to or less than `toExpNeg`.
+     *
+     */
+    toJSON(): string;
+
+    /**
+     * Create and return a Decimal constructor with the same configuration properties as this Decimal
+     * constructor.
+     *
+     * @param config? DecimalConfig
+     */
+    static clone(config?: DecimalConfig): typeof Decimal;
+
+    /**
+     * Configure global settings for a Decimal constructor.
+     */
+    static config(config: DecimalConfig): Decimal;
+
+    /**
+     * Configure global settings for a Decimal constructor.
+     */
+    static set(config: DecimalConfig): Decimal;
+
+    // The maximum number of significant digits of the result of a calculation or base conversion.
+    // E.g. `Decimal.config({ precision: 20 });`
+    static precision: number;
+
+    // The rounding mode used by default by `toInteger`, `toDecimalPlaces`, `toExponential`,
+    // `toFixed`, `toPrecision` and `toSignificantDigits`.
+    //
+    // E.g.
+    // `Decimal.rounding = 4;`
+    // `Decimal.rounding = Decimal.ROUND_HALF_UP;`
+    static rounding: number;
+    static +ROUND_UP: number;
+    static +ROUND_DOWN: number;
+    static +ROUND_CEIL: number;
+    static +ROUND_FLOOR: number;
+    static +ROUND_HALF_UP: number;
+    static +ROUND_HALF_DOWN: number;
+    static +ROUND_HALF_EVEN: number;
+    static +ROUND_HALF_CEIL: number;
+    static +ROUND_HALF_FLOOR: number;
+
+    // The exponent value at and beneath which `toString` returns exponential notation.
+    // JavaScript numbers: -7
+    static toExpNeg: number; // 0 to -MAX_E
+
+    // The exponent value at and above which `toString` returns exponential notation.
+    // JavaScript numbers: 21
+    static toExpPos: number;// 0 to MAX_E
+
+    // The natural logarithm of 10.
+    static LN10: Decimal;
+  }
+
+  declare module.exports: typeof Decimal;
+}

--- a/definitions/npm/decimal.js-light_v2.4.x/test_decimal.js-light_v2.4.x.js
+++ b/definitions/npm/decimal.js-light_v2.4.x/test_decimal.js-light_v2.4.x.js
@@ -1,0 +1,308 @@
+// @flow
+
+import Decimal from 'decimal.js-light';
+
+// $ExpectError
+Decimal.set({ precision: '2' });
+// $ExpectError
+Decimal.set({ rounding: '2' });
+// $ExpectError
+Decimal.set({ toExpNeg: '2' });
+// $ExpectError
+Decimal.set({ toExpPos: '2' });
+// $ExpectError
+Decimal.set({ LN10: [] });
+
+Decimal.set({
+  precision: 8, rounding: 8, toExpNeg: 9, toExpPos: 10, LN10: 2
+});
+
+// $ExpectError
+Decimal.config({ precision: '2' });
+// $ExpectError
+Decimal.config({ rounding: '2' });
+// $ExpectError
+Decimal.config({ toExpNeg: '2' });
+// $ExpectError
+Decimal.config({ toExpPos: '2' });
+// $ExpectError
+Decimal.config({ LN10: [] });
+
+Decimal.config({
+  precision: 8, rounding: 8, toExpNeg: 9, toExpPos: 10, LN10: 2
+});
+
+// $ExpectError
+Decimal.clone({ precision: '2' });
+// $ExpectError
+Decimal.clone({ rounding: '2' });
+// $ExpectError
+Decimal.clone({ toExpNeg: '2' });
+// $ExpectError
+Decimal.clone({ toExpPos: '2' });
+// $ExpectError
+Decimal.clone({ LN10: [] });
+
+Decimal.clone({
+  precision: 8, rounding: 8, toExpNeg: 9, toExpPos: 10, LN10: 2
+});
+
+const precision: number = Decimal.precision;
+const rounding: number = Decimal.rounding;
+const ROUND_UP: number = Decimal.ROUND_UP;
+const ROUND_DOWN: number = Decimal.ROUND_DOWN;
+const ROUND_CEIL: number = Decimal.ROUND_CEIL;
+const ROUND_FLOOR: number = Decimal.ROUND_FLOOR;
+const ROUND_HALF_UP: number = Decimal.ROUND_HALF_UP;
+const ROUND_HALF_DOWN: number = Decimal.ROUND_HALF_DOWN;
+const ROUND_HALF_EVEN: number = Decimal.ROUND_HALF_EVEN;
+const ROUND_HALF_CEIL: number = Decimal.ROUND_HALF_CEIL;
+const ROUND_HALF_FLOOR: number = Decimal.ROUND_HALF_FLOOR;
+const toExpNeg: number = Decimal.toExpNeg;
+const toExpPos: number = Decimal.toExpPos;
+const LN10: Decimal = Decimal.LN10;
+
+// $ExpectError
+new Decimal({})
+// $ExpectError
+new Decimal({})
+
+new Decimal(1);
+new Decimal('2');
+new Decimal(new Decimal(1));
+
+const sample = new Decimal(1);
+const abs1: Decimal = sample.absoluteValue();
+const abs2: Decimal = sample.abs();
+
+const cmp1: 1 | 0 | -1 = sample.comparedTo(2);
+const cmp2: 1 | 0 | -1 = sample.cmp(2);
+// $ExpectError
+sample.comparedTo({});
+// $ExpectError
+sample.cmp({});
+
+const dp1: number = sample.decimalPlaces();
+const dp2: number = sample.dp();
+
+const div1: Decimal = sample.dividedBy(1);
+sample.dividedBy('2');
+sample.dividedBy(new Decimal(1));
+// $ExpectError
+sample.dividedBy({});
+const div2: Decimal = sample.div(1);
+sample.div('2');
+sample.div(new Decimal(1));
+// $ExpectError
+sample.div({});
+
+const idiv1: Decimal = sample.dividedToIntegerBy(1);
+sample.dividedToIntegerBy('2');
+sample.dividedToIntegerBy(new Decimal(1));
+// $ExpectError
+sample.dividedToIntegerBy({});
+const idiv2: Decimal = sample.idiv(1);
+sample.idiv('2');
+sample.idiv(new Decimal(1));
+// $ExpectError
+sample.idiv({});
+
+const eq1: boolean = sample.equals(1);
+sample.equals('2');
+sample.equals(new Decimal(3));
+// $ExpectError
+sample.equals({});
+
+const eq2: boolean = sample.eq(1);
+sample.eq('2');
+sample.eq(new Decimal(3));
+// $ExpectError
+sample.eq({});
+
+const exp: number = sample.exponent();
+
+const b1: boolean = sample.isInteger();
+const b2: boolean = sample.isint();
+const b3: boolean = sample.isNegative();
+const b4: boolean = sample.isneg();
+const b5: boolean = sample.isPositive();
+const b6: boolean = sample.ispos();
+const b7: boolean = sample.isZero();
+const b8: boolean = sample.lessThan(1);
+sample.lessThan('2');
+sample.lessThan(new Decimal(3));
+// $ExpectError
+sample.lessThan({});
+const b9: boolean = sample.lt(1);
+sample.lt('2');
+sample.lt(new Decimal(3));
+// $ExpectError
+sample.lt({});
+const b10: boolean = sample.lessThanOrEqualTo(1);
+sample.lessThanOrEqualTo('2');
+sample.lessThanOrEqualTo(new Decimal(3));
+// $ExpectError
+sample.lessThanOrEqualTo({});
+const b11: boolean = sample.lte(1);
+sample.lte('2');
+sample.lte(new Decimal(3));
+// $ExpectError
+sample.lte({});
+const b12: boolean = sample.greaterThan(1);
+sample.greaterThan('2');
+sample.greaterThan(new Decimal(3));
+// $ExpectError
+sample.greaterThan({});
+const b13: boolean = sample.gt(1);
+sample.gt('2');
+sample.gt(new Decimal(3));
+// $ExpectError
+sample.gt({});
+const b14: boolean = sample.greaterThanOrEqualTo(1);
+sample.greaterThanOrEqualTo('2');
+sample.greaterThanOrEqualTo(new Decimal(3));
+// $ExpectError
+sample.greaterThanOrEqualTo({});
+const b15: boolean = sample.gte(1);
+sample.gte('2');
+sample.gte(new Decimal(3));
+// $ExpectError
+sample.gte({});
+
+const min1: Decimal = sample.minus(1);
+sample.minus('2');
+sample.minus(new Decimal(1));
+// $ExpectError
+sample.minus({});
+const min2: Decimal = sample.sub(1);
+sample.sub('2');
+sample.sub(new Decimal(1));
+// $ExpectError
+sample.sub({});
+
+const add1: Decimal = sample.plus(1);
+sample.plus('2');
+sample.plus(new Decimal(1));
+// $ExpectError
+sample.plus({});
+const add2: Decimal = sample.add(1);
+sample.add('2');
+sample.add(new Decimal(1));
+// $ExpectError
+sample.add({});
+
+const mod1: Decimal = sample.modulo(1);
+sample.modulo('2');
+sample.modulo(new Decimal(1));
+// $ExpectError
+sample.modulo({});
+const mod2: Decimal = sample.mod(1);
+sample.mod('2');
+sample.mod(new Decimal(1));
+// $ExpectError
+sample.mod({});
+
+const tm1: Decimal = sample.times(1);
+sample.times('2');
+sample.times(new Decimal(1));
+// $ExpectError
+sample.times({});
+const tm2: Decimal = sample.mul(1);
+sample.mul('2');
+sample.mul(new Decimal(1));
+// $ExpectError
+sample.mul({});
+
+const pow1: Decimal = sample.toPower(1);
+sample.toPower('2');
+sample.toPower(new Decimal(1));
+// $ExpectError
+sample.toPower({});
+const pow2: Decimal = sample.pow(1);
+sample.pow('2');
+sample.pow(new Decimal(1));
+// $ExpectError
+sample.pow({});
+
+const log1: Decimal = sample.logarithm(1);
+sample.logarithm('2');
+sample.logarithm(new Decimal(1));
+sample.logarithm();
+// $ExpectError
+sample.logarithm({});
+const log2: Decimal = sample.log(1);
+sample.log('2');
+sample.log(new Decimal(1));
+sample.log();
+// $ExpectError
+sample.log({});
+
+const exp2: Decimal = sample.naturalExponetial();
+const exp3: Decimal = sample.exp();
+const ln1: Decimal = sample.naturalLogarithm();
+const ln2: Decimal = sample.ln();
+const neg1: Decimal = sample.negated();
+const neg2: Decimal = sample.neg();
+const sqrt1: Decimal = sample.squareRoot();
+const sqrt2: Decimal = sample.sqrt();
+const int1: Decimal = sample.toInteger();
+const int2: Decimal = sample.toint();
+const num: number = sample.toNumber();
+
+const pre1: number = sample.precision(true);
+sample.precision(1);
+// $ExpectError
+sample.precision('2');
+// $ExpectError
+sample.precision({});
+const pre2: number = sample.sd(true);
+sample.sd(1);
+// $ExpectError
+sample.sd('2');
+// $ExpectError
+sample.sd({});
+
+const str: string = sample.toString();
+const val1: string = sample.valueOf();
+const val2: string = sample.val();
+const js: string = sample.toJSON();
+
+const dp3: Decimal = sample.toDecimalPlaces();
+sample.toDecimalPlaces(1);
+sample.toDecimalPlaces(1, 2);
+// $ExpectError
+sample.toDecimalPlaces('1', '2');
+const dp4: Decimal = sample.todp();
+sample.todp(1);
+sample.todp(1, 2);
+// $ExpectError
+sample.todp('1', '2');
+
+const te1: string = sample.toExponential();
+sample.toExponential(1);
+sample.toExponential(1, 2);
+// $ExpectError
+sample.toExponential('1', '2');
+
+const f1: string = sample.toFixed();
+sample.toFixed(1);
+sample.toFixed(1, 2);
+// $ExpectError
+sample.toFixed('1', '2');
+
+const pre3: string = sample.toPrecision();
+sample.toPrecision(1);
+sample.toPrecision(1, 2);
+// $ExpectError
+sample.toPrecision('1', '2');
+
+const sd1: Decimal = sample.toSignificantDigits();
+sample.toSignificantDigits(1);
+sample.toSignificantDigits(1, 2);
+// $ExpectError
+sample.toSignificantDigits('1', '2');
+const sd2: Decimal = sample.tosd();
+sample.tosd(1);
+sample.tosd(1, 2);
+// $ExpectError
+sample.tosd('1', '2');


### PR DESCRIPTION
Copied from 2.3.x, because there were no API changes introduced: https://github.com/MikeMcl/decimal.js-light/compare/v2.3.1...v2.4.1