### PR TITLE
fix history_4.x.x BrowserHistory.replace def

### DIFF
--- a/definitions/npm/history_v4.x.x/flow_v0.25.x-/history_v4.x.x.js
+++ b/definitions/npm/history_v4.x.x/flow_v0.25.x-/history_v4.x.x.js
@@ -25,6 +25,7 @@ declare module "history/createBrowserHistory" {
     block: (message: string) => Unblock,
     block: ((location: BrowserLocation, action: Action) => string) => Unblock,
     push: (path: string) => void,
+    replace: (path: string) => void,
   };
 
   declare type HistoryOpts = {


### PR DESCRIPTION
'.replace' should have the same annotation as '.push'