### PR TITLE
[react-router-dom] Make <Link> component of ReactRouterDOM not exact + update tests

### DIFF
--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/react-router-dom_v4.x.x.js
@@ -14,12 +14,12 @@ declare module "react-router-dom" {
     children?: React$Node
   |}> {}
 
-  declare export class Link extends React$Component<{|
+  declare export class Link extends React$Component<{
     className?: string,
     to: string | LocationShape,
     replace?: boolean,
     children?: React$Node
-  |}> {}
+  }> {}
 
   declare export class NavLink extends React$Component<{|
     to: string | LocationShape,

--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/test_react-router-dom.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/test_react-router-dom.js
@@ -80,6 +80,19 @@ describe("react-router-dom", () => {
       </Link>;
     });
 
+    it("allows attributes of <a> element", () => {
+      <Link
+        to="/about"
+        download
+        hreflang="de"
+        ping="https://www.example.com"
+        referrerpolicy="no-referrer"
+        target="_self"
+        type="foo"
+        onClick={() => {}}
+      >About</Link>;
+    });
+
     it("raises error if passed incorrect props", () => {
       // $ExpectError - to prop is required
       <Link />;


### PR DESCRIPTION
## Context
In https://github.com/flowtype/flow-typed/pull/2306, the `<Link>` component has been made exact. However, in the official React Router DOM documentation (https://reacttraining.com/react-router/web/api/Link/others), it is explicitly stated that the `<Link>` component accepts all attributes for the `<a>` element in HTML.

Instead of defining all `<a>` properties explicitly in the flow-type, I chose to make the `<Link>` component not exact. I do this to make the `<Link>` flow-type independent of the HTML-spec for  `<a>`, since some of the HTML-specced properties are dynamic (`data-` attributes for example). I think this is the most pragmatic way.

## What has been done?
* Make `Link` property definition not exact
* Updated tests for the `Link` component to verify the `<a>` attributes can be passed