### PR TITLE
cord: fix export style for cors library definition

### DIFF
--- a/definitions/npm/cors_v2.x.x/flow_v0.53.x-/cors_v2.x.x.js
+++ b/definitions/npm/cors_v2.x.x/flow_v0.53.x-/cors_v2.x.x.js
@@ -22,5 +22,5 @@ type CorsOptions = {
 }
 
 declare module "cors" {
-    declare export default (options?: CorsOptions) => RequestHandler;
+    declare module.exports: (options?: CorsOptions) => RequestHandler;
 }


### PR DESCRIPTION
With the change to `declare export default (options?: CorsOptions) => RequestHandler;` (https://github.com/flowtype/flow-typed/pull/2319) a problem with CommonJS appeared.

This code was throwing an error:
```
const cors = require('cors');
cors(corsOptions) // Cannot call cors because a callable signature is missing in module cors [1].
```

Flow was sure, that cors in that case is an object with a default function inside:
<img width="502" alt="screen shot 2018-06-13 at 15 49 04" src="https://user-images.githubusercontent.com/3503252/41352172-56ba692e-6f21-11e8-8241-d140e3be5b01.png">

Fixed the problem, made sure that the tests are passing.