### PR TITLE
Fix and add test case for named imports from winston

### DIFF
--- a/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/flow_v0.34.x-/winston_v3.x.x.js
@@ -81,7 +81,8 @@ declare class $winstonContainer<T> {
 }
 
 declare module "winston" {
-  declare module.exports: $winstonDefaultLogger & {
+  declare module.exports: {
+    ...$winstonDefaultLogger,
     format: $winstonFormatSubModule,
     transports: {
       Console: typeof $winstonConsoleTransport,

--- a/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
+++ b/definitions/npm/winston_v3.x.x/test_winston_v3.x.x.js
@@ -1,4 +1,5 @@
 import winston from "winston";
+import {createLogger as importedCreateLogger} from "winston";
 
 winston.log({
   level: "info",
@@ -13,6 +14,7 @@ winston.nonExistantLevel("default logger nonExistantLevel message");
 const customPrintf = winston.format.printf(info => {
   return `${info.level}: ${info.message}`;
 });
+importedCreateLogger({});
 let logger = winston.createLogger({
   format: winston.format.combine(
     winston.format.json(),


### PR DESCRIPTION
Without this error, the following error occurs:

> [flow] Cannot import `createLogger` because there is no `createLogger` export in `winston`. Did you mean `import createLogger from "..."`?