### PR TITLE
Add location prop to Switch in react-router & react-router-dom

### DIFF
--- a/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/react-router-dom_v4.x.x.js
+++ b/definitions/npm/react-router-dom_v4.x.x/flow_v0.63.x-/react-router-dom_v4.x.x.js
@@ -143,7 +143,8 @@ declare module "react-router-dom" {
   |}> {}
 
   declare export class Switch extends React$Component<{|
-    children?: React$Node
+    children?: React$Node,
+    location?: Location
   |}> {}
 
   declare export function withRouter<P: {}, Component: React$ComponentType<P>>(

--- a/definitions/npm/react-router_v4.x.x/flow_v0.53.x-/react-router_v4.x.x.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.53.x-/react-router_v4.x.x.js
@@ -103,7 +103,8 @@ declare module "react-router" {
   }> {}
 
   declare export class Switch extends React$Component<{
-    children?: React$Node
+    children?: React$Node,
+    location?: Location
   }> {}
 
   declare export function withRouter<P>(


### PR DESCRIPTION
There was no possibility to use react-router(-dom) with react-transition-group because of the lack of `location` prop in Switch component.
```js
<TransitionGroup component={null}>
    <CSSTransition key={location.key} timeout={2000} classNames="fade">
      <Switch location={location}>
        <Route exact path="/somepath" component={SomeComponent} />
      </Switch>
    </CSSTransition>
</TransitionGroup>
```