### PR TITLE
Missing `isWidthDown` declaration

### DIFF
--- a/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
+++ b/definitions/npm/@material-ui/core_v1.x.x/flow_v0.58.x-/core_v1.x.x.js
@@ -474,6 +474,7 @@ declare module "@material-ui/core/withMobileDialog" {
 declare module "@material-ui/core/withWidth" {
   import type { Breakpoint } from "@material-ui/core/styles/createBreakpoints";
   declare export var isWidthUp: (matchWidth: Breakpoint, currentWidth: Breakpoint) => boolean;
+  declare export var isWidthDown: (matchWidth: Breakpoint, currentWidth: Breakpoint) => boolean;
   declare export default $Exports<"@material-ui/core/withWidth/withWidth">;
 }
 


### PR DESCRIPTION
`isWidthDown` is also exported from withWidth. I think it should be declared as well. 

