### PR TITLE
libdef for mongoose add propert aggregate type

### DIFF
--- a/definitions/npm/mongoose_v4.x.x/flow_v0.50.x-/mongoose_v4.x.x.js
+++ b/definitions/npm/mongoose_v4.x.x/flow_v0.50.x-/mongoose_v4.x.x.js
@@ -252,7 +252,7 @@ declare class Mongoose$Document {
   ): Promise<UpdateResult> & { exec(): Promise<UpdateResult> };
   static create(doc: $Shape<this> | Array<$Shape<this>>): Promise<this>;
   static where(criteria?: Object): Mongoose$Query<this, this>;
-  static aggregate(pipeline: Object[]): Promise<any>;
+  static aggregate(pipeline: Object[]): Aggregate$Query;
   static bulkWrite(ops: Object[]): Promise<any>;
   static deleteMany(criteria: Object): Promise<any>;
   static deleteOne(criteria: Object): Promise<any>;
@@ -418,6 +418,38 @@ declare class Mongoose$Query<Result, Doc> extends Promise<Result> {
   stream(opts?: Object): Mongoose$QueryStream;
   tailable(bool: boolean, opts?: Object): Mongoose$Query<Result, Doc>;
   toConstructor(): Class<Mongoose$Query<Result, Doc>>;
+}
+
+declare class Aggregate$Query extends Promise<any> {
+  exec(): Promise<any>;
+  allowDiskUse(bool: boolean): Aggregate$Query;
+  addCursorFlag(str: string, bool: boolean): Aggregate$Query;
+  addFields(opts?: Object): Aggregate$Query;
+  append(opts?: Object): Aggregate$Query;
+  collation(opts?: Object): Aggregate$Query;
+  count(str: string): Promise<number>;
+  cursor(opts?: Object): Mongoose$QueryCursor<Object>;
+  exec(cb?:Function): Promise<any>;
+  explain(cb?:Function): Aggregate$Query;
+  facet(opts?: Object): Aggregate$Query;
+  graphLookup(opts?: Object): Aggregate$Query;
+  group(opts?: Object): Aggregate$Query;
+  hint(opts?: Object): Aggregate$Query;
+  limit(n: number): Aggregate$Query;
+  lookup(opts?: Object): Aggregate$Query;
+  match(opts?: Object): Aggregate$Query;
+  model(opts?: Object): Aggregate$Query;
+  near(opts?: Object): Aggregate$Query;
+  option(opts?: Object): Aggregate$Query;
+  pipeline(): Object[];
+  project(opts?: Object): Aggregate$Query;
+  read(str: string): Aggregate$Query;
+  replaceRoot(opts?: Object): Aggregate$Query;
+  sample(n: number): Aggregate$Query;
+  skip(n: number): Aggregate$Query;
+  sort(options: {} | string): Aggregate$Query;
+  sortByCount(options: {} | string): Aggregate$Query;
+  unwind(str: string): Aggregate$Query;
 }
 
 declare class Mongoose$QueryCursor<Doc> {

--- a/definitions/npm/mongoose_v4.x.x/test_mongoose-v4.js
+++ b/definitions/npm/mongoose_v4.x.x/test_mongoose-v4.js
@@ -108,6 +108,9 @@ const a1 = new Admin({ email: "123", token: "www" });
 // $ExpectError
 const a2 = new Admin({ email: 123, token: "www" });
 
+
+Admin.aggregate([ { $project : { email : 1 } } ]).allowDiskUse(true).exec()
+
 //
 export const UserSchema = new Schema(
   {


### PR DESCRIPTION
Added proper types for aggregate method in mongoose, now it's just Promise<any> so things this for example `Model.aggregate(..).allowDiskUse(true).exec(callback)` doesn't work