### PR TITLE
Add types for asynchronous jest mocks

### DIFF
--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
@@ -68,7 +68,23 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   /**
    * Sugar for only returning a value once inside your mock
    */
-  mockReturnValueOnce(value: TReturn): JestMockFn<TArguments, TReturn>
+  mockReturnValueOnce(value: TReturn): JestMockFn<TArguments, TReturn>,
+  /** 
+   * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
+   */
+  mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  /**
+   * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
+   */
+  mockResolvedValueOnce(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  /**
+   * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))
+   */
+  mockRejectedValue(value: TReturn): JestMockFn<TArguments, Promise<any>>,
+  /**
+   * Sugar for jest.fn().mockImplementationOnce(() => Promise.reject(value))
+   */
+  mockRejectedValueOnce(value: TReturn): JestMockFn<TArguments, Promise<any>>
 };
 
 type JestAsymmetricEqualityType = {

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
@@ -48,16 +48,16 @@ foo.doStuff = jest.fn().mockReturnValueOnce(10);
 // $ExpectError Mock function expected to return number, not string.
 foo.doStuff = jest.fn().mockReturnValueOnce("10");
 
-foo.doAsyncStuff.mockResolvedValue(10);
+foo.doAsyncStuff = jest.fn().mockResolvedValue(10);
 // $ExpectError Mock function expected to return Promise<number>, not Promise<string>
-foo.doAsyncStuff.mockResolvedValue("10");
+foo.doAsyncStuff = jest.fn().mockResolvedValue("10");
 
-foo.doAsyncStuff.mockResolvedValueOnce(10);
+foo.doAsyncStuff = jest.fn().mockResolvedValueOnce(10);
 // $ExpectError Mock function expected to return Promise<number>, not Promise<string>
-foo.doAsyncStuff.mockResolvedValueOnce("10");
+foo.doAsyncStuff = jest.fn().mockResolvedValueOnce("10");
 
-foo.doAsyncStuff.mockRejectedValue(10);
-foo.doAsyncStuff.mockRejectedValueOnce(10);
+foo.doAsyncStuff = jest.fn().mockRejectedValue(10);
+foo.doAsyncStuff = jest.fn().mockRejectedValueOnce(10);
 
 foo.doStuff = jest.fn().mockName("10");
 // $ExpectError mockName expects a string, not a number

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
@@ -14,11 +14,15 @@ const mockFn = jest.fn();
 mockFn.mock.calls.map(String).map(a => a + a);
 
 type Foo = {
-  doStuff: string => number
+  doStuff: string => number,
+  doAsyncStuff: string => Promise<number>
 };
 const foo: Foo = {
   doStuff(str: string): number {
     return 5;
+  },
+  doAsyncStuff(str: string): Promise<number> {
+    return Promise.resolve(5);
   }
 };
 foo.doStuff = jest.fn().mockImplementation(str => 10);
@@ -43,6 +47,17 @@ foo.doStuff = jest.fn().mockReturnValue("10");
 foo.doStuff = jest.fn().mockReturnValueOnce(10);
 // $ExpectError Mock function expected to return number, not string.
 foo.doStuff = jest.fn().mockReturnValueOnce("10");
+
+foo.doAsyncStuff.mockResolvedValue(10);
+// $ExpectError Mock function expected to return Promise<number>, not Promise<string>
+foo.doAsyncStuff.mockResolvedValue("10");
+
+foo.doAsyncStuff.mockResolvedValueOnce(10);
+// $ExpectError Mock function expected to return Promise<number>, not Promise<string>
+foo.doAsyncStuff.mockResolvedValueOnce("10");
+
+foo.doAsyncStuff.mockRejectedValue(10);
+foo.doAsyncStuff.mockRejectedValueOnce(10);
 
 foo.doStuff = jest.fn().mockName("10");
 // $ExpectError mockName expects a string, not a number


### PR DESCRIPTION
jest 23 has [4 functions](https://facebook.github.io/jest/docs/en/mock-function-api.html#mockfnmockresolvedvaluevalue) the libdefs were missing. Some of the work for #2264.