### PR TITLE
Allow momentjs day and weekday to accept string

### DIFF
--- a/definitions/npm/moment_v2.x.x/flow_v0.63.x-/moment_v2.x.x.js
+++ b/definitions/npm/moment_v2.x.x/flow_v0.63.x-/moment_v2.x.x.js
@@ -144,9 +144,9 @@ declare class moment$Moment {
   days(day: number|string): this;
   day(): number;
   days(): number;
-  weekday(number: number): this;
+  weekday(day: number|string): this;
   weekday(): number;
-  isoWeekday(number: number): this;
+  isoWeekday(day: number|string): this;
   isoWeekday(): number;
   dayOfYear(number: number): this;
   dayOfYear(): number;


### PR DESCRIPTION
In Momentjs `weekday` and `isoWeekday` can accept strings

https://momentjs.com/docs/#/get-set/day/ and  https://momentjs.com/docs/#/get-set/iso-weekday/

here is my quick fix