### PR TITLE
[react-router-v4] Add missing Switch.props.location

### DIFF
--- a/definitions/npm/react-router_v4.x.x/flow_v0.30.x-v0.52.x/react-router_v4.x.x.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.30.x-v0.52.x/react-router_v4.x.x.js
@@ -111,6 +111,7 @@ declare module 'react-router' {
   declare export class Switch extends React$Component {
     props: {
       children?: Array<React$Element<*>>,
+      location?: Location,
     }
   }
 


### PR DESCRIPTION
See the source code:
https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/Switch.js#L19