### PR TITLE
Allow nullable papaparse UnparseConfig properties #2386 

### DIFF
--- a/definitions/npm/papaparse_v4.x.x/flow_v0.39.x-/papaparse_v4.x.x.js
+++ b/definitions/npm/papaparse_v4.x.x/flow_v0.39.x-/papaparse_v4.x.x.js
@@ -42,11 +42,11 @@ declare interface PapaParse$ParseConfig {
 }
 
 declare interface PapaParse$UnparseConfig {
-    quotes: boolean,
-    quoteChar: string,
-    delimiter: string,
-    header: boolean,
-    newline: string
+    quotes?: boolean,
+    quoteChar?: string,
+    delimiter?: string,
+    header?: boolean,
+    newline?: string
 }
 
 declare interface PapaParse$UnparseObject {

--- a/definitions/npm/papaparse_v4.x.x/test_papaparse_v4.x.x.js
+++ b/definitions/npm/papaparse_v4.x.x/test_papaparse_v4.x.x.js
@@ -62,5 +62,12 @@ Papa.unparse({
   data: ["3"]
 });
 
+Papa.unparse({
+  fields: ["3"],
+  data: ["3"]
+}, { 
+  quotes: true 
+});
+
 Papa.SCRIPT_PATH;
 Papa.LocalChunkSize;


### PR DESCRIPTION
Fix to UnparseConfig so we can set individual properties, without having to specify every property