### PR TITLE
Allow Parse.ACL() constructor without arguments

### DIFF
--- a/definitions/npm/parse_v1.9.x/flow_v0.30.x-/parse_v1.9.x.js
+++ b/definitions/npm/parse_v1.9.x/flow_v0.30.x-/parse_v1.9.x.js
@@ -201,8 +201,8 @@ declare type $npm$parse$ByIdMap = { [userId: string]: $npm$parse$PermissionsMap 
 
 declare class $npm$parse$ParseACL {
   permissionsById: $npm$parse$ByIdMap,
-  static(arg1: $npm$parse$ParseUser | $npm$parse$ByIdMap): $npm$parse$ParseACL,
-  constructor(arg1: $npm$parse$ParseUser | $npm$parse$ByIdMap): $npm$parse$ParseACL,
+  static(arg1: $npm$parse$ParseUser | $npm$parse$ByIdMap | void): $npm$parse$ParseACL,
+  constructor(arg1: $npm$parse$ParseUser | $npm$parse$ByIdMap | void): $npm$parse$ParseACL,
   toJSON(): $npm$parse$ByIdMap,
   equals(other: $npm$parse$ParseACL): boolean,
   setReadAccess(userId: $npm$parse$ParseUser | $npm$parse$ParseRole | string, allowed: boolean): void,

--- a/definitions/npm/parse_v1.9.x/flow_v0.30.x-/parse_v1.9.x.js
+++ b/definitions/npm/parse_v1.9.x/flow_v0.30.x-/parse_v1.9.x.js
@@ -201,8 +201,8 @@ declare type $npm$parse$ByIdMap = { [userId: string]: $npm$parse$PermissionsMap 
 
 declare class $npm$parse$ParseACL {
   permissionsById: $npm$parse$ByIdMap,
-  static(arg1: $npm$parse$ParseUser | $npm$parse$ByIdMap | void): $npm$parse$ParseACL,
-  constructor(arg1: $npm$parse$ParseUser | $npm$parse$ByIdMap | void): $npm$parse$ParseACL,
+  static(arg1?: $npm$parse$ParseUser | $npm$parse$ByIdMap): $npm$parse$ParseACL,
+  constructor(arg1?: $npm$parse$ParseUser | $npm$parse$ByIdMap): $npm$parse$ParseACL,
   toJSON(): $npm$parse$ByIdMap,
   equals(other: $npm$parse$ParseACL): boolean,
   setReadAccess(userId: $npm$parse$ParseUser | $npm$parse$ParseRole | string, allowed: boolean): void,


### PR DESCRIPTION
According to the Parse SDK [docs](http://parseplatform.org/Parse-SDK-JS/api/v1.11.1/Parse.ACL.html) the constructor for `Parse.ACL` can be called with no arguments:

> Creates a new ACL. **If no argument is given**, the ACL has no permissions for anyone. If the argument is a Parse.User, the ACL will have read and write permission for only that user. If the argument is any other JSON object, that object will be interpretted as a serialized ACL created with toJSON().

But at the moment the constructor is typed as:

```javascript
declare class $npm$parse$ParseACL {
  //...
  constructor(arg1: $npm$parse$ParseUser | $npm$parse$ByIdMap): $npm$parse$ParseACL
  //...
}
```

Making impossible to call it with no arguments:

```
Cannot call Parse.ACL because:
 • Either undefined [1] is incompatible with $npm$parse$ParseUser [2].
 • Or undefined [1] is incompatible with $npm$parse$ByIdMap [3].

        src/file.js
         15│
    [1]  16│   const acl = new Parse.ACL();
         17│   acl.setPublicReadAccess(false);
         18│   acl.setPublicWriteAccess(false);
         19│   object.setACL(acl);

        flow-typed/npm/parse_v1.9.x.js
 [2][3] 231│   constructor(arg1: $npm$parse$ParseUser | $npm$parse$ByIdMap): $npm$parse$ParseACL;
```

This PR makes the first constructor argument optional.