### PR TITLE
[react-router-v4] Add missing Switch.props.location (take II)

### DIFF
--- a/definitions/npm/react-router_v4.x.x/flow_v0.63.x-/react-router_v4.x.x.js
+++ b/definitions/npm/react-router_v4.x.x/flow_v0.63.x-/react-router_v4.x.x.js
@@ -109,7 +109,8 @@ declare module "react-router" {
   |}> {}
 
   declare export class Switch extends React$Component<{|
-    children?: React$Node
+    children?: React$Node,
+    location?: Location
   |}> {}
 
   declare export function withRouter<P>(


### PR DESCRIPTION
See the source code:
https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/Switch.js#L19

This is not the same PR as #2374 