### PR TITLE
add transportOptions types and test

### DIFF
--- a/definitions/npm/socket.io-client_v2.x.x/flow_v0.34.x-/socket.io-client_v2.x.x.js
+++ b/definitions/npm/socket.io-client_v2.x.x/flow_v0.34.x-/socket.io-client_v2.x.x.js
@@ -10,6 +10,11 @@ declare module "socket.io-client" {
     randomizationFactor: number,
     timeout: number,
     transports: ("polling" | "websocket")[],
+    transportOptions: {
+      polling: {
+        extraHeaders: {[string]:string}
+      }
+    },
     autoConnect: boolean,
     query: { [string]: string },
     parser: any

--- a/definitions/npm/socket.io-client_v2.x.x/test_socket.io-client_v2.x.x.js
+++ b/definitions/npm/socket.io-client_v2.x.x/test_socket.io-client_v2.x.x.js
@@ -2,7 +2,8 @@ import io from "socket.io-client";
 
 io("foo");
 io("foo", {});
-io("foo", { forceNew: true, path: "/foobar", transports: ["websocket"], transportOptions:  { polling: { extraHeaders: { Authorization: "Basic 12345" }}}});
+io("foo", { forceNew: true, path: "/foobar", transports: ["websocket"]});
+io("foo", { transportOptions: { polling: { extraHeaders: { Authorization: "Basic 12345" }}}})
 
 io.connect("foo");
 io.connect("foo", {});

--- a/definitions/npm/socket.io-client_v2.x.x/test_socket.io-client_v2.x.x.js
+++ b/definitions/npm/socket.io-client_v2.x.x/test_socket.io-client_v2.x.x.js
@@ -2,7 +2,7 @@ import io from "socket.io-client";
 
 io("foo");
 io("foo", {});
-io("foo", { forceNew: true, path: "/foobar", transports: ["websocket"] });
+io("foo", { forceNew: true, path: "/foobar", transports: ["websocket"], transportOptions:  polling: { extraHeaders: { Authorization: "Basic 12345" }}});
 
 io.connect("foo");
 io.connect("foo", {});

--- a/definitions/npm/socket.io-client_v2.x.x/test_socket.io-client_v2.x.x.js
+++ b/definitions/npm/socket.io-client_v2.x.x/test_socket.io-client_v2.x.x.js
@@ -2,7 +2,7 @@ import io from "socket.io-client";
 
 io("foo");
 io("foo", {});
-io("foo", { forceNew: true, path: "/foobar", transports: ["websocket"], transportOptions:  polling: { extraHeaders: { Authorization: "Basic 12345" }}});
+io("foo", { forceNew: true, path: "/foobar", transports: ["websocket"], transportOptions:  { polling: { extraHeaders: { Authorization: "Basic 12345" }}}});
 
 io.connect("foo");
 io.connect("foo", {});


### PR DESCRIPTION
Current types are inconsistent with the [docs](https://socket.io/docs/client-api/#with-extraheaders). 