### PR TITLE
Fix underscore#mapObject argument type

### DIFF
--- a/definitions/npm/underscore_v1.x.x/flow_v0.38.x-v0.49.x/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.38.x-v0.49.x/underscore_v1.x.x.js
@@ -437,7 +437,7 @@ declare module "underscore" {
     values<K, V>(object: {[keys: K]: V}): Array<V>;
     mapObject(
       object: Object,
-      iteratee: (val: any, key: string) => Object,
+      iteratee: (val: any, key: string) => mixed,
       context?: mixed
     ): Object;
     pairs<K, V>(object: {[keys: K]: V}): Array<[K, V]>;

--- a/definitions/npm/underscore_v1.x.x/flow_v0.50.x-/underscore_v1.x.x.js
+++ b/definitions/npm/underscore_v1.x.x/flow_v0.50.x-/underscore_v1.x.x.js
@@ -439,7 +439,7 @@ declare module "underscore" {
     values<K, V>(object: {[keys: K]: V}): Array<V>;
     mapObject(
       object: Object,
-      iteratee: (val: any, key: string) => Object,
+      iteratee: (val: any, key: string) => mixed,
       context?: mixed
     ): Object;
     pairs<K, V>(object: {[keys: K]: V}): Array<[K, V]>;


### PR DESCRIPTION
http://underscorejs.org/#mapObject
shows that the `iteratee` only need to return new value
But the returned value doesn't need to be `Object`