### PR TITLE
(jest) Update expect.not.*

### DIFF
--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/jest_v23.x.x.js
@@ -1009,7 +1009,13 @@ declare var expect: {
   objectContaining(value: Object): Object,
   /** Matches any received string that contains the exact expected string. */
   stringContaining(value: string): string,
-  stringMatching(value: string | RegExp): string
+  stringMatching(value: string | RegExp): string,
+  not: {
+    arrayContaining: (value: $ReadOnlyArray<mixed>) => Array<mixed>,
+    objectContaining: (value: {}) => Object,
+    stringContaining: (value: string) => string,
+    stringMatching: (value: string | RegExp) => string,
+  },
 };
 
 // TODO handle return type

--- a/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
+++ b/definitions/npm/jest_v23.x.x/flow_v0.39.x-/test_jest-v23.x.x.js
@@ -232,6 +232,11 @@ expect.objectContaining({
 expect.arrayContaining(["red", "blue"]);
 expect.stringMatching("*this part*");
 
+expect.not.arrayContaining(['red', 'blue']);
+expect.not.objectContaining({foo: 'bar'});
+expect.not.stringContaining('foobar');
+expect.not.stringMatching(/foobar/);
+
 test.concurrent("test", () => {});
 
 expect([1, 2, 3]).toHaveLength(3);


### PR DESCRIPTION
Jest has some documented matchers under `expect.not` [0]. They're not in the flow-typed libdefs yet. This adds them.

[0] http://jestjs.io/docs/en/expect.html#expectnotarraycontainingarray