### PR TITLE
Add label to winston format definition

### DIFF
--- a/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
@@ -63,6 +63,7 @@ declare type $winstonConfigSubModule = {
 declare type $winstonFormatSubModule = {
   combine: (...args: Array<$winstonFormat>) => $winstonFormat,
   json: () => $winstonFormat,
+  label: (config?: Object) => $winstonFormat,
   prettyPrint: () => $winstonFormat,
   simple: () => $winstonFormat,
   timestamp: () => $winstonFormat

--- a/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
@@ -9,7 +9,10 @@ winston.error("default logger error message");
 winston.nonExistantLevel("default logger nonExistantLevel message");
 
 let logger = winston.createLogger({
-  format: winston.format.json(),
+  format: winston.format.combine(
+    winston.format.json(),
+    winston.format.label({label: 'label'})
+  ),
   level: "debug",
   exitOnError: false,
   transports: [


### PR DESCRIPTION
Resolves this issue:
```
Cannot call `winston.format.label` because property `label` is missing in `$winstonFormatSubModule` [1].
```
We can see this is part of winston [in this example](https://github.com/winstonjs/winston/blob/5223ab9264a9e93603ecbbd87b334ae6d047b698/examples/custom-timestamp.js#L5)