### PR TITLE
[winston_v3.x.x] Add colorize, logstash, printf types to winstonFormatSubModule

### DIFF
--- a/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
@@ -66,7 +66,10 @@ declare type $winstonFormatSubModule = {
   label: (config?: Object) => $winstonFormat,
   prettyPrint: () => $winstonFormat,
   simple: () => $winstonFormat,
-  timestamp: () => $winstonFormat
+  timestamp: () => $winstonFormat,
+  colorize: () => $winstonFormat,
+  logstash: () => $winstonFormat,
+  printf: ((args: $winstonInfo<Object>) => string) => $winstonFormat
 };
 
 declare type $winstonDefaultLogger = $winstonLogger<$winstonNpmLogLevels>;

--- a/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
@@ -8,10 +8,18 @@ winston.error("default logger error message");
 // $ExpectError
 winston.nonExistantLevel("default logger nonExistantLevel message");
 
+// See example:
+// https://github.com/winstonjs/winston/blob/c868f0ccdc6ddc45e586c9808d99ebae8351113b/README.md#formats
+const customPrintf = winston.format.printf(info => {
+  return `${info.level}: ${info.message}`;
+});
 let logger = winston.createLogger({
   format: winston.format.combine(
     winston.format.json(),
-    winston.format.label({label: 'label'})
+    winston.format.label({label: 'label'}),
+    winston.format.colorize(),
+    winston.format.logstash(),
+    customPrintf
   ),
   level: "debug",
   exitOnError: false,


### PR DESCRIPTION
`winston.format` exposes a few more properties we'd like to type, namely:

`colorize` -- [docs ref](https://github.com/winstonjs/winston#colorizing-standard-logging-levels), [source ref](https://github.com/winstonjs/logform/blob/master/colorize.js)
`logstash` -- [source ref](https://github.com/winstonjs/logform/blob/master/logstash.js)
`printf` -- [docs ref](https://github.com/winstonjs/winston#formats), [source ref](https://github.com/winstonjs/logform/blob/master/printf.js)