### PR TITLE
relax react-router-dom Link constraints

### DIFF
--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/react-router-dom_v4.x.x.js
@@ -14,14 +14,14 @@ declare module "react-router-dom" {
     children?: React$Node
   |}> {}
 
-  declare export class Link extends React$Component<{|
+  declare export class Link extends React$Component<{
     className?: string,
     to: string | LocationShape,
     replace?: boolean,
     children?: React$Node
-  |}> {}
+  }> {}
 
-  declare export class NavLink extends React$Component<{|
+  declare export class NavLink extends React$Component<{
     to: string | LocationShape,
     activeClassName?: string,
     className?: string,
@@ -31,7 +31,7 @@ declare module "react-router-dom" {
     children?: React$Node,
     exact?: boolean,
     strict?: boolean
-  |}> {}
+  }> {}
 
   // NOTE: Below are duplicated from react-router. If updating these, please
   // update the react-router and react-router-native types as well.

--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/test_react-router-dom.js
@@ -80,6 +80,19 @@ describe("react-router-dom", () => {
       </Link>;
     });
 
+    it("allows attributes of <a> element", () => {
+      <Link
+        to="/about"
+        download
+        hreflang="de"
+        ping="https://www.example.com"
+        referrerpolicy="no-referrer"
+        target="_self"
+        type="foo"
+        onClick={() => {}}
+      >About</Link>;
+    });
+
     it("raises error if passed incorrect props", () => {
       // $ExpectError - to prop is required
       <Link />;
@@ -116,6 +129,19 @@ describe("react-router-dom", () => {
       >
         About
       </NavLink>;
+    });
+
+    it("allows attributes of <a> element", () => {
+      <NavLink
+        to="/about"
+        download
+        hreflang="de"
+        ping="https://www.example.com"
+        referrerpolicy="no-referrer"
+        target="_self"
+        type="foo"
+        onClick={() => {}}
+      >About</NavLink>;
     });
 
     it("raises error if passed incorrect props", () => {


### PR DESCRIPTION
Small PR to relax over-strict type checking on router-react-dom.

react-router-dom `<Link>` accepts any user properties and passes them through to the generated `<a>`. Also `<NavLink>` extends `<Link>`. 

for reference 
https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/Link.md#others

code 
https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/modules/Link.js#L75
https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/modules/NavLink.js#L46
