### PR TITLE
Remove `import { Component } from "react";`

### DIFF
--- a/definitions/npm/react-collapsible_v2.0.x/flow_v0.54.x-/react-collapsible_v2.0.x.js
+++ b/definitions/npm/react-collapsible_v2.0.x/flow_v0.54.x-/react-collapsible_v2.0.x.js
@@ -1,5 +1,3 @@
-import { Component } from "react";
-
 declare module "react-collapsible" {
   declare type Props = {
     trigger: string | React$Node,
@@ -33,6 +31,6 @@ declare module "react-collapsible" {
     contentInnerClassName?: string
   };
 
-  declare class Collapsible extends Component<Props> {}
+  declare class Collapsible extends React$Component<Props> {}
   declare module.exports: typeof Collapsible;
 }

--- a/definitions/npm/react-collapsible_v2.0.x/test_react-collapsible_v2.0.x.js
+++ b/definitions/npm/react-collapsible_v2.0.x/test_react-collapsible_v2.0.x.js
@@ -2,15 +2,7 @@
 import React from "react";
 import Collapsible from "react-collapsible";
 
-var success = (
-  <Collapsible trigger="Click me">
-    <p>Children</p>
-  </Collapsible>
-);
+const success = <Collapsible trigger="Click me"><p>Children</p></Collapsible>;
 
 // $ExpectError
-var error = (
-  <Collapsible>
-    <p>I don't have a trigger prop</p>
-  </Collapsible>
-);
+const error = <Collapsible><p>I don't have a trigger prop</p></Collapsible>;


### PR DESCRIPTION
Use `React$Component` instead.
https://github.com/flowtype/flow-typed/blob/master/CONTRIBUTING.md#dont-import-types-from-other-libdefs

This is generating erros in other projects.
- https://github.com/facebook/flow/issues/5678
- https://github.com/facebook/flow/issues/6014