### PR TITLE
Mark opts parameter as optional in react-apollo MutationFunc

### DIFF
--- a/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
+++ b/definitions/npm/react-apollo_v2.x.x/flow_v0.58.x-/react-apollo_v2.x.x.js
@@ -739,7 +739,7 @@ declare module "react-apollo" {
   }
 
   declare export type MutationFunc<TResult, TVariables> = (
-    opts: MutationOpts<TVariables>
+    opts?: MutationOpts<TVariables>
   ) => Promise<ApolloQueryResult<TResult>>;
 
   declare export type GraphqlData<TResult, TVariables> = TResult &


### PR DESCRIPTION
This fixes the ability to use `react-apollo` mutation functions in React components without needing to supply an empty options object.

#### Example

```js
export type Props = {
    openAppMenu: MutationFunc<Result, Variables>
};

const withOpenAppMenu: OperationComponent<Result, Props, Variables> = graphql(OPEN_APP_MENU, {
    name: 'openAppMenu',
    options: {
        variables: {
            open: true
        }
    }
});
```

The `openAppMenu` mutation can now be consumed without supplying a parameter, using its default of `open: true`:

```js
this.props.openAppMenu(); // Previously, an empty object was required
```