### PR TITLE
Use supportsColor as object

### DIFF
--- a/definitions/npm/chalk_v2.x.x/flow_v0.25.x-/chalk_v2.x.x.js
+++ b/definitions/npm/chalk_v2.x.x/flow_v0.25.x-/chalk_v2.x.x.js
@@ -15,7 +15,12 @@ declare module "chalk" {
     level?: Level
   |};
 
-  declare type ColorSupport = boolean;
+  declare type ColorSupport = {|
+    level: Level,
+    hasBasic: boolean,
+    has256: boolean,
+    has16m: boolean
+  |};
 
   declare interface Chalk {
     (...text: string[]): string,

--- a/definitions/npm/chalk_v2.x.x/test_chalk_v2.x.x.js
+++ b/definitions/npm/chalk_v2.x.x/test_chalk_v2.x.x.js
@@ -5,7 +5,17 @@ import chalk, { bold } from 'chalk';
 const requiredChalk = require('chalk');
 
 const enabled: boolean = chalk.enabled;
-const supportsColor: boolean = chalk.supportsColor;
+const supportsColor: {
+  level: $Values<{
+    None: 0,
+    Basic: 1,
+    Ansi256: 2,
+    TrueColor: 3
+  }>,
+  hasBasic: boolean,
+  has256: boolean,
+  has16m: boolean,
+} = chalk.supportsColor;
 
 const colorfulString: string = chalk.red.bgGreen("a soon to be colorful string");
 const supportsDim: string = chalk.dim("oh to be dimmed");


### PR DESCRIPTION
https://github.com/chalk/chalk/issues/267#issuecomment-396445028

In `chalk@2.x.x`, supportsColor had changed to be an `object`.