### PR TITLE
Make data field of PapaParse$UnparseObject covariant

### DIFF
--- a/definitions/npm/papaparse_v4.x.x/flow_v0.39.x-/papaparse_v4.x.x.js
+++ b/definitions/npm/papaparse_v4.x.x/flow_v0.39.x-/papaparse_v4.x.x.js
@@ -51,7 +51,7 @@ declare interface PapaParse$UnparseConfig {
 
 declare interface PapaParse$UnparseObject {
     fields: Array<any>,
-    data: string | Array<any>
+    +data: string | Array<any>
 }
 
 declare interface PapaParse$ParseError {

--- a/definitions/npm/papaparse_v4.x.x/test_papaparse_v4.x.x.js
+++ b/definitions/npm/papaparse_v4.x.x/test_papaparse_v4.x.x.js
@@ -31,6 +31,32 @@ var flat: Array<Object> = [{a: 1, b: 1, c: 1}];
 var nested: Array<Array<any>> = [[1, 2, 3], [4, 5, 6]];
 (Papa.unparse(nested): string);
 
+var explicit: PapaParse$UnparseObject = {
+  fields: ['One', 'Two'],
+  data: '1,2',
+};
+(Papa.unparse(explicit): string);
+
+var explicitAnyData: PapaParse$UnparseObject = {
+  fields: ['One', 'Two'],
+  data: [1, 2]
+};
+(Papa.unparse(explicitAnyData): string);
+
+// $ExpectError
+var explicitInvalidData: PapaParse$UnparseObject = {
+  fields: ['One', 'Two'],
+  data: 1
+};
+(Papa.unparse(explicitInvalidData): string);
+
+// $ExpectError
+var explicitInvalidFields: PapaParse$UnparseObject = {
+  fields: 'One,Two',
+  data: '1,2'
+};
+(Papa.unparse(explicitInvalidFields): string);
+
 Papa.unparse({
   fields: ["3"],
   data: ["3"]


### PR DESCRIPTION
This change makes it possible for the data property of
the PapaParse$UnparseObject interface respect its union typing of
"string | Array<any>"